### PR TITLE
fix: fetch inline comments from child blocks when processing Notion feedback

### DIFF
--- a/src/adapters/agent/spec-generator.ts
+++ b/src/adapters/agent/spec-generator.ts
@@ -222,6 +222,7 @@ export class OMCSpecGenerator implements SpecGenerator {
       `>>>`,
     ].filter(line => line !== undefined).join('\n');
 
+    this.logger.debug({ event: 'spec_revision.input', idea_id: feedback.idea_id, notion_comment_count: notion_comments.length, comment_ids: notion_comments.map(c => c.id) }, 'Revise called with Notion comments');
     this.logger.debug({ event: 'omc.invoked', idea_id: feedback.idea_id }, 'Invoking OMC for spec revision');
 
     let artifactPath: string;
@@ -246,6 +247,7 @@ export class OMCSpecGenerator implements SpecGenerator {
       throw new Error(`Failed to read artifact at "${artifactPath}": ${String(err)}`, { cause: err });
     }
 
+    this.logger.debug({ event: 'omc.artifact_content', idea_id: feedback.idea_id, artifactContent }, 'Raw OMC artifact for revision');
     const rawOutput = extractRawOutput(artifactContent, 'Spec revision');
 
     // Parse JSON response
@@ -283,6 +285,7 @@ export class OMCSpecGenerator implements SpecGenerator {
       commentResponses.push({ comment_id: entry['comment_id'], response: entry['response'] });
     }
 
+    this.logger.debug({ event: 'spec_revision.output', idea_id: feedback.idea_id, comment_response_count: commentResponses.length, comment_response_ids: commentResponses.map(r => r.comment_id) }, 'Parsed comment responses from revision');
     writeFileSync(spec_path, obj['spec'] as string, 'utf-8');
     this.logger.info({ event: 'spec.revised', idea_id: feedback.idea_id, spec_path }, 'Spec revised');
 

--- a/src/adapters/notion/notion-feedback-source.ts
+++ b/src/adapters/notion/notion-feedback-source.ts
@@ -32,12 +32,38 @@ export class NotionFeedbackSource implements FeedbackSource {
   }
 
   async fetch(publisher_ref: string): Promise<NotionComment[]> {
-    const response = await this.client.comments.list({ block_id: publisher_ref } as Parameters<NotionClient['comments']['list']>[0]);
-    const comments = response.results as unknown as NotionCommentRecord[];
+    // Collect all raw comment records from the page and every direct child block.
+    // The Notion API only returns comments for the specific block_id supplied — there
+    // is no recursive or "all comments on page" endpoint — so we must enumerate child
+    // blocks and query each one individually.
+    const allComments: NotionCommentRecord[] = [];
+
+    // Page-level comments
+    const pageResponse = await this.client.comments.list({ block_id: publisher_ref } as Parameters<NotionClient['comments']['list']>[0]);
+    allComments.push(...(pageResponse.results as unknown as NotionCommentRecord[]));
+
+    // Inline comments on direct child blocks (paginated)
+    let cursor: string | undefined;
+    do {
+      const blocksResponse = await this.client.blocks.children.list({
+        block_id: publisher_ref,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      } as Parameters<NotionClient['blocks']['children']['list']>[0]);
+
+      const blocks = blocksResponse.results as unknown as Array<{ id: string }>;
+      for (const block of blocks) {
+        const blockComments = await this.client.comments.list({ block_id: block.id } as Parameters<NotionClient['comments']['list']>[0]);
+        allComments.push(...(blockComments.results as unknown as NotionCommentRecord[]));
+      }
+
+      cursor = (blocksResponse as unknown as { has_more: boolean; next_cursor?: string }).has_more
+        ? ((blocksResponse as unknown as { next_cursor?: string }).next_cursor ?? undefined)
+        : undefined;
+    } while (cursor);
 
     // Group comments by discussion_id, only include unresolved
     const threadMap = new Map<string, NotionCommentRecord[]>();
-    for (const comment of comments) {
+    for (const comment of allComments) {
       if (comment.resolved) continue;
       const existing = threadMap.get(comment.discussion_id) ?? [];
       existing.push(comment);

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -190,6 +190,8 @@ export class OrchestratorImpl implements Orchestrator {
       return;
     }
 
+    this.logger.debug({ event: 'spec_revision.responses', run_id: run.id, idea_id: run.idea_id, comment_response_count: commentResponses?.length ?? 0, comment_response_ids: commentResponses?.map(r => r.comment_id) ?? [] }, 'Comment responses returned from revise()');
+
     // Step 3: Update published page
     try {
       await this.deps.specPublisher.update(run.publisher_ref, run.spec_path);

--- a/tests/adapters/notion/notion-feedback-source.test.ts
+++ b/tests/adapters/notion/notion-feedback-source.test.ts
@@ -9,7 +9,10 @@ function makeMockClient(): NotionClient {
   return {
     pages: { create: vi.fn() },
     blocks: {
-      children: { list: vi.fn(), append: vi.fn() },
+      children: {
+        list: vi.fn().mockResolvedValue({ results: [], has_more: false }),
+        append: vi.fn(),
+      },
       delete: vi.fn(),
     },
     comments: {
@@ -18,6 +21,10 @@ function makeMockClient(): NotionClient {
       update: vi.fn().mockResolvedValue(undefined),
     },
   };
+}
+
+function makeBlock(id: string) {
+  return { id, type: 'paragraph', has_children: false };
 }
 
 function makeComment(overrides: {
@@ -145,6 +152,79 @@ describe('NotionFeedbackSource.fetch', () => {
 
     expect(result).toHaveLength(2);
     expect(result.map(r => r.id)).toEqual(['disc-1', 'disc-2']);
+  });
+
+  it('returns inline comments from child blocks when page-level has none', async () => {
+    const client = makeMockClient();
+    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      results: [makeBlock('block-child-1')],
+      has_more: false,
+    });
+    // page-level: no comments; child block: one comment
+    (client.comments.list as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [makeComment({ discussion_id: 'disc-inline-1' })] });
+    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('disc-inline-1');
+  });
+
+  it('combines page-level and child block comments into a single result', async () => {
+    const client = makeMockClient();
+    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      results: [makeBlock('block-child-1')],
+      has_more: false,
+    });
+    // page-level: one comment; child block: one comment
+    (client.comments.list as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ results: [makeComment({ discussion_id: 'disc-page-1' })] })
+      .mockResolvedValueOnce({ results: [makeComment({ discussion_id: 'disc-inline-1' })] });
+    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.id)).toEqual(expect.arrayContaining(['disc-page-1', 'disc-inline-1']));
+  });
+
+  it('skips child blocks that have no comments', async () => {
+    const client = makeMockClient();
+    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      results: [makeBlock('block-no-comments'), makeBlock('block-with-comment')],
+      has_more: false,
+    });
+    (client.comments.list as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ results: [] })          // page-level: empty
+      .mockResolvedValueOnce({ results: [] })          // block-no-comments: empty
+      .mockResolvedValueOnce({ results: [makeComment({ discussion_id: 'disc-inline-1' })] }); // block-with-comment
+    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('disc-inline-1');
+  });
+
+  it('fetches all child blocks when listing is paginated', async () => {
+    const client = makeMockClient();
+    (client.blocks.children.list as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ results: [makeBlock('block-1')], has_more: true, next_cursor: 'cursor-1' })
+      .mockResolvedValueOnce({ results: [makeBlock('block-2')], has_more: false });
+    (client.comments.list as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ results: [] })           // page-level: empty
+      .mockResolvedValueOnce({ results: [makeComment({ discussion_id: 'disc-1' })] }) // block-1
+      .mockResolvedValueOnce({ results: [makeComment({ discussion_id: 'disc-2' })] }); // block-2
+    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.id)).toEqual(expect.arrayContaining(['disc-1', 'disc-2']));
+    expect(client.blocks.children.list).toHaveBeenCalledTimes(2);
+    expect(client.blocks.children.list).toHaveBeenNthCalledWith(2, expect.objectContaining({ start_cursor: 'cursor-1' }));
   });
 });
 


### PR DESCRIPTION
## Summary
- `notion-feedback-source.ts` `fetch()` previously called `comments.list` with the page ID only, which returns page-level comments but not inline comments (those are attached to specific child blocks)
- Fix enumerates all direct child blocks (with pagination) and fetches comments on each one, combining with page-level comments before processing
- Adds diagnostic logging to `spec-generator.ts` and `orchestrator.ts` to trace comment counts at each stage of the pipeline

## Test plan
- [ ] Two inline comments + one page-level comment → all three fetched, all three addressed in a single run
- [ ] 4 new tests covering: inline-only, combined, blocks-with-no-comments, paginated block listing
- [ ] 207/207 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #9