### PR TITLE
feat: feedback loop improvements (#10, #18, #19, #20)

### DIFF
--- a/src/adapters/agent/spec-generator.ts
+++ b/src/adapters/agent/spec-generator.ts
@@ -141,8 +141,7 @@ export class OMCSpecGenerator implements SpecGenerator {
 
   async create(idea: Idea, workspace_path: string): Promise<string> {
     const prompt = [
-      `Using mm:planning conventions, generate a SHORT product spec for the following idea.`,
-      `Only include these sections: What, Why, Personas, and Narratives. No tech spec, no task list.`,
+      `Using mm:planning conventions, generate a complete product spec for the following idea.`,
       ``,
       `On the very first line of your response, write: FILENAME: <feature-or-enhancement-slug>.md`,
       `Then write the spec as a Markdown document with YAML frontmatter.`,

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -12,8 +12,7 @@ import type {
 } from '@notionhq/client/build/src/api-endpoints.js';
 
 export type MarkdownOperation =
-  | { type: 'replace_content'; replace_content: { new_str: string } }
-  | { type: 'update_content'; update_content: { content_updates: Array<{ old_str: string; new_str: string }> } };
+  { type: 'replace_content'; replace_content: { new_str: string } };
 
 export interface NotionClient {
   pages: {
@@ -29,7 +28,6 @@ export interface NotionClient {
   comments: {
     list(args: ListCommentsParameters): Promise<ListCommentsResponse>;
     create(args: CreateCommentParameters): Promise<CreateCommentResponse>;
-    update(comment_id: string): Promise<void>; // best-effort resolve; may 404/405
   };
 }
 
@@ -79,15 +77,5 @@ export class NotionClientImpl implements NotionClient {
       this.client.comments.list(args),
     create: (args: CreateCommentParameters): Promise<CreateCommentResponse> =>
       this.client.comments.create(args),
-    update: async (comment_id: string): Promise<void> => {
-      // PATCH /v1/comments/:id — best-effort; Notion API may not support this
-      await (this.client as unknown as {
-        request: (args: { path: string; method: string; body: unknown }) => Promise<unknown>;
-      }).request({
-        path: `comments/${comment_id}`,
-        method: 'PATCH',
-        body: { resolved: true },
-      });
-    },
   };
 }

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -29,6 +29,9 @@ export interface NotionClient {
     list(args: ListCommentsParameters): Promise<ListCommentsResponse>;
     create(args: CreateCommentParameters): Promise<CreateCommentResponse>;
   };
+  users: {
+    me(): Promise<{ id: string }>;
+  };
 }
 
 export class NotionClientImpl implements NotionClient {
@@ -77,5 +80,18 @@ export class NotionClientImpl implements NotionClient {
       this.client.comments.list(args),
     create: (args: CreateCommentParameters): Promise<CreateCommentResponse> =>
       this.client.comments.create(args),
+  };
+
+  readonly users = {
+    me: async (): Promise<{ id: string }> => {
+      const response = await (this.client as unknown as {
+        request: (args: { path: string; method: string }) => Promise<unknown>;
+      }).request({
+        path: 'users/me',
+        method: 'GET',
+      });
+      // Top-level `id` is the bot's own user ID — matches `created_by.id` on comments
+      return { id: (response as { id: string }).id };
+    },
   };
 }

--- a/src/adapters/notion/notion-feedback-source.ts
+++ b/src/adapters/notion/notion-feedback-source.ts
@@ -7,7 +7,6 @@ import type { NotionComment } from '../agent/spec-generator.js';
 export interface FeedbackSource {
   fetch(publisher_ref: string): Promise<NotionComment[]>;
   reply(publisher_ref: string, comment_id: string, response: string): Promise<void>;
-  resolve(publisher_ref: string, comment_ids: string[]): Promise<void>;
 }
 
 interface NotionFeedbackSourceOptions {
@@ -95,19 +94,4 @@ export class NotionFeedbackSource implements FeedbackSource {
     this.logger.debug({ event: 'notion_comment.replied', publisher_ref, comment_id }, 'Replied to Notion comment');
   }
 
-  async resolve(publisher_ref: string, comment_ids: string[]): Promise<void> {
-    for (const comment_id of comment_ids) {
-      try {
-        await this.client.comments.update(comment_id);
-        this.logger.debug({ event: 'notion_comments.resolved', publisher_ref, comment_id }, 'Resolved Notion comment');
-      } catch (err: unknown) {
-        const status = (err as { status?: number }).status;
-        if (status === 404 || status === 405) {
-          this.logger.warn({ event: 'notion_comments.resolve_skipped', publisher_ref, comment_id, status }, 'Notion comment resolve not supported; skipping');
-        } else {
-          throw err;
-        }
-      }
-    }
-  }
 }

--- a/src/adapters/notion/notion-feedback-source.ts
+++ b/src/adapters/notion/notion-feedback-source.ts
@@ -10,6 +10,7 @@ export interface FeedbackSource {
 }
 
 interface NotionFeedbackSourceOptions {
+  bot_user_id?: string;
   logDestination?: pino.DestinationStream;
 }
 
@@ -23,10 +24,12 @@ interface NotionCommentRecord {
 
 export class NotionFeedbackSource implements FeedbackSource {
   private readonly client: NotionClient;
+  private readonly bot_user_id?: string;
   private readonly logger: pino.Logger;
 
   constructor(client: NotionClient, options?: NotionFeedbackSourceOptions) {
     this.client = client;
+    this.bot_user_id = options?.bot_user_id;
     this.logger = createLogger('notion-feedback-source', { destination: options?.logDestination });
   }
 
@@ -69,6 +72,18 @@ export class NotionFeedbackSource implements FeedbackSource {
       threadMap.set(comment.discussion_id, existing);
     }
 
+    // Filter out threads where the last comment is from the bot
+    let botSkippedCount = 0;
+    if (this.bot_user_id) {
+      for (const [discussion_id, threadComments] of threadMap) {
+        const lastComment = threadComments[threadComments.length - 1];
+        if (lastComment.created_by.id === this.bot_user_id) {
+          threadMap.delete(discussion_id);
+          botSkippedCount++;
+        }
+      }
+    }
+
     const result: NotionComment[] = [];
     for (const [discussion_id, threadComments] of threadMap) {
       const body = threadComments
@@ -81,7 +96,7 @@ export class NotionFeedbackSource implements FeedbackSource {
       result.push({ id: discussion_id, body });
     }
 
-    this.logger.debug({ event: 'notion_comments.fetched', publisher_ref, comment_count: result.length }, 'Fetched Notion comments');
+    this.logger.debug({ event: 'notion_comments.fetched', publisher_ref, comment_count: result.length, bot_skipped_count: botSkippedCount }, 'Fetched Notion comments');
     return result;
   }
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -23,6 +23,7 @@ interface OrchestratorDeps {
   specPublisher: SpecPublisher;
   feedbackSource?: FeedbackSource;
   postError: (channel_id: string, thread_ts: string, text: string) => Promise<void>;
+  postMessage: (channel_id: string, thread_ts: string, text: string) => Promise<void>;
   repo_url: string;
 }
 
@@ -220,6 +221,18 @@ export class OrchestratorImpl implements Orchestrator {
           this.logger.error({ event: 'run.reply_failed', run_id: run.id, comment_id: cr.comment_id, error: String(err) }, 'Failed to reply to Notion comment');
         }
       }
+    }
+
+    // Step 5: Notify user that comment processing is complete
+    const count = commentResponses?.length ?? 0;
+    const noun = count === 1 ? 'comment' : 'comments';
+    const summary = count > 0
+      ? `Done \u2014 responded to ${count} ${noun}. The spec is ready for another look.`
+      : `Done \u2014 the spec has been updated. Ready for another look.`;
+    try {
+      await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, summary);
+    } catch (err) {
+      this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post completion notification');
     }
 
     this.transition(run, 'review');

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -220,11 +220,6 @@ export class OrchestratorImpl implements Orchestrator {
           this.logger.error({ event: 'run.reply_failed', run_id: run.id, comment_id: cr.comment_id, error: String(err) }, 'Failed to reply to Notion comment');
         }
       }
-      try {
-        await this.deps.feedbackSource.resolve(run.publisher_ref, commentResponses.map(r => r.comment_id));
-      } catch (err) {
-        this.logger.error({ event: 'run.resolve_failed', run_id: run.id, error: String(err) }, 'Failed to resolve Notion comments');
-      }
     }
 
     this.transition(run, 'review');

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,9 @@ try {
     postError: async (channel_id, thread_ts, text) => {
       await boltApp.client.chat.postMessage({ channel: channel_id, thread_ts, text });
     },
+    postMessage: async (channel_id, thread_ts, text) => {
+      await boltApp.client.chat.postMessage({ channel: channel_id, thread_ts, text });
+    },
     repo_url,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,16 @@ try {
       process.exit(1);
     }
     const notionClient = new NotionClientImpl({ integration_token: notionToken });
+    let botUser: { id: string };
+    try {
+      botUser = await notionClient.users.me();
+    } catch (err) {
+      logger.error({ event: 'notion.auth_failed', error: String(err) }, 'Failed to detect Notion bot user. Check AC_NOTION_INTEGRATION_TOKEN permissions.');
+      process.exit(1);
+    }
+    logger.info({ event: 'service.config', bot_user_id: botUser.id }, 'Detected Notion bot user ID');
     specPublisher = new NotionPublisher(notionClient, boltApp, parentPageId);
-    feedbackSource = new NotionFeedbackSource(notionClient);
+    feedbackSource = new NotionFeedbackSource(notionClient, { bot_user_id: botUser.id });
     logger.info({ event: 'service.config', publisher: 'notion' }, 'Using Notion publisher');
   } else {
     specPublisher = new SlackCanvasPublisher(boltApp);

--- a/tests/adapters/notion/notion-client.test.ts
+++ b/tests/adapters/notion/notion-client.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import type { NotionClient } from '../../../src/adapters/notion/notion-client.js';
+
+describe('NotionClient interface', () => {
+  it('users.me is defined on the interface', () => {
+    // Type-level check: this test verifies the interface shape compiles
+    const client: NotionClient = {
+      pages: { create: async () => ({}) as never, getMarkdown: async () => '', updateMarkdown: async () => {} },
+      blocks: { children: { list: async () => ({}) as never } },
+      comments: { list: async () => ({}) as never, create: async () => ({}) as never },
+      users: { me: async () => ({ id: 'test' }) },
+    };
+    expect(typeof client.users.me).toBe('function');
+  });
+});

--- a/tests/adapters/notion/notion-feedback-source.test.ts
+++ b/tests/adapters/notion/notion-feedback-source.test.ts
@@ -17,6 +17,7 @@ function makeMockClient(): NotionClient {
       list: vi.fn(),
       create: vi.fn().mockResolvedValue({}),
     },
+    users: { me: vi.fn() },
   };
 }
 
@@ -244,6 +245,71 @@ describe('NotionFeedbackSource.reply', () => {
     const source = new NotionFeedbackSource(client, { logDestination: nullDest });
 
     await expect(source.reply('page-abc', 'disc-123', 'response')).rejects.toThrow('create error');
+  });
+});
+
+describe('NotionFeedbackSource.fetch — bot thread filtering', () => {
+  it('skips thread where last comment is from the bot', async () => {
+    const client = makeMockClient();
+    (client.comments.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [
+        makeComment({ discussion_id: 'disc-1', created_by: { id: 'user-1', name: 'Phoebe' } }),
+        makeComment({ id: 'comment-2', discussion_id: 'disc-1', created_by: { id: 'bot-user-1', name: 'Autocatalyst' } }),
+      ],
+    });
+    const source = new NotionFeedbackSource(client, { bot_user_id: 'bot-user-1', logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toEqual([]);
+  });
+
+  it('includes thread where last comment is from a human', async () => {
+    const client = makeMockClient();
+    (client.comments.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [
+        makeComment({ discussion_id: 'disc-1', created_by: { id: 'bot-user-1', name: 'Autocatalyst' } }),
+        makeComment({ id: 'comment-2', discussion_id: 'disc-1', created_by: { id: 'user-1', name: 'Phoebe' } }),
+      ],
+    });
+    const source = new NotionFeedbackSource(client, { bot_user_id: 'bot-user-1', logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('disc-1');
+  });
+
+  it('includes thread when no bot_user_id configured', async () => {
+    const client = makeMockClient();
+    (client.comments.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [
+        makeComment({ discussion_id: 'disc-1', created_by: { id: 'bot-user-1', name: 'Autocatalyst' } }),
+      ],
+    });
+    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
+
+    const result = await source.fetch('page-abc');
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('logs skipped thread count', async () => {
+    const client = makeMockClient();
+    (client.comments.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [
+        makeComment({ discussion_id: 'disc-1', created_by: { id: 'bot-user-1', name: 'Autocatalyst' } }),
+      ],
+    });
+    const logLines: unknown[] = [];
+    const dest = { write: (line: string) => logLines.push(JSON.parse(line)) };
+    const source = new NotionFeedbackSource(client, { bot_user_id: 'bot-user-1', logDestination: dest });
+
+    await source.fetch('page-abc');
+
+    const fetchLog = logLines.find((l: unknown) => (l as { event?: string }).event === 'notion_comments.fetched');
+    expect(fetchLog).toBeDefined();
+    expect((fetchLog as { bot_skipped_count?: number }).bot_skipped_count).toBe(1);
   });
 });
 

--- a/tests/adapters/notion/notion-feedback-source.test.ts
+++ b/tests/adapters/notion/notion-feedback-source.test.ts
@@ -11,14 +11,11 @@ function makeMockClient(): NotionClient {
     blocks: {
       children: {
         list: vi.fn().mockResolvedValue({ results: [], has_more: false }),
-        append: vi.fn(),
       },
-      delete: vi.fn(),
     },
     comments: {
       list: vi.fn(),
       create: vi.fn().mockResolvedValue({}),
-      update: vi.fn().mockResolvedValue(undefined),
     },
   };
 }
@@ -250,57 +247,3 @@ describe('NotionFeedbackSource.reply', () => {
   });
 });
 
-describe('NotionFeedbackSource.resolve', () => {
-  it('calls comments.update once per ID', async () => {
-    const client = makeMockClient();
-    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
-
-    await source.resolve('page-abc', ['disc-1', 'disc-2', 'disc-3']);
-
-    expect(client.comments.update).toHaveBeenCalledTimes(3);
-    expect(client.comments.update).toHaveBeenCalledWith('disc-1');
-    expect(client.comments.update).toHaveBeenCalledWith('disc-2');
-    expect(client.comments.update).toHaveBeenCalledWith('disc-3');
-  });
-
-  it('empty array: no API calls made', async () => {
-    const client = makeMockClient();
-    const source = new NotionFeedbackSource(client, { logDestination: nullDest });
-
-    await source.resolve('page-abc', []);
-
-    expect(client.comments.update).not.toHaveBeenCalled();
-  });
-
-  it('404 on one ID: logs notion_comments.resolve_skipped, does not throw, continues processing remaining IDs', async () => {
-    const client = makeMockClient();
-    (client.comments.update as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce(undefined)        // disc-1 succeeds
-      .mockRejectedValueOnce(Object.assign(new Error('not found'), { status: 404 }))  // disc-2 fails
-      .mockResolvedValueOnce(undefined);        // disc-3 succeeds
-    const logLines: unknown[] = [];
-    const dest = { write: (line: string) => logLines.push(JSON.parse(line)) };
-    const source = new NotionFeedbackSource(client, { logDestination: dest });
-
-    await expect(source.resolve('page-abc', ['disc-1', 'disc-2', 'disc-3'])).resolves.toBeUndefined();
-
-    expect(client.comments.update).toHaveBeenCalledTimes(3);
-    const warnLog = logLines.find((l: unknown) => (l as { event?: string }).event === 'notion_comments.resolve_skipped');
-    expect(warnLog).toBeDefined();
-    expect((warnLog as { comment_id?: string }).comment_id).toBe('disc-2');
-  });
-
-  it('405 on one ID: same warn-and-continue behavior', async () => {
-    const client = makeMockClient();
-    (client.comments.update as ReturnType<typeof vi.fn>)
-      .mockRejectedValueOnce(Object.assign(new Error('method not allowed'), { status: 405 }));
-    const logLines: unknown[] = [];
-    const dest = { write: (line: string) => logLines.push(JSON.parse(line)) };
-    const source = new NotionFeedbackSource(client, { logDestination: dest });
-
-    await expect(source.resolve('page-abc', ['disc-1'])).resolves.toBeUndefined();
-
-    const warnLog = logLines.find((l: unknown) => (l as { event?: string }).event === 'notion_comments.resolve_skipped');
-    expect(warnLog).toBeDefined();
-  });
-});

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -41,7 +41,6 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
     comments: {
       list: vi.fn().mockResolvedValue({ results: [] }),
       create: vi.fn().mockResolvedValue({}),
-      update: vi.fn().mockResolvedValue(undefined),
     },
   };
 }

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -42,6 +42,7 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
       list: vi.fn().mockResolvedValue({ results: [] }),
       create: vi.fn().mockResolvedValue({}),
     },
+    users: { me: vi.fn() },
   };
 }
 

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -420,7 +420,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     await vi.waitUntil(() => runs.get('idea-001')?.stage !== 'speccing', { timeout: 2000 });
   }
 
-  it('with feedbackSource: fetch called before revise, revise receives notion_comments, update/reply/resolve called in order', async () => {
+  it('with feedbackSource: fetch called before revise, revise receives notion_comments, update/reply called in order', async () => {
     const notionComments: NotionComment[] = [
       { id: 'disc-1', body: 'Phoebe: first feedback' },
       { id: 'disc-2', body: 'Enzo: second feedback' },
@@ -467,7 +467,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     expect(fs.reply).toHaveBeenCalledWith('CANVAS001', 'disc-2', 'Updated per Enzo');
   });
 
-  it('empty fetch: revise called with []; no reply or resolve', async () => {
+  it('empty fetch: revise called with []; no reply', async () => {
     const fs = makeFeedbackSource({ fetch: vi.fn().mockResolvedValue([]) });
     const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
     const adapter = makeMockAdapter();
@@ -490,7 +490,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     expect(fs.reply).not.toHaveBeenCalled();
   });
 
-  it('no feedbackSource: revise called with []; no fetch/reply/resolve', async () => {
+  it('no feedbackSource: revise called with []; no fetch/reply', async () => {
     const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
     const adapter = makeMockAdapter();
 
@@ -533,7 +533,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     expect(postError).toHaveBeenCalled();
   });
 
-  it('reply fails on one of three: run stays in review; resolve still called; postError not called', async () => {
+  it('reply fails on one of three: run stays in review; postError not called', async () => {
     const commentResponses: NotionCommentResponse[] = [
       { comment_id: 'd1', response: 'r1' },
       { comment_id: 'd2', response: 'r2' },

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -59,7 +59,6 @@ function makeFeedbackSource(overrides: Partial<FeedbackSource> = {}): FeedbackSo
   return {
     fetch: vi.fn().mockResolvedValue([]),
     reply: vi.fn().mockResolvedValue(undefined),
-    resolve: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -442,7 +441,6 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     (sg.revise as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('revise'); return { comment_responses: commentResponses }; });
     (sp.update as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('update'); });
     (fs.reply as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('reply'); });
-    (fs.resolve as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('resolve'); });
 
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, repo_url: 'https://github.com/org/repo' } as never,
@@ -454,7 +452,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
     expect(runs.get('idea-001')?.stage).toBe('review');
-    expect(callOrder).toEqual(['fetch', 'getPageMarkdown', 'revise', 'update', 'reply', 'reply', 'resolve']);
+    expect(callOrder).toEqual(['fetch', 'getPageMarkdown', 'revise', 'update', 'reply', 'reply']);
     expect(sp.getPageMarkdown).toHaveBeenCalledWith('CANVAS001');
     expect(fs.fetch).toHaveBeenCalledWith('CANVAS001');
     expect(sg.revise).toHaveBeenCalledWith(
@@ -467,7 +465,6 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     expect(fs.reply).toHaveBeenCalledTimes(2);
     expect(fs.reply).toHaveBeenCalledWith('CANVAS001', 'disc-1', 'Updated per Phoebe');
     expect(fs.reply).toHaveBeenCalledWith('CANVAS001', 'disc-2', 'Updated per Enzo');
-    expect(fs.resolve).toHaveBeenCalledWith('CANVAS001', ['disc-1', 'disc-2']);
   });
 
   it('empty fetch: revise called with []; no reply or resolve', async () => {
@@ -491,7 +488,6 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
       undefined,
     );
     expect(fs.reply).not.toHaveBeenCalled();
-    expect(fs.resolve).not.toHaveBeenCalled();
   });
 
   it('no feedbackSource: revise called with []; no fetch/reply/resolve', async () => {
@@ -565,29 +561,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
     expect(runs.get('idea-001')?.stage).toBe('review');
     expect(fs.reply).toHaveBeenCalledTimes(3);
-    expect(fs.resolve).toHaveBeenCalled();
     expect(postError).not.toHaveBeenCalled();
   });
 
-  it('resolve rejects: run stays in review; postError not called', async () => {
-    const fs = makeFeedbackSource({
-      fetch: vi.fn().mockResolvedValue([{ id: 'd1', body: 'feedback' }]),
-      resolve: vi.fn().mockRejectedValue(new Error('resolve error')),
-    });
-    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [{ comment_id: 'd1', response: 'r1' }] }) });
-    const adapter = makeMockAdapter();
-    const postError = vi.fn().mockResolvedValue(undefined);
-
-    const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, repo_url: 'r' } as never,
-      { logDestination: nullDest },
-    );
-    await orch.start();
-    await seedAndFeedback(orch, adapter);
-    await adapter.stop();
-
-    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')?.stage).toBe('review');
-    expect(postError).not.toHaveBeenCalled();
-  });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -105,7 +105,7 @@ describe('Orchestrator — new_idea happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     const idea = makeIdea();
@@ -127,7 +127,7 @@ describe('Orchestrator — new_idea happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
@@ -153,7 +153,7 @@ describe('Orchestrator — new_idea failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
     await new Promise(r => setTimeout(r, 50));
@@ -174,7 +174,7 @@ describe('Orchestrator — new_idea failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
     await new Promise(r => setTimeout(r, 50));
@@ -195,7 +195,7 @@ describe('Orchestrator — new_idea failure paths', () => {
     const cp = makeSpecPublisher({ create: vi.fn().mockRejectedValue(new Error('canvas error')) });
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
     await new Promise(r => setTimeout(r, 50));
@@ -217,7 +217,7 @@ describe('Orchestrator — spec_feedback happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     // First seed the idea to get a run in review
@@ -254,7 +254,7 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'spec_feedback', payload: makeFeedback({ idea_id: 'unknown-idea' }) });
@@ -276,7 +276,7 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
@@ -304,7 +304,7 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
@@ -328,7 +328,7 @@ describe('Orchestrator — spec_feedback failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
@@ -351,7 +351,7 @@ describe('Orchestrator — spec_feedback failure paths', () => {
     const cp = makeSpecPublisher({ update: vi.fn().mockRejectedValue(new Error('update failed')) });
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_idea', payload: makeIdea() });
@@ -388,7 +388,7 @@ describe('Orchestrator — concurrency', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo' }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_idea', payload: makeIdea({ id: 'idea-A', thread_ts: 'A.0' }) });
@@ -404,22 +404,22 @@ describe('Orchestrator — concurrency', () => {
   });
 });
 
-describe('Orchestrator — spec_feedback with feedbackSource', () => {
-  // Helper to seed a run to 'review' stage, then trigger feedback
-  async function seedAndFeedback(
-    orch: OrchestratorImpl,
-    adapter: ReturnType<typeof makeMockAdapter>,
-    feedbackOverrides: Partial<SpecFeedback> = {},
-  ) {
-    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
-    // Wait for run to reach 'review'
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'review', { timeout: 2000 });
-    adapter._emit({ type: 'spec_feedback', payload: makeFeedback(feedbackOverrides) });
-    // Wait for run to no longer be 'speccing'
-    await vi.waitUntil(() => runs.get('idea-001')?.stage !== 'speccing', { timeout: 2000 });
-  }
+// Helper to seed a run to 'review' stage, then trigger feedback
+async function seedAndFeedback(
+  orch: OrchestratorImpl,
+  adapter: ReturnType<typeof makeMockAdapter>,
+  feedbackOverrides: Partial<SpecFeedback> = {},
+) {
+  const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+  adapter._emit({ type: 'new_idea', payload: makeIdea() });
+  // Wait for run to reach 'review'
+  await vi.waitUntil(() => runs.get('idea-001')?.stage === 'review', { timeout: 2000 });
+  adapter._emit({ type: 'spec_feedback', payload: makeFeedback(feedbackOverrides) });
+  // Wait for run to no longer be 'speccing'
+  await vi.waitUntil(() => runs.get('idea-001')?.stage !== 'speccing', { timeout: 2000 });
+}
 
+describe('Orchestrator — spec_feedback with feedbackSource', () => {
   it('with feedbackSource: fetch called before revise, revise receives notion_comments, update/reply called in order', async () => {
     const notionComments: NotionComment[] = [
       { id: 'disc-1', body: 'Phoebe: first feedback' },
@@ -441,9 +441,10 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     (sg.revise as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('revise'); return { comment_responses: commentResponses }; });
     (sp.update as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('update'); });
     (fs.reply as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('reply'); });
+    const postMessage = vi.fn().mockImplementation(async () => { callOrder.push('postMessage'); });
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, repo_url: 'https://github.com/org/repo' } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, postMessage, repo_url: 'https://github.com/org/repo' } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -452,7 +453,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
     expect(runs.get('idea-001')?.stage).toBe('review');
-    expect(callOrder).toEqual(['fetch', 'getPageMarkdown', 'revise', 'update', 'reply', 'reply']);
+    expect(callOrder).toEqual(['fetch', 'getPageMarkdown', 'revise', 'update', 'reply', 'reply', 'postMessage']);
     expect(sp.getPageMarkdown).toHaveBeenCalledWith('CANVAS001');
     expect(fs.fetch).toHaveBeenCalledWith('CANVAS001');
     expect(sg.revise).toHaveBeenCalledWith(
@@ -473,7 +474,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const adapter = makeMockAdapter();
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), repo_url: 'r' } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r' } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -495,7 +496,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const adapter = makeMockAdapter();
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), repo_url: 'r' },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r' },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -518,7 +519,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const postError = vi.fn().mockResolvedValue(undefined);
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, repo_url: 'r' } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r' } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -551,7 +552,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const postError = vi.fn().mockResolvedValue(undefined);
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, repo_url: 'r' } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r' } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -564,4 +565,60 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     expect(postError).not.toHaveBeenCalled();
   });
 
+});
+
+describe('Orchestrator — spec_feedback completion notification', () => {
+  it('posts completion message with comment count after replies', async () => {
+    const notionComments = [{ id: 'disc-1', body: 'feedback' }];
+    const commentResponses = [{ comment_id: 'disc-1', response: 'Done' }];
+    const fs = makeFeedbackSource({ fetch: vi.fn().mockResolvedValue(notionComments) });
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: commentResponses }) });
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r' } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    await seedAndFeedback(orch, adapter);
+    await adapter.stop();
+
+    expect(postMessage).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('1 comment'));
+  });
+
+  it('posts message with zero comments when none addressed', async () => {
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r' } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    await seedAndFeedback(orch, adapter);
+    await adapter.stop();
+
+    expect(postMessage).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('updated'));
+  });
+
+  it('postMessage failure: logged, run still transitions to review', async () => {
+    const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockRejectedValue(new Error('Slack error'));
+    const postError = vi.fn().mockResolvedValue(undefined);
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage, repo_url: 'r' } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    await seedAndFeedback(orch, adapter);
+    await adapter.stop();
+
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    expect(runs.get('idea-001')?.stage).toBe('review');
+    expect(postError).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- **Remove broken comment resolution (#19):** `resolve()` removed from `FeedbackSource` interface, `comments.update` from `NotionClient`, and the orchestrator call site. The Notion API does not support `PATCH /v1/comments/:id`.
- **Skip bot-authored threads (#18):** Auto-detect bot user ID via `GET /v1/users/me` at startup. `fetch()` now skips threads where the last comment was authored by the bot, preventing re-processing.
- **Slack completion notification (#10):** After processing comments and updating the spec, posts a summary message in the Slack thread ("Done — responded to N comments").
- **Restore full spec prompt (#20):** Undo the SHORT constraint so `create()` generates a complete product spec.

## Test plan
- [ ] Start service — verify `bot_user_id` appears in startup logs
- [ ] Create a spec via Slack idea — add a Notion comment — post feedback in thread
- [ ] Verify bot replies to Notion comment and posts Slack notification ("Done — responded to 1 comment")
- [ ] Post feedback again without new comments — verify bot skips already-replied thread and posts "spec has been updated" message
- [ ] Verify no `run.resolve_failed` errors in logs
- [ ] Verify new specs are full-length (not SHORT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)