### PR TITLE
chore: add docs/plans and .omc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ venv/
 # Ephemeral implementation plans
 .superpowers-plans/
 context-human/.superpowers-plans/
+docs/plans/
+
+# oh-my-claudecode
+.omc/
 
 # eng-docs (project uses context-human/ structure)
 .eng-docs/


### PR DESCRIPTION
## Summary
- Add `docs/plans/` (ephemeral artifacts from superpowers) to `.gitignore`
- Add `.omc/` (ephemeral artifacts from oh-my-claudecode) to `.gitignore`

## Test plan
- [x] Verify `.gitignore` entries are correct
- [x] Confirm `docs/plans/` and `.omc/` no longer show in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)