### PR TITLE
feat: Slack message routing adapter

### DIFF
--- a/context-agent/wiki/domain-model.md
+++ b/context-agent/wiki/domain-model.md
@@ -6,7 +6,7 @@ Core concepts in the Autocatalyst system.
 
 The seed input from a human. A short description of what to build or change. Arrives through the human interface adapter.
 
-**Fields:** `id`, `source` (which adapter), `content` (raw text), `author`, `received_at`
+**Fields:** `id`, `source` (which adapter), `content` (raw text), `author`, `received_at`, `thread_ts` (Slack thread identifier for posting replies), `channel_id`
 
 ## Spec
 

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -434,8 +434,8 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: Task: Extend WorkflowConfig with slack fields
 
-- [ ] **Story: Thread registry**
-  - [ ] **Task: Implement ThreadRegistry**
+- [x] **Story: Thread registry**
+  - [x] **Task: Implement ThreadRegistry**
     - **Description**: Create `src/adapters/slack/thread-registry.ts`. The class maintains an in-memory `Map<string, string>` mapping `thread_ts` to `idea_id`. Expose two methods: `register(thread_ts: string, idea_id: string): void` and `resolve(thread_ts: string): string | undefined`. No persistence — the registry is empty on construction and lost on process exit. Write unit tests in `tests/adapters/slack/thread-registry.test.ts` covering all cases in the testing plan.
     - **Acceptance criteria**:
       - [ ] `ThreadRegistry` class created with `register` and `resolve` methods

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -460,7 +460,7 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: Story: Thread registry
 
-- [ ] **Story: Slack adapter**
+- [x] **Story: Slack adapter**
   - [x] **Task: Implement BoltApp factory**
     - **Description**: Create `src/adapters/slack/bolt-app.ts`. Export a `createBoltApp(botToken: string, appToken: string): App` factory function that initializes a Slack Bolt `App` configured for Socket Mode using `SocketModeReceiver`. The factory creates and returns the app instance; event handlers are not registered here.
     - **Acceptance criteria**:
@@ -484,7 +484,7 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: Task: Implement BoltApp factory, Task: Implement Classifier, Story: Thread registry, Task: Extend validateConfig with slack validation
 
-  - [ ] **Task: Write SlackAdapter integration tests**
+  - [x] **Task: Write SlackAdapter integration tests**
     - **Description**: Write `tests/adapters/slack/slack-adapter.test.ts`. Inject a Bolt test double — mock `App` and `WebClient` — via the adapter constructor so no live Slack API calls are made. Cover all integration test cases from the testing plan: startup (channel found, channel not found, handler ordering), new idea pipeline (event shape, acknowledgement text, thread registration, chaining to spec_feedback), spec feedback pipeline, approval signal pipeline, all four ignore cases, error handling (postMessage failure, Bolt error event), and service lifecycle (start/stop).
     - **Acceptance criteria**:
       - [ ] All integration test cases from the testing plan pass

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -401,7 +401,7 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
 
 ## Task list
 
-- [ ] **Story: Types and configuration**
+- [x] **Story: Types and configuration**
   - [x] **Task: Define event types and update adapter interface**
     - **Description**: Create `src/types/events.ts` with the `Idea`, `SpecFeedback`, and `ApprovalSignal` interfaces and the `InboundEvent` union type. Update the `HumanInterfaceAdapter` interface's `receive()` return type from `AsyncIterable<Idea>` to `AsyncIterable<InboundEvent>`. Update `context-agent/wiki/domain-model.md` to reflect the `thread_ts` and `channel_id` fields added to `Idea`.
     - **Acceptance criteria**:
@@ -420,7 +420,7 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: None
 
-  - [ ] **Task: Extend validateConfig with slack validation**
+  - [x] **Task: Extend validateConfig with slack validation**
     - **Description**: Add slack validation logic to `validateConfig` in `src/core/config.ts`. When `slack` is present: `bot_token`, `app_token`, and `channel_name` must be non-empty strings; `approval_emojis` defaults to `['thumbsup']` when absent and must be a non-empty array when present. Missing `slack` section is valid. Extend `redactConfig` to mask `bot_token` and `app_token`. Write unit tests in `tests/core/config.test.ts` (extending existing tests) covering all cases in the testing plan.
     - **Acceptance criteria**:
       - [ ] Missing `slack` section passes validation

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -1,18 +1,495 @@
 ---
 created: 2026-04-08
 last_updated: 2026-04-08
-status: stub
+status: implementing
+issue: TBD
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
 ---
 
-# Slack + message routing
+# Slack message routing
 
-Slack connection and intelligent message classification.
+## What
 
-## Scope
+Slack message routing connects Autocatalyst to a Slack workspace so that team members can interact with the system through a channel they already use. The feature listens to a designated Slack channel, reads each incoming message, and routes it to the right part of the system based on what the message is trying to do. A new idea gets handed off to the spec pipeline. A reply in an existing idea thread is treated as feedback on that idea's spec. Anything else — a question, a comment, casual conversation — gets a direct conversational response in Slack.
 
-- Bolt SDK connection to configured channel
-- Receive all messages in channel
-- Classify intent: new idea, spec feedback (thread reply), or general conversation
-- General messages get a conversational response from the AI
-- Ideas and spec feedback are routed to the appropriate handler (features 3 and 4)
-- One channel per repo, one thread per idea
+One channel maps to one repository. Ideas and their related threads are organized as one thread per idea, so all discussion about a given idea stays in one place and the system always knows which idea a reply belongs to.
+
+## Why
+
+Human attention is the scarcest resource on the team. Meeting people in Slack — where they already are, where they can respond asynchronously at the right moment — removes friction that would otherwise suppress the volume and quality of ideas and feedback. The combination of a familiar channel and low-ceremony @tagging makes it easy to act on a thought in the moment rather than scheduling it for later.
+
+## Personas
+
+- **Phoebe: Product manager** — seeds ideas and provides spec feedback via Slack
+- **Enzo: Engineer** — seeds technical ideas and reviews implementation feedback in threads
+
+## Narratives
+
+### Seeding an idea and refining the spec
+
+Phoebe is reviewing AMP's onboarding metrics when she notices new users struggle with the initial CLI configuration step. Without leaving Slack, she drops a message in `#autocatalyst-amp`: `@ac add a setup wizard to the CLI that walks new users through initial configuration`. Autocatalyst recognizes this as a new idea, opens a thread, and posts a structured spec draft — what, why, narratives, all the way through a task list.
+
+Enzo sees the thread notification, reads the spec, and replies: `@ac the wizard shouldn't require all settings before exiting — new users won't have everything ready`. Autocatalyst routes the reply as spec feedback and acknowledges it in the thread.
+
+> **Note:** The spec revision and updated draft posted in response to Enzo's feedback are handled by a future feature (idea-to-spec). This narrative shows the full loop for context but only the routing and classification steps are in scope here.
+
+### A message not meant for Autocatalyst
+
+Enzo posts in `#autocatalyst-amp`: `anyone know if the Victoria stack supports cardinality limits out of the box?`. No `@ac` mention — it's a question for the team, not a task for the system. Autocatalyst ignores the message entirely. The channel stays usable as a normal team channel without every conversation triggering a response.
+
+## User stories
+
+**Seeding an idea and refining the spec**
+
+- Phoebe can seed a new idea by @mentioning `@ac` in the channel with a description
+- Phoebe can see Autocatalyst acknowledge the idea and open a thread with a spec draft
+- Enzo can reply to an idea thread with `@ac` to provide spec feedback
+- Enzo can see Autocatalyst acknowledge the feedback in the thread
+
+**A message not meant for Autocatalyst**
+
+- Phoebe can post in the channel without `@ac` and have Autocatalyst ignore the message
+- Enzo can use the channel for normal team conversation without triggering a response
+
+## Goals
+
+- Autocatalyst connects to a configured Slack channel within 5 seconds of startup
+- Messages that do not mention the configured bot handle are never processed or responded to
+- Messages that mention the configured bot handle are classified and routed within 3 seconds of receipt
+- A new-idea message produces a thread with an acknowledgement reply
+- A thread reply mentioning the configured bot handle is correctly identified as spec feedback and routed to the appropriate handler
+
+## Non-goals
+
+- Generating or posting the spec draft (future feature)
+- Processing approval signals or implementation feedback (future feature)
+- Supporting multiple channels per repo
+- Supporting Slack channels across multiple workspaces
+
+## Tech spec
+
+### 1. Introduction and overview
+
+**Dependencies**
+- `context-agent/decisions/human-interface-adapter.md` — Slack Bolt SDK chosen; adapter interface defined
+- `context-agent/wiki/domain-model.md` — `Idea`, `Approval` entities
+- Foundation feature — `Service` lifecycle, `loadConfig`, WORKFLOW.md config loading
+
+**Technical goals**
+- Bolt app connects within 5s of service startup and remains connected
+- Messages without a bot @mention are dropped before any processing
+- @mention messages are classified and routed within 3s of receipt
+- Thread-to-idea mapping maintained in memory; a thread reply always resolves to the correct idea
+
+**Non-goals**
+- Persisting message history or thread mappings across restarts
+
+**Glossary**
+- **Socket Mode** — Slack connection via persistent WebSocket; no public URL required
+- **`thread_ts`** — Slack's timestamp-based identifier for a message thread; used to correlate replies to their parent idea
+- **Intent classification** — determining what a message is asking the system to do (new idea, spec feedback, or nothing)
+
+### 2. System design and architecture
+
+**New components**
+
+- `src/adapters/slack/bolt-app.ts` — initializes the Bolt app with Socket Mode; connects using `AC_SLACK_BOT_TOKEN` and `AC_SLACK_APP_TOKEN`
+- `src/adapters/slack/classifier.ts` — classifies inbound messages as `new_idea`, `spec_feedback`, or `ignore` using the logic below
+- `src/adapters/slack/thread-registry.ts` — in-memory `Map<thread_ts, idea_id>`; registers new threads and resolves replies to their parent idea
+- `src/adapters/slack/slack-adapter.ts` — implements `HumanInterfaceAdapter`; wires Bolt events to classified event stream
+
+**Classification logic**
+
+Bolt provides the bot's user ID after connecting. Slack encodes mentions as `<@U12345>` in message text. The classifier applies these rules in order:
+
+```
+1. Does message.text contain <@{botUserId}>?
+   → No: ignore
+2. Does message have a thread_ts different from its own ts?
+   → Yes + thread_ts in registry: spec_feedback
+   → Yes + thread_ts NOT in registry: ignore (unrelated thread reply)
+   → No: new_idea
+```
+
+The existing `HumanInterfaceAdapter` interface defines `receive(): AsyncIterable<Idea>`. This feature extends the emitted type to a union so both event kinds can flow through:
+
+```typescript
+type InboundEvent =
+  | { type: 'new_idea'; payload: Idea }
+  | { type: 'spec_feedback'; payload: SpecFeedback }
+  | { type: 'approval_signal'; payload: ApprovalSignal }
+```
+
+**High-level flow**
+
+```mermaid
+flowchart LR
+    Slack -->|Socket Mode events| BoltApp
+    BoltApp -->|raw message| Classifier
+    Classifier -->|ignore| /dev/null
+    Classifier -->|new_idea| SlackAdapter
+    Classifier -->|spec_feedback| SlackAdapter
+    SlackAdapter -->|InboundEvent| Orchestrator
+```
+
+**Sequence diagram — new idea**
+
+```mermaid
+sequenceDiagram
+    actor Phoebe
+    participant Slack
+    participant BoltApp
+    participant Classifier
+    participant ThreadRegistry
+    participant Orchestrator
+
+    Phoebe->>Slack: @ac add a setup wizard...
+    Slack->>BoltApp: message event
+    BoltApp->>Classifier: classify(message)
+    Classifier-->>BoltApp: new_idea
+    BoltApp->>ThreadRegistry: register(thread_ts, idea_id)
+    BoltApp->>Slack: post acknowledgement in thread
+    BoltApp->>Orchestrator: emit({ type: 'new_idea', payload: Idea })
+```
+
+**Sequence diagram — spec feedback**
+
+```mermaid
+sequenceDiagram
+    actor Enzo
+    participant Slack
+    participant BoltApp
+    participant Classifier
+    participant ThreadRegistry
+    participant Orchestrator
+
+    Enzo->>Slack: @ac the wizard shouldn't require...
+    Slack->>BoltApp: message event (thread reply)
+    BoltApp->>Classifier: classify(message)
+    Classifier->>ThreadRegistry: resolve(thread_ts)
+    ThreadRegistry-->>Classifier: idea_id
+    Classifier-->>BoltApp: spec_feedback
+    BoltApp->>Slack: post acknowledgement in thread
+    BoltApp->>Orchestrator: emit({ type: 'spec_feedback', payload })
+```
+
+### 3. Detailed design
+
+**New types** (`src/types/events.ts`)
+
+```typescript
+export interface Idea {
+  id: string;
+  source: 'slack';
+  content: string;
+  author: string;
+  received_at: string;   // ISO 8601
+  thread_ts: string;     // used to post replies back to the thread
+  channel_id: string;
+}
+
+export interface SpecFeedback {
+  idea_id: string;
+  content: string;
+  author: string;
+  received_at: string;
+  thread_ts: string;
+  channel_id: string;
+}
+
+export interface ApprovalSignal {
+  idea_id: string;
+  approver: string;
+  emoji: string;
+  received_at: string;   // ISO 8601
+}
+
+export type InboundEvent =
+  | { type: 'new_idea'; payload: Idea }
+  | { type: 'spec_feedback'; payload: SpecFeedback }
+  | { type: 'approval_signal'; payload: ApprovalSignal }
+```
+
+**WorkflowConfig extension** (`src/types/config.ts`)
+
+```typescript
+slack?: {
+  bot_token?: string;       // $AC_SLACK_BOT_TOKEN (xoxb-)
+  app_token?: string;       // $AC_SLACK_APP_TOKEN (xapp-) — required for Socket Mode
+  channel_name?: string;    // e.g. "autocatalyst-amp"; resolved to channel ID at startup
+  approval_emojis?: string[]; // default: ['thumbsup']
+}
+```
+
+**WORKFLOW.md config shape**
+
+```yaml
+slack:
+  bot_token: $AC_SLACK_BOT_TOKEN
+  app_token: $AC_SLACK_APP_TOKEN
+  channel_name: autocatalyst-amp
+  approval_emojis:
+    - thumbsup
+    - white_check_mark
+```
+
+**validateConfig extension**
+
+When `slack` is present, `bot_token`, `app_token`, and `channel_name` must be non-empty strings; `approval_emojis` must be a non-empty array of strings if present, defaulting to `['thumbsup']`. Missing `slack` section is valid — adapter simply won't start.
+
+**Thread registry**
+
+In-memory `Map<string, string>` — `thread_ts → idea_id`. Populated when a new-idea acknowledgement is posted; consulted on every thread reply. Not persisted — lost on restart (deferred to a future feature along with message history replay).
+
+**Acknowledgement messages**
+
+- New idea: `"Got it — I'll work on a spec and post it here."`
+- Spec feedback: `"Thanks — I'll incorporate that feedback."`
+
+No API contracts — no HTTP endpoints; all interaction is event-driven through Bolt.
+
+### 4. Security, privacy, and compliance
+
+**Authentication and authorization**
+
+- Bolt SDK verifies Slack request signatures automatically (Socket Mode); no additional auth layer needed
+- `AC_SLACK_BOT_TOKEN` and `AC_SLACK_APP_TOKEN` are loaded via `$VAR` resolution in `loadConfig` and redacted before logging per the foundation's logging standard
+- No per-user authorization — any Slack user in the configured channel can interact with the bot
+
+**Data privacy**
+
+- Message content is not logged — only metadata (author, channel, intent classification, `thread_ts`)
+- Tokens are never written to disk or included in log output
+
+### 5. Observability
+
+**Log events**
+
+| Event | Level | Fields |
+|---|---|---|
+| `slack.connected` | info | `channel_id`, `channel_name` |
+| `slack.message.ignored` | debug | `author`, `channel_id` |
+| `slack.message.classified` | info | `author`, `channel_id`, `intent`, `thread_ts` |
+| `slack.post.sent` | info | `channel_id`, `thread_ts`, `intent` |
+| `slack.disconnected` | warn | `reason` |
+| `slack.error` | error | `error` |
+| `slack.reaction.classified` | info | `author`, `thread_ts`, `intent` |
+| `slack.reaction.ignored` | debug | `author`, `thread_ts` |
+| `slack.startup.channel_resolved` | info | `channel_name`, `channel_id` |
+
+Message content is never logged — only metadata. Token values are redacted per the foundation's logging standard.
+
+**Metrics**
+
+- `slack.messages.received` — counter; incremented on every message event reaching the classifier
+- `slack.messages.ignored` — counter; incremented when classifier returns `ignore`
+- `slack.messages.classified` — counter with `intent` label (`new_idea`, `spec_feedback`); incremented on every routed message
+- `slack.connection.status` — gauge; `1` when connected, `0` when disconnected
+
+**Alerting**
+
+`slack.disconnected` not followed by `slack.connected` within 30 seconds triggers an alert. Reconnection within that window is treated as a transient blip; beyond it is an operational issue.
+
+### 6. Testing plan
+
+Tests are organized by component. All tests run in-process with no live Slack API calls. Integration tests use a test double for the Bolt app client, injected via the adapter constructor.
+
+**`classifier.ts` — unit tests**
+
+*Message classification:*
+- No `@mention` in text → `ignore`
+- `@mention` present, no `thread_ts` → `new_idea`
+- `@mention` present, `thread_ts === ts` (root message that started a thread) → `new_idea`
+- `@mention` present, `thread_ts !== ts`, `thread_ts` in registry → `spec_feedback`
+- `@mention` present, `thread_ts !== ts`, `thread_ts` not in registry → `ignore`
+- Message from the bot's own user ID → `ignore` (prevents response loops when the bot posts an acknowledgement)
+- `@mention` token is an exact match (`<@U12345>` does not match when botUserId is `U123456`) — substring false-positive guard
+
+*Reaction classification:*
+- Emoji in `approval_emojis`, `item.ts` in registry → `approval_signal`
+- Emoji not in `approval_emojis` → `ignore` (regardless of registry)
+- Emoji in `approval_emojis`, `item.ts` not in registry → `ignore`
+- Reaction from the bot's own user ID → `ignore`
+
+**`thread-registry.ts` — unit tests**
+
+- Starts empty: resolve on any key returns `undefined`
+- Register `thread_ts → idea_id`, resolve returns correct `idea_id`
+- Resolve unregistered key returns `undefined`
+- Registering the same `thread_ts` twice: second write overwrites first (last-writer-wins)
+
+**`validateConfig` extension — unit tests**
+
+- Missing `slack` section → valid (adapter won't start, not an error)
+- `slack` with all three required fields non-empty → valid
+- `slack` with empty `bot_token` → fails with field-specific error
+- `slack` with empty `app_token` → fails
+- `slack` with empty `channel_name` → fails
+- `slack` with `approval_emojis` absent → valid, defaults to `['thumbsup']`
+- `slack` with `approval_emojis` as non-empty array → valid, uses provided value
+- `slack` with `approval_emojis` as empty array → fails (non-empty required)
+- `$VAR` values for `bot_token` and `app_token` resolve from environment correctly
+- `redactConfig` masks `bot_token` and `app_token` values
+
+**`slack-adapter.ts` — integration tests (Bolt test double)**
+
+*Startup:*
+- `conversations.list` returns a channel matching `channel_name` → ID resolved, `slack.startup.channel_resolved` logged, `slack.connected` logged after connection
+- `conversations.list` returns no matching channel → adapter fails to start with a clear error; no messages are processed
+- Adapter registers message and reaction event handlers only after channel is resolved (startup ordering)
+
+*New idea pipeline:*
+- `@mention` in root message → `client.chat.postMessage` called with correct acknowledgement text in the correct channel/thread; `new_idea` event emitted on the `InboundEvent` stream; `thread_ts` registered in the thread registry
+- Emitted `Idea` shape: `source: 'slack'`, `content` is the raw message text, `author` is the Slack user ID, `received_at` is a valid ISO 8601 string, `thread_ts` and `channel_id` match the event
+- A subsequent reply to that thread is correctly classified as `spec_feedback` (registry populated by prior step)
+
+*Spec feedback pipeline:*
+- `@mention` in thread reply with registered `thread_ts` → acknowledgement posted; `spec_feedback` event emitted
+- Emitted `SpecFeedback`: `idea_id` resolved from registry, all other fields correct
+
+*Approval signal pipeline:*
+- Reaction in `approval_emojis` on registered message → `approval_signal` emitted
+- Emitted `ApprovalSignal`: `idea_id` resolved from registry, `approver` and `received_at` set correctly
+
+*Ignore cases (verify no side effects):*
+- Non-mention message in channel → no `postMessage` call, no event emitted
+- `@mention` reply to unregistered thread → no `postMessage`, no event
+- Non-approval emoji reaction → no event
+- Approval emoji reaction on unregistered message → no event
+- Message from the bot's own user ID → no `postMessage`, no event
+
+*Error handling:*
+- `client.chat.postMessage` throws → `slack.error` logged, exception does not propagate, adapter continues processing subsequent messages
+- Bolt emits an `error` event → logged at error level; adapter continues running
+
+*Service lifecycle:*
+- `Service.start()` initiates `bolt.start()`; `Service.stop()` calls `bolt.stop()`
+
+### 7. Alternatives considered
+
+**Polling instead of Socket Mode**
+
+Slack offers a REST API that can be polled for new messages. The trade-off is simplicity (no persistent connection to manage) against latency and rate limits. Socket Mode gives near-real-time delivery with no public URL, which fits the local deployment target. Polling was rejected for this reason — it introduces artificial latency and adds complexity to manage polling intervals and deduplication.
+
+**Webhook / Events API instead of Socket Mode**
+
+The Slack Events API sends HTTP POST requests to a public URL. This would require exposing an endpoint, which adds infrastructure that doesn't exist yet and conflicts with the local-first deployment model. Socket Mode achieves the same event delivery without a public URL. This is the primary reason Socket Mode was chosen.
+
+**Storing the bot handle in config instead of resolving from the SDK**
+
+The classifier needs the bot's user ID to detect `<@{botUserId}>` mentions. An alternative is to require operators to configure the user ID explicitly. Resolving it at startup via the SDK is preferable — it removes a manual config step and eliminates a class of misconfiguration where a configured ID drifts from the live bot.
+
+**Persisting the thread registry to disk**
+
+The in-memory registry is lost on restart. Persisting it would allow the adapter to resume correlating replies after a restart. This was deferred to a future feature alongside message history replay — both require a consistent storage strategy, and solving one without the other produces a half-measure. Restarting the service creates a clean registry; replies to threads created before the restart will be classified as `ignore`.
+
+### 8. Risks
+
+**Prompt injection via message content**
+
+A Slack message could contain text crafted to manipulate downstream AI processing — for example, instructions embedded in an idea that attempt to override system prompts. The adapter treats message content as untrusted user input throughout: it logs only metadata, passes `content` as a typed field (not interpolated into any prompt), and never executes or evaluates message text. The risk is noted here because the content does flow into AI processing in later stages; those stages are responsible for maintaining prompt isolation.
+
+**Thread registry lost on restart**
+
+The thread registry is in-memory and not persisted. If the service restarts, all prior `thread_ts → idea_id` mappings are lost. Thread replies that arrive after a restart will be classified as `ignore` rather than `spec_feedback`. Users would need to seed a new idea message to re-establish routing. This is a known limitation deferred with message history replay to a future feature.
+
+**Message history lost during downtime**
+
+Socket Mode delivers events in real time; there is no replay of events missed while the service was offline. Messages sent during downtime are silently dropped. The service has no way to detect or surface this gap on reconnection. This is acceptable for the initial deployment (local machine, not expected to have extended downtime) but will need to be addressed before hosted deployment.
+
+## Task list
+
+- [ ] **Story: Types and configuration**
+  - [x] **Task: Define event types and update adapter interface**
+    - **Description**: Create `src/types/events.ts` with the `Idea`, `SpecFeedback`, and `ApprovalSignal` interfaces and the `InboundEvent` union type. Update the `HumanInterfaceAdapter` interface's `receive()` return type from `AsyncIterable<Idea>` to `AsyncIterable<InboundEvent>`. Update `context-agent/wiki/domain-model.md` to reflect the `thread_ts` and `channel_id` fields added to `Idea`.
+    - **Acceptance criteria**:
+      - [ ] `src/types/events.ts` created with `Idea` (`id`, `source`, `content`, `author`, `received_at`, `thread_ts`, `channel_id`), `SpecFeedback` (`idea_id`, `content`, `author`, `received_at`, `thread_ts`, `channel_id`), `ApprovalSignal` (`idea_id`, `approver`, `emoji`, `received_at`)
+      - [ ] `InboundEvent` union covers `new_idea`, `spec_feedback`, `approval_signal`
+      - [ ] `HumanInterfaceAdapter.receive()` updated to `AsyncIterable<InboundEvent>`
+      - [ ] `context-agent/wiki/domain-model.md` updated to include `thread_ts` and `channel_id` on `Idea`
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: None
+
+  - [x] **Task: Extend WorkflowConfig with slack fields**
+    - **Description**: Add the optional `slack` field to `WorkflowConfig` in `src/types/config.ts` with `bot_token`, `app_token`, `channel_name`, and `approval_emojis` sub-fields — all optional at the type level (runtime validation handles which are required).
+    - **Acceptance criteria**:
+      - [ ] `WorkflowConfig.slack?` added with correct shape matching the tech spec
+      - [ ] All sub-fields typed as optional (`string | undefined`, `string[] | undefined`)
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: None
+
+  - [ ] **Task: Extend validateConfig with slack validation**
+    - **Description**: Add slack validation logic to `validateConfig` in `src/core/config.ts`. When `slack` is present: `bot_token`, `app_token`, and `channel_name` must be non-empty strings; `approval_emojis` defaults to `['thumbsup']` when absent and must be a non-empty array when present. Missing `slack` section is valid. Extend `redactConfig` to mask `bot_token` and `app_token`. Write unit tests in `tests/core/config.test.ts` (extending existing tests) covering all cases in the testing plan.
+    - **Acceptance criteria**:
+      - [ ] Missing `slack` section passes validation
+      - [ ] `slack` with all required fields non-empty passes
+      - [ ] `slack` with empty `bot_token`, `app_token`, or `channel_name` fails with a field-specific error message
+      - [ ] `approval_emojis` absent → defaults to `['thumbsup']`
+      - [ ] `approval_emojis` empty array → validation error
+      - [ ] `redactConfig` masks `bot_token` and `app_token`
+      - [ ] `$VAR` env var resolution works for `bot_token` and `app_token`
+      - [ ] All unit test cases from the testing plan for this component pass
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Extend WorkflowConfig with slack fields
+
+- [ ] **Story: Thread registry**
+  - [ ] **Task: Implement ThreadRegistry**
+    - **Description**: Create `src/adapters/slack/thread-registry.ts`. The class maintains an in-memory `Map<string, string>` mapping `thread_ts` to `idea_id`. Expose two methods: `register(thread_ts: string, idea_id: string): void` and `resolve(thread_ts: string): string | undefined`. No persistence — the registry is empty on construction and lost on process exit. Write unit tests in `tests/adapters/slack/thread-registry.test.ts` covering all cases in the testing plan.
+    - **Acceptance criteria**:
+      - [ ] `ThreadRegistry` class created with `register` and `resolve` methods
+      - [ ] New instance starts empty; `resolve` on any key returns `undefined`
+      - [ ] `register` followed by `resolve` returns the registered `idea_id`
+      - [ ] `resolve` on unregistered key returns `undefined`
+      - [ ] Re-registering the same `thread_ts` overwrites the previous `idea_id`
+      - [ ] All unit test cases from the testing plan pass
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: None
+
+- [ ] **Story: Message classifier**
+  - [ ] **Task: Implement Classifier**
+    - **Description**: Create `src/adapters/slack/classifier.ts`. Implement two pure functions with no side effects. `classifyMessage(message, botUserId, registry)` applies the rules from the tech spec: check for `<@{botUserId}>` → check `thread_ts` → check registry. `classifyReaction(event, approvalEmojis, registry)` checks emoji membership then registry. Both functions suppress events from the bot's own user ID. The `@mention` check must use exact token matching — `<@U12345>` should not match a bot ID of `U1234` or `U123456`. Write unit tests in `tests/adapters/slack/classifier.test.ts` covering all cases in the testing plan.
+    - **Acceptance criteria**:
+      - [ ] `classifyMessage` returns the correct intent for all branches: no `@mention` → `ignore`; `@mention` root message → `new_idea`; `@mention` reply with registered `thread_ts` → `spec_feedback`; `@mention` reply with unregistered `thread_ts` → `ignore`
+      - [ ] `classifyMessage` returns `ignore` for messages from `botUserId`
+      - [ ] `@mention` matching does not false-positive on a user ID that contains `botUserId` as a substring
+      - [ ] `classifyReaction` returns `approval_signal` only when emoji is in the list AND `item.ts` is in registry
+      - [ ] `classifyReaction` returns `ignore` for reactions from `botUserId`
+      - [ ] All unit test cases from the testing plan pass
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Story: Thread registry
+
+- [ ] **Story: Slack adapter**
+  - [ ] **Task: Implement BoltApp factory**
+    - **Description**: Create `src/adapters/slack/bolt-app.ts`. Export a `createBoltApp(botToken: string, appToken: string): App` factory function that initializes a Slack Bolt `App` configured for Socket Mode using `SocketModeReceiver`. The factory creates and returns the app instance; event handlers are not registered here.
+    - **Acceptance criteria**:
+      - [ ] `createBoltApp` creates a Bolt `App` with `SocketModeReceiver` using the provided tokens
+      - [ ] Returned `App` instance is ready to have event listeners added
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Define event types and update adapter interface
+
+  - [ ] **Task: Implement SlackAdapter**
+    - **Description**: Create `src/adapters/slack/slack-adapter.ts`. This is the main wiring component implementing `HumanInterfaceAdapter`. On `start()`: (1) call `app.client.conversations.list` to resolve `channel_name` → `channel_id`, logging `slack.startup.channel_resolved`; fail with a clear error if not found; (2) register `message` and `reaction_added` event handlers filtered to the resolved channel; (3) call `app.start()` and log `slack.connected`. Message handler: classify via `classifyMessage`; on `new_idea`, post the acknowledgement, register the thread, emit the event; on `spec_feedback`, post the acknowledgement, emit; on `ignore`, log at debug and drop. Reaction handler: classify via `classifyReaction`; on `approval_signal`, emit; on `ignore`, log at debug and drop. On `stop()`: call `app.stop()` and log `slack.disconnected`. Emit all observability events from Section 5. Never log message content.
+    - **Acceptance criteria**:
+      - [ ] Channel name resolved to ID before any event handlers process messages
+      - [ ] `conversations.list` returning no match fails with a clear log error
+      - [ ] `@mention` root message → correct acknowledgement text posted in thread, `new_idea` event on `InboundEvent` stream, `thread_ts` registered
+      - [ ] `@mention` reply to registered thread → acknowledgement posted, `spec_feedback` event emitted with `idea_id` from registry
+      - [ ] Approval emoji reaction on registered message → `approval_signal` event emitted
+      - [ ] All ignore cases produce no acknowledgement and no emitted event
+      - [ ] Bot's own messages and reactions are silently dropped
+      - [ ] `chat.postMessage` failure logs `slack.error` and does not crash the adapter
+      - [ ] All 9 observability events from Section 5 emitted at the correct levels with the correct fields
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Implement BoltApp factory, Task: Implement Classifier, Story: Thread registry, Task: Extend validateConfig with slack validation
+
+  - [ ] **Task: Write SlackAdapter integration tests**
+    - **Description**: Write `tests/adapters/slack/slack-adapter.test.ts`. Inject a Bolt test double — mock `App` and `WebClient` — via the adapter constructor so no live Slack API calls are made. Cover all integration test cases from the testing plan: startup (channel found, channel not found, handler ordering), new idea pipeline (event shape, acknowledgement text, thread registration, chaining to spec_feedback), spec feedback pipeline, approval signal pipeline, all four ignore cases, error handling (postMessage failure, Bolt error event), and service lifecycle (start/stop).
+    - **Acceptance criteria**:
+      - [ ] All integration test cases from the testing plan pass
+      - [ ] Tests verify no `postMessage` call is made for ignore cases
+      - [ ] Tests verify the `InboundEvent` stream emits events with the correct shape
+      - [ ] No live Slack API calls (Bolt test double injected)
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Implement SlackAdapter

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -461,7 +461,7 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
     - **Dependencies**: Story: Thread registry
 
 - [ ] **Story: Slack adapter**
-  - [ ] **Task: Implement BoltApp factory**
+  - [x] **Task: Implement BoltApp factory**
     - **Description**: Create `src/adapters/slack/bolt-app.ts`. Export a `createBoltApp(botToken: string, appToken: string): App` factory function that initializes a Slack Bolt `App` configured for Socket Mode using `SocketModeReceiver`. The factory creates and returns the app instance; event handlers are not registered here.
     - **Acceptance criteria**:
       - [ ] `createBoltApp` creates a Bolt `App` with `SocketModeReceiver` using the provided tokens

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -469,7 +469,7 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: Task: Define event types and update adapter interface
 
-  - [ ] **Task: Implement SlackAdapter**
+  - [x] **Task: Implement SlackAdapter**
     - **Description**: Create `src/adapters/slack/slack-adapter.ts`. This is the main wiring component implementing `HumanInterfaceAdapter`. On `start()`: (1) call `app.client.conversations.list` to resolve `channel_name` → `channel_id`, logging `slack.startup.channel_resolved`; fail with a clear error if not found; (2) register `message` and `reaction_added` event handlers filtered to the resolved channel; (3) call `app.start()` and log `slack.connected`. Message handler: classify via `classifyMessage`; on `new_idea`, post the acknowledgement, register the thread, emit the event; on `spec_feedback`, post the acknowledgement, emit; on `ignore`, log at debug and drop. Reaction handler: classify via `classifyReaction`; on `approval_signal`, emit; on `ignore`, log at debug and drop. On `stop()`: call `app.stop()` and log `slack.disconnected`. Emit all observability events from Section 5. Never log message content.
     - **Acceptance criteria**:
       - [ ] Channel name resolved to ID before any event handlers process messages

--- a/context-human/specs/feature-slack-message-routing.md
+++ b/context-human/specs/feature-slack-message-routing.md
@@ -447,8 +447,8 @@ Socket Mode delivers events in real time; there is no replay of events missed wh
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: None
 
-- [ ] **Story: Message classifier**
-  - [ ] **Task: Implement Classifier**
+- [x] **Story: Message classifier**
+  - [x] **Task: Implement Classifier**
     - **Description**: Create `src/adapters/slack/classifier.ts`. Implement two pure functions with no side effects. `classifyMessage(message, botUserId, registry)` applies the rules from the tech spec: check for `<@{botUserId}>` → check `thread_ts` → check registry. `classifyReaction(event, approvalEmojis, registry)` checks emoji membership then registry. Both functions suppress events from the bot's own user ID. The `@mention` check must use exact token matching — `<@U12345>` should not match a bot ID of `U1234` or `U123456`. Write unit tests in `tests/adapters/slack/classifier.test.ts` covering all cases in the testing plan.
     - **Acceptance criteria**:
       - [ ] `classifyMessage` returns the correct intent for all branches: no `@mention` → `ignore`; `@mention` root message → `new_idea`; `@mention` reply with registered `thread_ts` → `spec_feedback`; `@mention` reply with unregistered `thread_ts` → `ignore`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "autocatalyst",
       "version": "0.0.1",
       "dependencies": {
+        "@slack/bolt": "^4.7.0",
         "pino": "9.6.0",
         "yaml": "2.7.1"
       },
@@ -862,6 +863,134 @@
         "win32"
       ]
     },
+    "node_modules/@slack/bolt": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.7.0.tgz",
+      "integrity": "sha512-Xpf+gKegNvkHpft1z4YiuqZdciJ3tUp1bIRQxylW30Ovf+hzjb0M1zTHVtJsRw9jsjPxHTPoyanEXVvG6qVE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/oauth": "^3.0.5",
+        "@slack/socket-mode": "^2.0.6",
+        "@slack/types": "^2.20.1",
+        "@slack/web-api": "^7.15.0",
+        "axios": "^1.12.0",
+        "express": "^5.0.0",
+        "path-to-regexp": "^8.1.0",
+        "raw-body": "^3",
+        "tsscmp": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8.6.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/oauth": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.5.tgz",
+      "integrity": "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
+        "@types/jsonwebtoken": "^9",
+        "@types/node": ">=18",
+        "jsonwebtoken": "^9"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.6.tgz",
+      "integrity": "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
+        "@types/node": ">=18",
+        "@types/ws": "^8",
+        "eventemitter3": "^5",
+        "ws": "^8"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.1.tgz",
+      "integrity": "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
+      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.13.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -869,14 +998,111 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
       "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1018,6 +1244,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1028,6 +1267,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1035,6 +1280,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -1045,6 +1340,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1074,11 +1398,62 @@
         "node": ">= 16"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1102,12 +1477,113 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1151,6 +1627,12 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1161,6 +1643,21 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1169,6 +1666,49 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-redact": {
@@ -1198,6 +1738,102 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1213,6 +1849,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -1225,6 +1907,217 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1243,11 +2136,65 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1269,6 +2216,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -1276,6 +2244,102 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -1397,11 +2461,72 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -1420,6 +2545,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -1467,6 +2601,42 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -1474,6 +2644,147 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -1517,6 +2828,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -1595,6 +2915,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.19.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
@@ -1615,6 +2953,20 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -1633,8 +2985,25 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -1819,6 +3188,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@slack/bolt": "^4.7.0",
     "pino": "9.6.0",
     "yaml": "2.7.1"
   },
   "devDependencies": {
-    "typescript": "5.8.3",
-    "vitest": "3.1.1",
+    "@types/node": "22.14.1",
     "tsx": "4.19.3",
-    "@types/node": "22.14.1"
+    "typescript": "5.8.3",
+    "vitest": "3.1.1"
   }
 }

--- a/src/adapters/human-interface-adapter.ts
+++ b/src/adapters/human-interface-adapter.ts
@@ -1,0 +1,7 @@
+import type { InboundEvent } from '../types/events.js';
+
+export interface HumanInterfaceAdapter {
+  receive(): AsyncIterable<InboundEvent>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/src/adapters/slack/bolt-app.ts
+++ b/src/adapters/slack/bolt-app.ts
@@ -1,0 +1,9 @@
+import { App } from '@slack/bolt';
+
+export function createBoltApp(botToken: string, appToken: string): App {
+  return new App({
+    token: botToken,
+    appToken,
+    socketMode: true,
+  });
+}

--- a/src/adapters/slack/classifier.ts
+++ b/src/adapters/slack/classifier.ts
@@ -1,0 +1,64 @@
+import type { ThreadRegistry } from './thread-registry.js';
+
+export interface MessageInput {
+  text: string | undefined;
+  user: string;
+  ts: string;
+  thread_ts?: string;
+}
+
+export interface ReactionInput {
+  reaction: string;
+  user: string;
+  item_ts: string;
+}
+
+export type MessageClassification =
+  | { intent: 'new_idea' }
+  | { intent: 'spec_feedback'; idea_id: string }
+  | { intent: 'ignore' };
+
+export type ReactionClassification =
+  | { intent: 'approval_signal'; idea_id: string }
+  | { intent: 'ignore' };
+
+export function classifyMessage(
+  message: MessageInput,
+  botUserId: string,
+  registry: ThreadRegistry,
+): MessageClassification {
+  // Suppress bot's own messages (prevents response loops)
+  if (message.user === botUserId) return { intent: 'ignore' };
+
+  // Must contain exact @mention token
+  const mention = `<@${botUserId}>`;
+  if (!message.text || !message.text.includes(mention)) {
+    return { intent: 'ignore' };
+  }
+
+  // Thread reply: thread_ts exists and differs from ts
+  const isReply = message.thread_ts !== undefined && message.thread_ts !== message.ts;
+  if (isReply) {
+    const idea_id = registry.resolve(message.thread_ts!);
+    if (idea_id === undefined) return { intent: 'ignore' };
+    return { intent: 'spec_feedback', idea_id };
+  }
+
+  return { intent: 'new_idea' };
+}
+
+export function classifyReaction(
+  reaction: ReactionInput,
+  approvalEmojis: string[],
+  registry: ThreadRegistry,
+  botUserId: string,
+): ReactionClassification {
+  // Suppress bot's own reactions
+  if (reaction.user === botUserId) return { intent: 'ignore' };
+
+  if (!approvalEmojis.includes(reaction.reaction)) return { intent: 'ignore' };
+
+  const idea_id = registry.resolve(reaction.item_ts);
+  if (idea_id === undefined) return { intent: 'ignore' };
+  return { intent: 'approval_signal', idea_id };
+}

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -1,0 +1,225 @@
+import { randomUUID } from 'node:crypto';
+import type { App } from '@slack/bolt';
+import type pino from 'pino';
+import { createLogger } from '../../core/logger.js';
+import type { HumanInterfaceAdapter } from '../human-interface-adapter.js';
+import type { InboundEvent, Idea, SpecFeedback, ApprovalSignal } from '../../types/events.js';
+import { classifyMessage, classifyReaction } from './classifier.js';
+import { ThreadRegistry } from './thread-registry.js';
+
+interface SlackAdapterConfig {
+  channelName: string;
+  approvalEmojis: string[];
+}
+
+interface SlackAdapterOptions {
+  registry?: ThreadRegistry;
+  logDestination?: pino.DestinationStream;
+}
+
+export class SlackAdapter implements HumanInterfaceAdapter {
+  private readonly app: App;
+  private readonly config: SlackAdapterConfig;
+  private readonly registry: ThreadRegistry;
+  private readonly logger: pino.Logger;
+
+  private botUserId: string | undefined;
+  private channelId: string | undefined;
+
+  // AsyncIterable queue
+  private readonly eventQueue: InboundEvent[] = [];
+  private waiter: (() => void) | null = null;
+  private closed = false;
+
+  constructor(app: App, config: SlackAdapterConfig, options?: SlackAdapterOptions) {
+    this.app = app;
+    this.config = config;
+    this.registry = options?.registry ?? new ThreadRegistry();
+    this.logger = createLogger('slack-adapter', { destination: options?.logDestination });
+  }
+
+  async start(): Promise<void> {
+    // Resolve bot user ID
+    const authResult = await this.app.client.auth.test();
+    this.botUserId = authResult.user_id as string;
+
+    // Resolve channel name → channel ID
+    const listResult = await this.app.client.conversations.list({
+      types: 'public_channel,private_channel',
+      limit: 1000,
+    });
+    const channel = listResult.channels?.find(
+      (c: { name?: string }) => c.name === this.config.channelName,
+    );
+    if (!channel || !('id' in channel) || typeof channel.id !== 'string') {
+      this.logger.error(
+        { event: 'slack.error', error: `channel not found: ${this.config.channelName}` },
+        'Slack channel not found — adapter cannot start',
+      );
+      throw new Error(`Slack channel not found: ${this.config.channelName}`);
+    }
+    this.channelId = channel.id;
+    this.logger.info(
+      { event: 'slack.startup.channel_resolved', channel_name: this.config.channelName, channel_id: this.channelId },
+      'Channel resolved',
+    );
+
+    // Register message handler (must happen before app.start())
+    this.app.message(async ({ message }) => {
+      // Skip non-regular messages (bot_message, message_changed, etc.)
+      if ('subtype' in message && (message as { subtype?: string }).subtype !== undefined) return;
+      // Filter to target channel
+      if (!('channel' in message) || (message as { channel?: string }).channel !== this.channelId) return;
+
+      const msg = message as {
+        text?: string;
+        user?: string;
+        ts: string;
+        thread_ts?: string;
+        channel: string;
+      };
+
+      if (!msg.user) return; // no user field means it's a system/bot message
+
+      const result = classifyMessage(
+        { text: msg.text, user: msg.user, ts: msg.ts, thread_ts: msg.thread_ts },
+        this.botUserId!,
+        this.registry,
+      );
+
+      if (result.intent === 'ignore') {
+        this.logger.debug(
+          { event: 'slack.message.ignored', author: msg.user, channel_id: this.channelId },
+          'Message ignored',
+        );
+        return;
+      }
+
+      this.logger.info(
+        { event: 'slack.message.classified', author: msg.user, channel_id: this.channelId, intent: result.intent, thread_ts: msg.ts },
+        'Message classified',
+      );
+
+      if (result.intent === 'new_idea') {
+        const idea: Idea = {
+          id: randomUUID(),
+          source: 'slack',
+          content: msg.text ?? '',
+          author: msg.user,
+          received_at: new Date().toISOString(),
+          thread_ts: msg.ts,
+          channel_id: this.channelId!,
+        };
+
+        // Post acknowledgement and register thread before emitting
+        await this.postMessage(this.channelId!, msg.ts, "Got it — I'll work on a spec and post it here.");
+        this.registry.register(msg.ts, idea.id);
+        this.emit({ type: 'new_idea', payload: idea });
+
+      } else if (result.intent === 'spec_feedback') {
+        const feedback: SpecFeedback = {
+          idea_id: result.idea_id,
+          content: msg.text ?? '',
+          author: msg.user,
+          received_at: new Date().toISOString(),
+          thread_ts: msg.thread_ts!,
+          channel_id: this.channelId!,
+        };
+
+        await this.postMessage(this.channelId!, msg.thread_ts!, "Thanks — I'll incorporate that feedback.");
+        this.emit({ type: 'spec_feedback', payload: feedback });
+      }
+    });
+
+    // Register reaction handler
+    this.app.event('reaction_added', async ({ event }) => {
+      if (event.item.type !== 'message') return;
+      if (event.item.channel !== this.channelId) return;
+
+      const result = classifyReaction(
+        { reaction: event.reaction, user: event.user, item_ts: event.item.ts },
+        this.config.approvalEmojis,
+        this.registry,
+        this.botUserId!,
+      );
+
+      if (result.intent === 'ignore') {
+        this.logger.debug(
+          { event: 'slack.reaction.ignored', author: event.user, thread_ts: event.item.ts },
+          'Reaction ignored',
+        );
+        return;
+      }
+
+      this.logger.info(
+        { event: 'slack.reaction.classified', author: event.user, thread_ts: event.item.ts, intent: 'approval_signal' },
+        'Reaction classified',
+      );
+
+      const signal: ApprovalSignal = {
+        idea_id: result.idea_id,
+        approver: event.user,
+        emoji: event.reaction,
+        received_at: new Date().toISOString(),
+      };
+      this.emit({ type: 'approval_signal', payload: signal });
+    });
+
+    // Start Bolt (opens Socket Mode WebSocket)
+    await this.app.start();
+    this.logger.info(
+      { event: 'slack.connected', channel_id: this.channelId, channel_name: this.config.channelName },
+      'Connected to Slack',
+    );
+  }
+
+  async stop(): Promise<void> {
+    await this.app.stop();
+    this.closed = true;
+    if (this.waiter) {
+      const resolve = this.waiter;
+      this.waiter = null;
+      resolve();
+    }
+    this.logger.warn(
+      { event: 'slack.disconnected', reason: 'stop() called' },
+      'Disconnected from Slack',
+    );
+  }
+
+  async *receive(): AsyncIterable<InboundEvent> {
+    while (!this.closed || this.eventQueue.length > 0) {
+      if (this.eventQueue.length > 0) {
+        yield this.eventQueue.shift()!;
+      } else {
+        await new Promise<void>(resolve => {
+          this.waiter = resolve;
+        });
+      }
+    }
+  }
+
+  private emit(event: InboundEvent): void {
+    this.eventQueue.push(event);
+    if (this.waiter) {
+      const resolve = this.waiter;
+      this.waiter = null;
+      resolve();
+    }
+  }
+
+  private async postMessage(channel: string, thread_ts: string, text: string): Promise<void> {
+    try {
+      await this.app.client.chat.postMessage({ channel, thread_ts, text });
+      this.logger.info(
+        { event: 'slack.post.sent', channel_id: channel, thread_ts, intent: 'ack' },
+        'Acknowledgement posted',
+      );
+    } catch (err) {
+      this.logger.error(
+        { event: 'slack.error', error: String(err) },
+        'Failed to post message',
+      );
+    }
+  }
+}

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -51,6 +51,13 @@ export class SlackAdapter implements HumanInterfaceAdapter {
       types: 'public_channel,private_channel',
       limit: 1000,
     });
+    // Warn if results were truncated — the target channel may be in a subsequent page
+    if ((listResult as { response_metadata?: { next_cursor?: string } }).response_metadata?.next_cursor) {
+      this.logger.warn(
+        { event: 'slack.error', error: 'conversations.list result truncated — channel may not be found if workspace has >1000 channels' },
+        'Channel list truncated; consider paginating if channel is not found',
+      );
+    }
     const channel = listResult.channels?.find(
       (c: { name?: string }) => c.name === this.config.channelName,
     );

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -41,7 +41,10 @@ export class SlackAdapter implements HumanInterfaceAdapter {
   async start(): Promise<void> {
     // Resolve bot user ID
     const authResult = await this.app.client.auth.test();
-    this.botUserId = authResult.user_id as string;
+    if (typeof authResult.user_id !== 'string') {
+      throw new Error('auth.test() did not return a user_id');
+    }
+    this.botUserId = authResult.user_id;
 
     // Resolve channel name → channel ID
     const listResult = await this.app.client.conversations.list({
@@ -112,8 +115,8 @@ export class SlackAdapter implements HumanInterfaceAdapter {
         };
 
         // Post acknowledgement and register thread before emitting
-        await this.postMessage(this.channelId!, msg.ts, "Got it — I'll work on a spec and post it here.");
         this.registry.register(msg.ts, idea.id);
+        await this.postMessage(this.channelId!, msg.ts, "Got it — I'll work on a spec and post it here.");
         this.emit({ type: 'new_idea', payload: idea });
 
       } else if (result.intent === 'spec_feedback') {
@@ -136,6 +139,8 @@ export class SlackAdapter implements HumanInterfaceAdapter {
       if (event.item.type !== 'message') return;
       if (event.item.channel !== this.channelId) return;
 
+      // item_ts is the ts of the reacted-to message — only original idea messages are registered;
+      // reactions on bot reply messages are intentionally ignored.
       const result = classifyReaction(
         { reaction: event.reaction, user: event.user, item_ts: event.item.ts },
         this.config.approvalEmojis,
@@ -175,6 +180,8 @@ export class SlackAdapter implements HumanInterfaceAdapter {
 
   async stop(): Promise<void> {
     await this.app.stop();
+    // Events that arrive during app.stop() teardown are discarded intentionally —
+    // stop() signals end-of-stream, remaining queued events will still be drained by receive().
     this.closed = true;
     if (this.waiter) {
       const resolve = this.waiter;

--- a/src/adapters/slack/thread-registry.ts
+++ b/src/adapters/slack/thread-registry.ts
@@ -1,0 +1,11 @@
+export class ThreadRegistry {
+  private readonly map = new Map<string, string>();
+
+  register(thread_ts: string, idea_id: string): void {
+    this.map.set(thread_ts, idea_id);
+  }
+
+  resolve(thread_ts: string): string | undefined {
+    return this.map.get(thread_ts);
+  }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -100,6 +100,30 @@ export function validateConfig(config: WorkflowConfig): void {
       throw new Error('workspace.root must be a non-empty string');
     }
   }
+
+  if (config.slack !== undefined) {
+    const slack = config.slack as {
+      bot_token?: unknown;
+      app_token?: unknown;
+      channel_name?: unknown;
+      approval_emojis?: unknown;
+    };
+
+    if (typeof slack.bot_token !== 'string' || slack.bot_token.trim() === '') {
+      throw new Error('slack.bot_token must be a non-empty string');
+    }
+    if (typeof slack.app_token !== 'string' || slack.app_token.trim() === '') {
+      throw new Error('slack.app_token must be a non-empty string');
+    }
+    if (typeof slack.channel_name !== 'string' || slack.channel_name.trim() === '') {
+      throw new Error('slack.channel_name must be a non-empty string');
+    }
+    if (slack.approval_emojis === undefined) {
+      slack.approval_emojis = ['thumbsup']; // apply default in-place
+    } else if (!Array.isArray(slack.approval_emojis) || (slack.approval_emojis as unknown[]).length === 0) {
+      throw new Error('slack.approval_emojis must be a non-empty array of strings');
+    }
+  }
 }
 
 export function redactConfig(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -102,6 +102,7 @@ export function validateConfig(config: WorkflowConfig): void {
   }
 
   if (config.slack !== undefined) {
+    // Re-cast to unknown sub-fields: YAML can deliver null for any optional field
     const slack = config.slack as {
       bot_token?: unknown;
       app_token?: unknown;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,6 +5,12 @@ export interface WorkflowConfig {
   workspace?: {
     root?: string;
   };
+  slack?: {
+    bot_token?: string;
+    app_token?: string;
+    channel_name?: string;
+    approval_emojis?: string[];
+  };
   [key: string]: unknown;
 }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,30 @@
+export interface Idea {
+  id: string;
+  source: 'slack';
+  content: string;
+  author: string;
+  received_at: string; // ISO 8601
+  thread_ts: string;   // Slack thread identifier; used to post replies
+  channel_id: string;
+}
+
+export interface SpecFeedback {
+  idea_id: string;
+  content: string;
+  author: string;
+  received_at: string; // ISO 8601
+  thread_ts: string;
+  channel_id: string;
+}
+
+export interface ApprovalSignal {
+  idea_id: string;
+  approver: string;
+  emoji: string;
+  received_at: string; // ISO 8601
+}
+
+export type InboundEvent =
+  | { type: 'new_idea'; payload: Idea }
+  | { type: 'spec_feedback'; payload: SpecFeedback }
+  | { type: 'approval_signal'; payload: ApprovalSignal };

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -13,7 +13,7 @@ export interface SpecFeedback {
   content: string;
   author: string;
   received_at: string; // ISO 8601
-  thread_ts: string;
+  thread_ts: string;   // Slack thread identifier; used to post replies
   channel_id: string;
 }
 

--- a/tests/adapters/slack/classifier.test.ts
+++ b/tests/adapters/slack/classifier.test.ts
@@ -19,6 +19,14 @@ describe('classifyMessage', () => {
     ).intent).toBe('ignore');
   });
 
+  it('returns ignore when message text is undefined', () => {
+    expect(classifyMessage(
+      { text: undefined, user: 'U999', ts: '100.0' },
+      'UBOT001',
+      new ThreadRegistry(),
+    ).intent).toBe('ignore');
+  });
+
   it('returns new_idea for @mention in root message (no thread_ts)', () => {
     expect(classifyMessage(
       { text: `<@${BOT_ID}> add a setup wizard`, user: 'U999', ts: '100.0' },

--- a/tests/adapters/slack/classifier.test.ts
+++ b/tests/adapters/slack/classifier.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { classifyMessage, classifyReaction } from '../../../src/adapters/slack/classifier.js';
+import { ThreadRegistry } from '../../../src/adapters/slack/thread-registry.js';
+
+const BOT_ID = 'UBOT001';
+
+function makeRegistry(entries: Record<string, string> = {}): ThreadRegistry {
+  const r = new ThreadRegistry();
+  for (const [ts, id] of Object.entries(entries)) r.register(ts, id);
+  return r;
+}
+
+describe('classifyMessage', () => {
+  it('returns ignore when message has no @mention', () => {
+    expect(classifyMessage(
+      { text: 'hello world', user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    ).intent).toBe('ignore');
+  });
+
+  it('returns new_idea for @mention in root message (no thread_ts)', () => {
+    expect(classifyMessage(
+      { text: `<@${BOT_ID}> add a setup wizard`, user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    ).intent).toBe('new_idea');
+  });
+
+  it('returns new_idea for @mention when thread_ts equals ts', () => {
+    expect(classifyMessage(
+      { text: `<@${BOT_ID}> start an idea`, user: 'U999', ts: '100.0', thread_ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    ).intent).toBe('new_idea');
+  });
+
+  it('returns spec_feedback for @mention reply to registered thread', () => {
+    const result = classifyMessage(
+      { text: `<@${BOT_ID}> that field is confusing`, user: 'U999', ts: '200.0', thread_ts: '100.0' },
+      BOT_ID,
+      makeRegistry({ '100.0': 'idea-xyz' }),
+    );
+    expect(result.intent).toBe('spec_feedback');
+    if (result.intent === 'spec_feedback') expect(result.idea_id).toBe('idea-xyz');
+  });
+
+  it('returns ignore for @mention reply to unregistered thread', () => {
+    expect(classifyMessage(
+      { text: `<@${BOT_ID}> something`, user: 'U999', ts: '200.0', thread_ts: '999.0' },
+      BOT_ID,
+      makeRegistry(),
+    ).intent).toBe('ignore');
+  });
+
+  it('returns ignore for messages from the bot itself', () => {
+    expect(classifyMessage(
+      { text: `<@${BOT_ID}> ignored`, user: BOT_ID, ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    ).intent).toBe('ignore');
+  });
+
+  it('does not false-positive when botUserId is a substring of another user ID', () => {
+    // BOT_ID is UBOT001; message mentions UBOT0011 (longer, different user)
+    expect(classifyMessage(
+      { text: '<@UBOT0011> hello', user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    ).intent).toBe('ignore');
+  });
+});
+
+describe('classifyReaction', () => {
+  const EMOJIS = ['thumbsup', 'white_check_mark'];
+
+  it('returns approval_signal for approval emoji on registered message', () => {
+    const result = classifyReaction(
+      { reaction: 'thumbsup', user: 'U999', item_ts: '100.0' },
+      EMOJIS,
+      makeRegistry({ '100.0': 'idea-xyz' }),
+      BOT_ID,
+    );
+    expect(result.intent).toBe('approval_signal');
+    if (result.intent === 'approval_signal') expect(result.idea_id).toBe('idea-xyz');
+  });
+
+  it('returns ignore for non-approval emoji', () => {
+    expect(classifyReaction(
+      { reaction: 'wave', user: 'U999', item_ts: '100.0' },
+      EMOJIS,
+      makeRegistry({ '100.0': 'idea-xyz' }),
+      BOT_ID,
+    ).intent).toBe('ignore');
+  });
+
+  it('returns ignore for approval emoji on unregistered message', () => {
+    expect(classifyReaction(
+      { reaction: 'thumbsup', user: 'U999', item_ts: '999.0' },
+      EMOJIS,
+      makeRegistry(),
+      BOT_ID,
+    ).intent).toBe('ignore');
+  });
+
+  it('returns ignore for reaction from the bot itself', () => {
+    expect(classifyReaction(
+      { reaction: 'thumbsup', user: BOT_ID, item_ts: '100.0' },
+      EMOJIS,
+      makeRegistry({ '100.0': 'idea-xyz' }),
+      BOT_ID,
+    ).intent).toBe('ignore');
+  });
+});

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -202,6 +202,7 @@ describe('SlackAdapter — spec feedback pipeline', () => {
     expect(feedback.idea_id).toBe((ideaEvent.payload as Idea).id);
     expect(feedback.author).toBe('U456');
     expect(feedback.thread_ts).toBe('100.0');
+    expect(feedback.content).toBe(`<@${BOT_ID}> the field is confusing`);
 
     expect(mock.client.chat.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -71,6 +71,8 @@ describe('SlackAdapter — startup', () => {
   it('registers event handlers before calling app.start()', async () => {
     const mock = makeMockApp({});
     const order: string[] = [];
+    // Override to record ordering only — handler capture is intentionally skipped
+    // because this test does not trigger messages or reactions after start().
     mock.message.mockImplementation(() => { order.push('message_registered'); });
     mock.event.mockImplementation(() => { order.push('event_registered'); });
     mock.start.mockImplementation(async () => { order.push('app_started'); });
@@ -101,9 +103,9 @@ describe('SlackAdapter — new idea pipeline', () => {
       ts: '100.0',
       channel: CHANNEL_ID,
     });
-    await adapter.stop();
 
     const event = await eventPromise;
+    await adapter.stop();
     expect(event.type).toBe('new_idea');
     const idea = event.payload as Idea;
     expect(idea.source).toBe('slack');
@@ -203,6 +205,8 @@ describe('SlackAdapter — spec feedback pipeline', () => {
     expect(feedback.author).toBe('U456');
     expect(feedback.thread_ts).toBe('100.0');
     expect(feedback.content).toBe(`<@${BOT_ID}> the field is confusing`);
+    expect(feedback.channel_id).toBe(CHANNEL_ID);
+    expect(feedback.received_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
     expect(mock.client.chat.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { App } from '@slack/bolt';
+import { SlackAdapter } from '../../../src/adapters/slack/slack-adapter.js';
+import type { Idea, SpecFeedback, ApprovalSignal } from '../../../src/types/events.js';
+
+// Captures one event from the AsyncIterable then stops
+async function takeOne<T>(iterable: AsyncIterable<T>): Promise<T> {
+  for await (const item of iterable) return item;
+  throw new Error('Stream ended without emitting an event');
+}
+
+const nullDest = { write: () => {} };
+
+function makeMockApp(opts: {
+  botUserId?: string;
+  channels?: Array<{ name: string; id: string }>;
+}) {
+  const messageHandlers: Array<(args: { message: unknown }) => Promise<void>> = [];
+  const reactionHandlers: Array<(args: { event: unknown }) => Promise<void>> = [];
+
+  const app = {
+    client: {
+      auth: {
+        test: vi.fn().mockResolvedValue({ user_id: opts.botUserId ?? 'UBOT001' }),
+      },
+      conversations: {
+        list: vi.fn().mockResolvedValue({
+          channels: opts.channels ?? [{ name: 'my-channel', id: 'C123' }],
+        }),
+      },
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({}),
+      },
+    },
+    message: vi.fn((handler: (args: { message: unknown }) => Promise<void>) => {
+      messageHandlers.push(handler);
+    }),
+    event: vi.fn((name: string, handler: (args: { event: unknown }) => Promise<void>) => {
+      if (name === 'reaction_added') reactionHandlers.push(handler);
+    }),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    // Test helpers — not part of the real App API
+    _triggerMessage: async (msg: unknown) => {
+      for (const h of messageHandlers) await h({ message: msg });
+    },
+    _triggerReaction: async (evt: unknown) => {
+      for (const h of reactionHandlers) await h({ event: evt });
+    },
+  };
+  return app;
+}
+
+describe('SlackAdapter — startup', () => {
+  it('resolves channel name to ID and logs slack.startup.channel_resolved', async () => {
+    const mock = makeMockApp({ channels: [{ name: 'my-channel', id: 'C123' }] });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+    await adapter.stop();
+    expect(mock.client.conversations.list).toHaveBeenCalled();
+    expect(mock.start).toHaveBeenCalled();
+  });
+
+  it('throws when channel is not found', async () => {
+    const mock = makeMockApp({ channels: [] });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'missing-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await expect(adapter.start()).rejects.toThrow(/missing-channel/);
+    expect(mock.start).not.toHaveBeenCalled();
+  });
+
+  it('registers event handlers before calling app.start()', async () => {
+    const mock = makeMockApp({});
+    const order: string[] = [];
+    mock.message.mockImplementation(() => { order.push('message_registered'); });
+    mock.event.mockImplementation(() => { order.push('event_registered'); });
+    mock.start.mockImplementation(async () => { order.push('app_started'); });
+
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+    await adapter.stop();
+
+    expect(order.indexOf('message_registered')).toBeLessThan(order.indexOf('app_started'));
+    expect(order.indexOf('event_registered')).toBeLessThan(order.indexOf('app_started'));
+  });
+});
+
+describe('SlackAdapter — new idea pipeline', () => {
+  const BOT_ID = 'UBOT001';
+  const CHANNEL_ID = 'C123';
+  const CHANNEL_NAME = 'my-channel';
+
+  it('emits new_idea event with correct Idea shape', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME, approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> add a setup wizard`,
+      user: 'U123',
+      ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+    await adapter.stop();
+
+    const event = await eventPromise;
+    expect(event.type).toBe('new_idea');
+    const idea = event.payload as Idea;
+    expect(idea.source).toBe('slack');
+    expect(idea.author).toBe('U123');
+    expect(idea.content).toBe(`<@${BOT_ID}> add a setup wizard`);
+    expect(idea.thread_ts).toBe('100.0');
+    expect(idea.channel_id).toBe(CHANNEL_ID);
+    expect(idea.received_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(typeof idea.id).toBe('string');
+  });
+
+  it('posts acknowledgement in the correct thread', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME, approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> new idea`,
+      user: 'U123',
+      ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+    await eventPromise;
+    await adapter.stop();
+
+    expect(mock.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: CHANNEL_ID,
+        thread_ts: '100.0',
+        text: "Got it — I'll work on a spec and post it here.",
+      }),
+    );
+  });
+
+  it('registers the thread so a subsequent reply is spec_feedback', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME, approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+
+    // Seed the idea to populate the registry
+    const ideaEventPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> new idea`,
+      user: 'U123',
+      ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+    await ideaEventPromise;
+
+    // Now trigger a reply — should be spec_feedback
+    const feedbackEventPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> revise this`,
+      user: 'U456',
+      ts: '200.0',
+      thread_ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+
+    const event = await feedbackEventPromise;
+    await adapter.stop();
+
+    expect(event.type).toBe('spec_feedback');
+  });
+});
+
+describe('SlackAdapter — spec feedback pipeline', () => {
+  const BOT_ID = 'UBOT001';
+  const CHANNEL_ID = 'C123';
+
+  it('emits spec_feedback with correct shape and posts acknowledgement', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+
+    // Seed idea first
+    const ideaPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({ text: `<@${BOT_ID}> seed`, user: 'U123', ts: '100.0', channel: CHANNEL_ID });
+    const ideaEvent = await ideaPromise;
+
+    // Trigger feedback
+    const feedbackPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> the field is confusing`,
+      user: 'U456',
+      ts: '200.0',
+      thread_ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+    const feedbackEvent = await feedbackPromise;
+    await adapter.stop();
+
+    expect(feedbackEvent.type).toBe('spec_feedback');
+    const feedback = feedbackEvent.payload as SpecFeedback;
+    expect(feedback.idea_id).toBe((ideaEvent.payload as Idea).id);
+    expect(feedback.author).toBe('U456');
+    expect(feedback.thread_ts).toBe('100.0');
+
+    expect(mock.client.chat.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        channel: CHANNEL_ID,
+        thread_ts: '100.0',
+        text: "Thanks — I'll incorporate that feedback.",
+      }),
+    );
+  });
+});
+
+describe('SlackAdapter — approval signal pipeline', () => {
+  const BOT_ID = 'UBOT001';
+  const CHANNEL_ID = 'C123';
+
+  it('emits approval_signal for approval emoji on registered message', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+
+    // Seed idea to register the thread
+    const ideaPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({ text: `<@${BOT_ID}> seed`, user: 'U123', ts: '100.0', channel: CHANNEL_ID });
+    const ideaEvent = await ideaPromise;
+
+    // React to the idea message
+    const signalPromise = takeOne(adapter.receive());
+    await mock._triggerReaction({
+      reaction: 'thumbsup',
+      user: 'U456',
+      item: { type: 'message', ts: '100.0', channel: CHANNEL_ID },
+    });
+    const signalEvent = await signalPromise;
+    await adapter.stop();
+
+    expect(signalEvent.type).toBe('approval_signal');
+    const signal = signalEvent.payload as ApprovalSignal;
+    expect(signal.idea_id).toBe((ideaEvent.payload as Idea).id);
+    expect(signal.approver).toBe('U456');
+    expect(signal.emoji).toBe('thumbsup');
+  });
+});
+
+describe('SlackAdapter — ignore cases', () => {
+  const BOT_ID = 'UBOT001';
+  const CHANNEL_ID = 'C123';
+
+  async function setupAdapter(mock: ReturnType<typeof makeMockApp>) {
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+    return adapter;
+  }
+
+  it('non-mention message: no postMessage, no event', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = await setupAdapter(mock);
+    await mock._triggerMessage({ text: 'hello team', user: 'U123', ts: '100.0', channel: CHANNEL_ID });
+    await adapter.stop();
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('@mention reply to unregistered thread: no postMessage, no event', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = await setupAdapter(mock);
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> reply to unknown thread`,
+      user: 'U123',
+      ts: '200.0',
+      thread_ts: '999.0', // not registered
+      channel: CHANNEL_ID,
+    });
+    await adapter.stop();
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('non-approval emoji reaction: no event', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = await setupAdapter(mock);
+    // Seed idea to register thread
+    const ideaPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({ text: `<@${BOT_ID}> seed`, user: 'U123', ts: '100.0', channel: CHANNEL_ID });
+    await ideaPromise;
+    // React with non-approval emoji
+    mock.client.chat.postMessage.mockClear();
+    await mock._triggerReaction({
+      reaction: 'wave',
+      user: 'U456',
+      item: { type: 'message', ts: '100.0', channel: CHANNEL_ID },
+    });
+    await adapter.stop();
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('approval emoji on unregistered message: no event', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = await setupAdapter(mock);
+    await mock._triggerReaction({
+      reaction: 'thumbsup',
+      user: 'U456',
+      item: { type: 'message', ts: '999.0', channel: CHANNEL_ID }, // not registered
+    });
+    await adapter.stop();
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("bot's own message: no postMessage, no event", async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = await setupAdapter(mock);
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> ignored`,
+      user: BOT_ID, // bot's own message
+      ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+    await adapter.stop();
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('SlackAdapter — error handling', () => {
+  const BOT_ID = 'UBOT001';
+  const CHANNEL_ID = 'C123';
+
+  it('postMessage failure does not propagate — adapter continues running', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    mock.client.chat.postMessage.mockRejectedValueOnce(new Error('rate limited'));
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+
+    // This should not throw even though postMessage fails
+    await expect(
+      mock._triggerMessage({ text: `<@${BOT_ID}> add wizard`, user: 'U123', ts: '100.0', channel: CHANNEL_ID }),
+    ).resolves.not.toThrow();
+
+    await adapter.stop();
+  });
+});
+
+describe('SlackAdapter — service lifecycle', () => {
+  it('start() calls app.start(); stop() calls app.stop()', async () => {
+    const mock = makeMockApp({});
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', approvalEmojis: ['thumbsup'] }, { logDestination: nullDest });
+    await adapter.start();
+    expect(mock.start).toHaveBeenCalledTimes(1);
+    await adapter.stop();
+    expect(mock.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/adapters/slack/thread-registry.test.ts
+++ b/tests/adapters/slack/thread-registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { ThreadRegistry } from '../../../src/adapters/slack/thread-registry.js';
+
+describe('ThreadRegistry', () => {
+  it('starts empty: resolve returns undefined for any key', () => {
+    const registry = new ThreadRegistry();
+    expect(registry.resolve('any-ts')).toBeUndefined();
+  });
+
+  it('register then resolve returns the idea_id', () => {
+    const registry = new ThreadRegistry();
+    registry.register('1234567890.000001', 'idea-abc');
+    expect(registry.resolve('1234567890.000001')).toBe('idea-abc');
+  });
+
+  it('resolve returns undefined for an unregistered key', () => {
+    const registry = new ThreadRegistry();
+    registry.register('1234567890.000001', 'idea-abc');
+    expect(registry.resolve('9999999999.000001')).toBeUndefined();
+  });
+
+  it('re-registering the same thread_ts overwrites the previous idea_id', () => {
+    const registry = new ThreadRegistry();
+    registry.register('1234567890.000001', 'idea-first');
+    registry.register('1234567890.000001', 'idea-second');
+    expect(registry.resolve('1234567890.000001')).toBe('idea-second');
+  });
+
+  it('multiple thread_ts entries are independent', () => {
+    const registry = new ThreadRegistry();
+    registry.register('ts-one', 'idea-one');
+    registry.register('ts-two', 'idea-two');
+    expect(registry.resolve('ts-one')).toBe('idea-one');
+    expect(registry.resolve('ts-two')).toBe('idea-two');
+  });
+});

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parseWorkflow, resolveEnvVars, validateConfig, redactConfig } from '../../src/core/config.js';
+import type { WorkflowConfig } from '../../src/types/config.js';
 
 const fixture = (name: string) =>
   readFileSync(join(import.meta.dirname, '../fixtures', name), 'utf-8');
@@ -148,8 +149,8 @@ describe('validateConfig', () => {
 
   it('does not throw for unknown keys', () => {
     expect(() => validateConfig({
-      slack: { channel: 'general' },
       custom: 'value',
+      another_unknown: { nested: true },
     })).not.toThrow();
   });
 });
@@ -174,5 +175,95 @@ describe('redactConfig', () => {
     const config = { outer: { inner: 'secret-value' } };
     const redacted = redactConfig(config, { SECRET: 'secret-value' });
     expect((redacted.outer as Record<string, string>).inner).toBe('[from env]');
+  });
+});
+
+describe('validateConfig — slack', () => {
+  it('passes when slack section is absent', () => {
+    expect(() => validateConfig({})).not.toThrow();
+  });
+
+  it('passes with all required slack fields present', () => {
+    expect(() => validateConfig({
+      slack: { bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: 'my-channel' },
+    })).not.toThrow();
+  });
+
+  it('throws when bot_token is missing', () => {
+    expect(() => validateConfig({
+      slack: { app_token: 'xapp-test', channel_name: 'my-channel' },
+    })).toThrow(/slack\.bot_token/);
+  });
+
+  it('throws when bot_token is empty', () => {
+    expect(() => validateConfig({
+      slack: { bot_token: '', app_token: 'xapp-test', channel_name: 'my-channel' },
+    })).toThrow(/slack\.bot_token/);
+  });
+
+  it('throws when app_token is missing', () => {
+    expect(() => validateConfig({
+      slack: { bot_token: 'xoxb-test', channel_name: 'my-channel' },
+    })).toThrow(/slack\.app_token/);
+  });
+
+  it('throws when app_token is empty', () => {
+    expect(() => validateConfig({
+      slack: { bot_token: 'xoxb-test', app_token: '', channel_name: 'my-channel' },
+    })).toThrow(/slack\.app_token/);
+  });
+
+  it('throws when channel_name is missing', () => {
+    expect(() => validateConfig({
+      slack: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+    })).toThrow(/slack\.channel_name/);
+  });
+
+  it('throws when channel_name is empty', () => {
+    expect(() => validateConfig({
+      slack: { bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: '' },
+    })).toThrow(/slack\.channel_name/);
+  });
+
+  it('defaults approval_emojis to ["thumbsup"] when absent', () => {
+    const config: WorkflowConfig = {
+      slack: { bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: 'ch' },
+    };
+    validateConfig(config);
+    expect(config.slack?.approval_emojis).toEqual(['thumbsup']);
+  });
+
+  it('passes when approval_emojis is a non-empty array', () => {
+    expect(() => validateConfig({
+      slack: {
+        bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: 'ch',
+        approval_emojis: ['thumbsup', 'white_check_mark'],
+      },
+    })).not.toThrow();
+  });
+
+  it('throws when approval_emojis is an empty array', () => {
+    expect(() => validateConfig({
+      slack: {
+        bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: 'ch',
+        approval_emojis: [],
+      },
+    })).toThrow(/slack\.approval_emojis/);
+  });
+});
+
+describe('redactConfig — slack tokens', () => {
+  it('redacts bot_token and app_token values resolved from env', () => {
+    const config = {
+      slack: { bot_token: 'xoxb-secret', app_token: 'xapp-secret', channel_name: 'ch' },
+    };
+    const redacted = redactConfig(config, {
+      AC_SLACK_BOT_TOKEN: 'xoxb-secret',
+      AC_SLACK_APP_TOKEN: 'xapp-secret',
+    });
+    const slack = redacted.slack as Record<string, string>;
+    expect(slack.bot_token).toBe('[from env]');
+    expect(slack.app_token).toBe('[from env]');
+    expect(slack.channel_name).toBe('ch');
   });
 });

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -225,6 +225,20 @@ describe('validateConfig — slack', () => {
     })).toThrow(/slack\.channel_name/);
   });
 
+  it('$VAR references in bot_token and app_token are resolved before validation', () => {
+    const raw = {
+      slack: { bot_token: '$AC_SLACK_BOT_TOKEN', app_token: '$AC_SLACK_APP_TOKEN', channel_name: 'ch' },
+    };
+    const { resolved } = resolveEnvVars(raw, {
+      AC_SLACK_BOT_TOKEN: 'xoxb-real',
+      AC_SLACK_APP_TOKEN: 'xapp-real',
+    });
+    // After resolution the values are real tokens; validateConfig should pass
+    expect(() => validateConfig(resolved as WorkflowConfig)).not.toThrow();
+    expect((resolved as WorkflowConfig).slack?.bot_token).toBe('xoxb-real');
+    expect((resolved as WorkflowConfig).slack?.app_token).toBe('xapp-real');
+  });
+
   it('defaults approval_emojis to ["thumbsup"] when absent', () => {
     const config: WorkflowConfig = {
       slack: { bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: 'ch' },


### PR DESCRIPTION
## Summary

- Connects Autocatalyst to a Slack workspace via Socket Mode (no public URL required)
- Classifies inbound @mentions as `new_idea`, `spec_feedback`, or `approval_signal` and surfaces them through `AsyncIterable<InboundEvent>`
- Posts acknowledgement replies in-thread; maintains an in-memory `thread_ts → idea_id` registry

## Components

- `src/types/events.ts` — `Idea`, `SpecFeedback`, `ApprovalSignal`, `InboundEvent` union
- `src/adapters/human-interface-adapter.ts` — `HumanInterfaceAdapter` interface
- `src/adapters/slack/thread-registry.ts` — in-memory thread-to-idea map
- `src/adapters/slack/classifier.ts` — pure classification functions
- `src/adapters/slack/bolt-app.ts` — Bolt app factory (Socket Mode)
- `src/adapters/slack/slack-adapter.ts` — main adapter implementing `HumanInterfaceAdapter`
- `src/types/config.ts` / `src/core/config.ts` — `WorkflowConfig.slack` field + validation

## Notes

The adapter is not wired into `Service` yet — that happens in Feature 3 (idea to spec to review), which is also where this becomes end-to-end testable.

## Test plan

- [ ] `npm test` — 111 tests, all passing
- [ ] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)