### PR TITLE
fix: preserve inline Notion comments during spec revision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@notionhq/client": "^5.17.0",
         "@slack/bolt": "^4.7.0",
-        "@tryfabric/martian": "^1.2.4",
         "pino": "9.6.0",
         "yaml": "2.7.1"
       },
@@ -981,35 +980,6 @@
         "npm": ">= 8.6.0"
       }
     },
-    "node_modules/@tryfabric/martian": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@tryfabric/martian/-/martian-1.2.4.tgz",
-      "integrity": "sha512-g7SP7beaxrjxLnW//vskra07a1jsJowqp07KMouxh4gCwaF+ItHbRZN8O+1dhJivBi3VdasT71BPyk+8wzEreQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@notionhq/client": "^1.0.4",
-        "remark-gfm": "^1.0.0",
-        "remark-math": "^4.0.0",
-        "remark-parse": "^9.0.0",
-        "unified": "^9.2.1"
-      },
-      "engines": {
-        "node": ">=15"
-      }
-    },
-    "node_modules/@tryfabric/martian/node_modules/@notionhq/client": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
-      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-fetch": "^2.5.10",
-        "node-fetch": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1080,15 +1050,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/mdast": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
-      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2"
-      }
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -1102,16 +1063,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/qs": {
@@ -1154,12 +1105,6 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/unist": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1358,16 +1303,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1446,16 +1381,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ccount": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
-      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1471,36 +1396,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -1524,12 +1419,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -1754,18 +1643,6 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1843,12 +1720,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",
@@ -2149,87 +2020,11 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-electron": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
       "license": "MIT"
-    },
-    "node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -2292,18 +2087,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/katex": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
-      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.19.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2346,16 +2129,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
-    "node_modules/longest-streak": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2373,19 +2146,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/markdown-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2393,153 +2153,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
-      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
-      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-gfm-autolink-literal": "^0.1.0",
-        "mdast-util-gfm-strikethrough": "^0.2.0",
-        "mdast-util-gfm-table": "^0.1.0",
-        "mdast-util-gfm-task-list-item": "^0.1.0",
-        "mdast-util-to-markdown": "^0.6.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
-      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "mdast-util-find-and-replace": "^1.1.0",
-        "micromark": "^2.11.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
-      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-to-markdown": "^0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
-      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "markdown-table": "^2.0.0",
-        "mdast-util-to-markdown": "~0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
-      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-to-markdown": "~0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-math": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-0.1.2.tgz",
-      "integrity": "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg==",
-      "license": "MIT",
-      "dependencies": {
-        "longest-streak": "^2.0.0",
-        "mdast-util-to-markdown": "^0.6.0",
-        "repeat-string": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
-      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "longest-streak": "^2.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.0.0",
-        "zwitch": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -2561,120 +2174,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
-      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0",
-        "micromark-extension-gfm-autolink-literal": "~0.5.0",
-        "micromark-extension-gfm-strikethrough": "~0.6.5",
-        "micromark-extension-gfm-table": "~0.4.0",
-        "micromark-extension-gfm-tagfilter": "~0.3.0",
-        "micromark-extension-gfm-task-list-item": "~0.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
-      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
-      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
-      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
-      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
-      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-math": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-0.1.2.tgz",
-      "integrity": "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "katex": "^0.12.0",
-        "micromark": "~2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mime-db": {
@@ -2734,26 +2233,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/object-inspect": {
@@ -2852,24 +2331,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/parse-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/parseurl": {
@@ -3084,56 +2545,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
-      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-gfm": "^0.1.0",
-        "micromark-extension-gfm": "^0.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-math": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-4.0.0.tgz",
-      "integrity": "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-math": "^0.1.0",
-        "micromark-extension-math": "^0.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^0.8.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -3523,22 +2934,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/tsscmp": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
@@ -3602,61 +2997,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
-    "node_modules/unified": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -3673,36 +3013,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -3873,22 +3183,6 @@
         }
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3943,16 +3237,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@notionhq/client": "^5.17.0",
     "@slack/bolt": "^4.7.0",
-    "@tryfabric/martian": "^1.2.4",
     "pino": "9.6.0",
     "yaml": "2.7.1"
   },

--- a/src/adapters/agent/spec-generator.ts
+++ b/src/adapters/agent/spec-generator.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 import type { Idea, SpecFeedback } from '../../types/events.js';
+import { stripCommentSpans, extractCommentSpans, ensureSpansPreserved } from '../notion/markdown-diff.js';
 
 export interface NotionComment {
   id: string;   // discussion ID — used to post the reply
@@ -23,6 +24,11 @@ type ExecFn = (file: string, args: string[], opts?: { cwd?: string }) => Promise
 
 const FILENAME_REGEX = /^(feature|enhancement)-[a-z0-9-]+\.md$/;
 
+export interface ReviseResult {
+  comment_responses: NotionCommentResponse[];
+  page_content?: string;  // span-bearing markdown for publisher; undefined if no spans in input
+}
+
 export interface SpecGenerator {
   create(idea: Idea, workspace_path: string): Promise<string>;
   revise(
@@ -30,7 +36,8 @@ export interface SpecGenerator {
     notion_comments: NotionComment[],
     spec_path: string,
     workspace_path: string,
-  ): Promise<NotionCommentResponse[]>;
+    current_page_markdown?: string,
+  ): Promise<ReviseResult>;
 }
 
 interface SpecGeneratorOptions {
@@ -89,6 +96,17 @@ function unwrapFence(text: string): string {
   return result.join('\n');
 }
 
+// Extract the content between "LABEL:\n<<<\n" and "\n>>>" delimiters.
+function extractDelimitedSection(text: string, label: string, context: string): string {
+  const startMarker = `${label}\n<<<\n`;
+  const start = text.indexOf(startMarker);
+  if (start === -1) throw new Error(`${context}: missing ${label} section`);
+  const contentStart = start + startMarker.length;
+  const end = text.indexOf('\n>>>', contentStart);
+  if (end === -1) throw new Error(`${context}: ${label} section missing closing >>>`);
+  return text.slice(contentStart, end);
+}
+
 function parseArtifact(artifactContent: string): { filename: string; body: string } {
   const rawOutput = extractRawOutput(artifactContent, 'Spec creation');
 
@@ -123,10 +141,11 @@ export class OMCSpecGenerator implements SpecGenerator {
 
   async create(idea: Idea, workspace_path: string): Promise<string> {
     const prompt = [
-      `Using mm:planning conventions, generate a complete product spec for the following idea.`,
+      `Using mm:planning conventions, generate a SHORT product spec for the following idea.`,
+      `Only include these sections: What, Why, Personas, and Narratives. No tech spec, no task list.`,
       ``,
       `On the very first line of your response, write: FILENAME: <feature-or-enhancement-slug>.md`,
-      `Then write the complete spec as a Markdown document with YAML frontmatter.`,
+      `Then write the spec as a Markdown document with YAML frontmatter.`,
       ``,
       `Idea:`,
       `<<<`,
@@ -173,8 +192,11 @@ export class OMCSpecGenerator implements SpecGenerator {
     notion_comments: NotionComment[],
     spec_path: string,
     workspace_path: string,
-  ): Promise<NotionCommentResponse[]> {
-    const currentSpec = readFileSync(spec_path, 'utf-8');
+    current_page_markdown?: string,
+  ): Promise<ReviseResult> {
+    const originalSpans = current_page_markdown ? extractCommentSpans(current_page_markdown) : [];
+    const hasSpans = originalSpans.length > 0;
+    const currentSpec = hasSpans ? current_page_markdown! : readFileSync(spec_path, 'utf-8');
 
     const notionSection = notion_comments.length > 0
       ? [
@@ -186,29 +208,47 @@ export class OMCSpecGenerator implements SpecGenerator {
         ].join('\n')
       : '';
 
-    const shapeLines = notion_comments.length > 0
+    const commentResponsesShape = notion_comments.length > 0
+      ? `[{ "comment_id": "<id from [COMMENT_ID:] tag>", "response": "<1-2 sentences explaining how this comment was addressed>" }, ...]`
+      : `[]`;
+
+    const shapeLines = [
+      `Your response must use this structure exactly — no other text before or after it:`,
+      ``,
+      `SPEC:`,
+      `<<<`,
+      `[complete revised spec as a Markdown document — preserve YAML frontmatter]`,
+      `>>>`,
+      ``,
+      `COMMENT_RESPONSES:`,
+      `<<<`,
+      commentResponsesShape,
+      `>>>`,
+      ...(notion_comments.length === 0 ? [``, `Use an empty array for COMMENT_RESPONSES since there are no Notion comments.`] : []),
+    ];
+
+    const spanInstructions = hasSpans
       ? [
-          `Your response must match this shape exactly:`,
-          `{`,
-          `  "spec": "<complete revised spec as a Markdown string — preserve YAML frontmatter>",`,
-          `  "comment_responses": [`,
-          `    { "comment_id": "<id from [COMMENT_ID:] tag>", "response": "<1-2 sentences explaining how this comment was addressed>" }`,
-          `  ]`,
-          `}`,
+          ``,
+          `CRITICAL: The spec contains <span discussion-urls="..."> tags marking inline comment anchors.`,
+          `Every span in the input MUST appear somewhere in your output. Follow these rules exactly:`,
+          ``,
+          `1. Span text unchanged — keep the span wrapping that same text.`,
+          `2. Span text rewritten — move the span to wrap the closest equivalent text in your revision.`,
+          `3. Span text removed entirely — add an "## Orphaned comments" section at the very end`,
+          `   of the spec with one bullet per orphaned span:`,
+          `   - <span discussion-urls="EXACT_UUID_HERE">exact original inner text</span>`,
+          ``,
+          `DO NOT drop any span. If you are uncertain where to place one, orphan it.`,
+          `The "## Orphaned comments" section must be the last section in the document.`,
         ]
-      : [
-          `Your response must match this shape exactly:`,
-          `{`,
-          `  "spec": "<complete revised spec as a Markdown string — preserve YAML frontmatter>",`,
-          `  "comment_responses": []`,
-          `}`,
-          `Return "comment_responses": [] since there are no Notion comments.`,
-        ];
+      : [];
 
     const prompt = [
-      `Revise the spec below based on the following feedback. Respond with only a JSON object — no other text before or after it.`,
+      `Revise the spec below based on the following feedback.`,
       ``,
       ...shapeLines,
+      ...spanInstructions,
       ``,
       `Slack message:`,
       `<<<`,
@@ -249,29 +289,28 @@ export class OMCSpecGenerator implements SpecGenerator {
 
     this.logger.debug({ event: 'omc.artifact_content', idea_id: feedback.idea_id, artifactContent }, 'Raw OMC artifact for revision');
     const rawOutput = extractRawOutput(artifactContent, 'Spec revision');
+    const unwrapped = unwrapFence(rawOutput.trim());
 
-    // Parse JSON response
-    let parsed: unknown;
+    // Extract spec from SPEC: <<< ... >>> section
+    const spec = extractDelimitedSection(unwrapped, 'SPEC:', 'Spec revision');
+    if (!spec) {
+      throw new Error(`Spec revision: response missing non-empty SPEC section`);
+    }
+
+    // Extract and parse comment_responses from COMMENT_RESPONSES: <<< ... >>> section
+    const commentResponsesRaw = extractDelimitedSection(unwrapped, 'COMMENT_RESPONSES:', 'Spec revision');
+    let parsedResponses: unknown;
     try {
-      parsed = JSON.parse(unwrapFence(rawOutput.trim()));
+      parsedResponses = JSON.parse(commentResponsesRaw.trim() || '[]');
     } catch {
-      throw new Error(`Spec revision: OMC response is not valid JSON`);
+      throw new Error(`Spec revision: COMMENT_RESPONSES section is not valid JSON`);
     }
-
-    if (typeof parsed !== 'object' || parsed === null) {
-      throw new Error(`Spec revision: OMC response is not a JSON object`);
-    }
-    const obj = parsed as Record<string, unknown>;
-
-    if (typeof obj['spec'] !== 'string' || obj['spec'].length === 0) {
-      throw new Error(`Spec revision: JSON response missing non-empty "spec" field`);
-    }
-    if (!Array.isArray(obj['comment_responses'])) {
-      throw new Error(`Spec revision: JSON response missing "comment_responses" array`);
+    if (!Array.isArray(parsedResponses)) {
+      throw new Error(`Spec revision: COMMENT_RESPONSES is not a JSON array`);
     }
 
     const commentResponses: NotionCommentResponse[] = [];
-    for (const item of obj['comment_responses'] as unknown[]) {
+    for (const item of parsedResponses as unknown[]) {
       if (typeof item !== 'object' || item === null) {
         throw new Error(`Spec revision: comment_responses entry is not an object`);
       }
@@ -286,9 +325,16 @@ export class OMCSpecGenerator implements SpecGenerator {
     }
 
     this.logger.debug({ event: 'spec_revision.output', idea_id: feedback.idea_id, comment_response_count: commentResponses.length, comment_response_ids: commentResponses.map(r => r.comment_id) }, 'Parsed comment responses from revision');
-    writeFileSync(spec_path, obj['spec'] as string, 'utf-8');
-    this.logger.info({ event: 'spec.revised', idea_id: feedback.idea_id, spec_path }, 'Spec revised');
 
-    return commentResponses;
+    if (hasSpans) {
+      const pageContent = ensureSpansPreserved(spec, originalSpans);
+      writeFileSync(spec_path, stripCommentSpans(pageContent), 'utf-8');
+      this.logger.info({ event: 'spec.revised', idea_id: feedback.idea_id, spec_path, spans_preserved: true }, 'Spec revised with span passthrough');
+      return { comment_responses: commentResponses, page_content: pageContent };
+    }
+
+    writeFileSync(spec_path, spec, 'utf-8');
+    this.logger.info({ event: 'spec.revised', idea_id: feedback.idea_id, spec_path }, 'Spec revised');
+    return { comment_responses: commentResponses };
   }
 }

--- a/src/adapters/notion/markdown-diff.ts
+++ b/src/adapters/notion/markdown-diff.ts
@@ -1,0 +1,57 @@
+// src/adapters/notion/markdown-diff.ts
+
+/**
+ * Strip Notion inline comment span tags, preserving the inner text.
+ * Only removes spans with discussion-urls attribute (comment anchors).
+ */
+export function stripCommentSpans(raw: string): string {
+  return raw
+    .replace(/<span\s[^>]*discussion-urls="[^"]*"[^>]*>([\s\S]*?)<\/span>/g, '$1');
+}
+
+export interface CommentSpan {
+  uuid: string;       // full discussion-urls value, e.g. "discussion://abc-123"
+  inner_text: string;  // text wrapped by the span
+}
+
+/**
+ * Extract all comment span anchors from markdown content.
+ * Returns spans in document order with their discussion-urls UUID and inner text.
+ */
+export function extractCommentSpans(markdown: string): CommentSpan[] {
+  const re = /<span\s[^>]*discussion-urls="([^"]*)"[^>]*>([\s\S]*?)<\/span>/g;
+  const spans: CommentSpan[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(markdown)) !== null) {
+    spans.push({ uuid: match[1], inner_text: match[2] });
+  }
+  return spans;
+}
+
+/**
+ * Ensure all original comment spans are present in the revised content.
+ * Missing spans are appended to an "## Orphaned comments" section with
+ * a "[dropped by Claude]" tag.
+ *
+ * Returns content unchanged if no spans are missing.
+ */
+export function ensureSpansPreserved(
+  revisedContent: string,
+  originalSpans: CommentSpan[],
+): string {
+  if (originalSpans.length === 0) return revisedContent;
+
+  const missing = originalSpans.filter(span => !revisedContent.includes(span.uuid));
+  if (missing.length === 0) return revisedContent;
+
+  const orphanLines = missing.map(
+    s => `- <span discussion-urls="${s.uuid}">${s.inner_text}</span> [dropped by Claude]`,
+  );
+
+  const orphanedHeading = '## Orphaned comments';
+  if (revisedContent.includes(orphanedHeading)) {
+    return revisedContent + '\n' + orphanLines.join('\n');
+  }
+
+  return revisedContent + '\n\n' + orphanedHeading + '\n\n' + orphanLines.join('\n');
+}

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -5,26 +5,26 @@ import type {
   CreatePageResponse,
   ListBlockChildrenParameters,
   ListBlockChildrenResponse,
-  AppendBlockChildrenParameters,
-  AppendBlockChildrenResponse,
-  DeleteBlockParameters,
-  DeleteBlockResponse,
   ListCommentsParameters,
   ListCommentsResponse,
   CreateCommentParameters,
   CreateCommentResponse,
 } from '@notionhq/client/build/src/api-endpoints.js';
 
+export type MarkdownOperation =
+  | { type: 'replace_content'; replace_content: { new_str: string } }
+  | { type: 'update_content'; update_content: { content_updates: Array<{ old_str: string; new_str: string }> } };
+
 export interface NotionClient {
   pages: {
     create(args: CreatePageParameters): Promise<CreatePageResponse>;
+    getMarkdown(page_id: string): Promise<string>;
+    updateMarkdown(page_id: string, operation: MarkdownOperation): Promise<void>;
   };
   blocks: {
     children: {
       list(args: ListBlockChildrenParameters): Promise<ListBlockChildrenResponse>;
-      append(args: AppendBlockChildrenParameters): Promise<AppendBlockChildrenResponse>;
     };
-    delete(args: DeleteBlockParameters): Promise<DeleteBlockResponse>;
   };
   comments: {
     list(args: ListCommentsParameters): Promise<ListCommentsResponse>;
@@ -43,17 +43,35 @@ export class NotionClientImpl implements NotionClient {
   readonly pages = {
     create: (args: CreatePageParameters): Promise<CreatePageResponse> =>
       this.client.pages.create(args),
+
+    getMarkdown: async (page_id: string): Promise<string> => {
+      const response = await (this.client as unknown as {
+        request: (args: { path: string; method: string; headers?: Record<string, string> }) => Promise<unknown>;
+      }).request({
+        path: `pages/${page_id}/markdown`,
+        method: 'GET',
+        headers: { 'Notion-Version': '2026-03-11' },
+      });
+      return (response as { markdown: string }).markdown;
+    },
+
+    updateMarkdown: async (page_id: string, operation: MarkdownOperation): Promise<void> => {
+      await (this.client as unknown as {
+        request: (args: { path: string; method: string; body: unknown; headers?: Record<string, string> }) => Promise<unknown>;
+      }).request({
+        path: `pages/${page_id}/markdown`,
+        method: 'PATCH',
+        headers: { 'Notion-Version': '2026-03-11' },
+        body: operation,
+      });
+    },
   };
 
   readonly blocks = {
     children: {
       list: (args: ListBlockChildrenParameters): Promise<ListBlockChildrenResponse> =>
         this.client.blocks.children.list(args),
-      append: (args: AppendBlockChildrenParameters): Promise<AppendBlockChildrenResponse> =>
-        this.client.blocks.children.append(args),
     },
-    delete: (args: DeleteBlockParameters): Promise<DeleteBlockResponse> =>
-      this.client.blocks.delete(args),
   };
 
   readonly comments = {

--- a/src/adapters/notion/notion-publisher.ts
+++ b/src/adapters/notion/notion-publisher.ts
@@ -1,7 +1,6 @@
 // src/adapters/notion/notion-publisher.ts
 import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
-import { markdownToBlocks } from '@tryfabric/martian';
 import type { App } from '@slack/bolt';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
@@ -40,17 +39,18 @@ export class NotionPublisher implements SpecPublisher {
   async create(channel_id: string, thread_ts: string, spec_path: string): Promise<string> {
     const content = readFileSync(spec_path, 'utf-8');
     const title = this.titleFromPath(spec_path);
-    const blocks = markdownToBlocks(content);
 
     const page = await this.client.pages.create({
       parent: { page_id: this.parent_page_id },
       properties: {
         title: [{ type: 'text', text: { content: title } }],
       } as unknown as Parameters<NotionClient['pages']['create']>[0]['properties'],
-      children: blocks as Parameters<NotionClient['pages']['create']>[0]['children'],
     });
 
     const pageId = page.id;
+
+    await this.client.pages.updateMarkdown(pageId, { type: 'replace_content', replace_content: { new_str: content } });
+
     const pageUrl = `https://notion.so/${pageId.replace(/-/g, '')}`;
 
     await this.app.client.chat.postMessage({
@@ -63,29 +63,18 @@ export class NotionPublisher implements SpecPublisher {
     return pageId;
   }
 
-  async update(publisher_ref: string, spec_path: string): Promise<void> {
-    const content = readFileSync(spec_path, 'utf-8');
-    const blocks = markdownToBlocks(content);
+  async getPageMarkdown(publisher_ref: string): Promise<string> {
+    return this.client.pages.getMarkdown(publisher_ref);
+  }
 
-    // Fetch existing child block IDs
-    const existing = await this.client.blocks.children.list({ block_id: publisher_ref });
-    // Guard: Notion paginates at 100 blocks; throw loudly rather than silently corrupting the page
-    if ((existing as { has_more?: boolean }).has_more) {
-      throw new Error(`Notion page ${publisher_ref} has more than 100 blocks; pagination not yet supported`);
-    }
-    const blockIds = existing.results.map((b: { id: string }) => b.id);
+  async update(publisher_ref: string, spec_path: string, page_content?: string): Promise<void> {
+    const content = page_content ?? readFileSync(spec_path, 'utf-8');
 
-    // Delete each existing block sequentially
-    for (const block_id of blockIds) {
-      await this.client.blocks.delete({ block_id });
-    }
-
-    // Append new blocks
-    await this.client.blocks.children.append({
-      block_id: publisher_ref,
-      children: blocks as Parameters<NotionClient['blocks']['children']['append']>[0]['children'],
+    await this.client.pages.updateMarkdown(publisher_ref, {
+      type: 'replace_content',
+      replace_content: { new_str: content },
     });
 
-    this.logger.info({ event: 'notion_page.updated', page_id: publisher_ref, block_count: blocks.length }, 'Notion page updated');
+    this.logger.info({ event: 'notion_page.updated', page_id: publisher_ref }, 'Notion page updated');
   }
 }

--- a/src/adapters/slack/canvas-publisher.ts
+++ b/src/adapters/slack/canvas-publisher.ts
@@ -7,7 +7,8 @@ import { createLogger } from '../../core/logger.js';
 
 export interface SpecPublisher {
   create(channel_id: string, thread_ts: string, spec_path: string): Promise<string>;
-  update(publisher_ref: string, spec_path: string): Promise<void>;
+  update(publisher_ref: string, spec_path: string, page_content?: string): Promise<void>;
+  getPageMarkdown(publisher_ref: string): Promise<string>;
 }
 
 interface CanvasPublisherOptions {
@@ -80,7 +81,11 @@ export class SlackCanvasPublisher implements SpecPublisher {
     return canvas_id;
   }
 
-  async update(canvas_id: string, spec_path: string): Promise<void> {
+  async getPageMarkdown(_publisher_ref: string): Promise<string> {
+    return '';
+  }
+
+  async update(canvas_id: string, spec_path: string, _page_content?: string): Promise<void> {
     const content = readFileSync(spec_path, 'utf-8');
 
     await (this.app.client as unknown as {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -4,7 +4,7 @@ import type pino from 'pino';
 import { createLogger } from './logger.js';
 import type { SlackAdapter } from '../adapters/slack/slack-adapter.js';
 import type { WorkspaceManager } from './workspace-manager.js';
-import type { SpecGenerator } from '../adapters/agent/spec-generator.js';
+import type { SpecGenerator, ReviseResult } from '../adapters/agent/spec-generator.js';
 import type { SpecPublisher } from '../adapters/slack/canvas-publisher.js';
 import type { Run, RunStage } from '../types/runs.js';
 import type { Idea, SpecFeedback } from '../types/events.js';
@@ -173,28 +173,39 @@ export class OrchestratorImpl implements Orchestrator {
       }
     }
 
+    // Step 1.5: Get page markdown with comment spans
+    let pageMarkdown: string | undefined;
+    try {
+      pageMarkdown = await this.deps.specPublisher.getPageMarkdown(run.publisher_ref);
+      if (!pageMarkdown) pageMarkdown = undefined;
+    } catch (err) {
+      this.logger.warn({ event: 'page_markdown.failed', run_id: run.id, idea_id: run.idea_id, error: String(err) }, 'Failed to get page markdown; spans will not be preserved');
+    }
+
     this.logger.debug({
       event: 'spec_revision.enriched',
       run_id: run.id,
       idea_id: run.idea_id,
       slack_feedback: feedback.content.length > 0,
       notion_comment_count: notionComments.length,
+      has_page_markdown: !!pageMarkdown,
     }, 'Revision enriched with feedback sources');
 
     // Step 2: Revise spec
-    let commentResponses;
+    let result: ReviseResult;
     try {
-      commentResponses = await this.deps.specGenerator.revise(feedback, notionComments, run.spec_path, run.workspace_path);
+      result = await this.deps.specGenerator.revise(feedback, notionComments, run.spec_path, run.workspace_path, pageMarkdown);
     } catch (err) {
       await this.failRun(run, feedback.channel_id, feedback.thread_ts, err);
       return;
     }
 
+    const { comment_responses: commentResponses, page_content } = result;
     this.logger.debug({ event: 'spec_revision.responses', run_id: run.id, idea_id: run.idea_id, comment_response_count: commentResponses?.length ?? 0, comment_response_ids: commentResponses?.map(r => r.comment_id) ?? [] }, 'Comment responses returned from revise()');
 
     // Step 3: Update published page
     try {
-      await this.deps.specPublisher.update(run.publisher_ref, run.spec_path);
+      await this.deps.specPublisher.update(run.publisher_ref, run.spec_path, page_content);
     } catch (err) {
       await this.failRun(run, feedback.channel_id, feedback.thread_ts, err);
       return;

--- a/tests/adapters/agent/spec-generator.test.ts
+++ b/tests/adapters/agent/spec-generator.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { OMCSpecGenerator } from '../../../src/adapters/agent/spec-generator.js';
 import type { Idea, SpecFeedback } from '../../../src/types/events.js';
-import type { NotionCommentResponse } from '../../../src/adapters/agent/spec-generator.js';
+import type { NotionCommentResponse, ReviseResult } from '../../../src/adapters/agent/spec-generator.js';
 
 const nullDest = { write: () => {} };
 
@@ -38,10 +38,22 @@ function makeArtifact(filenameLineContent: string, body: string): string {
   return `# claude advisor artifact\n\n## Raw output\n\n\`\`\`text\n${filenameLineContent}\n${body}\n\`\`\`\n`;
 }
 
-function makeRevisionArtifact(rawContent: string): string {
-  // rawContent is placed in the ## Raw output section
-  // After Task 9, revise() will parse it as JSON
-  // So rawContent should be a JSON string like: JSON.stringify({ spec: "...", comment_responses: [] })
+function makeRevisionArtifact(spec: string, commentResponses: unknown[] = []): string {
+  const sections = [
+    `SPEC:`,
+    `<<<`,
+    spec,
+    `>>>`,
+    ``,
+    `COMMENT_RESPONSES:`,
+    `<<<`,
+    JSON.stringify(commentResponses),
+    `>>>`,
+  ].join('\n');
+  return `# claude advisor artifact\n\n## Raw output\n\n\`\`\`text\n${sections}\n\`\`\`\n`;
+}
+
+function makeRevisionArtifactRaw(rawContent: string): string {
   return `# claude advisor artifact\n\n## Raw output\n\n\`\`\`text\n${rawContent}\n\`\`\`\n`;
 }
 
@@ -154,7 +166,7 @@ describe('SpecGenerator.create', () => {
 
 describe('SpecGenerator.revise', () => {
   it('prompt leads with feedback in <<<>>>, follows with spec content in <<<>>>', async () => {
-    const artifact = makeRevisionArtifact(JSON.stringify({ spec: '# Revised Spec', comment_responses: [] }));
+    const artifact = makeRevisionArtifact('# Revised Spec');
     const artifactPath = writeArtifactFile(artifact);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath, stderr: '' });
 
@@ -171,11 +183,11 @@ describe('SpecGenerator.revise', () => {
     const feedbackIdx = prompt.indexOf('the wizard should not require');
     const specIdx = prompt.indexOf('# Original Spec');
     expect(feedbackIdx).toBeLessThan(specIdx); // feedback before spec
-    expect(result).toEqual([]);
+    expect(result.comment_responses).toEqual([]);
   });
 
   it('reads the current spec from spec_path before invoking OMC', async () => {
-    const artifact = makeRevisionArtifact(JSON.stringify({ spec: '# Revised', comment_responses: [] }));
+    const artifact = makeRevisionArtifact('# Revised');
     const artifactPath = writeArtifactFile(artifact);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath, stderr: '' });
 
@@ -189,12 +201,12 @@ describe('SpecGenerator.revise', () => {
     const args = execFn.mock.calls[0][1] as string[];
     const prompt = args[args.length - 1];
     expect(prompt).toContain('# Original Spec Content');
-    expect(result).toEqual([]);
+    expect(result.comment_responses).toEqual([]);
   });
 
   it('overwrites spec_path in place with revised content', async () => {
     const revisedBody = '# Revised Spec\ncontent\n';
-    const artifact = makeRevisionArtifact(JSON.stringify({ spec: revisedBody, comment_responses: [] }));
+    const artifact = makeRevisionArtifact(revisedBody);
     const artifactPath = writeArtifactFile(artifact);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath, stderr: '' });
 
@@ -206,11 +218,11 @@ describe('SpecGenerator.revise', () => {
 
     const revised = readFileSync(specPath, 'utf-8');
     expect(revised).toBe('# Revised Spec\ncontent\n');
-    expect(result).toEqual([]);
+    expect(result.comment_responses).toEqual([]);
   });
 
-  it('returns [] when comment_responses is empty in JSON output', async () => {
-    const artifact = makeRevisionArtifact(JSON.stringify({ spec: '# Revised Spec\nsome content\n', comment_responses: [] }));
+  it('returns empty comment_responses when none present', async () => {
+    const artifact = makeRevisionArtifact('# Revised Spec\nsome content\n');
     const artifactPath = writeArtifactFile(artifact);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath, stderr: '' });
 
@@ -223,7 +235,7 @@ describe('SpecGenerator.revise', () => {
     const revised = readFileSync(specPath, 'utf-8');
     expect(revised).not.toContain('comment_responses');
     expect(revised).toContain('# Revised Spec');
-    expect(result).toEqual([]);
+    expect(result.comment_responses).toEqual([]);
   });
 
   it('throws if OMC exits non-zero', async () => {
@@ -238,10 +250,7 @@ describe('SpecGenerator.revise', () => {
 
 describe('SpecGenerator.revise — Notion comments', () => {
   it('prompt includes [COMMENT_ID:] blocks when notion_comments is non-empty', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({
-      spec: '# Revised\n\ncontent',
-      comment_responses: [{ comment_id: 'disc-abc', response: 'Updated X' }],
-    }));
+    const revisionArtifactContent = makeRevisionArtifact('# Revised\n\ncontent', [{ comment_id: 'disc-abc', response: 'Updated X' }]);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -256,14 +265,11 @@ describe('SpecGenerator.revise — Notion comments', () => {
     const prompt = args[args.length - 1]; // the last arg to omc is the prompt
     expect(prompt).toContain('[COMMENT_ID: disc-abc]');
     expect(prompt).toContain('Phoebe: use inline flow');
-    expect(prompt).toContain('comment_responses');
+    expect(prompt).toContain('COMMENT_RESPONSES:');
   });
 
   it('prompt omits Notion section when notion_comments is []', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({
-      spec: '# Revised',
-      comment_responses: [],
-    }));
+    const revisionArtifactContent = makeRevisionArtifact('# Revised', []);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -279,11 +285,8 @@ describe('SpecGenerator.revise — Notion comments', () => {
     expect(prompt).not.toContain('Notion page comments');
   });
 
-  it('valid JSON: spec written to disk, NotionCommentResponse[] returned', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({
-      spec: '# Revised\n\ncontent',
-      comment_responses: [{ comment_id: 'disc-abc', response: 'Done' }],
-    }));
+  it('spec written to disk, comment_responses returned in ReviseResult', async () => {
+    const revisionArtifactContent = makeRevisionArtifact('# Revised\n\ncontent', [{ comment_id: 'disc-abc', response: 'Done' }]);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -294,11 +297,11 @@ describe('SpecGenerator.revise — Notion comments', () => {
     const result = await sg.revise(makeFeedback(), [{ id: 'disc-abc', body: 'feedback' }], specPath, tempRoot);
 
     expect(readFileSync(specPath, 'utf-8')).toBe('# Revised\n\ncontent');
-    expect(result).toEqual([{ comment_id: 'disc-abc', response: 'Done' }]);
+    expect(result.comment_responses).toEqual([{ comment_id: 'disc-abc', response: 'Done' }]);
   });
 
-  it('valid JSON with empty comment_responses: spec written, [] returned', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '# Revised', comment_responses: [] }));
+  it('empty comment_responses: spec written, empty array returned', async () => {
+    const revisionArtifactContent = makeRevisionArtifact('# Revised', []);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -309,11 +312,13 @@ describe('SpecGenerator.revise — Notion comments', () => {
     const result = await sg.revise(makeFeedback(), [], specPath, tempRoot);
 
     expect(readFileSync(specPath, 'utf-8')).toBe('# Revised');
-    expect(result).toEqual([]);
+    expect(result.comment_responses).toEqual([]);
   });
 
-  it('malformed JSON: throws, spec file not modified', async () => {
-    const revisionArtifactContent = makeRevisionArtifact('this is not json');
+  it('malformed COMMENT_RESPONSES JSON: throws, spec file not modified', async () => {
+    const revisionArtifactContent = makeRevisionArtifactRaw(
+      'SPEC:\n<<<\n# Revised\n>>>\n\nCOMMENT_RESPONSES:\n<<<\nthis is not json\n>>>',
+    );
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -325,8 +330,8 @@ describe('SpecGenerator.revise — Notion comments', () => {
     expect(readFileSync(specPath, 'utf-8')).toBe('# Original');
   });
 
-  it('missing spec field: throws', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ comment_responses: [] }));
+  it('missing SPEC section: throws', async () => {
+    const revisionArtifactContent = makeRevisionArtifactRaw('COMMENT_RESPONSES:\n<<<\n[]\n>>>');
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -337,8 +342,8 @@ describe('SpecGenerator.revise — Notion comments', () => {
     await expect(sg.revise(makeFeedback(), [], specPath, tempRoot)).rejects.toThrow(/spec/i);
   });
 
-  it('empty spec field: throws', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '', comment_responses: [] }));
+  it('empty SPEC section: throws', async () => {
+    const revisionArtifactContent = makeRevisionArtifact('', []);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -349,8 +354,8 @@ describe('SpecGenerator.revise — Notion comments', () => {
     await expect(sg.revise(makeFeedback(), [], specPath, tempRoot)).rejects.toThrow(/spec/i);
   });
 
-  it('missing comment_responses field: throws', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '# Revised' }));
+  it('missing COMMENT_RESPONSES section: throws', async () => {
+    const revisionArtifactContent = makeRevisionArtifactRaw('SPEC:\n<<<\n# Revised\n>>>');
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -361,8 +366,10 @@ describe('SpecGenerator.revise — Notion comments', () => {
     await expect(sg.revise(makeFeedback(), [], specPath, tempRoot)).rejects.toThrow(/comment_responses/i);
   });
 
-  it('comment_responses is not an array: throws', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '# Revised', comment_responses: 'oops' }));
+  it('COMMENT_RESPONSES is not a JSON array: throws', async () => {
+    const revisionArtifactContent = makeRevisionArtifactRaw(
+      'SPEC:\n<<<\n# Revised\n>>>\n\nCOMMENT_RESPONSES:\n<<<\n"oops"\n>>>',
+    );
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -374,7 +381,7 @@ describe('SpecGenerator.revise — Notion comments', () => {
   });
 
   it('comment_responses entry missing comment_id: throws', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '# Revised', comment_responses: [{ response: 'done' }] }));
+    const revisionArtifactContent = makeRevisionArtifact('# Revised', [{ response: 'done' }]);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -386,7 +393,7 @@ describe('SpecGenerator.revise — Notion comments', () => {
   });
 
   it('comment_responses entry missing response: throws', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '# Revised', comment_responses: [{ comment_id: 'disc-1' }] }));
+    const revisionArtifactContent = makeRevisionArtifact('# Revised', [{ comment_id: 'disc-1' }]);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -397,8 +404,8 @@ describe('SpecGenerator.revise — Notion comments', () => {
     await expect(sg.revise(makeFeedback(), [], specPath, tempRoot)).rejects.toThrow(/response/i);
   });
 
-  it('extra unknown fields in JSON: tolerated', async () => {
-    const revisionArtifactContent = makeRevisionArtifact(JSON.stringify({ spec: '# Revised', comment_responses: [], extra_field: 'ignored' }));
+  it('extra fields in comment_responses entries: tolerated', async () => {
+    const revisionArtifactContent = makeRevisionArtifact('# Revised', [{ comment_id: 'x', response: 'y', extra_field: 'ignored' }]);
     const artifactPath = writeArtifactFile(revisionArtifactContent);
     const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
     const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
@@ -406,6 +413,133 @@ describe('SpecGenerator.revise — Notion comments', () => {
     const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
     writeFileSync(specPath, '# Original', 'utf-8');
 
-    await expect(sg.revise(makeFeedback(), [], specPath, tempRoot)).resolves.toEqual([]);
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot);
+    expect(result.comment_responses).toEqual([{ comment_id: 'x', response: 'y' }]);
+  });
+});
+
+describe('SpecGenerator.revise — span passthrough', () => {
+  it('uses page markdown as prompt source when current_page_markdown provided with spans', async () => {
+    const pageMarkdown = '# Spec\n\n<span discussion-urls="discussion://abc">commented text</span> here.';
+    const artifact = makeRevisionArtifact('# Revised\n\n<span discussion-urls="discussion://abc">commented text</span> here.');
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Spec\n\ncommented text here.', 'utf-8');
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, pageMarkdown);
+
+    const [, args] = execFn.mock.calls[0] as [string, string[]];
+    const prompt = args[args.length - 1];
+    // Prompt should contain the span-bearing page markdown, not the disk spec
+    expect(prompt).toContain('<span discussion-urls="discussion://abc">');
+    expect(prompt).toContain('discussion-urls');
+  });
+
+  it('adds span-preservation instructions when spans present', async () => {
+    const pageMarkdown = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
+    const artifact = makeRevisionArtifact('# Revised\n\n<span discussion-urls="discussion://abc">text</span>');
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Spec\n\ntext', 'utf-8');
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, pageMarkdown);
+
+    const [, args] = execFn.mock.calls[0] as [string, string[]];
+    const prompt = args[args.length - 1];
+    expect(prompt).toContain('CRITICAL');
+    expect(prompt).toContain('span');
+  });
+
+  it('returns page_content with spans preserved', async () => {
+    const pageMarkdown = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
+    const revisedWithSpan = '# Revised\n\n<span discussion-urls="discussion://abc">text</span>';
+    const artifact = makeRevisionArtifact(revisedWithSpan);
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Spec\n\ntext', 'utf-8');
+
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot, pageMarkdown);
+
+    expect(result.page_content).toContain('<span discussion-urls="discussion://abc">');
+  });
+
+  it('writes stripped (clean) spec to disk when spans present', async () => {
+    const pageMarkdown = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
+    const revisedWithSpan = '# Revised\n\n<span discussion-urls="discussion://abc">text</span>';
+    const artifact = makeRevisionArtifact(revisedWithSpan);
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Spec\n\ntext', 'utf-8');
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, pageMarkdown);
+
+    const diskContent = readFileSync(specPath, 'utf-8');
+    expect(diskContent).not.toContain('<span');
+    expect(diskContent).toContain('# Revised');
+    expect(diskContent).toContain('text');
+  });
+
+  it('appends orphaned spans when Claude drops them', async () => {
+    const pageMarkdown = '# Spec\n\n<span discussion-urls="discussion://abc">commented</span> text.';
+    // Claude's output drops the span entirely
+    const revisedNoSpan = '# Revised\n\ntext without the span.';
+    const artifact = makeRevisionArtifact(revisedNoSpan);
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Spec\n\ncommented text.', 'utf-8');
+
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot, pageMarkdown);
+
+    // page_content should have the orphaned comments section
+    expect(result.page_content).toContain('## Orphaned comments');
+    expect(result.page_content).toContain('<span discussion-urls="discussion://abc">commented</span>');
+    expect(result.page_content).toContain('[dropped by Claude]');
+  });
+
+  it('does not return page_content when no spans in input', async () => {
+    const pageMarkdown = '# Spec\n\nno spans here';
+    const artifact = makeRevisionArtifact('# Revised');
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Spec\n\nno spans here', 'utf-8');
+
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot, pageMarkdown);
+
+    expect(result.page_content).toBeUndefined();
+  });
+
+  it('falls back to disk spec when no current_page_markdown provided', async () => {
+    const artifact = makeRevisionArtifact('# Revised');
+    const artifactPath = writeArtifactFile(artifact);
+    const execFn = vi.fn().mockResolvedValue({ stdout: artifactPath + '\n', stderr: '' });
+    const sg = new OMCSpecGenerator({ execFn, logDestination: nullDest });
+
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    writeFileSync(specPath, '# Disk Spec Content', 'utf-8');
+
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot);
+
+    const [, args] = execFn.mock.calls[0] as [string, string[]];
+    const prompt = args[args.length - 1];
+    expect(prompt).toContain('# Disk Spec Content');
+    expect(result.page_content).toBeUndefined();
   });
 });

--- a/tests/adapters/notion/markdown-diff.test.ts
+++ b/tests/adapters/notion/markdown-diff.test.ts
@@ -1,0 +1,158 @@
+// tests/adapters/notion/markdown-diff.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  stripCommentSpans,
+  extractCommentSpans,
+  ensureSpansPreserved,
+} from '../../../src/adapters/notion/markdown-diff.js';
+
+// ─── stripCommentSpans ──────────────────────────────────────────────────
+
+describe('stripCommentSpans', () => {
+  it('returns unchanged text when no spans present', () => {
+    const input = '# Hello\n\nSome paragraph text.';
+    expect(stripCommentSpans(input)).toBe(input);
+  });
+
+  it('strips a single span, preserving inner text', () => {
+    const input = 'Before <span discussion-urls="discussion://abc123">commented text</span> after.';
+    expect(stripCommentSpans(input)).toBe('Before commented text after.');
+  });
+
+  it('strips multiple spans in the same line', () => {
+    const input = '<span discussion-urls="discussion://a">one</span> and <span discussion-urls="discussion://b">two</span>';
+    expect(stripCommentSpans(input)).toBe('one and two');
+  });
+
+  it('strips spans across multiple lines', () => {
+    const input = 'Line 1 <span discussion-urls="discussion://a">word</span>\nLine 2 <span discussion-urls="discussion://b">other</span>';
+    expect(stripCommentSpans(input)).toBe('Line 1 word\nLine 2 other');
+  });
+
+  it('handles span with extra attributes', () => {
+    const input = '<span discussion-urls="discussion://abc" data-other="x">text</span>';
+    expect(stripCommentSpans(input)).toBe('text');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripCommentSpans('')).toBe('');
+  });
+
+  it('preserves non-comment span tags', () => {
+    const input = '<span class="highlight">text</span>';
+    expect(stripCommentSpans(input)).toBe('<span class="highlight">text</span>');
+  });
+});
+
+// ─── extractCommentSpans ────────────────────────────────────────────────
+
+describe('extractCommentSpans', () => {
+  it('returns empty array when no spans present', () => {
+    expect(extractCommentSpans('# Hello\n\nParagraph text.')).toEqual([]);
+  });
+
+  it('extracts a single span with uuid and inner_text', () => {
+    const input = 'Before <span discussion-urls="discussion://abc-123">commented text</span> after.';
+    expect(extractCommentSpans(input)).toEqual([
+      { uuid: 'discussion://abc-123', inner_text: 'commented text' },
+    ]);
+  });
+
+  it('extracts multiple spans in document order', () => {
+    const input = '<span discussion-urls="discussion://a">first</span> then <span discussion-urls="discussion://b">second</span>';
+    expect(extractCommentSpans(input)).toEqual([
+      { uuid: 'discussion://a', inner_text: 'first' },
+      { uuid: 'discussion://b', inner_text: 'second' },
+    ]);
+  });
+
+  it('extracts span with extra attributes', () => {
+    const input = '<span data-other="x" discussion-urls="discussion://abc" class="y">text</span>';
+    expect(extractCommentSpans(input)).toEqual([
+      { uuid: 'discussion://abc', inner_text: 'text' },
+    ]);
+  });
+
+  it('handles empty inner text', () => {
+    const input = '<span discussion-urls="discussion://abc"></span>';
+    expect(extractCommentSpans(input)).toEqual([
+      { uuid: 'discussion://abc', inner_text: '' },
+    ]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(extractCommentSpans('')).toEqual([]);
+  });
+
+  it('ignores non-comment spans', () => {
+    const input = '<span class="highlight">text</span>';
+    expect(extractCommentSpans(input)).toEqual([]);
+  });
+});
+
+// ─── ensureSpansPreserved ───────────────────────────────────────────────
+
+describe('ensureSpansPreserved', () => {
+  it('returns content unchanged when all spans present', () => {
+    const content = '# Spec\n\n<span discussion-urls="discussion://abc">text</span> here.';
+    const spans = [{ uuid: 'discussion://abc', inner_text: 'text' }];
+    expect(ensureSpansPreserved(content, spans)).toBe(content);
+  });
+
+  it('returns content unchanged when originalSpans is empty', () => {
+    const content = '# Spec\n\nNo spans here.';
+    expect(ensureSpansPreserved(content, [])).toBe(content);
+  });
+
+  it('appends missing span to new Orphaned comments section', () => {
+    const content = '# Spec\n\nRevised content.';
+    const spans = [{ uuid: 'discussion://abc-123', inner_text: 'original text' }];
+    const result = ensureSpansPreserved(content, spans);
+    expect(result).toContain('## Orphaned comments');
+    expect(result).toContain('<span discussion-urls="discussion://abc-123">original text</span>');
+    expect(result).toContain('[dropped by Claude]');
+  });
+
+  it('appends multiple missing spans', () => {
+    const content = '# Spec\n\nRevised.';
+    const spans = [
+      { uuid: 'discussion://a', inner_text: 'first' },
+      { uuid: 'discussion://b', inner_text: 'second' },
+    ];
+    const result = ensureSpansPreserved(content, spans);
+    expect(result).toContain('<span discussion-urls="discussion://a">first</span> [dropped by Claude]');
+    expect(result).toContain('<span discussion-urls="discussion://b">second</span> [dropped by Claude]');
+  });
+
+  it('appends to existing Orphaned comments section', () => {
+    const content = [
+      '# Spec',
+      '',
+      'Revised.',
+      '',
+      '## Orphaned comments',
+      '',
+      '- <span discussion-urls="discussion://existing">old orphan</span>',
+    ].join('\n');
+    const spans = [{ uuid: 'discussion://new', inner_text: 'new orphan' }];
+    const result = ensureSpansPreserved(content, spans);
+    // Existing orphan should still be there
+    expect(result).toContain('discussion://existing');
+    // New orphan appended
+    expect(result).toContain('<span discussion-urls="discussion://new">new orphan</span> [dropped by Claude]');
+  });
+
+  it('only appends missing spans — preserves already-present ones', () => {
+    const content = '# Spec\n\n<span discussion-urls="discussion://kept">kept</span> here.';
+    const spans = [
+      { uuid: 'discussion://kept', inner_text: 'kept' },
+      { uuid: 'discussion://dropped', inner_text: 'dropped' },
+    ];
+    const result = ensureSpansPreserved(content, spans);
+    expect(result).toContain('## Orphaned comments');
+    expect(result).toContain('discussion://dropped');
+    // The "kept" span should NOT be in the orphaned section
+    const orphanedSection = result.slice(result.indexOf('## Orphaned comments'));
+    expect(orphanedSection).not.toContain('discussion://kept');
+  });
+});

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -5,14 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { App } from '@slack/bolt';
 import type { NotionClient } from '../../../src/adapters/notion/notion-client.js';
-
-// Mock @tryfabric/martian before importing NotionPublisher
-vi.mock('@tryfabric/martian', () => ({
-  markdownToBlocks: vi.fn().mockReturnValue([{ type: 'paragraph', paragraph: { rich_text: [{ type: 'text', text: { content: 'mocked' } }] } }]),
-}));
-
 import { NotionPublisher } from '../../../src/adapters/notion/notion-publisher.js';
-import { markdownToBlocks } from '@tryfabric/martian';
 
 const nullDest = { write: () => {} };
 
@@ -37,13 +30,13 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
   return {
     pages: {
       create: vi.fn().mockResolvedValue({ id: pageId }),
+      getMarkdown: vi.fn().mockResolvedValue(''),
+      updateMarkdown: vi.fn().mockResolvedValue(undefined),
     },
     blocks: {
       children: {
-        list: vi.fn().mockResolvedValue({ results: [{ id: 'block-1' }, { id: 'block-2' }] }),
-        append: vi.fn().mockResolvedValue({}),
+        list: vi.fn().mockResolvedValue({ results: [], has_more: false }),
       },
-      delete: vi.fn().mockResolvedValue({}),
     },
     comments: {
       list: vi.fn().mockResolvedValue({ results: [] }),
@@ -64,7 +57,7 @@ function makeMockApp() {
 }
 
 describe('NotionPublisher.create', () => {
-  it('calls pages.create with correct parent_page_id', async () => {
+  it('calls pages.create with correct parent_page_id and title only (no children)', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
@@ -75,6 +68,9 @@ describe('NotionPublisher.create', () => {
     expect(client.pages.create).toHaveBeenCalledWith(
       expect.objectContaining({ parent: { page_id: 'parent-page-xyz' } }),
     );
+    // No children in pages.create — content set via markdown API
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.children).toBeUndefined();
   });
 
   it('derives title from filename slug — feature-setup-wizard.md → "Setup wizard"', async () => {
@@ -115,17 +111,27 @@ describe('NotionPublisher.create', () => {
     );
   });
 
-  it('passes markdownToBlocks output as children', async () => {
+  it('calls pages.updateMarkdown with replace_content after pages.create', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
     const specPath = makeSpecFile('# My Spec\n\ncontent');
 
+    const callOrder: string[] = [];
+    (client.pages.create as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      callOrder.push('pages.create');
+      return { id: 'page-abc123' };
+    });
+    (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      callOrder.push('pages.updateMarkdown');
+    });
+
     await publisher.create('C123', '100.0', specPath);
 
-    expect(markdownToBlocks).toHaveBeenCalledWith(expect.stringContaining('My Spec'));
-    expect(client.pages.create).toHaveBeenCalledWith(
-      expect.objectContaining({ children: expect.any(Array) }),
+    expect(callOrder).toEqual(['pages.create', 'pages.updateMarkdown']);
+    expect(client.pages.updateMarkdown).toHaveBeenCalledWith(
+      'page-abc123',
+      { type: 'replace_content', replace_content: { new_str: '# My Spec\n\ncontent' } },
     );
   });
 
@@ -140,6 +146,9 @@ describe('NotionPublisher.create', () => {
       callOrder.push('pages.create');
       return { id: 'page-abc-123-xyz' };
     });
+    (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      callOrder.push('pages.updateMarkdown');
+    });
     (app.client.chat.postMessage as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
       callOrder.push('postMessage');
       return {};
@@ -147,7 +156,7 @@ describe('NotionPublisher.create', () => {
 
     await publisher.create('C123', '100.0', specPath);
 
-    expect(callOrder).toEqual(['pages.create', 'postMessage']);
+    expect(callOrder).toEqual(['pages.create', 'pages.updateMarkdown', 'postMessage']);
     expect(app.client.chat.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: 'C123',
@@ -167,17 +176,28 @@ describe('NotionPublisher.create', () => {
     expect(result).toBe('returned-page-id');
   });
 
-  it('throws if pages.create rejects; postMessage never called', async () => {
+  it('throws if pages.create rejects; updateMarkdown and postMessage never called', async () => {
     const client = makeMockNotionClient();
     (client.pages.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('API error'));
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
 
     await expect(publisher.create('C123', '100.0', makeSpecFile())).rejects.toThrow('API error');
+    expect(client.pages.updateMarkdown).not.toHaveBeenCalled();
     expect(app.client.chat.postMessage).not.toHaveBeenCalled();
   });
 
-  it('throws if postMessage rejects after successful pages.create', async () => {
+  it('throws if pages.updateMarkdown rejects; postMessage never called', async () => {
+    const client = makeMockNotionClient();
+    (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Markdown error'));
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+
+    await expect(publisher.create('C123', '100.0', makeSpecFile())).rejects.toThrow('Markdown error');
+    expect(app.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('throws if postMessage rejects after successful create and updateMarkdown', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
     (app.client.chat.postMessage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Slack error'));
@@ -188,73 +208,50 @@ describe('NotionPublisher.create', () => {
 });
 
 describe('NotionPublisher.update', () => {
-  it('fetches existing blocks, deletes each in order, then appends new blocks', async () => {
+  it('reads spec from disk and calls replace_content when no page_content provided', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
-    const specPath = makeSpecFile('# Updated');
 
-    const callOrder: string[] = [];
-    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
-      callOrder.push('list');
-      return { results: [{ id: 'block-1' }, { id: 'block-2' }] };
-    });
-    (client.blocks.delete as ReturnType<typeof vi.fn>).mockImplementation(async ({ block_id }: { block_id: string }) => {
-      callOrder.push(`delete:${block_id}`);
-      return {};
-    });
-    (client.blocks.children.append as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
-      callOrder.push('append');
-      return {};
-    });
+    await publisher.update('page-xyz', makeSpecFile('# My Spec\n\ncontent'));
 
-    await publisher.update('page-xyz', specPath);
-
-    expect(callOrder).toEqual(['list', 'delete:block-1', 'delete:block-2', 'append']);
+    expect(client.pages.updateMarkdown).toHaveBeenCalledWith(
+      'page-xyz',
+      { type: 'replace_content', replace_content: { new_str: '# My Spec\n\ncontent' } },
+    );
   });
 
-  it('handles empty page: no deletes, append proceeds', async () => {
+  it('uses page_content directly when provided (span-bearing)', async () => {
     const client = makeMockNotionClient();
-    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: [] });
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
 
-    await publisher.update('page-xyz', makeSpecFile());
+    const spanContent = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
+    await publisher.update('page-xyz', makeSpecFile('# Spec\n\ntext'), spanContent);
 
-    expect(client.blocks.delete).not.toHaveBeenCalled();
-    expect(client.blocks.children.append).toHaveBeenCalled();
+    expect(client.pages.updateMarkdown).toHaveBeenCalledWith(
+      'page-xyz',
+      { type: 'replace_content', replace_content: { new_str: spanContent } },
+    );
   });
 
-  it('throws if blocks.children.list rejects; no deletes or appends', async () => {
+  it('does not call getMarkdown (no diff needed)', async () => {
     const client = makeMockNotionClient();
-    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('list error'));
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
 
-    await expect(publisher.update('page-xyz', makeSpecFile())).rejects.toThrow('list error');
-    expect(client.blocks.delete).not.toHaveBeenCalled();
-    expect(client.blocks.children.append).not.toHaveBeenCalled();
+    await publisher.update('page-xyz', makeSpecFile('# Spec'));
+
+    expect(client.pages.getMarkdown).not.toHaveBeenCalled();
   });
 
-  it('throws if blocks.delete rejects; append not called', async () => {
+  it('throws if pages.updateMarkdown rejects', async () => {
     const client = makeMockNotionClient();
-    (client.blocks.delete as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({})
-      .mockRejectedValueOnce(new Error('delete error'));
+    (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('patch error'));
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
 
-    await expect(publisher.update('page-xyz', makeSpecFile())).rejects.toThrow('delete error');
-    expect(client.blocks.children.append).not.toHaveBeenCalled();
-  });
-
-  it('throws if blocks.children.append rejects', async () => {
-    const client = makeMockNotionClient();
-    (client.blocks.children.append as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('append error'));
-    const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
-
-    await expect(publisher.update('page-xyz', makeSpecFile())).rejects.toThrow('append error');
+    await expect(publisher.update('page-xyz', makeSpecFile('# New'))).rejects.toThrow('patch error');
   });
 
   it('never calls postMessage during update', async () => {
@@ -262,21 +259,45 @@ describe('NotionPublisher.update', () => {
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
 
-    await publisher.update('page-xyz', makeSpecFile());
+    await publisher.update('page-xyz', makeSpecFile('# New'));
 
     expect(app.client.chat.postMessage).not.toHaveBeenCalled();
   });
+});
 
-  it('throws if blocks.children.list returns has_more: true', async () => {
+describe('NotionPublisher.getPageMarkdown', () => {
+  it('returns page markdown from client', async () => {
     const client = makeMockNotionClient();
-    (client.blocks.children.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      results: [{ id: 'block-1' }],
-      has_more: true,
-    });
     const app = makeMockApp();
     const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
 
-    await expect(publisher.update('page-xyz', makeSpecFile())).rejects.toThrow(/pagination not yet supported/i);
-    expect(client.blocks.delete).not.toHaveBeenCalled();
+    const markdown = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
+    (client.pages.getMarkdown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(markdown);
+
+    const result = await publisher.getPageMarkdown('page-xyz');
+
+    expect(client.pages.getMarkdown).toHaveBeenCalledWith('page-xyz');
+    expect(result).toBe(markdown);
+  });
+
+  it('returns empty string when page has no content', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+
+    (client.pages.getMarkdown as ReturnType<typeof vi.fn>).mockResolvedValueOnce('');
+
+    const result = await publisher.getPageMarkdown('page-xyz');
+
+    expect(result).toBe('');
+  });
+
+  it('throws if client rejects', async () => {
+    const client = makeMockNotionClient();
+    (client.pages.getMarkdown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('API error'));
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+
+    await expect(publisher.getPageMarkdown('page-xyz')).rejects.toThrow('API error');
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -50,7 +50,7 @@ function makeWorkspaceManager(overrides: Partial<WorkspaceManager> = {}): Worksp
 function makeSpecGenerator(overrides: Partial<SpecGenerator> = {}): SpecGenerator {
   return {
     create: vi.fn().mockResolvedValue('/ws/idea-001/context-human/specs/feature-test.md'),
-    revise: vi.fn().mockResolvedValue([]),
+    revise: vi.fn().mockResolvedValue({ comment_responses: [] }),
     ...overrides,
   };
 }
@@ -68,6 +68,7 @@ function makeSpecPublisher(overrides: Partial<SpecPublisher> = {}): SpecPublishe
   return {
     create: vi.fn().mockResolvedValue('CANVAS001'),
     update: vi.fn().mockResolvedValue(undefined),
+    getPageMarkdown: vi.fn().mockResolvedValue(''),
     ...overrides,
   };
 }
@@ -234,13 +235,15 @@ describe('Orchestrator — spec_feedback happy path', () => {
     expect(run.stage).toBe('review');
     expect(run.attempt).toBe(1);
 
+    expect(cp.getPageMarkdown).toHaveBeenCalledWith('CANVAS001');
     expect(sg.revise).toHaveBeenCalledWith(
       expect.objectContaining({ idea_id: 'idea-001' }),
       [],
       '/ws/idea-001/context-human/specs/feature-test.md',
       '/ws/idea-001',
+      undefined,
     );
-    expect(cp.update).toHaveBeenCalledWith('CANVAS001', '/ws/idea-001/context-human/specs/feature-test.md');
+    expect(cp.update).toHaveBeenCalledWith('CANVAS001', '/ws/idea-001/context-human/specs/feature-test.md', undefined);
   });
 });
 
@@ -381,7 +384,7 @@ describe('Orchestrator — concurrency', () => {
       create: vi.fn().mockImplementation(async (_idea: Idea, workspace_path: string) =>
         `${workspace_path}/context-human/specs/feature-test.md`
       ),
-      revise: vi.fn().mockResolvedValue([]),
+      revise: vi.fn().mockResolvedValue({ comment_responses: [] }),
     };
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
@@ -428,14 +431,15 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
       { comment_id: 'disc-2', response: 'Updated per Enzo' },
     ];
     const fs = makeFeedbackSource({ fetch: vi.fn().mockResolvedValue(notionComments) });
-    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue(commentResponses) });
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: commentResponses }) });
     const sp = makeSpecPublisher();
     const adapter = makeMockAdapter();
     const postError = vi.fn().mockResolvedValue(undefined);
 
     const callOrder: string[] = [];
+    (sp.getPageMarkdown as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('getPageMarkdown'); return ''; });
     (fs.fetch as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('fetch'); return notionComments; });
-    (sg.revise as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('revise'); return commentResponses; });
+    (sg.revise as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('revise'); return { comment_responses: commentResponses }; });
     (sp.update as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('update'); });
     (fs.reply as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('reply'); });
     (fs.resolve as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('resolve'); });
@@ -450,13 +454,15 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
     expect(runs.get('idea-001')?.stage).toBe('review');
-    expect(callOrder).toEqual(['fetch', 'revise', 'update', 'reply', 'reply', 'resolve']);
-    expect(fs.fetch).toHaveBeenCalledWith('CANVAS001'); // publisher_ref from sp.create mock
+    expect(callOrder).toEqual(['fetch', 'getPageMarkdown', 'revise', 'update', 'reply', 'reply', 'resolve']);
+    expect(sp.getPageMarkdown).toHaveBeenCalledWith('CANVAS001');
+    expect(fs.fetch).toHaveBeenCalledWith('CANVAS001');
     expect(sg.revise).toHaveBeenCalledWith(
       expect.objectContaining({ idea_id: 'idea-001' }),
       notionComments,
       expect.any(String),
       expect.any(String),
+      undefined,
     );
     expect(fs.reply).toHaveBeenCalledTimes(2);
     expect(fs.reply).toHaveBeenCalledWith('CANVAS001', 'disc-1', 'Updated per Phoebe');
@@ -466,7 +472,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
 
   it('empty fetch: revise called with []; no reply or resolve', async () => {
     const fs = makeFeedbackSource({ fetch: vi.fn().mockResolvedValue([]) });
-    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue([]) });
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
     const adapter = makeMockAdapter();
 
     const orch = new OrchestratorImpl(
@@ -482,13 +488,14 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
       [],
       expect.any(String),
       expect.any(String),
+      undefined,
     );
     expect(fs.reply).not.toHaveBeenCalled();
     expect(fs.resolve).not.toHaveBeenCalled();
   });
 
   it('no feedbackSource: revise called with []; no fetch/reply/resolve', async () => {
-    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue([]) });
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
     const adapter = makeMockAdapter();
 
     const orch = new OrchestratorImpl(
@@ -504,6 +511,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
       [],
       expect.any(String),
       expect.any(String),
+      undefined,
     );
   });
 
@@ -542,7 +550,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
         .mockRejectedValueOnce(new Error('reply error'))
         .mockResolvedValueOnce(undefined),
     });
-    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue(commentResponses) });
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: commentResponses }) });
     const adapter = makeMockAdapter();
     const postError = vi.fn().mockResolvedValue(undefined);
 
@@ -566,7 +574,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
       fetch: vi.fn().mockResolvedValue([{ id: 'd1', body: 'feedback' }]),
       resolve: vi.fn().mockRejectedValue(new Error('resolve error')),
     });
-    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue([{ comment_id: 'd1', response: 'r1' }]) });
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [{ comment_id: 'd1', response: 'r1' }] }) });
     const adapter = makeMockAdapter();
     const postError = vi.fn().mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary
- Replaces delete-all-recreate Notion update strategy with span passthrough — inline comment anchors (`<span discussion-urls="...">`) survive revisions
- Fetches page markdown with spans, passes through Claude with preservation instructions, post-processes dropped spans into an "Orphaned comments" section, then `replace_content` with span-bearing output
- Writes clean (span-stripped) spec to disk for git; removes dead LCS diff code and `@tryfabric/martian` dependency

## Test plan
- [ ] 236 unit tests passing (all phases TDD)
- [ ] Live: seed an idea, confirm Notion page created with formatted content
- [ ] Live: leave inline comment on spec, trigger revision, confirm comment anchor preserved on unchanged text
- [ ] Live: leave inline comment, trigger revision that changes the commented text, confirm span is moved or orphaned (not silently lost)

Closes #13
Closes #14
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)