### PR TITLE
feat: unified intent classification and Request rename (closes #27, #37, #41)

### DIFF
--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -311,6 +311,60 @@ Message content is never logged. `request_id` replaces `idea_id` in all existing
 **Alerting**
 - No new alerting thresholds beyond existing; `intent.classification_failed` warn-level events warrant investigation if sustained
 
+### 6. Testing plan
+
+**`intent-classifier.ts` — unit tests**
+
+*Unified taxonomy:*
+- `new_thread` context → valid intents are `idea`, `bug`, `question`, `ignore`
+- `reviewing_spec` context → valid intents are `feedback`, `approval`, `question`, `ignore`
+- `reviewing_implementation` context → valid intents are `feedback`, `approval`, `question`, `ignore`
+- `awaiting_impl_input` context → valid intents are `feedback`, `question`, `ignore`
+- `intake` context → valid intents are `idea`, `bug`, `question`, `ignore`
+- Model returns intent not valid for context → fallback to conservative default
+- Empty message → fallback to conservative default
+- API call fails → fallback to conservative default after 2 retries
+
+**`classifier.ts` (Slack) — unit tests**
+
+*Top-level:*
+- @mention, no `thread_ts` → top-level classification pass-through
+- No @mention → `ignore`
+- Message from bot's own user ID → `ignore`
+
+*In-thread:*
+- @mention in thread, `thread_ts` in registry → in-thread classification pass-through
+- @mention in thread, `thread_ts` not in registry → `ignore`
+- `@other_user` only in thread (no bot mention) → `ignore`
+- `@other_user` + `@bot` in thread → in-thread classification pass-through (bot is mentioned)
+- Message from bot's own user ID → `ignore`
+
+**`orchestrator.ts` — unit tests (delta on existing)**
+
+*New request routing:*
+- `new_request` + classifier returns `idea` → spec pipeline starts, `run.intent = 'idea'`
+- `new_request` + classifier returns `bug` → ack posted, run created with `intent = 'bug'`, stays at `intake`
+- `new_request` + classifier returns `question` → question answered, run created with `intent = 'question'`, stays at `intake`
+- `new_request` + classifier returns `ignore` → no run created, no response
+
+*Upgrade path:*
+- `thread_message` + `run.intent = 'question'` + `run.stage = 'intake'` + classifier returns `idea` → intent upgraded, spec pipeline starts
+- `thread_message` + `run.intent = 'question'` + `run.stage = 'intake'` + classifier returns `bug` → intent upgraded to `bug`, ack posted
+- `thread_message` + `run.intent = 'idea'` + classifier returns `question` → no upgrade, question answered, stage unchanged
+
+*In-thread routing:*
+- `feedback` + `reviewing_spec` → spec feedback handler
+- `feedback` + `reviewing_implementation` → impl feedback handler
+- `approval` + `reviewing_spec` → spec approval handler
+- `approval` + `reviewing_implementation` → impl approval handler
+- `question` + any active stage → question answered, stage unchanged
+- `ignore` → discarded
+
+*Rename coverage:*
+- All existing orchestrator tests pass with `request_id` / `new_request` — no `idea_id` / `new_idea` references remain
+
+**`thread-registry.ts` — no new tests**; rename-only change, existing tests cover behavior
+
 ## Task list
 
 *(Added by task decomposition stage)*

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -81,6 +81,88 @@ Every inbound message is a request for something — a new feature, a bug fix, a
 - **In-thread intent** — the intent of a reply in a tracked thread: `feedback`, `approval`, `question`, `ignore`
 - **Request** — the generic term for any incoming work item, replacing `Idea` in the codebase
 
+### 2. System design and architecture
+
+**Modified components**
+
+- `src/adapters/agent/intent-classifier.ts` — replace stage-specific taxonomy with unified taxonomy; add `'new_thread'` context for top-level classification alongside run-stage contexts
+- `src/adapters/slack/classifier.ts` — update ignore rules: suppress in-thread messages where only someone other than the bot is @mentioned; remove `spec_feedback` return (all @mentions pass through as top-level or in-thread)
+- `src/adapters/slack/slack-adapter.ts` — remove hardcoded `new_idea` / `spec_feedback` routing; emit `new_request` for top-level @mentions, `thread_message` for in-thread @mentions
+- `src/core/orchestrator.ts` — replace multi-handler intent dispatch with single `_handleRequest`; routing logic is intent × stage; add `intent` field to `Run`; implement upgrade path (question → idea/bug only when stage is `intake`)
+- `src/types/events.ts` — rename `Idea` → `Request`, `new_idea` → `new_request`; `ThreadMessage.idea_id` → `request_id`
+- `src/types/runs.ts` — add `intent` field; `idea_id` → `request_id`
+- `src/adapters/slack/thread-registry.ts` — rename `idea_id` references to `request_id` internally
+
+**High-level flow**
+
+```mermaid
+flowchart LR
+    Slack -->|Socket Mode| BoltApp
+    BoltApp -->|raw message| SlackClassifier
+    SlackClassifier -->|ignore| /dev/null
+    SlackClassifier -->|top-level @mention| SlackAdapter
+    SlackClassifier -->|in-thread @mention| SlackAdapter
+    SlackAdapter -->|new_request| Orchestrator
+    SlackAdapter -->|thread_message| Orchestrator
+    Orchestrator -->|content + context| IntentClassifier
+    IntentClassifier -->|unified intent| Orchestrator
+    Orchestrator -->|intent × stage| _handleRequest
+```
+
+**Sequence — top-level @mention**
+
+```mermaid
+sequenceDiagram
+    actor Phoebe
+    participant SlackAdapter
+    participant Orchestrator
+    participant IntentClassifier
+
+    Phoebe->>SlackAdapter: @ac add a setup wizard
+    SlackAdapter->>SlackAdapter: register thread, post ack
+    SlackAdapter->>Orchestrator: new_request
+    Orchestrator->>IntentClassifier: classify(content, 'new_thread')
+    IntentClassifier-->>Orchestrator: idea
+    Orchestrator->>Orchestrator: createRun(intent=idea) → speccing
+```
+
+**Sequence — in-thread question then upgrade**
+
+```mermaid
+sequenceDiagram
+    actor Enzo
+    participant SlackAdapter
+    participant Orchestrator
+    participant IntentClassifier
+
+    Enzo->>SlackAdapter: @ac how does the auth flow work?
+    SlackAdapter->>Orchestrator: new_request
+    Orchestrator->>IntentClassifier: classify(content, 'new_thread')
+    IntentClassifier-->>Orchestrator: question
+    Orchestrator->>Orchestrator: createRun(intent=question) → intake
+    Note over Orchestrator: answer question, stay at intake
+
+    Enzo->>SlackAdapter: @ac actually, let's fix this
+    SlackAdapter->>Orchestrator: thread_message
+    Orchestrator->>IntentClassifier: classify(content, run.stage=intake)
+    IntentClassifier-->>Orchestrator: idea
+    Orchestrator->>Orchestrator: upgrade run intent → idea → speccing
+```
+
+**Intent × stage routing table**
+
+| Intent | Stage | Action |
+|---|---|---|
+| `idea` | `new_thread` / `intake` | start spec pipeline |
+| `bug` | `new_thread` / `intake` | ack + log (handler in #42) |
+| `question` | `new_thread` / `intake` | answer, stay at `intake` |
+| `feedback` | `reviewing_spec` | revise spec |
+| `feedback` | `reviewing_implementation` / `awaiting_impl_input` | handle impl feedback |
+| `approval` | `reviewing_spec` | commit spec, start implementation |
+| `approval` | `reviewing_implementation` | create PR |
+| `question` | any other stage | answer, no stage change |
+| `ignore` | any | discard |
+
 ## Task list
 
 *(Added by task decomposition stage)*

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -405,4 +405,132 @@ Answering a question in-thread requires generating a response, which isn't curre
 
 ## Task list
 
-*(Added by task decomposition stage)*
+- [ ] **Story: Unify intent taxonomy**
+  - [ ] **Task: Refactor `IntentClassifier` to unified taxonomy and `ClassificationContext`**
+    - **Description**: Replace the existing stage-specific `Intent` type (`spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval`) with the unified taxonomy (`idea`, `bug`, `question`, `feedback`, `approval`, `ignore`). Replace the `RunStage` parameter with a `ClassificationContext` type (`'new_thread' | RunStage`). Update `VALID_INTENTS_BY_CONTEXT` to map each context to its valid intents. Update conservative fallbacks: `new_thread`/`intake` → `idea`; reviewing stages → `feedback`. Update the classifier prompt to use the new intent names and descriptions.
+    - **Acceptance criteria**:
+      - [ ] `Intent` type is `'idea' | 'bug' | 'question' | 'feedback' | 'approval' | 'ignore'`
+      - [ ] `ClassificationContext` type is `'new_thread' | RunStage`
+      - [ ] `VALID_INTENTS_BY_CONTEXT` covers `new_thread`, `intake`, `reviewing_spec`, `reviewing_implementation`, `awaiting_impl_input`
+      - [ ] Conservative fallback is `idea` for `new_thread`/`intake`, `feedback` for reviewing stages
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: None
+
+  - [ ] **Task: Update `IntentClassifier` unit tests**
+    - **Description**: Update `tests/adapters/agent/intent-classifier.test.ts` to cover the unified taxonomy. Add test cases for each `ClassificationContext` verifying valid intent sets. Add cases for fallback on invalid-for-context intent, empty message, and API failure. Remove tests for old stage-specific intents.
+    - **Acceptance criteria**:
+      - [ ] Test cases cover all five `ClassificationContext` values
+      - [ ] Invalid-for-context intent → conservative fallback asserted
+      - [ ] Empty message → conservative fallback asserted
+      - [ ] API failure → conservative fallback after 2 retries asserted
+      - [ ] No references to `spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval` remain in test file
+      - [ ] All tests pass
+    - **Dependencies**: Task: Refactor `IntentClassifier` to unified taxonomy and `ClassificationContext`
+
+- [ ] **Story: Rename `Idea` → `Request` throughout**
+  - [ ] **Task: Rename types in `events.ts` and `runs.ts`**
+    - **Description**: In `src/types/events.ts`: rename `Idea` → `Request`, `new_idea` → `new_request`, `ThreadMessage.idea_id` → `request_id`. In `src/types/runs.ts`: rename `idea_id` → `request_id`; add `intent: RequestIntent` field where `RequestIntent = 'idea' | 'bug' | 'question'`.
+    - **Acceptance criteria**:
+      - [ ] `Request` interface exists with same fields as old `Idea`
+      - [ ] `InboundEvent` uses `new_request` / `Request`
+      - [ ] `ThreadMessage.request_id` replaces `idea_id`
+      - [ ] `Run.request_id` replaces `idea_id`
+      - [ ] `Run.intent: RequestIntent` field added
+      - [ ] `RequestIntent` type exported from `runs.ts`
+      - [ ] `tsc --noEmit` passes (will have downstream errors until call sites updated)
+    - **Dependencies**: None
+
+  - [ ] **Task: Rename all call sites**
+    - **Description**: Update every file that references `idea_id`, `new_idea`, or `Idea` in the work-item context: `src/core/orchestrator.ts`, `src/adapters/slack/slack-adapter.ts`, `src/adapters/slack/thread-registry.ts`, `src/core/run-store.ts` (serialization — treat as breaking change, document in commit message), `src/index.ts`. Grep for remaining references after the rename: `grep -r "idea_id\|new_idea\|: Idea\b" src/`.
+    - **Acceptance criteria**:
+      - [ ] `grep -r "idea_id\|new_idea\|: Idea\b" src/` returns no matches
+      - [ ] Run store serialization updated; breaking change noted in commit message
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Rename types in `events.ts` and `runs.ts`
+
+  - [ ] **Task: Update all affected tests**
+    - **Description**: Update all test files that reference `idea_id`, `new_idea`, or `Idea` in the work-item context. Grep for remaining references: `grep -r "idea_id\|new_idea\|: Idea\b" tests/`.
+    - **Acceptance criteria**:
+      - [ ] `grep -r "idea_id\|new_idea\|: Idea\b" tests/` returns no matches
+      - [ ] All existing tests pass
+    - **Dependencies**: Task: Rename all call sites
+
+- [ ] **Story: Update Slack classifier ignore rules**
+  - [ ] **Task: Update `classifier.ts` for new ignore rules and return type**
+    - **Description**: Update `classifyMessage` in `src/adapters/slack/classifier.ts`. Add rule: if the message is a thread reply and @mentions at least one other user but does NOT mention the bot → `ignore`. Remove the `spec_feedback` return; in-thread @mentions that pass all ignore checks should return a new `{ intent: 'thread_message'; request_id: string }` result (the Slack adapter will emit the `thread_message` event). Remove `classifyReaction` and `ReactionClassification` (emoji approval is out of scope).
+    - **Acceptance criteria**:
+      - [ ] `@other_user` only in thread → `ignore`
+      - [ ] `@other_user` + `@bot` in thread → `thread_message` result
+      - [ ] `@bot` only in thread → `thread_message` result
+      - [ ] `@bot` top-level → `new_request` result (rename from `new_idea`)
+      - [ ] `classifyReaction` removed
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Rename types in `events.ts` and `runs.ts`
+
+  - [ ] **Task: Update `classifier.ts` unit tests**
+    - **Description**: Update `tests/adapters/slack/classifier.test.ts` to cover the new ignore rules and return types. Add cases: `@other_user` only in thread → `ignore`; `@other_user` + `@bot` in thread → `thread_message`; `@bot` only in thread → `thread_message`. Remove all `classifyReaction` tests.
+    - **Acceptance criteria**:
+      - [ ] All new ignore rule cases covered
+      - [ ] No `classifyReaction` tests remain
+      - [ ] No `spec_feedback` intent references remain
+      - [ ] All tests pass
+    - **Dependencies**: Task: Update `classifier.ts` for new ignore rules and return type
+
+- [ ] **Story: Wire top-level classification through `IntentClassifier`**
+  - [ ] **Task: Update `slack-adapter.ts` to emit `new_request` via `IntentClassifier`**
+    - **Description**: Update `src/adapters/slack/slack-adapter.ts`. On top-level @mention: call `IntentClassifier.classify(content, 'new_thread')` before emitting. Emit `{ type: 'new_request', payload: Request }` regardless of intent — the orchestrator handles routing. Remove hardcoded `new_idea` / `spec_feedback` paths. For in-thread @mentions that pass classification: emit `{ type: 'thread_message', payload: ThreadMessage }` unchanged. The `IntentClassifier` is injected via the adapter constructor (optional dep, same pattern as existing deps).
+    - **Acceptance criteria**:
+      - [ ] `IntentClassifier` injected via constructor as optional dep
+      - [ ] Top-level @mention → `IntentClassifier.classify(content, 'new_thread')` called
+      - [ ] `new_request` event emitted with correct `Request` shape
+      - [ ] In-thread @mention → `thread_message` event emitted (no classifier call here; orchestrator calls it)
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Update `classifier.ts` for new ignore rules and return type, Task: Refactor `IntentClassifier` to unified taxonomy and `ClassificationContext`
+
+  - [ ] **Task: Update `slack-adapter.ts` integration tests**
+    - **Description**: Update `tests/adapters/slack/slack-adapter.test.ts`. Replace `new_idea` event assertions with `new_request`. Add cases verifying `IntentClassifier` is called with `'new_thread'` context on top-level @mentions. Verify `thread_message` is still emitted correctly for in-thread @mentions. Verify `@other_user`-only threads are ignored.
+    - **Acceptance criteria**:
+      - [ ] `new_request` event shape verified
+      - [ ] `IntentClassifier.classify` called with `'new_thread'` on top-level @mention
+      - [ ] `thread_message` emitted correctly for in-thread @mention
+      - [ ] `@other_user`-only in-thread → no event emitted
+      - [ ] All tests pass
+    - **Dependencies**: Task: Update `slack-adapter.ts` to emit `new_request` via `IntentClassifier`
+
+- [ ] **Story: Refactor orchestrator to `_handleRequest`**
+  - [ ] **Task: Implement `_handleRequest` with intent × stage routing**
+    - **Description**: Refactor `src/core/orchestrator.ts`. Replace `_handleNewIdea` and the top-level dispatch in `_handleThreadMessage` with a single `_handleRequest(event: InboundEvent)` entry point. Implement the routing table from the tech spec: `idea` + new/intake → spec pipeline; `bug` + new/intake → ack + log; `feedback` + reviewing stage → existing feedback handlers; `approval` + reviewing stage → existing approval handlers. The existing `_handleSpecFeedback`, `_handleSpecApproval`, `_handleImplementationFeedback`, `_handleImplementationApproval` methods are retained as internal helpers — only the dispatch logic changes.
+    - **Acceptance criteria**:
+      - [ ] `_runLoop` calls `_handleRequest` for both `new_request` and `thread_message` events
+      - [ ] All intent × stage routing cases from the tech spec routing table are handled
+      - [ ] `run.intent` is set on run creation
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Rename all call sites, Task: Refactor `IntentClassifier` to unified taxonomy and `ClassificationContext`
+
+  - [ ] **Task: Implement intent upgrade path**
+    - **Description**: In `_handleRequest`, add the upgrade path: when a `thread_message` arrives for a run with `intent = 'question'` and `stage = 'intake'`, reclassify with `IntentClassifier.classify(content, 'intake')`. If result is `idea` or `bug`, update `run.intent`, log `run.intent_upgraded`, and route to the appropriate handler. If result is `question` or `ignore`, handle as before.
+    - **Acceptance criteria**:
+      - [ ] `run.intent = 'question'` + `stage = 'intake'` + classifier returns `idea` → intent upgraded, spec pipeline starts, `run.intent_upgraded` logged
+      - [ ] `run.intent = 'question'` + `stage = 'intake'` + classifier returns `bug` → intent upgraded to `bug`, ack posted
+      - [ ] `run.intent = 'idea'` + any stage + classifier returns `question` → no upgrade, question stub response posted
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Implement `_handleRequest` with intent × stage routing
+
+  - [ ] **Task: Add question stub handler and follow-up issue**
+    - **Description**: Add `_handleQuestion(content: string, channel_id: string, thread_ts: string)` to the orchestrator. For this PR, it posts a stub acknowledgement: `"I've noted your question — question answering is coming soon."`. Create a GitHub issue for implementing real question answering.
+    - **Acceptance criteria**:
+      - [ ] `_handleQuestion` posts stub acknowledgement
+      - [ ] All `question` intent cases in routing table call `_handleQuestion`
+      - [ ] GitHub issue created for real question answering implementation
+      - [ ] `tsc --noEmit` passes
+    - **Dependencies**: Task: Implement `_handleRequest` with intent × stage routing
+
+  - [ ] **Task: Update orchestrator unit tests**
+    - **Description**: Update `tests/core/orchestrator.test.ts` to cover the unified routing. Add test cases from the testing plan: `new_request` routing by intent; upgrade path cases; in-thread routing by intent × stage; question stub handler. Remove references to `new_idea`, `spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval`. Verify all existing pipeline tests (spec feedback, spec approval, impl feedback, impl approval) still pass under the new dispatch.
+    - **Acceptance criteria**:
+      - [ ] All new routing cases from §6 testing plan covered
+      - [ ] No references to `new_idea`, `spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval` in test file
+      - [ ] All existing pipeline tests pass
+      - [ ] `grep -r "idea_id\|new_idea\|spec_feedback\|spec_approval\|implementation_feedback\|implementation_approval" tests/core/orchestrator.test.ts` returns no matches
+      - [ ] All tests pass
+    - **Dependencies**: Task: Implement intent upgrade path, Task: Add question stub handler and follow-up issue

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-14
 last_updated: 2026-04-14
-status: draft
+status: approved
 issue: null
 specced_by: markdstafford
 implemented_by: null

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -1,0 +1,86 @@
+---
+created: 2026-04-14
+last_updated: 2026-04-14
+status: draft
+issue: null
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
+# Enhancement: Intent classifier routing
+
+## Parent feature
+
+`feature-slack-message-routing.md`
+
+## What
+
+The slack message routing feature currently classifies messages with a fixed ruleset: new top-level @mentions are always treated as feature ideas, and thread replies are always treated as spec feedback. This enhancement replaces that hardcoded routing with AI-powered intent classification on every inbound message — both top-level and in-thread — so the system can understand what a user is actually asking for and route it accordingly.
+
+## Why
+
+Every inbound message is a request for something — a new feature, a bug fix, a question, a piece of feedback — and the system needs to know which in order to respond correctly. The current fixed ruleset can only distinguish message position (new thread vs. reply), not intent, so it cannot route messages to the right handler or compose the right response. Classifying every message by intent gives the system what it needs to address each request appropriately.
+
+## User stories
+
+- Phoebe can @mention the bot with a bug report and have it routed as a bug, not a feature idea
+- Phoebe can ask the bot a direct question and get a response appropriate to a question
+- Phoebe can @mention the bot with a feature idea and have it routed as before
+- Enzo can reply to an in-progress thread with approval and have the system recognize it as such
+- Enzo can ask a question in an active thread and have it handled as a question rather than spec feedback
+- Enzo can provide feedback on a spec or implementation in a thread and have it routed correctly
+- Enzo can post in a channel without @mentioning the bot and have the bot ignore it entirely
+- Enzo can @mention another person in a thread without triggering a bot response
+- Phoebe can @mention both the bot and another person in a thread and have the bot respond normally
+
+## Design changes
+
+*(Added by design specs stage — frame as delta on the parent feature's design spec)*
+
+## Technical changes
+
+### Affected files
+
+*(Populated during tech specs stage — list files that will change and why)*
+
+### Changes
+
+### 1. Introduction and overview
+
+**Prerequisites and assumptions**
+- Depends on `feature-slack-message-routing.md` (complete) — the existing Slack `classifier.ts`, `ThreadRegistry`, `SlackAdapter`, and `InboundEvent` types
+- Depends on `adr-001-agent-first-development.md` — AI-first processing approach
+- Depends on PR #31 (merged) — `IntentClassifier` at `src/adapters/agent/intent-classifier.ts`, `thread_message` event type, and current orchestrator routing using stage-specific intents (`spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval`)
+- No new ADRs required; no database or API changes
+- The orchestrator handles routing by `InboundEvent.type` and run stage — replacing intent types here requires corresponding updates there
+
+**Technical goals**
+- Every inbound @mention — top-level or in-thread — is classified by a single `IntentClassifier` using a unified taxonomy before reaching the orchestrator
+- In-thread messages where someone other than the bot is @mentioned (and the bot is not) are ignored without classification
+- Classification completes within 2 seconds of message receipt
+- The classifier never produces an unhandled intent type at the orchestrator boundary
+- Terminology is consistent: `Idea` / `idea_id` / `new_idea` replaced with `Request` / `request_id` / `idea` throughout
+
+**Non-goals**
+- Implementing the downstream handler for `bug` intent (tracked in #42)
+- Emoji reaction approval
+- Persisting classification history
+- Multi-turn conversation or context tracking within a thread
+
+**In scope**
+- Top-level intents: `idea`, `bug` (classifier only, no handler), `question`, `ignore`
+- In-thread intents: `feedback`, `approval`, `question`, `ignore`
+- Refactor `IntentClassifier` to use the unified taxonomy, replacing stage-specific intents (`spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval`); orchestrator derives context from intent + run stage
+- Update Slack `classifier.ts` to route all @mentions through `IntentClassifier` and apply correct ignore rules
+- Update orchestrator to handle unified intents
+- Rename `Idea` → `Request` throughout types, events, orchestrator, and registry
+
+**Glossary**
+- **Top-level intent** — the intent of a new @mention that starts a thread: `idea`, `bug`, `question`, `ignore`
+- **In-thread intent** — the intent of a reply in a tracked thread: `feedback`, `approval`, `question`, `ignore`
+- **Request** — the generic term for any incoming work item, replacing `Idea` in the codebase
+
+## Task list
+
+*(Added by task decomposition stage)*

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -42,7 +42,17 @@ Every inbound message is a request for something — a new feature, a bug fix, a
 
 ### Affected files
 
-*(Populated during tech specs stage — list files that will change and why)*
+- `src/adapters/agent/intent-classifier.ts` — replace stage-specific taxonomy with unified taxonomy; add `new_thread` / `intake` contexts
+- `src/adapters/slack/classifier.ts` — update ignore rules for `@other_user` in-thread; remove `spec_feedback` return
+- `src/adapters/slack/slack-adapter.ts` — emit `new_request` / `thread_message`; remove hardcoded intent routing
+- `src/adapters/slack/thread-registry.ts` — rename `idea_id` → `request_id` internally
+- `src/core/orchestrator.ts` — replace multi-handler dispatch with `_handleRequest`; add intent upgrade logic; add question stub handler
+- `src/types/events.ts` — rename `Idea` → `Request`, `new_idea` → `new_request`, `ThreadMessage.idea_id` → `request_id`
+- `src/types/runs.ts` — add `intent: RequestIntent` field; rename `idea_id` → `request_id`
+- `tests/adapters/agent/intent-classifier.test.ts` — update for unified taxonomy
+- `tests/adapters/slack/classifier.test.ts` — update for new ignore rules and return types
+- `tests/adapters/slack/slack-adapter.test.ts` — update for `new_request` event type
+- `tests/core/orchestrator.test.ts` — update for unified intent routing and rename
 
 ### Changes
 

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -163,6 +163,114 @@ sequenceDiagram
 | `question` | any other stage | answer, no stage change |
 | `ignore` | any | discard |
 
+### 3. Detailed design
+
+**Updated types**
+
+`src/types/events.ts`:
+```typescript
+export interface Request {
+  id: string;
+  source: 'slack';
+  content: string;
+  author: string;
+  received_at: string; // ISO 8601
+  thread_ts: string;
+  channel_id: string;
+}
+
+export interface ThreadMessage {
+  request_id: string;
+  content: string;
+  author: string;
+  received_at: string; // ISO 8601
+  thread_ts: string;
+  channel_id: string;
+}
+
+export type InboundEvent =
+  | { type: 'new_request'; payload: Request }
+  | { type: 'thread_message'; payload: ThreadMessage };
+```
+
+`src/types/runs.ts` — add `intent` field, rename `idea_id`:
+```typescript
+export type RequestIntent = 'idea' | 'bug' | 'question';
+
+export interface Run {
+  id: string;
+  request_id: string;
+  intent: RequestIntent;
+  stage: RunStage;
+  // ... rest unchanged
+}
+```
+
+**Updated `IntentClassifier` interface**
+
+```typescript
+export type ClassificationContext =
+  | 'new_thread'
+  | RunStage; // only stages that accept messages: 'intake', 'reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input'
+
+export type Intent =
+  | 'idea'
+  | 'bug'
+  | 'question'
+  | 'feedback'
+  | 'approval'
+  | 'ignore';
+
+export const VALID_INTENTS_BY_CONTEXT: Record<ClassificationContext, Intent[]> = {
+  new_thread:                 ['idea', 'bug', 'question', 'ignore'],
+  intake:                     ['idea', 'bug', 'question', 'ignore'],  // upgrade path
+  reviewing_spec:             ['feedback', 'approval', 'question', 'ignore'],
+  reviewing_implementation:   ['feedback', 'approval', 'question', 'ignore'],
+  awaiting_impl_input:        ['feedback', 'question', 'ignore'],
+  // non-message stages not included — orchestrator guards before calling
+};
+
+export interface IntentClassifier {
+  classify(message: string, context: ClassificationContext): Promise<Intent>;
+}
+```
+
+**Orchestrator routing algorithm (`_handleRequest`)**
+
+```
+_handleRequest(event: InboundEvent):
+  if event.type === 'new_request':
+    create run with intent = 'question' (temporary, will be set after classification)
+    context = 'new_thread'
+  else:
+    run = runs.get(event.payload.request_id)
+    if no run → discard
+    if run.stage not in message-accepting stages → discard (or busy-notify)
+    context = run.stage
+
+  intent = intentClassifier.classify(content, context)
+
+  if intent === 'ignore' → discard
+
+  if event.type === 'new_request' OR (run.intent === 'question' AND run.stage === 'intake'):
+    // set or upgrade intent
+    run.intent = intent
+    if intent === 'idea'     → start spec pipeline
+    if intent === 'bug'      → ack + log (handler in #42)
+    if intent === 'question' → answer, leave at intake
+    return
+
+  // in-thread routing by intent × stage
+  if intent === 'feedback':
+    if run.stage === 'reviewing_spec' → _handleSpecFeedback
+    if run.stage in ['reviewing_implementation', 'awaiting_impl_input'] → _handleImplementationFeedback
+  if intent === 'approval':
+    if run.stage === 'reviewing_spec' → _handleSpecApproval
+    if run.stage === 'reviewing_implementation' → _handleImplementationApproval
+  if intent === 'question':
+    answer question, no stage change
+```
+
 ## Task list
 
 *(Added by task decomposition stage)*

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -286,6 +286,31 @@ _handleRequest(event: InboundEvent):
 - Message content is treated as untrusted user input throughout — passed as a typed field, never interpolated into system prompts without proper isolation
 - The classifier prompt treats the message as opaque user content, not as instructions — prompt injection risk is mitigated by structural separation between system instructions and message content
 
+### 5. Observability
+
+**Log events**
+
+| Event | Level | Fields |
+|---|---|---|
+| `slack.message.classified` | info | `author`, `channel_id`, `intent`, `thread_ts`, `context` |
+| `slack.message.ignored` | debug | `author`, `channel_id`, `reason` |
+| `intent.classified` | info | `context`, `classified_intent`, `message_length` |
+| `intent.classification_failed` | warn | `context`, `error` |
+| `intent.invalid_for_context` | warn | `returned_intent`, `context`, `valid_intents` |
+| `run.intent_upgraded` | info | `run_id`, `request_id`, `from_intent`, `to_intent` |
+| `thread_message.discarded` | debug | `run_id`, `request_id`, `stage`, `reason` |
+
+Message content is never logged. `request_id` replaces `idea_id` in all existing log fields.
+
+**Metrics**
+- `slack.messages.classified` — counter with `intent` and `context` labels
+- `slack.messages.ignored` — counter with `reason` label
+- `intent.classification_latency_ms` — histogram; classification call duration
+- `run.intent_upgrades` — counter with `from_intent` and `to_intent` labels
+
+**Alerting**
+- No new alerting thresholds beyond existing; `intent.classification_failed` warn-level events warrant investigation if sustained
+
 ## Task list
 
 *(Added by task decomposition stage)*

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -271,6 +271,21 @@ _handleRequest(event: InboundEvent):
     answer question, no stage change
 ```
 
+### 4. Security, privacy, and compliance
+
+**Authentication and authorization**
+- No changes to the authentication model — Bolt SDK verifies Slack request signatures; the orchestrator trusts only events from the authenticated adapter
+- Intent classification runs against message content using the Anthropic API; the API key is already managed via `AC_ANTHROPIC_API_KEY` and redacted in logs per the foundation's logging standard
+
+**Data privacy**
+- Message content is passed to the Anthropic API for classification — this is an extension of the existing `spec_generator` and `implementer` pattern; no new data sharing model is introduced
+- Message content is not logged at any stage; only metadata (author, channel, intent, `thread_ts`) is logged
+- `request_id` replaces `idea_id` in all log fields; no PII is introduced
+
+**Input validation**
+- Message content is treated as untrusted user input throughout — passed as a typed field, never interpolated into system prompts without proper isolation
+- The classifier prompt treats the message as opaque user content, not as instructions — prompt injection risk is mitigated by structural separation between system instructions and message content
+
 ## Task list
 
 *(Added by task decomposition stage)*

--- a/context-human/specs/backlog/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/backlog/enhancement-intent-classifier-routing.md
@@ -365,6 +365,34 @@ Message content is never logged. `request_id` replaces `idea_id` in all existing
 
 **`thread-registry.ts` — no new tests**; rename-only change, existing tests cover behavior
 
+### 7. Alternatives considered
+
+**Keep stage-specific intents in `IntentClassifier`, add separate top-level classifier**
+
+The existing `IntentClassifier` could be left as-is and a new classifier added for top-level messages. This avoids touching working code. Rejected because it splits the classification surface across two implementations with different taxonomies — exactly the inconsistency this enhancement exists to fix. One classifier, one taxonomy, one place to tune.
+
+**Keyword heuristics instead of AI classification for top-level messages**
+
+Simple pattern matching ("this is broken" → bug, ends with "?" → question) would be fast and cheap. Rejected because the AI classifier already exists and is proven; heuristics would need ongoing maintenance and would misclassify ambiguous messages that a language model handles well.
+
+**Persist intent on `ThreadRegistry` instead of `Run`**
+
+Intent could be stored alongside `thread_ts → request_id` in the registry rather than on the run. Rejected because `Run` is already the authoritative state record for a thread's lifecycle — adding intent there keeps all run state in one place and avoids a second lookup.
+
+### 8. Risks
+
+**Terminology rename blast radius**
+
+`idea_id` / `new_idea` / `Idea` appear across types, orchestrator, adapter, tests, and run store serialization. A partial rename will cause type errors; a serialization mismatch will break run persistence across the deploy. Mitigation: rename in a single task, run `tsc --noEmit` and full test suite before committing; treat the run store format as a breaking change and document it.
+
+**Classifier fallback produces wrong default for new contexts**
+
+The conservative fallback for `new_thread` and `intake` contexts needs to be defined explicitly — currently the fallback logic defaults to `spec_feedback` which won't exist after this change. Mitigation: define fallback as `idea` for `new_thread`/`intake` and `feedback` for reviewing stages; enforce via test.
+
+**Question handler requires a new AI call**
+
+Answering a question in-thread requires generating a response, which isn't currently implemented anywhere in the system. The spec says "answer question" but the mechanism isn't defined. Mitigation: for this PR, a question response can be a simple acknowledgement stub with a follow-up issue to implement real question answering.
+
 ## Task list
 
 *(Added by task decomposition stage)*

--- a/context-human/specs/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/enhancement-intent-classifier-routing.md
@@ -46,6 +46,7 @@ Every inbound message is a request for something — a new feature, a bug fix, a
 - `src/adapters/slack/classifier.ts` — update ignore rules for `@other_user` in-thread; remove `spec_feedback` return
 - `src/adapters/slack/slack-adapter.ts` — emit `new_request` / `thread_message`; remove hardcoded intent routing
 - `src/adapters/slack/thread-registry.ts` — rename `idea_id` → `request_id` internally
+- `src/adapters/agent/question-answerer.ts` — new: `QuestionAnswerer` interface and `AnthropicQuestionAnswerer` implementation for answering questions in-thread using the Anthropic API
 - `src/core/orchestrator.ts` — replace multi-handler dispatch with `_handleRequest`; add intent upgrade logic; add question stub handler
 - `src/types/events.ts` — rename `Idea` → `Request`, `new_idea` → `new_request`, `ThreadMessage.idea_id` → `request_id`
 - `src/types/runs.ts` — add `intent: RequestIntent` field; rename `idea_id` → `request_id`
@@ -401,7 +402,7 @@ The conservative fallback for `new_thread` and `intake` contexts needs to be def
 
 **Question handler requires a new AI call**
 
-Answering a question in-thread requires generating a response, which isn't currently implemented anywhere in the system. The spec says "answer question" but the mechanism isn't defined. Mitigation: for this PR, a question response can be a simple acknowledgement stub with a follow-up issue to implement real question answering.
+Answering a question in-thread requires generating a response, which isn't currently implemented anywhere in the system. The spec says "answer question" but the mechanism isn't defined. Mitigation: question answering is implemented in this PR using a `QuestionAnswerer` component (`AnthropicQuestionAnswerer`) that calls the Anthropic API with a focused system prompt. The orchestrator injects `QuestionAnswerer` as an optional dependency and falls back to a static acknowledgement message if it is not configured or if the API call fails.
 
 ## Task list
 
@@ -516,12 +517,14 @@ Answering a question in-thread requires generating a response, which isn't curre
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: Task: Implement `_handleRequest` with intent × stage routing
 
-  - [ ] **Task: Add question stub handler and follow-up issue**
-    - **Description**: Add `_handleQuestion(content: string, channel_id: string, thread_ts: string)` to the orchestrator. For this PR, it posts a stub acknowledgement: `"I've noted your question — question answering is coming soon."`. Create a GitHub issue for implementing real question answering.
+  - [ ] **Task: Add question handler with real AI answering**
+    - **Description**: Add `_handleQuestion(content: string, channel_id: string, thread_ts: string, run: Run)` to the orchestrator. Implement real question answering via a new `QuestionAnswerer` interface and `AnthropicQuestionAnswerer` class (`src/adapters/agent/question-answerer.ts`) that calls the Anthropic API with a focused system prompt. The orchestrator injects `questionAnswerer` as an optional dependency; if absent, falls back to a static acknowledgement. If the API call fails, a fallback message is posted and the run is not failed.
     - **Acceptance criteria**:
-      - [ ] `_handleQuestion` posts stub acknowledgement
+      - [ ] `QuestionAnswerer` interface and `AnthropicQuestionAnswerer` class created in `src/adapters/agent/question-answerer.ts`
+      - [ ] `_handleQuestion` calls `questionAnswerer.answer(content)` and posts the result
+      - [ ] On `questionAnswerer` error, fallback message posted; run not failed; `postError` not called
+      - [ ] When no `questionAnswerer` configured, static fallback text posted
       - [ ] All `question` intent cases in routing table call `_handleQuestion`
-      - [ ] GitHub issue created for real question answering implementation
       - [ ] `tsc --noEmit` passes
     - **Dependencies**: Task: Implement `_handleRequest` with intent × stage routing
 

--- a/context-human/specs/enhancement-intent-classifier-routing.md
+++ b/context-human/specs/enhancement-intent-classifier-routing.md
@@ -1,10 +1,10 @@
 ---
 created: 2026-04-14
 last_updated: 2026-04-14
-status: approved
-issue: null
+status: implementing
+issue: 43
 specced_by: markdstafford
-implemented_by: null
+implemented_by: markdstafford
 superseded_by: null
 ---
 

--- a/mm.toml
+++ b/mm.toml
@@ -1,0 +1,2 @@
+docs_root = "context-human"
+issue_tracker = "github"

--- a/src/adapters/agent/intent-classifier.ts
+++ b/src/adapters/agent/intent-classifier.ts
@@ -4,32 +4,39 @@ import { createLogger } from '../../core/logger.js';
 import type { RunStage } from '../../types/runs.js';
 
 export type Intent =
-  | 'spec_feedback'
-  | 'spec_approval'
-  | 'implementation_feedback'
-  | 'implementation_approval';
+  | 'idea'
+  | 'bug'
+  | 'question'
+  | 'feedback'
+  | 'approval'
+  | 'ignore';
 
-export interface IntentClassifier {
-  classify(message: string, run_stage: RunStage): Promise<Intent>;
-}
+export type ClassificationContext = 'new_thread' | RunStage;
 
-const ALL_INTENTS: Intent[] = [
-  'spec_feedback',
-  'spec_approval',
-  'implementation_feedback',
-  'implementation_approval',
-];
+const ALL_INTENTS: Intent[] = ['idea', 'bug', 'question', 'feedback', 'approval', 'ignore'];
 
-const VALID_INTENTS_BY_STAGE: Partial<Record<RunStage, Intent[]>> = {
-  reviewing_spec: ['spec_feedback', 'spec_approval'],
-  reviewing_implementation: ['implementation_feedback', 'implementation_approval'],
-  awaiting_impl_input: ['implementation_feedback'],
+export const VALID_INTENTS_BY_CONTEXT: Partial<Record<ClassificationContext, Intent[]>> = {
+  new_thread:               ['idea', 'bug', 'question', 'ignore'],
+  intake:                   ['idea', 'bug', 'question', 'ignore'],
+  reviewing_spec:           ['feedback', 'approval', 'question', 'ignore'],
+  reviewing_implementation: ['feedback', 'approval', 'question', 'ignore'],
+  awaiting_impl_input:      ['feedback', 'question', 'ignore'],
+  speccing:                 ['feedback', 'question', 'ignore'],
+  implementing:             ['feedback', 'question', 'ignore'],
+  done:                     ['ignore'],
+  failed:                   ['ignore'],
 };
 
-const CONSERVATIVE_FALLBACK: Partial<Record<RunStage, Intent>> = {
-  reviewing_spec: 'spec_feedback',
-  reviewing_implementation: 'implementation_feedback',
-  awaiting_impl_input: 'implementation_feedback',
+const CONSERVATIVE_FALLBACK: Partial<Record<ClassificationContext, Intent>> = {
+  new_thread:               'idea',
+  intake:                   'idea',
+  reviewing_spec:           'feedback',
+  reviewing_implementation: 'feedback',
+  awaiting_impl_input:      'feedback',
+  speccing:                 'feedback',
+  implementing:             'feedback',
+  done:                     'ignore',
+  failed:                   'ignore',
 };
 
 type CreateFn = (params: { model: string; max_tokens: number; messages: Array<{ role: 'user'; content: string }> }) => Promise<{ content: Array<{ type: string; text: string }> }>;
@@ -43,7 +50,6 @@ function parseIntentFromResponse(text: string): Intent | null {
   const trimmed = text.trim();
   if (!trimmed) return null;
 
-  // Try JSON unwrapping (handles `"spec_feedback"` format)
   if (trimmed.startsWith('"') || trimmed.startsWith('{')) {
     try {
       const parsed = JSON.parse(trimmed);
@@ -51,13 +57,16 @@ function parseIntentFromResponse(text: string): Intent | null {
         return ALL_INTENTS.includes(parsed as Intent) ? (parsed as Intent) : null;
       }
     } catch {
-      // fall through to token extraction
+      // fall through
     }
   }
 
-  // Extract first whitespace-delimited token (handles "spec_approval — explanation" format)
   const firstToken = trimmed.split(/[\s—–-]/)[0].trim();
   return ALL_INTENTS.includes(firstToken as Intent) ? (firstToken as Intent) : null;
+}
+
+export interface IntentClassifier {
+  classify(message: string, context: ClassificationContext): Promise<Intent>;
 }
 
 export class AnthropicIntentClassifier implements IntentClassifier {
@@ -74,27 +83,28 @@ export class AnthropicIntentClassifier implements IntentClassifier {
     this.logger = createLogger('intent-classifier', { destination: options?.logDestination });
   }
 
-  async classify(message: string, run_stage: RunStage): Promise<Intent> {
-    const fallback = CONSERVATIVE_FALLBACK[run_stage] ?? 'spec_feedback';
+  async classify(message: string, context: ClassificationContext): Promise<Intent> {
+    const fallback = CONSERVATIVE_FALLBACK[context] ?? 'feedback';
 
-    if (!message.trim()) {
-      return fallback;
-    }
+    if (!message.trim()) return fallback;
 
-    const validIntents = VALID_INTENTS_BY_STAGE[run_stage] ?? ALL_INTENTS;
+    const validIntents = VALID_INTENTS_BY_CONTEXT[context] ?? ALL_INTENTS;
+
     const intentDescriptions: Record<Intent, string> = {
-      spec_feedback: 'the human wants to revise or give feedback on the spec',
-      spec_approval: 'the human is approving the spec and wants implementation to begin',
-      implementation_feedback: 'the human is providing feedback, a bug report, or answering a question about the implementation',
-      implementation_approval: 'the human confirms the implementation is ready and wants a PR created',
+      idea:     'the human wants to build a new feature or improvement',
+      bug:      'the human is reporting a bug or something broken',
+      question: 'the human is asking a question',
+      feedback: 'the human is providing feedback, a revision request, or answering a question about the current work',
+      approval: 'the human is approving the current work and wants to proceed',
+      ignore:   'the message is not directed at the bot or has no actionable intent',
     };
 
     const prompt = [
-      `Classify the following Slack message into one of these intents, given the current workflow stage.`,
+      `Classify the following Slack message into one of these intents, given the current context.`,
       ``,
-      `Current stage: ${run_stage}`,
+      `Current context: ${context}`,
       ``,
-      `Valid intents for this stage:`,
+      `Valid intents for this context:`,
       ...validIntents.map(i => `- ${i}: ${intentDescriptions[i]}`),
       ``,
       `Message:`,
@@ -117,7 +127,7 @@ export class AnthropicIntentClassifier implements IntentClassifier {
 
         if (intent && validIntents.includes(intent)) {
           this.logger.info(
-            { event: 'intent.classified', run_stage, classified_intent: intent, message_length: message.length },
+            { event: 'intent.classified', context, classified_intent: intent, message_length: message.length },
             'Intent classified',
           );
           return intent;
@@ -125,13 +135,13 @@ export class AnthropicIntentClassifier implements IntentClassifier {
 
         if (intent && !validIntents.includes(intent)) {
           this.logger.warn(
-            { event: 'intent.invalid_for_stage', returned_intent: intent, run_stage, valid_intents: validIntents },
-            'Model returned intent not valid for stage',
+            { event: 'intent.invalid_for_context', returned_intent: intent, context, valid_intents: validIntents },
+            'Model returned intent not valid for context',
           );
         }
       } catch (err) {
         this.logger.warn(
-          { event: 'intent.classification_failed', run_stage, error: String(err) },
+          { event: 'intent.classification_failed', context, error: String(err) },
           'Intent classification API call failed',
         );
       }
@@ -140,7 +150,7 @@ export class AnthropicIntentClassifier implements IntentClassifier {
     }
 
     this.logger.warn(
-      { event: 'intent.classified', run_stage, classified_intent: fallback, message_length: message.length },
+      { event: 'intent.classified_fallback', context, classified_intent: fallback, message_length: message.length },
       'Falling back to conservative default intent',
     );
     return fallback;

--- a/src/adapters/agent/question-answerer.ts
+++ b/src/adapters/agent/question-answerer.ts
@@ -1,5 +1,8 @@
 // src/adapters/agent/question-answerer.ts
 import { query as _query } from '@anthropic-ai/claude-agent-sdk';
+import { readFile as _readFile, unlink } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 
@@ -11,40 +14,31 @@ export interface QuestionAnswerer {
 
 interface AgentSDKQuestionAnswererOptions {
   queryFn?: QueryFn;
+  readFile?: (path: string, encoding: 'utf-8') => Promise<string>;
   logDestination?: pino.DestinationStream;
 }
 
-const PROMPT_PREFIX = [
-  `You are Autocatalyst, an AI-powered product engineering assistant integrated into Slack.`,
-  ``,
-  `You have access to the repository via shell tools. Use them to answer the question accurately.`,
-  `For example: run \`gh issue list\`, \`gh pr list\`, \`git log\`, read files, etc.`,
-  ``,
-  `Answer concisely — this response will be posted directly to Slack.`,
-  `Do not include preamble or sign-off. Just the answer.`,
-  ``,
-  `Question:`,
-].join('\n');
-
 export class AgentSDKQuestionAnswerer implements QuestionAnswerer {
   private readonly queryFn: QueryFn;
+  private readonly readFileFn: (path: string, encoding: 'utf-8') => Promise<string>;
   private readonly logger: pino.Logger;
   private readonly repo_path: string;
 
   constructor(repo_path: string, options?: AgentSDKQuestionAnswererOptions) {
     this.repo_path = repo_path;
     this.queryFn = options?.queryFn ?? _query;
+    this.readFileFn = options?.readFile ?? ((path, enc) => _readFile(path, enc));
     this.logger = createLogger('question-answerer', { destination: options?.logDestination });
   }
 
   async answer(question: string): Promise<string> {
+    const resultPath = join(this.repo_path, '.autocatalyst', `question-${randomUUID()}.json`);
+    const prompt = buildPrompt(question, resultPath);
+
     this.logger.debug({ event: 'question.answering', question_length: question.length }, 'Answering question via Agent SDK');
 
-    const prompt = `${PROMPT_PREFIX}${question}`;
-    const chunks: string[] = [];
-
     try {
-      for await (const message of this.queryFn({
+      for await (const _message of this.queryFn({
         prompt,
         options: {
           cwd: this.repo_path,
@@ -55,27 +49,56 @@ export class AgentSDKQuestionAnswerer implements QuestionAnswerer {
           systemPrompt: { type: 'preset', preset: 'claude_code' },
         },
       })) {
-        // Collect assistant text from the final message
-        const msg = message as { role?: string; content?: Array<{ type: string; text?: string }> };
-        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-          for (const block of msg.content) {
-            if (block.type === 'text' && block.text) {
-              chunks.push(block.text);
-            }
-          }
-        }
+        // drain iterator — agent writes result file on completion
       }
     } catch (err) {
       this.logger.error({ event: 'question.agent_failed', error: String(err) }, 'Agent SDK exited with error during question answering');
       throw new Error(`Agent SDK question answering failed: ${String(err)}`);
     }
 
-    const response = chunks.join('').trim();
-    if (!response) {
-      throw new Error('Agent SDK returned no text response for question');
+    let content: string;
+    try {
+      content = await this.readFileFn(resultPath, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`Question answering: result file not found at "${resultPath}" after agent completed`);
+      }
+      throw err;
     }
 
-    this.logger.info({ event: 'question.answered', response_length: response.length }, 'Question answered');
-    return response;
+    // Clean up result file — best-effort
+    unlink(resultPath).catch(() => {});
+
+    let data: unknown;
+    try {
+      data = JSON.parse(content);
+    } catch (err) {
+      throw new Error(`Question answering: result file is not valid JSON: ${String(err)}`);
+    }
+    if (typeof data !== 'object' || data === null || typeof (data as Record<string, unknown>)['answer'] !== 'string') {
+      throw new Error(`Question answering: result file missing "answer" string`);
+    }
+
+    const answer = (data as Record<string, unknown>)['answer'] as string;
+    this.logger.info({ event: 'question.answered', response_length: answer.length }, 'Question answered');
+    return answer;
   }
+}
+
+function buildPrompt(question: string, resultPath: string): string {
+  return [
+    `You are Autocatalyst, an AI-powered product engineering assistant integrated into Slack.`,
+    ``,
+    `Answer the following question. You have access to shell tools — use them as needed.`,
+    `For example: \`gh issue list\`, \`gh pr list\`, \`git log\`, read files, etc.`,
+    ``,
+    `Question:`,
+    question,
+    ``,
+    `When you have your answer, write it to: ${resultPath}`,
+    `Content must be: { "answer": "<your answer as a single string>" }`,
+    ``,
+    `Keep the answer concise — it will be posted directly to Slack.`,
+    `Do not signal completion until the result file has been written.`,
+  ].join('\n');
 }

--- a/src/adapters/agent/question-answerer.ts
+++ b/src/adapters/agent/question-answerer.ts
@@ -1,0 +1,64 @@
+// src/adapters/agent/question-answerer.ts
+import Anthropic from '@anthropic-ai/sdk';
+import type pino from 'pino';
+import { createLogger } from '../../core/logger.js';
+
+type CreateFn = (params: {
+  model: string;
+  max_tokens: number;
+  system?: string;
+  messages: Array<{ role: 'user'; content: string }>;
+}) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+export interface QuestionAnswerer {
+  answer(question: string): Promise<string>;
+}
+
+interface AnthropicQuestionAnswererOptions {
+  createFn?: CreateFn;
+  logDestination?: pino.DestinationStream;
+}
+
+const SYSTEM_PROMPT = `You are Autocatalyst, an AI-powered product engineering assistant integrated into Slack.
+
+You help teams turn ideas into shipped features by:
+- Taking feature requests and bug reports from Slack
+- Generating product specs collaboratively with the team
+- Implementing features using AI agents and creating pull requests
+- Routing in-thread feedback and approvals to the right handlers
+
+Answer the user's question concisely and helpfully. If the question is about a specific codebase, repository, or domain you don't have context about, say so clearly and suggest they check with a team member directly.`;
+
+export class AnthropicQuestionAnswerer implements QuestionAnswerer {
+  private readonly createFn: CreateFn;
+  private readonly logger: pino.Logger;
+
+  constructor(apiKey: string, options?: AnthropicQuestionAnswererOptions) {
+    if (options?.createFn) {
+      this.createFn = options.createFn;
+    } else {
+      const client = new Anthropic({ apiKey });
+      this.createFn = (params) => client.messages.create(params) as Promise<{ content: Array<{ type: string; text: string }> }>;
+    }
+    this.logger = createLogger('question-answerer', { destination: options?.logDestination });
+  }
+
+  async answer(question: string): Promise<string> {
+    this.logger.debug({ event: 'question.answering', question_length: question.length }, 'Answering question');
+
+    const response = await this.createFn({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 500,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: question }],
+    });
+
+    const text = response.content.find(b => b.type === 'text')?.text ?? '';
+    if (!text) {
+      return "I'm not sure how to answer that — try rephrasing or asking the team directly.";
+    }
+
+    this.logger.info({ event: 'question.answered', response_length: text.length }, 'Question answered');
+    return text;
+  }
+}

--- a/src/adapters/agent/question-answerer.ts
+++ b/src/adapters/agent/question-answerer.ts
@@ -1,64 +1,81 @@
 // src/adapters/agent/question-answerer.ts
-import Anthropic from '@anthropic-ai/sdk';
+import { query as _query } from '@anthropic-ai/claude-agent-sdk';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 
-type CreateFn = (params: {
-  model: string;
-  max_tokens: number;
-  system?: string;
-  messages: Array<{ role: 'user'; content: string }>;
-}) => Promise<{ content: Array<{ type: string; text: string }> }>;
+type QueryFn = typeof _query;
 
 export interface QuestionAnswerer {
   answer(question: string): Promise<string>;
 }
 
-interface AnthropicQuestionAnswererOptions {
-  createFn?: CreateFn;
+interface AgentSDKQuestionAnswererOptions {
+  queryFn?: QueryFn;
   logDestination?: pino.DestinationStream;
 }
 
-const SYSTEM_PROMPT = `You are Autocatalyst, an AI-powered product engineering assistant integrated into Slack.
+const PROMPT_PREFIX = [
+  `You are Autocatalyst, an AI-powered product engineering assistant integrated into Slack.`,
+  ``,
+  `You have access to the repository via shell tools. Use them to answer the question accurately.`,
+  `For example: run \`gh issue list\`, \`gh pr list\`, \`git log\`, read files, etc.`,
+  ``,
+  `Answer concisely — this response will be posted directly to Slack.`,
+  `Do not include preamble or sign-off. Just the answer.`,
+  ``,
+  `Question:`,
+].join('\n');
 
-You help teams turn ideas into shipped features by:
-- Taking feature requests and bug reports from Slack
-- Generating product specs collaboratively with the team
-- Implementing features using AI agents and creating pull requests
-- Routing in-thread feedback and approvals to the right handlers
-
-Answer the user's question concisely and helpfully. If the question is about a specific codebase, repository, or domain you don't have context about, say so clearly and suggest they check with a team member directly.`;
-
-export class AnthropicQuestionAnswerer implements QuestionAnswerer {
-  private readonly createFn: CreateFn;
+export class AgentSDKQuestionAnswerer implements QuestionAnswerer {
+  private readonly queryFn: QueryFn;
   private readonly logger: pino.Logger;
+  private readonly repo_path: string;
 
-  constructor(apiKey: string, options?: AnthropicQuestionAnswererOptions) {
-    if (options?.createFn) {
-      this.createFn = options.createFn;
-    } else {
-      const client = new Anthropic({ apiKey });
-      this.createFn = (params) => client.messages.create(params) as Promise<{ content: Array<{ type: string; text: string }> }>;
-    }
+  constructor(repo_path: string, options?: AgentSDKQuestionAnswererOptions) {
+    this.repo_path = repo_path;
+    this.queryFn = options?.queryFn ?? _query;
     this.logger = createLogger('question-answerer', { destination: options?.logDestination });
   }
 
   async answer(question: string): Promise<string> {
-    this.logger.debug({ event: 'question.answering', question_length: question.length }, 'Answering question');
+    this.logger.debug({ event: 'question.answering', question_length: question.length }, 'Answering question via Agent SDK');
 
-    const response = await this.createFn({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 500,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: question }],
-    });
+    const prompt = `${PROMPT_PREFIX}${question}`;
+    const chunks: string[] = [];
 
-    const text = response.content.find(b => b.type === 'text')?.text ?? '';
-    if (!text) {
-      return "I'm not sure how to answer that — try rephrasing or asking the team directly.";
+    try {
+      for await (const message of this.queryFn({
+        prompt,
+        options: {
+          cwd: this.repo_path,
+          permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+          tools: { type: 'preset', preset: 'claude_code' },
+          settingSources: ['user', 'project'],
+          systemPrompt: { type: 'preset', preset: 'claude_code' },
+        },
+      })) {
+        // Collect assistant text from the final message
+        const msg = message as { role?: string; content?: Array<{ type: string; text?: string }> };
+        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block.type === 'text' && block.text) {
+              chunks.push(block.text);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      this.logger.error({ event: 'question.agent_failed', error: String(err) }, 'Agent SDK exited with error during question answering');
+      throw new Error(`Agent SDK question answering failed: ${String(err)}`);
     }
 
-    this.logger.info({ event: 'question.answered', response_length: text.length }, 'Question answered');
-    return text;
+    const response = chunks.join('').trim();
+    if (!response) {
+      throw new Error('Agent SDK returned no text response for question');
+    }
+
+    this.logger.info({ event: 'question.answered', response_length: response.length }, 'Question answered');
+    return response;
   }
 }

--- a/src/adapters/agent/spec-generator.ts
+++ b/src/adapters/agent/spec-generator.ts
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
-import type { Idea, ThreadMessage } from '../../types/events.js';
+import type { Request, ThreadMessage } from '../../types/events.js';
 import { stripCommentSpans, extractCommentSpans, ensureSpansPreserved } from '../notion/markdown-diff.js';
 
 export interface NotionComment {
@@ -26,7 +26,7 @@ export interface ReviseResult {
 }
 
 export interface SpecGenerator {
-  create(idea: Idea, workspace_path: string): Promise<string>;
+  create(request: Request, workspace_path: string): Promise<string>;
   revise(
     feedback: ThreadMessage,
     notion_comments: NotionComment[],
@@ -85,12 +85,12 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     this.readFileFn = options?.readFile ?? ((path, enc) => _readFile(path, enc));
   }
 
-  async create(idea: Idea, workspace_path: string): Promise<string> {
+  async create(request: Request, workspace_path: string): Promise<string> {
     const createResultPath = join(workspace_path, '.autocatalyst', 'spec-create-result.json');
     const specDir = join(workspace_path, 'context-human', 'specs');
-    const prompt = buildCreatePrompt(idea, specDir, createResultPath);
+    const prompt = buildCreatePrompt(request, specDir, createResultPath);
 
-    this.logger.debug({ event: 'spec.agent_invoked', idea_id: idea.id }, 'Invoking Agent SDK for spec creation');
+    this.logger.debug({ event: 'spec.agent_invoked', request_id: request.id }, 'Invoking Agent SDK for spec creation');
 
     try {
       for await (const _message of this.queryFn({
@@ -108,7 +108,7 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
       }
     } catch (err) {
       this.logger.error(
-        { event: 'spec.agent_failed', idea_id: idea.id, error: String(err) },
+        { event: 'spec.agent_failed', request_id: request.id, error: String(err) },
         'Agent SDK exited with error during spec creation',
       );
       throw new Error(`Agent SDK spec creation failed: ${String(err)}`);
@@ -139,8 +139,8 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     }
     const spec_path = obj['spec_path'];
 
-    this.logger.debug({ event: 'spec.agent_completed', idea_id: idea.id }, 'Agent SDK spec creation completed');
-    this.logger.info({ event: 'spec.generated', idea_id: idea.id, spec_path }, 'Spec generated');
+    this.logger.debug({ event: 'spec.agent_completed', request_id: request.id }, 'Agent SDK spec creation completed');
+    this.logger.info({ event: 'spec.generated', request_id: request.id, spec_path }, 'Spec generated');
     return spec_path;
   }
 
@@ -159,10 +159,10 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     const prompt = buildRevisePrompt(feedback, notion_comments, spec_path, reviseResultPath, currentSpec, hasSpans);
 
     this.logger.debug(
-      { event: 'spec_revision.input', idea_id: feedback.idea_id, notion_comment_count: notion_comments.length },
+      { event: 'spec_revision.input', request_id: feedback.request_id, notion_comment_count: notion_comments.length },
       'Revise called with Notion comments',
     );
-    this.logger.debug({ event: 'spec.agent_invoked', idea_id: feedback.idea_id }, 'Invoking Agent SDK for spec revision');
+    this.logger.debug({ event: 'spec.agent_invoked', request_id: feedback.request_id }, 'Invoking Agent SDK for spec revision');
 
     try {
       for await (const _message of this.queryFn({
@@ -180,7 +180,7 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
       }
     } catch (err) {
       this.logger.error(
-        { event: 'spec.agent_failed', idea_id: feedback.idea_id, error: String(err) },
+        { event: 'spec.agent_failed', request_id: feedback.request_id, error: String(err) },
         'Agent SDK exited with error during spec revision',
       );
       throw new Error(`Agent SDK spec revision failed: ${String(err)}`);
@@ -198,9 +198,9 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
 
     const commentResponses = parseCommentResponses(content, reviseResultPath);
 
-    this.logger.debug({ event: 'spec.agent_completed', idea_id: feedback.idea_id }, 'Agent SDK spec revision completed');
+    this.logger.debug({ event: 'spec.agent_completed', request_id: feedback.request_id }, 'Agent SDK spec revision completed');
     this.logger.debug(
-      { event: 'spec_revision.output', idea_id: feedback.idea_id, comment_response_count: commentResponses.length },
+      { event: 'spec_revision.output', request_id: feedback.request_id, comment_response_count: commentResponses.length },
       'Parsed comment responses from revision',
     );
 
@@ -209,26 +209,26 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
       const pageContent = ensureSpansPreserved(agentSpec, originalSpans);
       writeFileSync(spec_path, stripCommentSpans(pageContent), 'utf-8');
       this.logger.info(
-        { event: 'spec.revised', idea_id: feedback.idea_id, spec_path, spans_preserved: true },
+        { event: 'spec.revised', request_id: feedback.request_id, spec_path, spans_preserved: true },
         'Spec revised with span passthrough',
       );
       return { comment_responses: commentResponses, page_content: pageContent };
     }
 
-    this.logger.info({ event: 'spec.revised', idea_id: feedback.idea_id, spec_path }, 'Spec revised');
+    this.logger.info({ event: 'spec.revised', request_id: feedback.request_id, spec_path }, 'Spec revised');
     return { comment_responses: commentResponses };
   }
 }
 
-function buildCreatePrompt(idea: Idea, specDir: string, createResultPath: string): string {
+function buildCreatePrompt(request: Request, specDir: string, createResultPath: string): string {
   return [
-    `Use the /mm:planning skill to create a complete product spec for the following idea.`,
+    `Use the /mm:planning skill to create a complete product spec for the following request.`,
     ``,
     `/mm:planning`,
     ``,
-    `Idea:`,
+    `Request:`,
     `<<<`,
-    idea.content,
+    request.content,
     `>>>`,
     ``,
     `When the spec is complete:`,

--- a/src/adapters/slack/classifier.ts
+++ b/src/adapters/slack/classifier.ts
@@ -8,8 +8,8 @@ export interface MessageInput {
 }
 
 export type MessageClassification =
-  | { intent: 'new_idea' }
-  | { intent: 'spec_feedback'; idea_id: string }
+  | { intent: 'new_request' }
+  | { intent: 'thread_message'; request_id: string }
   | { intent: 'ignore' };
 
 export function classifyMessage(
@@ -20,19 +20,25 @@ export function classifyMessage(
   // Suppress bot's own messages (prevents response loops)
   if (message.user === botUserId) return { intent: 'ignore' };
 
-  // Must contain exact @mention token
+  // Thread reply: thread_ts exists and differs from ts
+  const isReply = message.thread_ts !== undefined && message.thread_ts !== message.ts;
+  if (isReply) {
+    // Must contain exact @mention token for bot
+    const mention = `<@${botUserId}>`;
+    if (!message.text || !message.text.includes(mention)) {
+      return { intent: 'ignore' };
+    }
+
+    const request_id = registry.resolve(message.thread_ts!);
+    if (request_id === undefined) return { intent: 'ignore' };
+    return { intent: 'thread_message', request_id };
+  }
+
+  // Root message: must contain exact @mention token
   const mention = `<@${botUserId}>`;
   if (!message.text || !message.text.includes(mention)) {
     return { intent: 'ignore' };
   }
 
-  // Thread reply: thread_ts exists and differs from ts
-  const isReply = message.thread_ts !== undefined && message.thread_ts !== message.ts;
-  if (isReply) {
-    const idea_id = registry.resolve(message.thread_ts!);
-    if (idea_id === undefined) return { intent: 'ignore' };
-    return { intent: 'spec_feedback', idea_id };
-  }
-
-  return { intent: 'new_idea' };
+  return { intent: 'new_request' };
 }

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -3,7 +3,7 @@ import type { App } from '@slack/bolt';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 import type { HumanInterfaceAdapter } from '../human-interface-adapter.js';
-import type { InboundEvent, Idea, ThreadMessage } from '../../types/events.js';
+import type { InboundEvent, Request, ThreadMessage } from '../../types/events.js';
 import { classifyMessage } from './classifier.js';
 import { ThreadRegistry } from './thread-registry.js';
 
@@ -109,8 +109,8 @@ export class SlackAdapter implements HumanInterfaceAdapter {
         'Message classified',
       );
 
-      if (result.intent === 'new_idea') {
-        const idea: Idea = {
+      if (result.intent === 'new_request') {
+        const request: Request = {
           id: randomUUID(),
           source: 'slack',
           content: msg.text ?? '',
@@ -121,13 +121,13 @@ export class SlackAdapter implements HumanInterfaceAdapter {
         };
 
         // Post acknowledgement and register thread before emitting
-        this.registry.register(msg.ts, idea.id);
+        this.registry.register(msg.ts, request.id);
         await this.postMessage(this.channelId!, msg.ts, "Got it — I'll work on a spec and post it here.");
-        this.emit({ type: 'new_idea', payload: idea });
+        this.emit({ type: 'new_request', payload: request });
 
-      } else if (result.intent === 'spec_feedback') {
+      } else if (result.intent === 'thread_message') {
         const message: ThreadMessage = {
-          idea_id: result.idea_id,
+          request_id: result.request_id,
           content: msg.text ?? '',
           author: msg.user,
           received_at: new Date().toISOString(),

--- a/src/adapters/slack/thread-registry.ts
+++ b/src/adapters/slack/thread-registry.ts
@@ -1,8 +1,8 @@
 export class ThreadRegistry {
   private readonly map = new Map<string, string>();
 
-  register(thread_ts: string, idea_id: string): void {
-    this.map.set(thread_ts, idea_id);
+  register(thread_ts: string, request_id: string): void {
+    this.map.set(thread_ts, request_id);
   }
 
   resolve(thread_ts: string): string | undefined {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -11,6 +11,7 @@ import type { Request, ThreadMessage, InboundEvent } from '../types/events.js';
 import type { FeedbackSource } from '../adapters/notion/notion-feedback-source.js';
 import type { NotionComment } from '../adapters/agent/spec-generator.js';
 import type { IntentClassifier, ClassificationContext, Intent } from '../adapters/agent/intent-classifier.js';
+import type { QuestionAnswerer } from '../adapters/agent/question-answerer.js';
 import type { SpecCommitter } from '../adapters/notion/spec-committer.js';
 import type { Implementer } from '../adapters/agent/implementer.js';
 import type { ImplementationFeedbackPage, FeedbackItem } from '../adapters/notion/implementation-feedback-page.js';
@@ -30,6 +31,7 @@ interface OrchestratorDeps {
   specPublisher: SpecPublisher;
   feedbackSource?: FeedbackSource;
   intentClassifier?: IntentClassifier;
+  questionAnswerer?: QuestionAnswerer;
   specCommitter?: SpecCommitter;
   implementer?: Implementer;
   implFeedbackPage?: ImplementationFeedbackPage;
@@ -133,7 +135,7 @@ export class OrchestratorImpl implements Orchestrator {
       } else if (intent === 'question') {
         run.intent = 'question';
         this._persistRuns();
-        await this._handleQuestion(request.channel_id, request.thread_ts, run);
+        await this._handleQuestion(request.content, request.channel_id, request.thread_ts, run);
       } else {
         // ignore
         this.runs.delete(request.id);
@@ -221,18 +223,31 @@ export class OrchestratorImpl implements Orchestrator {
           await this._handleImplementationApproval(feedback, run);
         }
       } else if (intent === 'question') {
-        await this._handleQuestion(feedback.channel_id, feedback.thread_ts, run);
+        await this._handleQuestion(feedback.content, feedback.channel_id, feedback.thread_ts, run);
       }
       // 'ignore' and other intents: silently discard
     }
   }
 
-  private async _handleQuestion(channel_id: string, thread_ts: string, run: Run): Promise<void> {
-    this.logger.info({ event: 'question.received', run_id: run.id, request_id: run.request_id }, 'Question received; stub handler');
+  private async _handleQuestion(content: string, channel_id: string, thread_ts: string, run: Run): Promise<void> {
+    this.logger.info({ event: 'question.received', run_id: run.id, request_id: run.request_id }, 'Question received');
+
+    let response: string;
+    if (this.deps.questionAnswerer) {
+      try {
+        response = await this.deps.questionAnswerer.answer(content);
+      } catch (err) {
+        this.logger.error({ event: 'question.answer_failed', run_id: run.id, error: String(err) }, 'Failed to answer question; posting fallback');
+        response = "I wasn't able to answer that right now \u2014 try asking the team directly.";
+      }
+    } else {
+      response = "I've noted your question \u2014 question answering is coming soon.";
+    }
+
     try {
-      await this.deps.postMessage(channel_id, thread_ts, "I noted your question. Question handling is not yet implemented \u2014 please ask the team directly for now.");
+      await this.deps.postMessage(channel_id, thread_ts, response);
     } catch (err) {
-      this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post question ack');
+      this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post question response');
     }
   }
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -6,11 +6,11 @@ import type { SlackAdapter } from '../adapters/slack/slack-adapter.js';
 import type { WorkspaceManager } from './workspace-manager.js';
 import type { SpecGenerator, ReviseResult } from '../adapters/agent/spec-generator.js';
 import type { SpecPublisher } from '../adapters/slack/canvas-publisher.js';
-import type { Run, RunStage } from '../types/runs.js';
-import type { Idea, ThreadMessage } from '../types/events.js';
+import type { Run, RunStage, RequestIntent } from '../types/runs.js';
+import type { Request, ThreadMessage, InboundEvent } from '../types/events.js';
 import type { FeedbackSource } from '../adapters/notion/notion-feedback-source.js';
 import type { NotionComment } from '../adapters/agent/spec-generator.js';
-import type { IntentClassifier } from '../adapters/agent/intent-classifier.js';
+import type { IntentClassifier, ClassificationContext, Intent } from '../adapters/agent/intent-classifier.js';
 import type { SpecCommitter } from '../adapters/notion/spec-committer.js';
 import type { Implementer } from '../adapters/agent/implementer.js';
 import type { ImplementationFeedbackPage, FeedbackItem } from '../adapters/notion/implementation-feedback-page.js';
@@ -58,8 +58,8 @@ export class OrchestratorImpl implements Orchestrator {
     if (deps.runStore) {
       const loaded = deps.runStore.load();
       for (const run of loaded) {
-        this.runs.set(run.idea_id, run);
-        deps.threadRegistry?.register(run.thread_ts, run.idea_id);
+        this.runs.set(run.request_id, run);
+        deps.threadRegistry?.register(run.thread_ts, run.request_id);
       }
       if (deps.runStore instanceof FileRunStore && deps.runStore.demotedIds.size > 0) {
         const demotedRuns = [...deps.runStore.demotedIds]
@@ -96,66 +96,144 @@ export class OrchestratorImpl implements Orchestrator {
   private async _runLoop(): Promise<void> {
     for await (const event of this.deps.adapter.receive()) {
       if (this._stopping) break;
-      if (event.type === 'new_idea') {
-        await this._handleNewIdea(event.payload);
-      } else if (event.type === 'thread_message') {
-        await this._handleThreadMessage(event.payload);
-      }
+      await this._handleRequest(event as InboundEvent);
     }
   }
 
-  private async _handleThreadMessage(feedback: ThreadMessage): Promise<void> {
-    const run = this.runs.get(feedback.idea_id);
-    if (!run) {
-      this.logger.debug({ event: 'thread_message.discarded', idea_id: feedback.idea_id, reason: 'no_run' }, 'No run for idea_id; discarding');
-      return;
-    }
+  private async _handleRequest(event: InboundEvent): Promise<void> {
+    if (event.type === 'new_request') {
+      const request = event.payload;
+      const run = this.createRun(request);
 
-    // Guard: implementation in progress — tell the user to wait
-    if (run.stage === 'implementing') {
-      this.logger.info({ event: 'thread_message.busy', run_id: run.id, idea_id: run.idea_id }, 'Implementation in progress; notifying user');
-      try {
-        await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, "Implementation is in progress — I'll let you know when it's ready for review.");
-      } catch (err) {
-        this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post busy notification');
+      // Classify intent for new request
+      let intent: Intent = 'idea';
+      if (this.deps.intentClassifier) {
+        try {
+          intent = await this.deps.intentClassifier.classify(request.content, 'new_thread');
+        } catch (err) {
+          this.logger.warn({ event: 'intent_classification.failed', run_id: run.id, error: String(err) }, 'Intent classification failed for new request; defaulting to idea');
+          intent = 'idea';
+        }
+        this.logger.debug({ event: 'intent_classification.result', run_id: run.id, intent }, 'Intent classified for new request');
+      }
+
+      // Route by intent
+      if (intent === 'idea') {
+        run.intent = 'idea';
+        this._persistRuns();
+        await this._startSpecPipeline(run, request);
+      } else if (intent === 'bug') {
+        run.intent = 'bug';
+        this._persistRuns();
+        try {
+          await this.deps.postMessage(request.channel_id, request.thread_ts, 'Got it \u2014 bug report noted. Bug triage is not yet implemented.');
+        } catch (err) {
+          this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post bug ack');
+        }
+      } else if (intent === 'question') {
+        run.intent = 'question';
+        this._persistRuns();
+        await this._handleQuestion(request.channel_id, request.thread_ts, run);
+      } else {
+        // ignore
+        this.runs.delete(request.id);
+        this._persistRuns();
+        this.logger.debug({ event: 'new_request.ignored', request_id: request.id }, 'New request classified as ignore; discarding');
       }
       return;
     }
 
-    // Only classify for stages that accept thread messages
-    if (run.stage !== 'reviewing_spec' && run.stage !== 'reviewing_implementation' && run.stage !== 'awaiting_impl_input') {
-      this.logger.debug({ event: 'thread_message.discarded', run_id: run.id, idea_id: run.idea_id, stage: run.stage, reason: 'wrong_stage' }, 'Run not in a reviewable stage; discarding');
-      return;
+    if (event.type === 'thread_message') {
+      const feedback = event.payload;
+      const run = this.runs.get(feedback.request_id);
+      if (!run) {
+        this.logger.debug({ event: 'thread_message.discarded', request_id: feedback.request_id, reason: 'no_run' }, 'No run for request_id; discarding');
+        return;
+      }
+
+      // Guard: implementation in progress -- tell the user to wait
+      if (run.stage === 'implementing') {
+        this.logger.info({ event: 'thread_message.busy', run_id: run.id, request_id: run.request_id }, 'Implementation in progress; notifying user');
+        try {
+          await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, "Implementation is in progress \u2014 I'll let you know when it's ready for review.");
+        } catch (err) {
+          this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post busy notification');
+        }
+        return;
+      }
+
+      // Only classify for stages that accept thread messages
+      if (run.stage !== 'reviewing_spec' && run.stage !== 'reviewing_implementation' && run.stage !== 'awaiting_impl_input' && run.stage !== 'intake') {
+        this.logger.debug({ event: 'thread_message.discarded', run_id: run.id, request_id: run.request_id, stage: run.stage, reason: 'wrong_stage' }, 'Run not in a reviewable stage; discarding');
+        return;
+      }
+
+      // Classify intent
+      let intent: Intent = 'feedback';
+      if (this.deps.intentClassifier) {
+        const context: ClassificationContext = run.stage;
+        try {
+          intent = await this.deps.intentClassifier.classify(feedback.content, context);
+        } catch (err) {
+          this.logger.warn({ event: 'intent_classification.failed', run_id: run.id, error: String(err) }, 'Intent classification failed; defaulting to feedback');
+          intent = 'feedback';
+        }
+        this.logger.debug({ event: 'intent_classification.result', run_id: run.id, intent, stage: run.stage }, 'Intent classified');
+      }
+
+      // Intent upgrade: run.intent='question' + stage='intake' + classifier returns 'idea'/'bug'
+      if (run.stage === 'intake' && (intent === 'idea' || intent === 'bug')) {
+        run.intent = intent as RequestIntent;
+        this._persistRuns();
+        if (intent === 'idea') {
+          // Build a Request from the thread message for spec pipeline
+          const request: Request = {
+            id: run.request_id,
+            source: 'slack',
+            content: feedback.content,
+            author: feedback.author,
+            received_at: feedback.received_at,
+            thread_ts: feedback.thread_ts,
+            channel_id: feedback.channel_id,
+          };
+          await this._startSpecPipeline(run, request);
+        } else {
+          try {
+            await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, 'Got it \u2014 bug report noted. Bug triage is not yet implemented.');
+          } catch (err) {
+            this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post bug ack');
+          }
+        }
+        return;
+      }
+
+      // Route by intent x stage
+      if (intent === 'feedback') {
+        if (run.stage === 'reviewing_spec') {
+          await this._handleSpecFeedback(feedback);
+        } else if (run.stage === 'reviewing_implementation' || run.stage === 'awaiting_impl_input') {
+          await this._handleImplementationFeedback(feedback, run);
+        }
+      } else if (intent === 'approval') {
+        if (run.stage === 'reviewing_spec') {
+          await this._handleSpecApproval(feedback, run);
+        } else if (run.stage === 'reviewing_implementation') {
+          await this._handleImplementationApproval(feedback, run);
+        }
+      } else if (intent === 'question') {
+        await this._handleQuestion(feedback.channel_id, feedback.thread_ts, run);
+      }
+      // 'ignore' and other intents: silently discard
     }
+  }
 
-    // Classify intent
-    if (this.deps.intentClassifier) {
-      let intent: string;
-      try {
-        intent = await this.deps.intentClassifier.classify(feedback.content, run.stage);
-      } catch (err) {
-        this.logger.warn({ event: 'intent_classification.failed', run_id: run.id, error: String(err) }, 'Intent classification failed; defaulting to spec_feedback');
-        intent = run.stage === 'reviewing_spec' ? 'spec_feedback' : 'implementation_feedback';
-      }
-
-      this.logger.debug({ event: 'intent_classification.result', run_id: run.id, intent }, 'Intent classified');
-
-      if (intent === 'spec_approval') {
-        await this._handleSpecApproval(feedback, run);
-        return;
-      }
-      if (intent === 'implementation_feedback') {
-        await this._handleImplementationFeedback(feedback, run);
-        return;
-      }
-      if (intent === 'implementation_approval') {
-        await this._handleImplementationApproval(feedback, run);
-        return;
-      }
-      // intent === 'spec_feedback' falls through to _handleSpecFeedback
+  private async _handleQuestion(channel_id: string, thread_ts: string, run: Run): Promise<void> {
+    this.logger.info({ event: 'question.received', run_id: run.id, request_id: run.request_id }, 'Question received; stub handler');
+    try {
+      await this.deps.postMessage(channel_id, thread_ts, "I noted your question. Question handling is not yet implemented \u2014 please ask the team directly for now.");
+    } catch (err) {
+      this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post question ack');
     }
-
-    await this._handleSpecFeedback(feedback);
   }
 
   private async _handleSpecApproval(feedback: ThreadMessage, run: Run): Promise<void> {
@@ -165,11 +243,11 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     this.transition(run, 'implementing');
-    this.logger.info({ event: 'implementation.started', run_id: run.id, idea_id: run.idea_id }, 'Implementation started');
+    this.logger.info({ event: 'implementation.started', run_id: run.id, request_id: run.request_id }, 'Implementation started');
     run.attempt += 1;
     this._persistRuns();
 
-    // Step 1: Acknowledge approval (best-effort — failure doesn't abort)
+    // Step 1: Acknowledge approval (best-effort -- failure doesn't abort)
     try {
       await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, 'Approved \u2014 committing spec and starting implementation.');
     } catch (err) {
@@ -201,7 +279,7 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     if (result.status === 'needs_input') {
-      this.logger.info({ event: 'implementation.needs_input', run_id: run.id, idea_id: run.idea_id }, 'Implementation needs input');
+      this.logger.info({ event: 'implementation.needs_input', run_id: run.id, request_id: run.request_id }, 'Implementation needs input');
       try {
         await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, `I need input \u2014 ${result.question ?? 'please provide more context'}`);
       } catch (err) {
@@ -217,9 +295,9 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     // status === 'complete'
-    this.logger.info({ event: 'implementation.complete', run_id: run.id, idea_id: run.idea_id, attempt: run.attempt }, 'Implementation complete');
+    this.logger.info({ event: 'implementation.complete', run_id: run.id, request_id: run.request_id, attempt: run.attempt }, 'Implementation complete');
 
-    // Create implementation feedback page (degraded if it fails — don't abort)
+    // Create implementation feedback page (degraded if it fails -- don't abort)
     let feedbackPageUrl: string | undefined;
     try {
       const specPageUrl = `https://notion.so/${run.publisher_ref!.replace(/-/g, '')}`;
@@ -238,7 +316,7 @@ export class OrchestratorImpl implements Orchestrator {
 
     const completionMsg = feedbackPageUrl
       ? `Implementation complete. Feedback page: ${feedbackPageUrl}`
-      : 'Implementation complete. (Could not create feedback page — check logs.)';
+      : 'Implementation complete. (Could not create feedback page \u2014 check logs.)';
     try {
       await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, completionMsg);
     } catch (err) {
@@ -287,7 +365,7 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     if (result.status === 'needs_input') {
-      this.logger.info({ event: 'implementation.needs_input', run_id: run.id, idea_id: run.idea_id }, 'Implementation needs more input');
+      this.logger.info({ event: 'implementation.needs_input', run_id: run.id, request_id: run.request_id }, 'Implementation needs more input');
       try {
         await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, `I need input \u2014 ${result.question ?? 'please provide more context'}`);
       } catch (err) {
@@ -303,9 +381,9 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     // status === 'complete'
-    this.logger.info({ event: 'implementation.complete', run_id: run.id, idea_id: run.idea_id, attempt: run.attempt }, 'Implementation complete');
+    this.logger.info({ event: 'implementation.complete', run_id: run.id, request_id: run.request_id, attempt: run.attempt }, 'Implementation complete');
 
-    // Step 3: Update feedback page (degraded if fails — don't abort)
+    // Step 3: Update feedback page (degraded if fails -- don't abort)
     if (run.impl_feedback_ref) {
       try {
         await this.deps.implFeedbackPage!.update(run.impl_feedback_ref, { summary: result.summary });
@@ -347,7 +425,7 @@ export class OrchestratorImpl implements Orchestrator {
     const from = run.stage;
     run.stage = stage;
     run.updated_at = new Date().toISOString();
-    this.logger.info({ event: 'run.stage_transition', run_id: run.id, idea_id: run.idea_id, from_stage: from, to_stage: stage }, 'Stage transition');
+    this.logger.info({ event: 'run.stage_transition', run_id: run.id, request_id: run.request_id, from_stage: from, to_stage: stage }, 'Stage transition');
     this._persistRuns();
   }
 
@@ -364,10 +442,11 @@ export class OrchestratorImpl implements Orchestrator {
     }
   }
 
-  private createRun(idea: Idea): Run {
+  private createRun(request: Request): Run {
     const run: Run = {
       id: randomUUID(),
-      idea_id: idea.id,
+      request_id: request.id,
+      intent: 'idea',
       stage: 'intake',
       workspace_path: '',
       branch: '',
@@ -375,61 +454,60 @@ export class OrchestratorImpl implements Orchestrator {
       publisher_ref: undefined,
       impl_feedback_ref: undefined,
       attempt: 0,
-      channel_id: idea.channel_id,
-      thread_ts: idea.thread_ts,
+      channel_id: request.channel_id,
+      thread_ts: request.thread_ts,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     };
-    // Keyed by idea_id: at most one active run per idea is the design invariant.
-    // The event loop is sequential, so a second new_idea for the same idea_id
+    // Keyed by request_id: at most one active run per request is the design invariant.
+    // The event loop is sequential, so a second new_request for the same request_id
     // would not arrive until the first is fully processed.
-    this.runs.set(idea.id, run);
+    this.runs.set(request.id, run);
     this._persistRuns();
-    this.logger.info({ event: 'run.created', run_id: run.id, idea_id: idea.id }, 'Run created');
+    this.logger.info({ event: 'run.created', run_id: run.id, request_id: request.id }, 'Run created');
     return run;
   }
 
   private async failRun(run: Run, channel_id: string, thread_ts: string, error: unknown): Promise<void> {
     this.transition(run, 'failed');
-    this.logger.error({ event: 'run.failed', run_id: run.id, idea_id: run.idea_id, error: String(error) }, 'Run failed');
+    this.logger.error({ event: 'run.failed', run_id: run.id, request_id: run.request_id, error: String(error) }, 'Run failed');
     await this.deps.postError(channel_id, thread_ts, `Sorry, something went wrong: ${String(error)}`);
   }
 
-  private async _handleNewIdea(idea: Idea): Promise<void> {
-    const run = this.createRun(idea);
+  private async _startSpecPipeline(run: Run, request: Request): Promise<void> {
     this.transition(run, 'speccing');
 
     // Step 1: Create workspace
     let workspace_path: string;
     let branch: string;
     try {
-      ({ workspace_path, branch } = await this.deps.workspaceManager.create(idea.id, this.deps.repo_url));
+      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, this.deps.repo_url));
       run.workspace_path = workspace_path;
       run.branch = branch;
     } catch (err) {
-      await this.failRun(run, idea.channel_id, idea.thread_ts, err);
+      await this.failRun(run, request.channel_id, request.thread_ts, err);
       return;
     }
 
     // Step 2: Generate spec
     let spec_path: string;
     try {
-      spec_path = await this.deps.specGenerator.create(idea, workspace_path);
+      spec_path = await this.deps.specGenerator.create(request, workspace_path);
       run.spec_path = spec_path;
     } catch (err) {
       await this.deps.workspaceManager.destroy(workspace_path);
-      await this.failRun(run, idea.channel_id, idea.thread_ts, err);
+      await this.failRun(run, request.channel_id, request.thread_ts, err);
       return;
     }
 
     // Step 3: Publish canvas
     let publisher_ref: string;
     try {
-      publisher_ref = await this.deps.specPublisher.create(idea.channel_id, idea.thread_ts, spec_path);
+      publisher_ref = await this.deps.specPublisher.create(request.channel_id, request.thread_ts, spec_path);
       run.publisher_ref = publisher_ref;
     } catch (err) {
       await this.deps.workspaceManager.destroy(workspace_path);
-      await this.failRun(run, idea.channel_id, idea.thread_ts, err);
+      await this.failRun(run, request.channel_id, request.thread_ts, err);
       return;
     }
 
@@ -437,7 +515,7 @@ export class OrchestratorImpl implements Orchestrator {
   }
 
   private async _handleSpecFeedback(feedback: ThreadMessage): Promise<void> {
-    const run = this.runs.get(feedback.idea_id);
+    const run = this.runs.get(feedback.request_id);
     if (!run || run.stage !== 'reviewing_spec') return;
 
     if (!run.spec_path || !run.publisher_ref) {
@@ -465,13 +543,13 @@ export class OrchestratorImpl implements Orchestrator {
       pageMarkdown = await this.deps.specPublisher.getPageMarkdown(run.publisher_ref);
       if (!pageMarkdown) pageMarkdown = undefined;
     } catch (err) {
-      this.logger.warn({ event: 'page_markdown.failed', run_id: run.id, idea_id: run.idea_id, error: String(err) }, 'Failed to get page markdown; spans will not be preserved');
+      this.logger.warn({ event: 'page_markdown.failed', run_id: run.id, request_id: run.request_id, error: String(err) }, 'Failed to get page markdown; spans will not be preserved');
     }
 
     this.logger.debug({
       event: 'spec_revision.enriched',
       run_id: run.id,
-      idea_id: run.idea_id,
+      request_id: run.request_id,
       slack_feedback: feedback.content.length > 0,
       notion_comment_count: notionComments.length,
       has_page_markdown: !!pageMarkdown,
@@ -487,7 +565,7 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     const { comment_responses: commentResponses, page_content } = result;
-    this.logger.debug({ event: 'spec_revision.responses', run_id: run.id, idea_id: run.idea_id, comment_response_count: commentResponses?.length ?? 0, comment_response_ids: commentResponses?.map(r => r.comment_id) ?? [] }, 'Comment responses returned from revise()');
+    this.logger.debug({ event: 'spec_revision.responses', run_id: run.id, request_id: run.request_id, comment_response_count: commentResponses?.length ?? 0, comment_response_ids: commentResponses?.map(r => r.comment_id) ?? [] }, 'Comment responses returned from revise()');
 
     // Step 3: Update published page
     try {
@@ -497,7 +575,7 @@ export class OrchestratorImpl implements Orchestrator {
       return;
     }
 
-    // Step 4: Dispatch comment responses (best-effort — failures don't fail the run)
+    // Step 4: Dispatch comment responses (best-effort -- failures don't fail the run)
     if (this.deps.feedbackSource && commentResponses && commentResponses.length > 0) {
       for (const cr of commentResponses) {
         try {

--- a/src/core/run-store.ts
+++ b/src/core/run-store.ts
@@ -59,7 +59,7 @@ export class FileRunStore implements RunStore {
     for (const run of runs) {
       // 4. Drop runs with missing workspace
       if (!run.workspace_path || !fs.existsSync(run.workspace_path)) {
-        this.logger.warn({ event: 'run_store.run_dropped', idea_id: run.idea_id, workspace_path: run.workspace_path }, 'Dropping run with missing workspace_path');
+        this.logger.warn({ event: 'run_store.run_dropped', request_id: run.request_id, workspace_path: run.workspace_path }, 'Dropping run with missing workspace_path');
         droppedCount++;
         continue;
       }
@@ -69,9 +69,9 @@ export class FileRunStore implements RunStore {
         const fromStage = run.stage;
         run.stage = 'failed';
         run.updated_at = new Date().toISOString();
-        this.demotedIds.add(run.idea_id);
+        this.demotedIds.add(run.request_id);
         demotedCount++;
-        this.logger.info({ event: 'run_store.run_demoted', idea_id: run.idea_id, from_stage: fromStage, to_stage: 'failed' }, 'Demoted stale run to failed');
+        this.logger.info({ event: 'run_store.run_demoted', request_id: run.request_id, from_stage: fromStage, to_stage: 'failed' }, 'Demoted stale run to failed');
       }
 
       kept.push(run);

--- a/src/core/workspace-manager.ts
+++ b/src/core/workspace-manager.ts
@@ -11,7 +11,7 @@ const defaultExec = promisify(_exec);
 type ExecFn = (cmd: string, opts?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }>;
 
 export interface WorkspaceManager {
-  create(idea_id: string, repo_url: string): Promise<{ workspace_path: string; branch: string }>;
+  create(request_id: string, repo_url: string): Promise<{ workspace_path: string; branch: string }>;
   destroy(workspace_path: string): Promise<void>;
 }
 
@@ -31,13 +31,13 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
     this.logger = createLogger('workspace-manager', { destination: options?.logDestination });
   }
 
-  async create(idea_id: string, repo_url: string): Promise<{ workspace_path: string; branch: string }> {
-    if (idea_id.includes('/') || idea_id.includes('..')) {
-      throw new Error(`Invalid idea_id: "${idea_id}"`);
+  async create(request_id: string, repo_url: string): Promise<{ workspace_path: string; branch: string }> {
+    if (request_id.includes('/') || request_id.includes('..')) {
+      throw new Error(`Invalid request_id: "${request_id}"`);
     }
-    const workspace_path = join(this.workspaceRoot, idea_id);
-    // idea_id is a UUID; strip non-alphanumeric chars for a valid branch name segment
-    const slug = idea_id.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+    const workspace_path = join(this.workspaceRoot, request_id);
+    // request_id is a UUID; strip non-alphanumeric chars for a valid branch name segment
+    const slug = request_id.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
     const branch = `spec/${slug}`;
 
     // Clone
@@ -58,7 +58,7 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
       throw new Error(`git checkout -b failed`, { cause: err });
     }
 
-    this.logger.info({ event: 'workspace.created', idea_id, workspace_path, branch }, 'Workspace created');
+    this.logger.info({ event: 'workspace.created', request_id, workspace_path, branch }, 'Workspace created');
     return { workspace_path, branch };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { NotionClientImpl } from './adapters/notion/notion-client.js';
 import { NotionPublisher } from './adapters/notion/notion-publisher.js';
 import { NotionFeedbackSource, type FeedbackSource } from './adapters/notion/notion-feedback-source.js';
 import { AnthropicIntentClassifier } from './adapters/agent/intent-classifier.js';
+import { AnthropicQuestionAnswerer } from './adapters/agent/question-answerer.js';
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AgentSDKImplementer } from './adapters/agent/implementer.js';
@@ -107,36 +108,38 @@ try {
     process.exit(1);
   }
 
-  // Build intent classifier — prefer direct API key, fall back to Bedrock via AWS credential chain
+  // Build intent classifier and question answerer — prefer direct API key, fall back to Bedrock via AWS credential chain
   const anthropicApiKey = process.env['AC_ANTHROPIC_API_KEY'];
   let intentClassifier: AnthropicIntentClassifier;
+  let questionAnswerer: AnthropicQuestionAnswerer;
   if (anthropicApiKey) {
     intentClassifier = new AnthropicIntentClassifier(anthropicApiKey);
-    logger.info({ event: 'service.config', auth: 'anthropic-api-key' }, 'Using Anthropic API key for intent classification');
+    questionAnswerer = new AnthropicQuestionAnswerer(anthropicApiKey);
+    logger.info({ event: 'service.config', auth: 'anthropic-api-key' }, 'Using Anthropic API key for AI features');
   } else {
     const bedrockClient = new AnthropicBedrock({
       providerChainResolver: () => Promise.resolve(fromNodeProviderChain()),
     });
-    intentClassifier = new AnthropicIntentClassifier('', {
-      createFn: async (params) => {
-        try {
-          return await bedrockClient.messages.create({
-            ...params,
-            model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
-          }) as unknown as { content: Array<{ type: string; text: string }> };
-        } catch (err) {
-          const msg = String(err);
-          if (msg.includes('CredentialsProviderError') || msg.includes('Could not load credentials') || msg.includes('sso')) {
-            logger.error(
-              { event: 'bedrock.credentials_expired', aws_profile: process.env['AWS_PROFILE'] ?? 'default' },
-              'AWS credentials expired or unavailable. Run: aws sso login --profile <profile>',
-            );
-          }
-          throw err;
+    const bedrockCreateFn = async (params: { model: string; max_tokens: number; system?: string; messages: Array<{ role: 'user'; content: string }> }) => {
+      try {
+        return await bedrockClient.messages.create({
+          ...params,
+          model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+        }) as unknown as { content: Array<{ type: string; text: string }> };
+      } catch (err) {
+        const msg = String(err);
+        if (msg.includes('CredentialsProviderError') || msg.includes('Could not load credentials') || msg.includes('sso')) {
+          logger.error(
+            { event: 'bedrock.credentials_expired', aws_profile: process.env['AWS_PROFILE'] ?? 'default' },
+            'AWS credentials expired or unavailable. Run: aws sso login --profile <profile>',
+          );
         }
-      },
-    });
-    logger.info({ event: 'service.config', auth: 'bedrock', aws_profile: process.env['AWS_PROFILE'] ?? 'default' }, 'Using AWS Bedrock for intent classification');
+        throw err;
+      }
+    };
+    intentClassifier = new AnthropicIntentClassifier('', { createFn: bedrockCreateFn });
+    questionAnswerer = new AnthropicQuestionAnswerer('', { createFn: bedrockCreateFn });
+    logger.info({ event: 'service.config', auth: 'bedrock', aws_profile: process.env['AWS_PROFILE'] ?? 'default' }, 'Using AWS Bedrock for AI features');
   }
 
   // Build adapter, components, orchestrator
@@ -195,6 +198,7 @@ try {
     specPublisher,
     feedbackSource,
     intentClassifier,
+    questionAnswerer,
     specCommitter,
     implementer,
     implFeedbackPage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { NotionClientImpl } from './adapters/notion/notion-client.js';
 import { NotionPublisher } from './adapters/notion/notion-publisher.js';
 import { NotionFeedbackSource, type FeedbackSource } from './adapters/notion/notion-feedback-source.js';
 import { AnthropicIntentClassifier } from './adapters/agent/intent-classifier.js';
-import { AnthropicQuestionAnswerer } from './adapters/agent/question-answerer.js';
+import { AgentSDKQuestionAnswerer } from './adapters/agent/question-answerer.js';
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { AgentSDKImplementer } from './adapters/agent/implementer.js';
@@ -108,19 +108,17 @@ try {
     process.exit(1);
   }
 
-  // Build intent classifier and question answerer — prefer direct API key, fall back to Bedrock via AWS credential chain
+  // Build intent classifier — prefer direct API key, fall back to Bedrock via AWS credential chain
   const anthropicApiKey = process.env['AC_ANTHROPIC_API_KEY'];
   let intentClassifier: AnthropicIntentClassifier;
-  let questionAnswerer: AnthropicQuestionAnswerer;
   if (anthropicApiKey) {
     intentClassifier = new AnthropicIntentClassifier(anthropicApiKey);
-    questionAnswerer = new AnthropicQuestionAnswerer(anthropicApiKey);
-    logger.info({ event: 'service.config', auth: 'anthropic-api-key' }, 'Using Anthropic API key for AI features');
+    logger.info({ event: 'service.config', auth: 'anthropic-api-key' }, 'Using Anthropic API key for intent classification');
   } else {
     const bedrockClient = new AnthropicBedrock({
       providerChainResolver: () => Promise.resolve(fromNodeProviderChain()),
     });
-    const bedrockCreateFn = async (params: { model: string; max_tokens: number; system?: string; messages: Array<{ role: 'user'; content: string }> }) => {
+    const bedrockCreateFn = async (params: { model: string; max_tokens: number; messages: Array<{ role: 'user'; content: string }> }) => {
       try {
         return await bedrockClient.messages.create({
           ...params,
@@ -138,9 +136,11 @@ try {
       }
     };
     intentClassifier = new AnthropicIntentClassifier('', { createFn: bedrockCreateFn });
-    questionAnswerer = new AnthropicQuestionAnswerer('', { createFn: bedrockCreateFn });
-    logger.info({ event: 'service.config', auth: 'bedrock', aws_profile: process.env['AWS_PROFILE'] ?? 'default' }, 'Using AWS Bedrock for AI features');
+    logger.info({ event: 'service.config', auth: 'bedrock', aws_profile: process.env['AWS_PROFILE'] ?? 'default' }, 'Using AWS Bedrock for intent classification');
   }
+
+  // Build question answerer — always uses Agent SDK with repo path as cwd (no Bedrock variant needed)
+  const questionAnswerer = new AgentSDKQuestionAnswerer(args.repoPath);
 
   // Build adapter, components, orchestrator
   const threadRegistry = new ThreadRegistry();

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,4 +1,4 @@
-export interface Idea {
+export interface Request {
   id: string;
   source: 'slack';
   content: string;
@@ -9,7 +9,7 @@ export interface Idea {
 }
 
 export interface ThreadMessage {
-  idea_id: string;
+  request_id: string;
   content: string;
   author: string;
   received_at: string; // ISO 8601
@@ -18,5 +18,5 @@ export interface ThreadMessage {
 }
 
 export type InboundEvent =
-  | { type: 'new_idea'; payload: Idea }
+  | { type: 'new_request'; payload: Request }
   | { type: 'thread_message'; payload: ThreadMessage };

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -10,9 +10,12 @@ export type RunStage =
   | 'done'
   | 'failed';
 
+export type RequestIntent = 'idea' | 'bug' | 'question';
+
 export interface Run {
   id: string;
-  idea_id: string;
+  request_id: string;
+  intent: RequestIntent;
   stage: RunStage;
   workspace_path: string;
   branch: string;

--- a/tests/adapters/agent/intent-classifier.test.ts
+++ b/tests/adapters/agent/intent-classifier.test.ts
@@ -1,18 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Intent } from '../../../src/adapters/agent/intent-classifier.js';
+import { describe, it, expect, vi } from 'vitest';
+import type { Intent, ClassificationContext } from '../../../src/adapters/agent/intent-classifier.js';
 import { AnthropicIntentClassifier } from '../../../src/adapters/agent/intent-classifier.js';
-import type { RunStage } from '../../../src/types/runs.js';
 
 const nullDest = { write: () => {} };
 
-// Helper: build a minimal Anthropic-like response
 function makeApiResponse(content: string) {
-  return {
-    content: [{ type: 'text' as const, text: content }],
-  };
+  return { content: [{ type: 'text' as const, text: content }] };
 }
 
-// Mock type for the Anthropic messages.create call
 type CreateFn = ReturnType<typeof vi.fn>;
 
 function makeClassifier(createFn: CreateFn) {
@@ -22,337 +17,248 @@ function makeClassifier(createFn: CreateFn) {
   });
 }
 
+describe('AnthropicIntentClassifier — unified taxonomy: valid intents by context', () => {
+  it('new_thread: model returns idea → idea', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('idea'));
+    expect(await makeClassifier(cf).classify('add a wizard', 'new_thread')).toBe('idea');
+  });
+
+  it('new_thread: model returns bug → bug', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('bug'));
+    expect(await makeClassifier(cf).classify('this is broken', 'new_thread')).toBe('bug');
+  });
+
+  it('new_thread: model returns question → question', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('question'));
+    expect(await makeClassifier(cf).classify('how does X work?', 'new_thread')).toBe('question');
+  });
+
+  it('new_thread: model returns ignore → ignore', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('ignore'));
+    expect(await makeClassifier(cf).classify('hey team', 'new_thread')).toBe('ignore');
+  });
+
+  it('new_thread: model returns feedback (not valid) → falls back to idea', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    expect(await makeClassifier(cf).classify('some message', 'new_thread')).toBe('idea');
+  });
+
+  it('intake: model returns idea → idea (upgrade path)', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('idea'));
+    expect(await makeClassifier(cf).classify('actually build this', 'intake')).toBe('idea');
+  });
+
+  it('intake: model returns question → question', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('question'));
+    expect(await makeClassifier(cf).classify('what does this do?', 'intake')).toBe('question');
+  });
+
+  it('intake: model returns feedback (not valid) → falls back to idea', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    expect(await makeClassifier(cf).classify('some message', 'intake')).toBe('idea');
+  });
+
+  it('reviewing_spec: model returns feedback → feedback', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    expect(await makeClassifier(cf).classify('change this section', 'reviewing_spec')).toBe('feedback');
+  });
+
+  it('reviewing_spec: model returns approval → approval', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('approval'));
+    expect(await makeClassifier(cf).classify('looks good, build it', 'reviewing_spec')).toBe('approval');
+  });
+
+  it('reviewing_spec: model returns question → question', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('question'));
+    expect(await makeClassifier(cf).classify('what does this mean?', 'reviewing_spec')).toBe('question');
+  });
+
+  it('reviewing_spec: model returns idea (not valid) → falls back to feedback', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('idea'));
+    expect(await makeClassifier(cf).classify('some message', 'reviewing_spec')).toBe('feedback');
+  });
+
+  it('reviewing_implementation: model returns feedback → feedback', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    expect(await makeClassifier(cf).classify('the button is broken', 'reviewing_implementation')).toBe('feedback');
+  });
+
+  it('reviewing_implementation: model returns approval → approval', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('approval'));
+    expect(await makeClassifier(cf).classify('ship it', 'reviewing_implementation')).toBe('approval');
+  });
+
+  it('awaiting_impl_input: model returns feedback → feedback', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    expect(await makeClassifier(cf).classify('go with option A', 'awaiting_impl_input')).toBe('feedback');
+  });
+
+  it('awaiting_impl_input: model returns approval (not valid) → falls back to feedback', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('approval'));
+    expect(await makeClassifier(cf).classify('some message', 'awaiting_impl_input')).toBe('feedback');
+  });
+});
+
 describe('AnthropicIntentClassifier — prompt construction', () => {
   it('classify sends the human message content in the prompt', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    await classifier.classify('the wizard should not require all settings', 'reviewing_spec');
-    const prompt = createFn.mock.calls[0][0].messages[0].content as string;
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    await makeClassifier(cf).classify('the wizard should not require all settings', 'reviewing_spec');
+    const prompt = cf.mock.calls[0][0].messages[0].content as string;
     expect(prompt).toContain('the wizard should not require all settings');
   });
 
-  it('classify includes the current run stage in the prompt', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    await classifier.classify('some message', 'reviewing_spec');
-    const prompt = createFn.mock.calls[0][0].messages[0].content as string;
+  it('classify includes the context in the prompt', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    await makeClassifier(cf).classify('some message', 'reviewing_spec');
+    const prompt = cf.mock.calls[0][0].messages[0].content as string;
     expect(prompt).toContain('reviewing_spec');
   });
 
-  it('prompt for reviewing_spec includes only spec_feedback and spec_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    await classifier.classify('any message', 'reviewing_spec');
-    const prompt = createFn.mock.calls[0][0].messages[0].content as string;
-    expect(prompt).toContain('spec_feedback');
-    expect(prompt).toContain('spec_approval');
-    expect(prompt).not.toContain('implementation_feedback');
-    expect(prompt).not.toContain('implementation_approval');
+  it('prompt for new_thread includes idea, bug, question, ignore and not feedback/approval', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('idea'));
+    await makeClassifier(cf).classify('any message', 'new_thread');
+    const prompt = cf.mock.calls[0][0].messages[0].content as string;
+    expect(prompt).toContain('idea');
+    expect(prompt).toContain('bug');
+    expect(prompt).toContain('question');
+    expect(prompt).toContain('ignore');
+    expect(prompt).not.toContain('feedback');
+    expect(prompt).not.toContain('approval');
   });
 
-  it('prompt for reviewing_implementation includes only implementation_feedback and implementation_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    await classifier.classify('any message', 'reviewing_implementation');
-    const prompt = createFn.mock.calls[0][0].messages[0].content as string;
-    expect(prompt).toContain('implementation_feedback');
-    expect(prompt).toContain('implementation_approval');
-    expect(prompt).not.toContain('spec_feedback');
-    expect(prompt).not.toContain('spec_approval');
+  it('prompt for reviewing_spec includes feedback, approval, question, ignore and not idea/bug', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    await makeClassifier(cf).classify('any message', 'reviewing_spec');
+    const prompt = cf.mock.calls[0][0].messages[0].content as string;
+    expect(prompt).toContain('feedback');
+    expect(prompt).toContain('approval');
+    expect(prompt).toContain('question');
+    expect(prompt).toContain('ignore');
+    expect(prompt).not.toContain('idea');
+    expect(prompt).not.toContain('bug');
   });
 
-  it('prompt for awaiting_impl_input includes only implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    await classifier.classify('go with option A', 'awaiting_impl_input');
-    const prompt = createFn.mock.calls[0][0].messages[0].content as string;
-    expect(prompt).toContain('implementation_feedback');
-    expect(prompt).not.toContain('implementation_approval');
-    expect(prompt).not.toContain('spec_feedback');
-    expect(prompt).not.toContain('spec_approval');
-  });
-});
-
-describe('AnthropicIntentClassifier — classification accuracy (reviewing_spec)', () => {
-  it('"approved, go ahead and build it" → spec_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('approved, go ahead and build it', 'reviewing_spec')).toBe('spec_approval');
-  });
-
-  it('"approved" (single word) → spec_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('approved', 'reviewing_spec')).toBe('spec_approval');
-  });
-
-  it('"yes, this looks right, let\'s build it" → spec_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify("yes, this looks right, let's build it", 'reviewing_spec')).toBe('spec_approval');
-  });
-
-  it('"the wizard shouldn\'t require all settings before exiting" → spec_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify("the wizard shouldn't require all settings before exiting", 'reviewing_spec')).toBe('spec_feedback');
-  });
-
-  it('"I think the scope is too broad here" → spec_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('I think the scope is too broad here', 'reviewing_spec')).toBe('spec_feedback');
-  });
-
-  it('"can you change the section about error handling?" → spec_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('can you change the section about error handling?', 'reviewing_spec')).toBe('spec_feedback');
-  });
-});
-
-describe('AnthropicIntentClassifier — classification accuracy (reviewing_implementation)', () => {
-  it('"looks good, ship it" → implementation_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('looks good, ship it', 'reviewing_implementation')).toBe('implementation_approval');
-  });
-
-  it('"confirmed, send the PR" → implementation_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('confirmed, send the PR', 'reviewing_implementation')).toBe('implementation_approval');
-  });
-
-  it('"LGTM, let\'s merge" → implementation_approval', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify("LGTM, let's merge", 'reviewing_implementation')).toBe('implementation_approval');
-  });
-
-  it('"the custom step isn\'t working — it gets swallowed on add" → implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify("the custom step isn't working — it gets swallowed on add", 'reviewing_implementation')).toBe('implementation_feedback');
-  });
-
-  it('"I\'ve added feedback on the implementation page" → implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify("I've added feedback on the implementation page", 'reviewing_implementation')).toBe('implementation_feedback');
-  });
-
-  it('"there\'s a bug when I run the setup wizard with no args" → implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify("there's a bug when I run the setup wizard with no args", 'reviewing_implementation')).toBe('implementation_feedback');
-  });
-});
-
-describe('AnthropicIntentClassifier — classification accuracy (awaiting_impl_input)', () => {
-  it('"go with the subtype approach" → implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('go with the subtype approach', 'awaiting_impl_input')).toBe('implementation_feedback');
-  });
-
-  it('"use option A" → implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_feedback'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('use option A', 'awaiting_impl_input')).toBe('implementation_feedback');
-  });
-});
-
-describe('AnthropicIntentClassifier — stage-intent validation', () => {
-  it('model returns spec_approval for reviewing_implementation → retries once, falls back to implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_approval'));
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('some message', 'reviewing_implementation');
-    expect(result).toBe('implementation_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('model returns implementation_approval for reviewing_spec → retries once, falls back to spec_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_approval'));
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('some message', 'reviewing_spec');
-    expect(result).toBe('spec_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('model returns implementation_approval for awaiting_impl_input → retries once, falls back to implementation_feedback', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_approval'));
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('some message', 'awaiting_impl_input');
-    expect(result).toBe('implementation_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('model returns invalid intent → retries once, falls back to conservative default', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('totally_unknown_intent'));
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('some message', 'reviewing_spec');
-    expect(result).toBe('spec_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('first call returns invalid intent, second returns valid → uses second result', async () => {
-    const createFn = vi.fn()
-      .mockResolvedValueOnce(makeApiResponse('implementation_approval'))
-      .mockResolvedValueOnce(makeApiResponse('spec_feedback'));
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('some message', 'reviewing_spec');
-    expect(result).toBe('spec_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
+  it('prompt for awaiting_impl_input includes feedback, question, ignore and not approval', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    await makeClassifier(cf).classify('any message', 'awaiting_impl_input');
+    const prompt = cf.mock.calls[0][0].messages[0].content as string;
+    expect(prompt).toContain('feedback');
+    expect(prompt).toContain('question');
+    expect(prompt).not.toContain('approval');
   });
 });
 
 describe('AnthropicIntentClassifier — response parsing', () => {
-  it('trims leading/trailing whitespace from model response', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('  spec_feedback  '));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('message', 'reviewing_spec')).toBe('spec_feedback');
+  it('trims whitespace from model response', async () => {
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('  feedback  '));
+    expect(await makeClassifier(cf).classify('message', 'reviewing_spec')).toBe('feedback');
   });
 
   it('extracts first token when response includes explanation', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_approval — the user is clearly approving'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('approved!', 'reviewing_spec')).toBe('spec_approval');
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('approval — user is clearly approving'));
+    expect(await makeClassifier(cf).classify('looks good', 'reviewing_spec')).toBe('approval');
   });
 
   it('parses valid JSON wrapping the intent', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('"spec_feedback"'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('message', 'reviewing_spec')).toBe('spec_feedback');
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('"feedback"'));
+    expect(await makeClassifier(cf).classify('message', 'reviewing_spec')).toBe('feedback');
   });
 
   it('empty response → falls back to conservative default', async () => {
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse(''));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('message', 'reviewing_spec')).toBe('spec_feedback');
+    const cf = vi.fn().mockResolvedValue(makeApiResponse(''));
+    expect(await makeClassifier(cf).classify('message', 'reviewing_spec')).toBe('feedback');
   });
 });
 
 describe('AnthropicIntentClassifier — error handling', () => {
-  it('HTTP 429 error → retries once; on second failure falls back to conservative default', async () => {
-    const err = Object.assign(new Error('rate limited'), { status: 429 });
-    const createFn = vi.fn().mockRejectedValue(err);
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('message', 'reviewing_spec');
-    expect(result).toBe('spec_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('HTTP 500 error → retries once; falls back to conservative default', async () => {
-    const err = Object.assign(new Error('internal server error'), { status: 500 });
-    const createFn = vi.fn().mockRejectedValue(err);
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('message', 'reviewing_implementation');
-    expect(result).toBe('implementation_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('connection timeout → retries once; falls back to conservative default', async () => {
-    const createFn = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('message', 'awaiting_impl_input');
-    expect(result).toBe('implementation_feedback');
-    expect(createFn).toHaveBeenCalledTimes(2);
+  it('API error → retries once; falls back to conservative default', async () => {
+    const cf = vi.fn().mockRejectedValue(new Error('network error'));
+    const result = await makeClassifier(cf).classify('message', 'reviewing_spec');
+    expect(result).toBe('feedback');
+    expect(cf).toHaveBeenCalledTimes(2);
   });
 
   it('first call fails, second succeeds → uses second result', async () => {
-    const createFn = vi.fn()
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockResolvedValueOnce(makeApiResponse('spec_approval'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('approved', 'reviewing_spec')).toBe('spec_approval');
+    const cf = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(makeApiResponse('approval'));
+    expect(await makeClassifier(cf).classify('approved', 'reviewing_spec')).toBe('approval');
   });
 
-  it('empty message string → falls back to conservative default without calling API', async () => {
-    const createFn = vi.fn();
-    const classifier = makeClassifier(createFn);
-    const result = await classifier.classify('', 'reviewing_spec');
-    expect(result).toBe('spec_feedback');
-    expect(createFn).not.toHaveBeenCalled();
+  it('empty message → falls back without calling API', async () => {
+    const cf = vi.fn();
+    expect(await makeClassifier(cf).classify('', 'reviewing_spec')).toBe('feedback');
+    expect(cf).not.toHaveBeenCalled();
   });
 });
 
-describe('AnthropicIntentClassifier — conservative fallback defaults', () => {
-  it('reviewing_spec defaults to spec_feedback', async () => {
-    const createFn = vi.fn().mockRejectedValue(new Error('fail'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('message', 'reviewing_spec')).toBe('spec_feedback');
+describe('AnthropicIntentClassifier — conservative fallbacks', () => {
+  it('new_thread defaults to idea', async () => {
+    const cf = vi.fn().mockRejectedValue(new Error('fail'));
+    expect(await makeClassifier(cf).classify('message', 'new_thread')).toBe('idea');
   });
 
-  it('reviewing_implementation defaults to implementation_feedback', async () => {
-    const createFn = vi.fn().mockRejectedValue(new Error('fail'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('message', 'reviewing_implementation')).toBe('implementation_feedback');
+  it('intake defaults to idea', async () => {
+    const cf = vi.fn().mockRejectedValue(new Error('fail'));
+    expect(await makeClassifier(cf).classify('message', 'intake')).toBe('idea');
   });
 
-  it('awaiting_impl_input defaults to implementation_feedback', async () => {
-    const createFn = vi.fn().mockRejectedValue(new Error('fail'));
-    const classifier = makeClassifier(createFn);
-    expect(await classifier.classify('message', 'awaiting_impl_input')).toBe('implementation_feedback');
+  it('reviewing_spec defaults to feedback', async () => {
+    const cf = vi.fn().mockRejectedValue(new Error('fail'));
+    expect(await makeClassifier(cf).classify('message', 'reviewing_spec')).toBe('feedback');
+  });
+
+  it('reviewing_implementation defaults to feedback', async () => {
+    const cf = vi.fn().mockRejectedValue(new Error('fail'));
+    expect(await makeClassifier(cf).classify('message', 'reviewing_implementation')).toBe('feedback');
+  });
+
+  it('awaiting_impl_input defaults to feedback', async () => {
+    const cf = vi.fn().mockRejectedValue(new Error('fail'));
+    expect(await makeClassifier(cf).classify('message', 'awaiting_impl_input')).toBe('feedback');
   });
 });
 
 describe('AnthropicIntentClassifier — logging', () => {
-  it('emits intent.classified on successful classification with correct fields', async () => {
+  it('emits intent.classified on success', async () => {
     const logs: unknown[] = [];
     const dest = { write: (line: string) => logs.push(JSON.parse(line)) };
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = new AnthropicIntentClassifier('key', { createFn, logDestination: dest });
-
-    await classifier.classify('some feedback message', 'reviewing_spec');
-
-    const classified = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'intent.classified');
-    expect(classified).toBeDefined();
-    expect(classified!['run_stage']).toBe('reviewing_spec');
-    expect(classified!['classified_intent']).toBe('spec_feedback');
-    expect(typeof classified!['message_length']).toBe('number');
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    const classifier = new AnthropicIntentClassifier('key', { createFn: cf, logDestination: dest });
+    await classifier.classify('some message', 'reviewing_spec');
+    const ev = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'intent.classified');
+    expect(ev).toBeDefined();
+    expect(ev!['classified_intent']).toBe('feedback');
   });
 
-  it('emits intent.classification_failed when API call fails', async () => {
+  it('emits intent.classification_failed on API error', async () => {
     const logs: unknown[] = [];
     const dest = { write: (line: string) => logs.push(JSON.parse(line)) };
-    const createFn = vi.fn().mockRejectedValue(new Error('api down'));
-    const classifier = new AnthropicIntentClassifier('key', { createFn, logDestination: dest });
-
+    const cf = vi.fn().mockRejectedValue(new Error('api down'));
+    const classifier = new AnthropicIntentClassifier('key', { createFn: cf, logDestination: dest });
     await classifier.classify('message', 'reviewing_spec');
-
-    const failed = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'intent.classification_failed');
-    expect(failed).toBeDefined();
-    expect(failed!['run_stage']).toBe('reviewing_spec');
-    expect(typeof failed!['error']).toBe('string');
+    const ev = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'intent.classification_failed');
+    expect(ev).toBeDefined();
   });
 
-  it('emits intent.invalid_for_stage when model returns wrong-stage intent', async () => {
+  it('emits intent.invalid_for_context when model returns wrong-context intent', async () => {
     const logs: unknown[] = [];
     const dest = { write: (line: string) => logs.push(JSON.parse(line)) };
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('implementation_approval'));
-    const classifier = new AnthropicIntentClassifier('key', { createFn, logDestination: dest });
-
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('bug'));
+    const classifier = new AnthropicIntentClassifier('key', { createFn: cf, logDestination: dest });
     await classifier.classify('message', 'reviewing_spec');
-
-    const invalid = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'intent.invalid_for_stage');
-    expect(invalid).toBeDefined();
-    expect(invalid!['returned_intent']).toBe('implementation_approval');
-    expect(invalid!['run_stage']).toBe('reviewing_spec');
-    expect(Array.isArray(invalid!['valid_intents'])).toBe(true);
+    const ev = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'intent.invalid_for_context');
+    expect(ev).toBeDefined();
+    expect(ev!['returned_intent']).toBe('bug');
   });
 
   it('human message content never appears in any log event', async () => {
     const logs: string[] = [];
     const dest = { write: (line: string) => logs.push(line) };
-    const createFn = vi.fn().mockResolvedValue(makeApiResponse('spec_feedback'));
-    const classifier = new AnthropicIntentClassifier('key', { createFn, logDestination: dest });
-
-    const secretMessage = 'super-secret-feedback-content-xyz123';
-    await classifier.classify(secretMessage, 'reviewing_spec');
-
-    for (const line of logs) {
-      expect(line).not.toContain(secretMessage);
-    }
+    const cf = vi.fn().mockResolvedValue(makeApiResponse('feedback'));
+    const classifier = new AnthropicIntentClassifier('key', { createFn: cf, logDestination: dest });
+    const secret = 'super-secret-feedback-content-xyz123';
+    await classifier.classify(secret, 'reviewing_spec');
+    for (const line of logs) expect(line).not.toContain(secret);
   });
 });

--- a/tests/adapters/agent/spec-generator.test.ts
+++ b/tests/adapters/agent/spec-generator.test.ts
@@ -4,13 +4,13 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'nod
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { AgentSDKSpecGenerator } from '../../../src/adapters/agent/spec-generator.js';
-import type { Idea, ThreadMessage } from '../../../src/types/events.js';
+import type { Request, ThreadMessage } from '../../../src/types/events.js';
 
 const nullDest = { write: () => {} };
 
-function makeIdea(overrides: Partial<Idea> = {}): Idea {
+function makeRequest(overrides: Partial<Request> = {}): Request {
   return {
-    id: 'idea-001',
+    id: 'request-001',
     source: 'slack',
     content: 'add a setup wizard to the CLI',
     author: 'U123',
@@ -23,7 +23,7 @@ function makeIdea(overrides: Partial<Idea> = {}): Idea {
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
-    idea_id: 'idea-001',
+    request_id: 'request-001',
     content: 'the wizard should not require all settings before exiting',
     author: 'U456',
     received_at: new Date().toISOString(),
@@ -82,7 +82,7 @@ describe('AgentSDKSpecGenerator.create — query invocation', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const call = queryFn.mock.calls[0][0] as { options: { cwd: string } };
     expect(call.options.cwd).toBe(tempRoot);
@@ -96,7 +96,7 @@ describe('AgentSDKSpecGenerator.create — query invocation', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const call = queryFn.mock.calls[0][0] as { options: { permissionMode: string } };
     expect(call.options.permissionMode).toBe('bypassPermissions');
@@ -110,7 +110,7 @@ describe('AgentSDKSpecGenerator.create — query invocation', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const call = queryFn.mock.calls[0][0] as { options: { settingSources: string[] } };
     expect(call.options.settingSources).toContain('user');
@@ -127,13 +127,13 @@ describe('AgentSDKSpecGenerator.create — prompt', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const call = queryFn.mock.calls[0][0] as { prompt: string };
     expect(call.prompt).toContain('/mm:planning');
   });
 
-  it('prompt contains idea content', async () => {
+  it('prompt contains request content', async () => {
     const queryFn = makeQueryFn();
     const sg = new AgentSDKSpecGenerator({
       queryFn,
@@ -141,7 +141,7 @@ describe('AgentSDKSpecGenerator.create — prompt', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea({ content: 'build a time machine' }), tempRoot);
+    await sg.create(makeRequest({ content: 'build a time machine' }), tempRoot);
 
     const call = queryFn.mock.calls[0][0] as { prompt: string };
     expect(call.prompt).toContain('build a time machine');
@@ -155,7 +155,7 @@ describe('AgentSDKSpecGenerator.create — prompt', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const call = queryFn.mock.calls[0][0] as { prompt: string };
     const expectedPath = join(tempRoot, '.autocatalyst', 'spec-create-result.json');
@@ -172,7 +172,7 @@ describe('AgentSDKSpecGenerator.create — result handling', () => {
       readFile: makeReadFileFn({ spec_path: specPath }),
     });
 
-    const result = await sg.create(makeIdea(), tempRoot);
+    const result = await sg.create(makeRequest(), tempRoot);
 
     expect(result).toBe(specPath);
   });
@@ -185,7 +185,7 @@ describe('AgentSDKSpecGenerator.create — result handling', () => {
       readFile: vi.fn().mockRejectedValue(enoentError),
     });
 
-    await expect(sg.create(makeIdea(), tempRoot)).rejects.toThrow(/result file not found/i);
+    await expect(sg.create(makeRequest(), tempRoot)).rejects.toThrow(/result file not found/i);
   });
 
   it('throws when result file is not valid JSON', async () => {
@@ -195,7 +195,7 @@ describe('AgentSDKSpecGenerator.create — result handling', () => {
       readFile: vi.fn().mockResolvedValue('not json'),
     });
 
-    await expect(sg.create(makeIdea(), tempRoot)).rejects.toThrow(/not valid JSON/i);
+    await expect(sg.create(makeRequest(), tempRoot)).rejects.toThrow(/not valid JSON/i);
   });
 
   it('throws when spec_path is missing from result', async () => {
@@ -205,7 +205,7 @@ describe('AgentSDKSpecGenerator.create — result handling', () => {
       readFile: makeReadFileFn({ other_field: 'oops' }),
     });
 
-    await expect(sg.create(makeIdea(), tempRoot)).rejects.toThrow(/spec_path/i);
+    await expect(sg.create(makeRequest(), tempRoot)).rejects.toThrow(/spec_path/i);
   });
 
   it('throws when queryFn iterator throws', async () => {
@@ -215,7 +215,7 @@ describe('AgentSDKSpecGenerator.create — result handling', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await expect(sg.create(makeIdea(), tempRoot)).rejects.toThrow(/agent crashed/);
+    await expect(sg.create(makeRequest(), tempRoot)).rejects.toThrow(/agent crashed/);
   });
 });
 
@@ -229,7 +229,7 @@ describe('AgentSDKSpecGenerator.create — logging', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const invoked = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'spec.agent_invoked');
     expect(invoked).toBeDefined();
@@ -244,7 +244,7 @@ describe('AgentSDKSpecGenerator.create — logging', () => {
       readFile: makeReadFileFn({ spec_path: join(tempRoot, 'context-human', 'specs', 'feature-wizard.md') }),
     });
 
-    await sg.create(makeIdea(), tempRoot);
+    await sg.create(makeRequest(), tempRoot);
 
     const completed = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'spec.agent_completed');
     expect(completed).toBeDefined();
@@ -259,7 +259,7 @@ describe('AgentSDKSpecGenerator.create — logging', () => {
       readFile: makeReadFileFn({ spec_path: '' }),
     });
 
-    await expect(sg.create(makeIdea(), tempRoot)).rejects.toThrow();
+    await expect(sg.create(makeRequest(), tempRoot)).rejects.toThrow();
 
     const failed = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'spec.agent_failed');
     expect(failed).toBeDefined();

--- a/tests/adapters/slack/classifier.test.ts
+++ b/tests/adapters/slack/classifier.test.ts
@@ -27,30 +27,30 @@ describe('classifyMessage', () => {
     ).intent).toBe('ignore');
   });
 
-  it('returns new_idea for @mention in root message (no thread_ts)', () => {
+  it('returns new_request for @mention in root message (no thread_ts)', () => {
     expect(classifyMessage(
       { text: `<@${BOT_ID}> add a setup wizard`, user: 'U999', ts: '100.0' },
       BOT_ID,
       makeRegistry(),
-    ).intent).toBe('new_idea');
+    ).intent).toBe('new_request');
   });
 
-  it('returns new_idea for @mention when thread_ts equals ts', () => {
+  it('returns new_request for @mention when thread_ts equals ts', () => {
     expect(classifyMessage(
       { text: `<@${BOT_ID}> start an idea`, user: 'U999', ts: '100.0', thread_ts: '100.0' },
       BOT_ID,
       makeRegistry(),
-    ).intent).toBe('new_idea');
+    ).intent).toBe('new_request');
   });
 
-  it('returns spec_feedback for @mention reply to registered thread', () => {
+  it('returns thread_message for @mention reply to registered thread', () => {
     const result = classifyMessage(
       { text: `<@${BOT_ID}> that field is confusing`, user: 'U999', ts: '200.0', thread_ts: '100.0' },
       BOT_ID,
-      makeRegistry({ '100.0': 'idea-xyz' }),
+      makeRegistry({ '100.0': 'request-xyz' }),
     );
-    expect(result.intent).toBe('spec_feedback');
-    if (result.intent === 'spec_feedback') expect(result.idea_id).toBe('idea-xyz');
+    expect(result.intent).toBe('thread_message');
+    if (result.intent === 'thread_message') expect(result.request_id).toBe('request-xyz');
   });
 
   it('returns ignore for @mention reply to unregistered thread', () => {
@@ -77,5 +77,22 @@ describe('classifyMessage', () => {
       makeRegistry(),
     ).intent).toBe('ignore');
   });
-});
 
+  it('returns ignore for in-thread message mentioning only another user (not bot)', () => {
+    expect(classifyMessage(
+      { text: '<@UOTHER> what do you think?', user: 'U999', ts: '200.0', thread_ts: '100.0' },
+      BOT_ID,
+      makeRegistry({ '100.0': 'request-xyz' }),
+    ).intent).toBe('ignore');
+  });
+
+  it('returns thread_message for in-thread message mentioning both bot and another user', () => {
+    const result = classifyMessage(
+      { text: `<@${BOT_ID}> <@UOTHER> please review`, user: 'U999', ts: '200.0', thread_ts: '100.0' },
+      BOT_ID,
+      makeRegistry({ '100.0': 'request-xyz' }),
+    );
+    expect(result.intent).toBe('thread_message');
+    if (result.intent === 'thread_message') expect(result.request_id).toBe('request-xyz');
+  });
+});

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { App } from '@slack/bolt';
 import { SlackAdapter } from '../../../src/adapters/slack/slack-adapter.js';
-import type { Idea, ThreadMessage } from '../../../src/types/events.js';
+import type { Request, ThreadMessage } from '../../../src/types/events.js';
 
 // Captures one event from the AsyncIterable then stops
 async function takeOne<T>(iterable: AsyncIterable<T>): Promise<T> {
@@ -77,12 +77,12 @@ describe('SlackAdapter — startup', () => {
   });
 });
 
-describe('SlackAdapter — new idea pipeline', () => {
+describe('SlackAdapter — new request pipeline', () => {
   const BOT_ID = 'UBOT001';
   const CHANNEL_ID = 'C123';
   const CHANNEL_NAME = 'my-channel';
 
-  it('emits new_idea event with correct Idea shape', async () => {
+  it('emits new_request event with correct Request shape', async () => {
     const mock = makeMockApp({ botUserId: BOT_ID });
     const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME, }, { logDestination: nullDest });
     await adapter.start();
@@ -97,15 +97,15 @@ describe('SlackAdapter — new idea pipeline', () => {
 
     const event = await eventPromise;
     await adapter.stop();
-    expect(event.type).toBe('new_idea');
-    const idea = event.payload as Idea;
-    expect(idea.source).toBe('slack');
-    expect(idea.author).toBe('U123');
-    expect(idea.content).toBe(`<@${BOT_ID}> add a setup wizard`);
-    expect(idea.thread_ts).toBe('100.0');
-    expect(idea.channel_id).toBe(CHANNEL_ID);
-    expect(idea.received_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    expect(typeof idea.id).toBe('string');
+    expect(event.type).toBe('new_request');
+    const request = event.payload as Request;
+    expect(request.source).toBe('slack');
+    expect(request.author).toBe('U123');
+    expect(request.content).toBe(`<@${BOT_ID}> add a setup wizard`);
+    expect(request.thread_ts).toBe('100.0');
+    expect(request.channel_id).toBe(CHANNEL_ID);
+    expect(request.received_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(typeof request.id).toBe('string');
   });
 
   it('posts acknowledgement in the correct thread', async () => {
@@ -132,7 +132,7 @@ describe('SlackAdapter — new idea pipeline', () => {
     );
   });
 
-  it('registers the thread so a subsequent reply is spec_feedback', async () => {
+  it('registers the thread so a subsequent reply is thread_message', async () => {
     const mock = makeMockApp({ botUserId: BOT_ID });
     const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME, }, { logDestination: nullDest });
     await adapter.start();
@@ -147,7 +147,7 @@ describe('SlackAdapter — new idea pipeline', () => {
     });
     await ideaEventPromise;
 
-    // Now trigger a reply — should be spec_feedback
+    // Now trigger a reply — should be thread_message
     const feedbackEventPromise = takeOne(adapter.receive());
     await mock._triggerMessage({
       text: `<@${BOT_ID}> revise this`,
@@ -168,7 +168,7 @@ describe('SlackAdapter — spec feedback pipeline', () => {
   const BOT_ID = 'UBOT001';
   const CHANNEL_ID = 'C123';
 
-  it('emits spec_feedback with correct shape and posts acknowledgement', async () => {
+  it('emits thread_message with correct shape and posts acknowledgement', async () => {
     const mock = makeMockApp({ botUserId: BOT_ID });
     const adapter = new SlackAdapter(mock as unknown as App, { channelName: 'my-channel', }, { logDestination: nullDest });
     await adapter.start();
@@ -192,7 +192,7 @@ describe('SlackAdapter — spec feedback pipeline', () => {
 
     expect(feedbackEvent.type).toBe('thread_message');
     const feedback = feedbackEvent.payload as ThreadMessage;
-    expect(feedback.idea_id).toBe((ideaEvent.payload as Idea).id);
+    expect(feedback.request_id).toBe((ideaEvent.payload as Request).id);
     expect(feedback.author).toBe('U456');
     expect(feedback.thread_ts).toBe('100.0');
     expect(feedback.content).toBe(`<@${BOT_ID}> the field is confusing`);

--- a/tests/adapters/slack/thread-registry.test.ts
+++ b/tests/adapters/slack/thread-registry.test.ts
@@ -7,30 +7,30 @@ describe('ThreadRegistry', () => {
     expect(registry.resolve('any-ts')).toBeUndefined();
   });
 
-  it('register then resolve returns the idea_id', () => {
+  it('register then resolve returns the request_id', () => {
     const registry = new ThreadRegistry();
-    registry.register('1234567890.000001', 'idea-abc');
-    expect(registry.resolve('1234567890.000001')).toBe('idea-abc');
+    registry.register('1234567890.000001', 'request-abc');
+    expect(registry.resolve('1234567890.000001')).toBe('request-abc');
   });
 
   it('resolve returns undefined for an unregistered key', () => {
     const registry = new ThreadRegistry();
-    registry.register('1234567890.000001', 'idea-abc');
+    registry.register('1234567890.000001', 'request-abc');
     expect(registry.resolve('9999999999.000001')).toBeUndefined();
   });
 
-  it('re-registering the same thread_ts overwrites the previous idea_id', () => {
+  it('re-registering the same thread_ts overwrites the previous request_id', () => {
     const registry = new ThreadRegistry();
-    registry.register('1234567890.000001', 'idea-first');
-    registry.register('1234567890.000001', 'idea-second');
-    expect(registry.resolve('1234567890.000001')).toBe('idea-second');
+    registry.register('1234567890.000001', 'request-first');
+    registry.register('1234567890.000001', 'request-second');
+    expect(registry.resolve('1234567890.000001')).toBe('request-second');
   });
 
   it('multiple thread_ts entries are independent', () => {
     const registry = new ThreadRegistry();
-    registry.register('ts-one', 'idea-one');
-    registry.register('ts-two', 'idea-two');
-    expect(registry.resolve('ts-one')).toBe('idea-one');
-    expect(registry.resolve('ts-two')).toBe('idea-two');
+    registry.register('ts-one', 'request-one');
+    registry.register('ts-two', 'request-two');
+    expect(registry.resolve('ts-one')).toBe('request-one');
+    expect(registry.resolve('ts-two')).toBe('request-two');
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -4,7 +4,7 @@ import { OrchestratorImpl } from '../../src/core/orchestrator.js';
 import type { WorkspaceManager } from '../../src/core/workspace-manager.js';
 import type { SpecGenerator } from '../../src/adapters/agent/spec-generator.js';
 import type { SpecPublisher } from '../../src/adapters/slack/canvas-publisher.js';
-import type { Idea, ThreadMessage } from '../../src/types/events.js';
+import type { Request, ThreadMessage } from '../../src/types/events.js';
 import type { FeedbackSource } from '../../src/adapters/notion/notion-feedback-source.js';
 import type { NotionComment, NotionCommentResponse } from '../../src/adapters/agent/spec-generator.js';
 import type { Run } from '../../src/types/runs.js';
@@ -45,7 +45,7 @@ function makeMockAdapter() {
 
 function makeWorkspaceManager(overrides: Partial<WorkspaceManager> = {}): WorkspaceManager {
   return {
-    create: vi.fn().mockResolvedValue({ workspace_path: '/ws/idea-001', branch: 'spec/idea-001' }),
+    create: vi.fn().mockResolvedValue({ workspace_path: '/ws/request-001', branch: 'spec/request-001' }),
     destroy: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -53,7 +53,7 @@ function makeWorkspaceManager(overrides: Partial<WorkspaceManager> = {}): Worksp
 
 function makeSpecGenerator(overrides: Partial<SpecGenerator> = {}): SpecGenerator {
   return {
-    create: vi.fn().mockResolvedValue('/ws/idea-001/context-human/specs/feature-test.md'),
+    create: vi.fn().mockResolvedValue('/ws/request-001/context-human/specs/feature-test.md'),
     revise: vi.fn().mockResolvedValue({ comment_responses: [] }),
     ...overrides,
   };
@@ -76,9 +76,9 @@ function makeSpecPublisher(overrides: Partial<SpecPublisher> = {}): SpecPublishe
   };
 }
 
-function makeIdea(overrides: Partial<Idea> = {}): Idea {
+function makeRequest(overrides: Partial<Request> = {}): Request {
   return {
-    id: 'idea-001',
+    id: 'request-001',
     source: 'slack',
     content: 'add a setup wizard',
     author: 'U123',
@@ -91,7 +91,7 @@ function makeIdea(overrides: Partial<Idea> = {}): Idea {
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
-    idea_id: 'idea-001',
+    request_id: 'request-001',
     content: 'wizard should not require all settings',
     author: 'U456',
     received_at: new Date().toISOString(),
@@ -101,7 +101,7 @@ function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   };
 }
 
-function makeIntentClassifier(intent = 'spec_feedback'): IntentClassifier {
+function makeIntentClassifier(intent = 'feedback'): IntentClassifier {
   return {
     classify: vi.fn().mockResolvedValue(intent),
   };
@@ -110,11 +110,12 @@ function makeIntentClassifier(intent = 'spec_feedback'): IntentClassifier {
 function makeRun(overrides: Partial<Run> = {}): Run {
   return {
     id: 'run-001',
-    idea_id: 'idea-001',
+    request_id: 'request-001',
+    intent: 'idea',
     stage: 'reviewing_spec',
-    workspace_path: '/ws/idea-001',
-    branch: 'spec/idea-001',
-    spec_path: '/ws/idea-001/context-human/specs/feature-test.md',
+    workspace_path: '/ws/request-001',
+    branch: 'spec/request-001',
+    spec_path: '/ws/request-001/context-human/specs/feature-test.md',
     publisher_ref: 'CANVAS001',
     impl_feedback_ref: undefined,
     attempt: 0,
@@ -154,7 +155,7 @@ function makeImplFeedbackPage(overrides: Partial<ImplementationFeedbackPage> = {
   };
 }
 
-describe('Orchestrator — new_idea happy path', () => {
+describe('Orchestrator — new_request happy path', () => {
   it('calls all four components in order with correct arguments', async () => {
     const adapter = makeMockAdapter();
     const wm = makeWorkspaceManager();
@@ -162,19 +163,19 @@ describe('Orchestrator — new_idea happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
-    const idea = makeIdea();
-    adapter._emit({ type: 'new_idea', payload: idea });
+    const request = makeRequest();
+    adapter._emit({ type: 'new_request', payload: request });
 
     // Give the loop time to process
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    expect(wm.create).toHaveBeenCalledWith('idea-001', 'https://github.com/org/repo');
-    expect(sg.create).toHaveBeenCalledWith(idea, '/ws/idea-001');
-    expect(cp.create).toHaveBeenCalledWith('C123', '100.0', '/ws/idea-001/context-human/specs/feature-test.md');
+    expect(wm.create).toHaveBeenCalledWith('request-001', 'https://github.com/org/repo');
+    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001');
+    expect(cp.create).toHaveBeenCalledWith('C123', '100.0', '/ws/request-001/context-human/specs/feature-test.md');
   });
 
   it('run ends in review stage with all fields populated', async () => {
@@ -184,25 +185,25 @@ describe('Orchestrator — new_idea happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
     // Access internal state to verify — cast through any for testing
     const runs = (orch as never as { runs: Map<string, { stage: string; workspace_path: string; branch: string; spec_path: string; publisher_ref: string }> }).runs;
-    const run = runs.get('idea-001')!;
+    const run = runs.get('request-001')!;
     expect(run.stage).toBe('reviewing_spec');
-    expect(run.workspace_path).toBe('/ws/idea-001');
-    expect(run.branch).toBe('spec/idea-001');
-    expect(run.spec_path).toBe('/ws/idea-001/context-human/specs/feature-test.md');
+    expect(run.workspace_path).toBe('/ws/request-001');
+    expect(run.branch).toBe('spec/request-001');
+    expect(run.spec_path).toBe('/ws/request-001/context-human/specs/feature-test.md');
     expect(run.publisher_ref).toBe('CANVAS001');
   });
 });
 
-describe('Orchestrator — new_idea failure paths', () => {
+describe('Orchestrator — new_request failure paths', () => {
   it('WorkspaceManager failure: run is failed, error posted, no further components called', async () => {
     const adapter = makeMockAdapter();
     const wm = makeWorkspaceManager({ create: vi.fn().mockRejectedValue(new Error('clone failed')) });
@@ -210,9 +211,9 @@ describe('Orchestrator — new_idea failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
@@ -221,7 +222,7 @@ describe('Orchestrator — new_idea failure paths', () => {
     expect(cp.create).not.toHaveBeenCalled();
 
     const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
   });
 
   it('SpecGenerator failure: run is failed, error posted, workspace destroyed', async () => {
@@ -231,18 +232,18 @@ describe('Orchestrator — new_idea failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    expect(wm.destroy).toHaveBeenCalledWith('/ws/idea-001');
+    expect(wm.destroy).toHaveBeenCalledWith('/ws/request-001');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('omc failed'));
     expect(cp.create).not.toHaveBeenCalled();
 
     const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
   });
 
   it('SpecPublisher failure: run is failed, error posted, workspace destroyed', async () => {
@@ -252,21 +253,21 @@ describe('Orchestrator — new_idea failure paths', () => {
     const cp = makeSpecPublisher({ create: vi.fn().mockRejectedValue(new Error('canvas error')) });
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    expect(wm.destroy).toHaveBeenCalledWith('/ws/idea-001');
+    expect(wm.destroy).toHaveBeenCalledWith('/ws/request-001');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('canvas error'));
 
     const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
   });
 });
 
-describe('Orchestrator — spec_feedback happy path', () => {
+describe('Orchestrator — feedback happy path', () => {
   it('increments attempt, calls revise and update, run back in review', async () => {
     const adapter = makeMockAdapter();
     const wm = makeWorkspaceManager();
@@ -274,11 +275,15 @@ describe('Orchestrator — spec_feedback happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    // First call: classify new_request as 'idea'; subsequent calls: classify thread_message as 'feedback'
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
-    // First seed the idea to get a run in review
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    // First seed the request to get a run in review
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
 
     // Then send feedback
@@ -287,34 +292,34 @@ describe('Orchestrator — spec_feedback happy path', () => {
     await orch.stop();
 
     const runs = (orch as never as { runs: Map<string, { stage: string; attempt: number }> }).runs;
-    const run = runs.get('idea-001')!;
+    const run = runs.get('request-001')!;
     expect(run.stage).toBe('reviewing_spec');
     expect(run.attempt).toBe(1);
 
     expect(cp.getPageMarkdown).toHaveBeenCalledWith('CANVAS001');
     expect(sg.revise).toHaveBeenCalledWith(
-      expect.objectContaining({ idea_id: 'idea-001' }),
+      expect.objectContaining({ request_id: 'request-001' }),
       [],
-      '/ws/idea-001/context-human/specs/feature-test.md',
-      '/ws/idea-001',
+      '/ws/request-001/context-human/specs/feature-test.md',
+      '/ws/request-001',
       undefined,
     );
-    expect(cp.update).toHaveBeenCalledWith('CANVAS001', '/ws/idea-001/context-human/specs/feature-test.md', undefined);
+    expect(cp.update).toHaveBeenCalledWith('CANVAS001', '/ws/request-001/context-human/specs/feature-test.md', undefined);
   });
 });
 
-describe('Orchestrator — spec_feedback guard conditions', () => {
-  it('discards feedback for unknown idea_id', async () => {
+describe('Orchestrator — feedback guard conditions', () => {
+  it('discards feedback for unknown request_id', async () => {
     const adapter = makeMockAdapter();
     const wm = makeWorkspaceManager();
     const sg = makeSpecGenerator();
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('feedback') }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'thread_message', payload: makeFeedback({ idea_id: 'unknown-idea' }) });
+    adapter._emit({ type: 'thread_message', payload: makeFeedback({ request_id: 'unknown-request' }) });
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
@@ -327,16 +332,19 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
     const adapter = makeMockAdapter();
     // Make spec generation slow so run stays in speccing when feedback arrives
     let resolveCreate!: () => void;
-    const slowCreate = vi.fn().mockReturnValue(new Promise<string>(r => { resolveCreate = () => r('/ws/idea-001/context-human/specs/feature-test.md'); }));
+    const slowCreate = vi.fn().mockReturnValue(new Promise<string>(r => { resolveCreate = () => r('/ws/request-001/context-human/specs/feature-test.md'); }));
     const wm = makeWorkspaceManager();
     const sg = makeSpecGenerator({ create: slowCreate });
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 10)); // let it reach speccing stage
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
@@ -347,8 +355,8 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    // NOTE: With a sequential event loop, spec_feedback is queued while new_idea is being processed.
-    // By the time spec_feedback is dequeued, the run is already in 'review', not 'speccing'.
+    // NOTE: With a sequential event loop, thread_message is queued while new_request is being processed.
+    // By the time thread_message is dequeued, the run is already in 'review', not 'speccing'.
     // So revise WILL be called — the guard for speccing stage is not observable in this sequential model.
     // We verify the actual observable behavior: run ends in review, revise was called once.
     expect(sg.revise).toHaveBeenCalledTimes(1);
@@ -361,10 +369,10 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50)); // run is now failed
 
     postError.mockClear();
@@ -377,7 +385,7 @@ describe('Orchestrator — spec_feedback guard conditions', () => {
   });
 });
 
-describe('Orchestrator — spec_feedback failure paths', () => {
+describe('Orchestrator — feedback failure paths', () => {
   it('SpecGenerator.revise failure: run is failed, error posted', async () => {
     const adapter = makeMockAdapter();
     const wm = makeWorkspaceManager();
@@ -385,10 +393,13 @@ describe('Orchestrator — spec_feedback failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
     postError.mockClear();
 
@@ -397,7 +408,7 @@ describe('Orchestrator — spec_feedback failure paths', () => {
     await orch.stop();
 
     const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('revise failed'));
   });
 
@@ -408,10 +419,13 @@ describe('Orchestrator — spec_feedback failure paths', () => {
     const cp = makeSpecPublisher({ update: vi.fn().mockRejectedValue(new Error('update failed')) });
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
     postError.mockClear();
 
@@ -422,22 +436,22 @@ describe('Orchestrator — spec_feedback failure paths', () => {
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('update failed'));
 
     const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
   });
 });
 
 describe('Orchestrator — concurrency', () => {
-  it('two simultaneous ideas produce independent runs with no cross-contamination', async () => {
+  it('two simultaneous requests produce independent runs with no cross-contamination', async () => {
     const adapter = makeMockAdapter();
     const wm: WorkspaceManager = {
-      create: vi.fn().mockImplementation(async (idea_id: string) => ({
-        workspace_path: `/ws/${idea_id}`,
-        branch: `spec/${idea_id}`,
+      create: vi.fn().mockImplementation(async (request_id: string) => ({
+        workspace_path: `/ws/${request_id}`,
+        branch: `spec/${request_id}`,
       })),
       destroy: vi.fn().mockResolvedValue(undefined),
     };
     const sg: SpecGenerator = {
-      create: vi.fn().mockImplementation(async (_idea: Idea, workspace_path: string) =>
+      create: vi.fn().mockImplementation(async (_request: Request, workspace_path: string) =>
         `${workspace_path}/context-human/specs/feature-test.md`
       ),
       revise: vi.fn().mockResolvedValue({ comment_responses: [] }),
@@ -445,19 +459,19 @@ describe('Orchestrator — concurrency', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea({ id: 'idea-A', thread_ts: 'A.0' }) });
-    adapter._emit({ type: 'new_idea', payload: makeIdea({ id: 'idea-B', thread_ts: 'B.0' }) });
+    adapter._emit({ type: 'new_request', payload: makeRequest({ id: 'request-A', thread_ts: 'A.0' }) });
+    adapter._emit({ type: 'new_request', payload: makeRequest({ id: 'request-B', thread_ts: 'B.0' }) });
     await new Promise(r => setTimeout(r, 100));
     await orch.stop();
 
     const runs = (orch as never as { runs: Map<string, { stage: string; workspace_path: string }> }).runs;
-    expect(runs.get('idea-A')!.stage).toBe('reviewing_spec');
-    expect(runs.get('idea-B')!.stage).toBe('reviewing_spec');
-    expect(runs.get('idea-A')!.workspace_path).toBe('/ws/idea-A');
-    expect(runs.get('idea-B')!.workspace_path).toBe('/ws/idea-B');
+    expect(runs.get('request-A')!.stage).toBe('reviewing_spec');
+    expect(runs.get('request-B')!.stage).toBe('reviewing_spec');
+    expect(runs.get('request-A')!.workspace_path).toBe('/ws/request-A');
+    expect(runs.get('request-B')!.workspace_path).toBe('/ws/request-B');
   });
 });
 
@@ -468,15 +482,15 @@ async function seedAndFeedback(
   feedbackOverrides: Partial<ThreadMessage> = {},
 ) {
   const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-  adapter._emit({ type: 'new_idea', payload: makeIdea() });
+  adapter._emit({ type: 'new_request', payload: makeRequest() });
   // Wait for run to reach 'reviewing_spec'
-  await vi.waitUntil(() => runs.get('idea-001')?.stage === 'reviewing_spec', { timeout: 2000 });
+  await vi.waitUntil(() => runs.get('request-001')?.stage === 'reviewing_spec', { timeout: 2000 });
   adapter._emit({ type: 'thread_message', payload: makeFeedback(feedbackOverrides) });
   // Wait for run to no longer be 'speccing'
-  await vi.waitUntil(() => runs.get('idea-001')?.stage !== 'speccing', { timeout: 2000 });
+  await vi.waitUntil(() => runs.get('request-001')?.stage !== 'speccing', { timeout: 2000 });
 }
 
-describe('Orchestrator — spec_feedback with feedbackSource', () => {
+describe('Orchestrator — feedback with feedbackSource', () => {
   it('with feedbackSource: fetch called before revise, revise receives notion_comments, update/reply called in order', async () => {
     const notionComments: NotionComment[] = [
       { id: 'disc-1', body: 'Phoebe: first feedback' },
@@ -500,8 +514,11 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     (fs.reply as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push('reply'); });
     const postMessage = vi.fn().mockImplementation(async () => { callOrder.push('postMessage'); });
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, postMessage, repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, postMessage, repo_url: 'https://github.com/org/repo', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -509,12 +526,12 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     await adapter.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')?.stage).toBe('reviewing_spec');
+    expect(runs.get('request-001')?.stage).toBe('reviewing_spec');
     expect(callOrder).toEqual(['fetch', 'getPageMarkdown', 'revise', 'update', 'reply', 'reply', 'postMessage']);
     expect(sp.getPageMarkdown).toHaveBeenCalledWith('CANVAS001');
     expect(fs.fetch).toHaveBeenCalledWith('CANVAS001');
     expect(sg.revise).toHaveBeenCalledWith(
-      expect.objectContaining({ idea_id: 'idea-001' }),
+      expect.objectContaining({ request_id: 'request-001' }),
       notionComments,
       expect.any(String),
       expect.any(String),
@@ -530,8 +547,11 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
     const adapter = makeMockAdapter();
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -539,7 +559,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     await adapter.stop();
 
     expect(sg.revise).toHaveBeenCalledWith(
-      expect.objectContaining({ idea_id: 'idea-001' }),
+      expect.objectContaining({ request_id: 'request-001' }),
       [],
       expect.any(String),
       expect.any(String),
@@ -552,8 +572,11 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const sg = makeSpecGenerator({ revise: vi.fn().mockResolvedValue({ comment_responses: [] }) });
     const adapter = makeMockAdapter();
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: makeIntentClassifier() },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -561,7 +584,7 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     await adapter.stop();
 
     expect(sg.revise).toHaveBeenCalledWith(
-      expect.objectContaining({ idea_id: 'idea-001' }),
+      expect.objectContaining({ request_id: 'request-001' }),
       [],
       expect.any(String),
       expect.any(String),
@@ -575,16 +598,19 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const adapter = makeMockAdapter();
     const postError = vi.fn().mockResolvedValue(undefined);
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'reviewing_spec', { timeout: 2000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'reviewing_spec', { timeout: 2000 });
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'failed', { timeout: 2000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'failed', { timeout: 2000 });
     await adapter.stop();
 
     expect(sg.revise).not.toHaveBeenCalled();
@@ -608,8 +634,11 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     const adapter = makeMockAdapter();
     const postError = vi.fn().mockResolvedValue(undefined);
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -617,14 +646,14 @@ describe('Orchestrator — spec_feedback with feedbackSource', () => {
     await adapter.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')?.stage).toBe('reviewing_spec');
+    expect(runs.get('request-001')?.stage).toBe('reviewing_spec');
     expect(fs.reply).toHaveBeenCalledTimes(3);
     expect(postError).not.toHaveBeenCalled();
   });
 
 });
 
-describe('Orchestrator — spec_feedback completion notification', () => {
+describe('Orchestrator — feedback completion notification', () => {
   it('posts completion message with comment count after replies', async () => {
     const notionComments = [{ id: 'disc-1', body: 'feedback' }];
     const commentResponses = [{ comment_id: 'disc-1', response: 'Done' }];
@@ -633,8 +662,11 @@ describe('Orchestrator — spec_feedback completion notification', () => {
     const adapter = makeMockAdapter();
     const postMessage = vi.fn().mockResolvedValue(undefined);
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -649,8 +681,11 @@ describe('Orchestrator — spec_feedback completion notification', () => {
     const adapter = makeMockAdapter();
     const postMessage = vi.fn().mockResolvedValue(undefined);
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -666,8 +701,11 @@ describe('Orchestrator — spec_feedback completion notification', () => {
     const postMessage = vi.fn().mockRejectedValue(new Error('Slack error'));
     const postError = vi.fn().mockResolvedValue(undefined);
 
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage, repo_url: 'r', intentClassifier: makeIntentClassifier() } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage, repo_url: 'r', intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -675,7 +713,7 @@ describe('Orchestrator — spec_feedback completion notification', () => {
     await adapter.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')?.stage).toBe('reviewing_spec');
+    expect(runs.get('request-001')?.stage).toBe('reviewing_spec');
     expect(postError).not.toHaveBeenCalled();
   });
 });
@@ -683,7 +721,8 @@ describe('Orchestrator — spec_feedback completion notification', () => {
 describe('Orchestrator — intent classification routing', () => {
   it('classifier called with feedback content and run stage when in reviewing_spec', async () => {
     const adapter = makeMockAdapter();
-    const ic = makeIntentClassifier('spec_feedback');
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: makeSpecGenerator(), specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
       { logDestination: nullDest },
@@ -692,16 +731,18 @@ describe('Orchestrator — intent classification routing', () => {
     await seedAndFeedback(orch, adapter);
     await adapter.stop();
 
+    // Second call is the thread_message classification (first is new_request)
     expect(ic.classify).toHaveBeenCalledWith(
       'wizard should not require all settings',
       'reviewing_spec',
     );
   });
 
-  it('spec_feedback intent routes to spec feedback handler (calls revise)', async () => {
+  it('feedback intent routes to spec feedback handler (calls revise)', async () => {
     const adapter = makeMockAdapter();
     const sg = makeSpecGenerator();
-    const ic = makeIntentClassifier('spec_feedback');
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
       { logDestination: nullDest },
@@ -713,19 +754,19 @@ describe('Orchestrator — intent classification routing', () => {
     expect(sg.revise).toHaveBeenCalledOnce();
   });
 
-  it('spec_approval intent: does not call revise', async () => {
+  it('approval intent: does not call revise', async () => {
     const adapter = makeMockAdapter();
     const sg = makeSpecGenerator();
-    const ic = makeIntentClassifier('spec_approval');
+    const ic = makeIntentClassifier('approval');
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
 
-    // Inject a run in reviewing_spec so we don't have to go through new_idea
+    // Inject a run in reviewing_spec so we don't have to go through new_request
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await new Promise(r => setTimeout(r, 50));
@@ -734,10 +775,10 @@ describe('Orchestrator — intent classification routing', () => {
     expect(sg.revise).not.toHaveBeenCalled();
   });
 
-  it('implementation_feedback intent: does not call revise', async () => {
+  it('feedback intent on reviewing_implementation: does not call revise', async () => {
     const adapter = makeMockAdapter();
     const sg = makeSpecGenerator();
-    const ic = makeIntentClassifier('implementation_feedback');
+    const ic = makeIntentClassifier('feedback');
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
       { logDestination: nullDest },
@@ -745,7 +786,7 @@ describe('Orchestrator — intent classification routing', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_implementation' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation' }));
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await new Promise(r => setTimeout(r, 50));
@@ -754,10 +795,10 @@ describe('Orchestrator — intent classification routing', () => {
     expect(sg.revise).not.toHaveBeenCalled();
   });
 
-  it('implementation_approval intent: does not call revise', async () => {
+  it('approval intent on reviewing_implementation: does not call revise', async () => {
     const adapter = makeMockAdapter();
     const sg = makeSpecGenerator();
-    const ic = makeIntentClassifier('implementation_approval');
+    const ic = makeIntentClassifier('approval');
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
       { logDestination: nullDest },
@@ -765,7 +806,7 @@ describe('Orchestrator — intent classification routing', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_implementation' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation' }));
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await new Promise(r => setTimeout(r, 50));
@@ -779,7 +820,7 @@ describe('Orchestrator — implementing stage guard', () => {
   it('posts busy message when run is in implementing stage; classifier not called', async () => {
     const adapter = makeMockAdapter();
     const sg = makeSpecGenerator();
-    const ic = makeIntentClassifier('spec_feedback');
+    const ic = makeIntentClassifier('feedback');
     const postMessage = vi.fn().mockResolvedValue(undefined);
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: ic },
@@ -788,7 +829,7 @@ describe('Orchestrator — implementing stage guard', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'implementing' }));
+    runs.set('request-001', makeRun({ stage: 'implementing' }));
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await new Promise(r => setTimeout(r, 50));
@@ -804,7 +845,7 @@ describe('Orchestrator — done stage guard', () => {
   it('discards thread_message when run is in done stage; classifier not called', async () => {
     const adapter = makeMockAdapter();
     const sg = makeSpecGenerator();
-    const ic = makeIntentClassifier('spec_feedback');
+    const ic = makeIntentClassifier('feedback');
     const postError = vi.fn().mockResolvedValue(undefined);
     const orch = new OrchestratorImpl(
       { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
@@ -813,7 +854,7 @@ describe('Orchestrator — done stage guard', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'done' }));
+    runs.set('request-001', makeRun({ stage: 'done' }));
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await new Promise(r => setTimeout(r, 50));
@@ -826,7 +867,7 @@ describe('Orchestrator — done stage guard', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Spec approval handler tests (Task 18 / Task 19)
+// Spec approval handler tests
 // ──────────────────────────────────────────────────────────────────────────────
 
 function makeApprovalOrch(opts: {
@@ -843,7 +884,7 @@ function makeApprovalOrch(opts: {
       workspaceManager: makeWorkspaceManager(),
       specGenerator: makeSpecGenerator(),
       specPublisher: makeSpecPublisher(),
-      intentClassifier: makeIntentClassifier('spec_approval'),
+      intentClassifier: makeIntentClassifier('approval'),
       specCommitter: opts.specCommitter ?? makeSpecCommitter(),
       implementer: opts.implementer ?? makeImplementer(),
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
@@ -855,17 +896,17 @@ function makeApprovalOrch(opts: {
   );
 }
 
-// Inject a run in reviewing_spec and emit spec_approval thread_message
+// Inject a run in reviewing_spec and emit approval thread_message
 async function approveSpec(
   orch: OrchestratorImpl,
   adapter: ReturnType<typeof makeMockAdapter>,
 ) {
   const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-  runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+  runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
   adapter._emit({ type: 'thread_message', payload: makeFeedback() });
   await vi.waitUntil(
     () => {
-      const r = runs.get('idea-001');
+      const r = runs.get('request-001');
       return r?.stage !== 'reviewing_spec' && r?.stage !== 'implementing';
     },
     { timeout: 3000 },
@@ -878,7 +919,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const stages: string[] = [];
     const commitFn = vi.fn().mockImplementation(async () => {
       const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-      stages.push(runs.get('idea-001')!.stage);
+      stages.push(runs.get('request-001')!.stage);
     });
     const sc = makeSpecCommitter({ commit: commitFn });
     const orch = makeApprovalOrch({ adapter, specCommitter: sc });
@@ -919,9 +960,9 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
 
     expect(sc.commit).toHaveBeenCalledOnce();
     expect(sc.commit).toHaveBeenCalledWith(
-      '/ws/idea-001',
+      '/ws/request-001',
       'CANVAS001',
-      '/ws/idea-001/context-human/specs/feature-test.md',
+      '/ws/request-001/context-human/specs/feature-test.md',
     );
   });
 
@@ -942,8 +983,8 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
 
     expect(callOrder.indexOf('commit')).toBeLessThan(callOrder.indexOf('implement'));
     expect(implementFn).toHaveBeenCalledWith(
-      '/ws/idea-001/context-human/specs/feature-test.md',
-      '/ws/idea-001',
+      '/ws/request-001/context-human/specs/feature-test.md',
+      '/ws/request-001',
     );
   });
 
@@ -972,7 +1013,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.impl_feedback_ref).toBe('impl-page-xyz');
+    expect(runs.get('request-001')!.impl_feedback_ref).toBe('impl-page-xyz');
   });
 
   it('complete result: posts completion message containing feedback page URL', async () => {
@@ -999,7 +1040,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('reviewing_implementation');
+    expect(runs.get('request-001')!.stage).toBe('reviewing_implementation');
   });
 
   it('needs_input result: question posted to Slack; run transitions to awaiting_impl_input', async () => {
@@ -1011,12 +1052,12 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'awaiting_impl_input', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'awaiting_impl_input', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('awaiting_impl_input');
+    expect(runs.get('request-001')!.stage).toBe('awaiting_impl_input');
     const messages = (postMessage as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[2] as string);
     expect(messages.some(m => m.includes('Which approach do you prefer?'))).toBe(true);
     expect(implFeedbackPage.create).not.toHaveBeenCalled();
@@ -1033,12 +1074,12 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'failed', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'failed', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('commit failed'));
     expect(impl.implement).not.toHaveBeenCalled();
   });
@@ -1052,12 +1093,12 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'failed', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'failed', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('agent crashed'));
     expect(implFeedbackPage.create).not.toHaveBeenCalled();
   });
@@ -1070,12 +1111,12 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'failed', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'failed', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('OMC crashed'));
   });
 
@@ -1090,12 +1131,12 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'reviewing_implementation', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'reviewing_implementation', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('reviewing_implementation');
+    expect(runs.get('request-001')!.stage).toBe('reviewing_implementation');
     // Completion message still posted even without page link
     expect(postMessage.mock.calls.length).toBeGreaterThanOrEqual(2); // approval ack + completion
     // postError not called for page creation failure (it's degraded, not fatal)
@@ -1112,18 +1153,18 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'reviewing_implementation', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'reviewing_implementation', { timeout: 3000 });
     await orch.stop();
 
     expect(sc.commit).toHaveBeenCalledOnce();
-    expect(runs.get('idea-001')!.stage).toBe('reviewing_implementation');
+    expect(runs.get('request-001')!.stage).toBe('reviewing_implementation');
   });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Implementation feedback handler tests (Task 20 / Task 21)
+// Implementation feedback handler tests
 // ──────────────────────────────────────────────────────────────────────────────
 
 function makeImplFeedbackOrch(opts: {
@@ -1140,7 +1181,7 @@ function makeImplFeedbackOrch(opts: {
       workspaceManager: makeWorkspaceManager(),
       specGenerator: makeSpecGenerator(),
       specPublisher: makeSpecPublisher(),
-      intentClassifier: makeIntentClassifier(opts.intentOverride ?? 'implementation_feedback'),
+      intentClassifier: makeIntentClassifier(opts.intentOverride ?? 'feedback'),
       specCommitter: makeSpecCommitter(),
       implementer: opts.implementer ?? makeImplementer(),
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
@@ -1152,7 +1193,7 @@ function makeImplFeedbackOrch(opts: {
   );
 }
 
-// Inject a run in reviewing_implementation and emit thread_message classified as implementation_feedback.
+// Inject a run in reviewing_implementation and emit thread_message classified as feedback.
 // Waits until the handler finishes: attempt incremented and no longer in 'implementing'.
 async function sendImplFeedback(
   orch: OrchestratorImpl,
@@ -1160,11 +1201,11 @@ async function sendImplFeedback(
   runOverrides: Partial<Run> = {},
 ) {
   const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-  runs.set('idea-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id', ...runOverrides }));
+  runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id', ...runOverrides }));
   adapter._emit({ type: 'thread_message', payload: makeFeedback() });
   await vi.waitUntil(
     () => {
-      const r = runs.get('idea-001');
+      const r = runs.get('request-001');
       // Handler increments attempt before implementing; done when attempt > 0 and no longer implementing
       return r !== undefined && r.attempt > 0 && r.stage !== 'implementing';
     },
@@ -1247,7 +1288,7 @@ describe('Orchestrator — _handleImplementationFeedback happy path (reviewing_i
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('reviewing_implementation');
+    expect(runs.get('request-001')!.stage).toBe('reviewing_implementation');
   });
 
   it('complete result: posts completion message to Slack', async () => {
@@ -1269,12 +1310,12 @@ describe('Orchestrator — _handleImplementationFeedback happy path (reviewing_i
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'awaiting_impl_input', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'awaiting_impl_input', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('awaiting_impl_input');
+    expect(runs.get('request-001')!.stage).toBe('awaiting_impl_input');
     const messages = (postMessage as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[2] as string);
     expect(messages.some(m => m.includes('Which refactor pattern?'))).toBe(true);
   });
@@ -1289,11 +1330,11 @@ describe('Orchestrator — _handleImplementationFeedback happy path (awaiting_im
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'awaiting_impl_input', impl_feedback_ref: 'feedback-page-id' }));
+    runs.set('request-001', makeRun({ stage: 'awaiting_impl_input', impl_feedback_ref: 'feedback-page-id' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback({ content: 'go with the subtype approach' }) });
     await vi.waitUntil(
       () => {
-        const r = runs.get('idea-001');
+        const r = runs.get('request-001');
         return r?.stage !== 'awaiting_impl_input' && r?.stage !== 'implementing';
       },
       { timeout: 3000 },
@@ -1318,12 +1359,12 @@ describe('Orchestrator — _handleImplementationFeedback failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'failed', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'failed', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('Notion read failed'));
     expect(impl.implement).not.toHaveBeenCalled();
   });
@@ -1337,12 +1378,12 @@ describe('Orchestrator — _handleImplementationFeedback failure paths', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id' }));
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'failed', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'failed', { timeout: 3000 });
     await orch.stop();
 
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('agent crashed'));
     expect(implFeedbackPage.update).not.toHaveBeenCalled();
   });
@@ -1359,13 +1400,13 @@ describe('Orchestrator — _handleImplementationFeedback failure paths', () => {
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('reviewing_implementation');
+    expect(runs.get('request-001')!.stage).toBe('reviewing_implementation');
     expect(postError).not.toHaveBeenCalled();
   });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Implementation approval handler tests (Task 22 / Task 23)
+// Implementation approval handler tests
 // ──────────────────────────────────────────────────────────────────────────────
 
 import type { PRCreator } from '../../src/adapters/agent/pr-creator.js';
@@ -1389,7 +1430,7 @@ function makeApprovalOrch2(opts: {
       workspaceManager: makeWorkspaceManager(),
       specGenerator: makeSpecGenerator(),
       specPublisher: makeSpecPublisher(),
-      intentClassifier: makeIntentClassifier('implementation_approval'),
+      intentClassifier: makeIntentClassifier('approval'),
       specCommitter: makeSpecCommitter(),
       implementer: makeImplementer(),
       implFeedbackPage: makeImplFeedbackPage(),
@@ -1407,11 +1448,11 @@ async function sendImplApproval(
   adapter: ReturnType<typeof makeMockAdapter>,
 ) {
   const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-  runs.set('idea-001', makeRun({ stage: 'reviewing_implementation', branch: 'spec/idea-001' }));
+  runs.set('request-001', makeRun({ stage: 'reviewing_implementation', branch: 'spec/request-001' }));
   adapter._emit({ type: 'thread_message', payload: makeFeedback() });
   await vi.waitUntil(
     () => {
-      const r = runs.get('idea-001');
+      const r = runs.get('request-001');
       return r?.stage === 'done' || r?.stage === 'failed';
     },
     { timeout: 3000 },
@@ -1429,8 +1470,8 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
 
     expect(prCreator.createPR).toHaveBeenCalledOnce();
     expect(prCreator.createPR).toHaveBeenCalledWith(
-      '/ws/idea-001',
-      'spec/idea-001',
+      '/ws/request-001',
+      'spec/request-001',
       expect.any(String),
     );
   });
@@ -1458,7 +1499,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('done');
+    expect(runs.get('request-001')!.stage).toBe('done');
   });
 });
 
@@ -1475,7 +1516,7 @@ describe('Orchestrator — _handleImplementationApproval failure paths', () => {
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('failed');
+    expect(runs.get('request-001')!.stage).toBe('failed');
     expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('gh pr create failed'));
   });
 
@@ -1489,7 +1530,7 @@ describe('Orchestrator — _handleImplementationApproval failure paths', () => {
     await orch.stop();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')!.stage).toBe('done');
+    expect(runs.get('request-001')!.stage).toBe('done');
     expect(postError).not.toHaveBeenCalled();
   });
 });
@@ -1504,8 +1545,8 @@ import { join } from 'node:path';
 import { FileRunStore } from '../../src/core/run-store.js';
 
 describe('Orchestrator — run persistence', () => {
-  it('loads runs on construction: existing run is matched by idea_id on thread_message', async () => {
-    const existingRun = makeRun({ idea_id: 'idea-loaded', stage: 'reviewing_spec', channel_id: 'C999', thread_ts: '9000.0' });
+  it('loads runs on construction: existing run is matched by request_id on thread_message', async () => {
+    const existingRun = makeRun({ request_id: 'request-loaded', stage: 'reviewing_spec', channel_id: 'C999', thread_ts: '9000.0' });
     const mockRunStore = { load: vi.fn().mockReturnValue([existingRun]), save: vi.fn() };
 
     const adapter = makeMockAdapter();
@@ -1516,7 +1557,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: sg,
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_feedback'),
+        intentClassifier: makeIntentClassifier('feedback'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
         repo_url: 'r',
@@ -1526,17 +1567,17 @@ describe('Orchestrator — run persistence', () => {
     );
     await orch.start();
 
-    // Send thread_message for the loaded run's idea_id — if loaded, revise will be called
-    adapter._emit({ type: 'thread_message', payload: { ...makeFeedback(), idea_id: 'idea-loaded', channel_id: 'C999', thread_ts: '9000.0' } });
+    // Send thread_message for the loaded run's request_id — if loaded, revise will be called
+    adapter._emit({ type: 'thread_message', payload: { ...makeFeedback(), request_id: 'request-loaded', channel_id: 'C999', thread_ts: '9000.0' } });
     await new Promise(r => setTimeout(r, 100));
     await orch.stop();
 
-    // revise called means the run was found by idea_id (not discarded as unknown)
+    // revise called means the run was found by request_id (not discarded as unknown)
     expect(sg.revise).toHaveBeenCalledOnce();
     expect(mockRunStore.load).toHaveBeenCalledOnce();
   });
 
-  it('persists after createRun: save is called when new_idea is processed', async () => {
+  it('persists after createRun: save is called when new_request is processed', async () => {
     const mockRunStore = { load: vi.fn().mockReturnValue([]), save: vi.fn() };
 
     const adapter = makeMockAdapter();
@@ -1546,7 +1587,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: makeSpecGenerator(),
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_feedback'),
+        intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
         repo_url: 'r',
@@ -1556,27 +1597,30 @@ describe('Orchestrator — run persistence', () => {
     );
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 100));
     await orch.stop();
 
     expect(mockRunStore.save).toHaveBeenCalled();
     // The Map passed to save should contain the new run
     const savedMap = (mockRunStore.save as ReturnType<typeof vi.fn>).mock.calls[0][0] as Map<string, Run>;
-    expect(savedMap.has('idea-001')).toBe(true);
+    expect(savedMap.has('request-001')).toBe(true);
   });
 
   it('persists after transition: save is called on stage transition', async () => {
     const mockRunStore = { load: vi.fn().mockReturnValue([]), save: vi.fn() };
 
     const adapter = makeMockAdapter();
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
     const orch = new OrchestratorImpl(
       {
         adapter: adapter as never,
         workspaceManager: makeWorkspaceManager(),
         specGenerator: makeSpecGenerator(),
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_feedback'),
+        intentClassifier: ic,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
         repo_url: 'r',
@@ -1588,12 +1632,12 @@ describe('Orchestrator — run persistence', () => {
 
     // Seed a run and send feedback to trigger a transition
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'reviewing_spec', { timeout: 2000 });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'reviewing_spec', { timeout: 2000 });
 
     mockRunStore.save.mockClear();
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.stage === 'reviewing_spec' && runs.get('idea-001')?.attempt === 1, { timeout: 2000 });
+    await vi.waitUntil(() => runs.get('request-001')?.stage === 'reviewing_spec' && runs.get('request-001')?.attempt === 1, { timeout: 2000 });
     await orch.stop();
 
     expect(mockRunStore.save).toHaveBeenCalled();
@@ -1609,7 +1653,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: makeSpecGenerator(),
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_approval'),
+        intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
         implementer: makeImplementer(),
         implFeedbackPage: makeImplFeedbackPage(),
@@ -1623,13 +1667,13 @@ describe('Orchestrator — run persistence', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     mockRunStore.save.mockClear();
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await vi.waitUntil(
       () => {
-        const r = runs.get('idea-001');
+        const r = runs.get('request-001');
         return r?.stage === 'reviewing_implementation' || r?.stage === 'failed';
       },
       { timeout: 3000 },
@@ -1649,7 +1693,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: makeSpecGenerator(),
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('implementation_feedback'),
+        intentClassifier: makeIntentClassifier('feedback'),
         specCommitter: makeSpecCommitter(),
         implementer: makeImplementer(),
         implFeedbackPage: makeImplFeedbackPage(),
@@ -1663,13 +1707,13 @@ describe('Orchestrator — run persistence', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'fp-id' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'fp-id' }));
     mockRunStore.save.mockClear();
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
     await vi.waitUntil(
       () => {
-        const r = runs.get('idea-001');
+        const r = runs.get('request-001');
         return r !== undefined && r.attempt > 0 && r.stage !== 'implementing';
       },
       { timeout: 3000 },
@@ -1690,7 +1734,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: makeSpecGenerator(),
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_approval'),
+        intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
         implementer: makeImplementer(),
         implFeedbackPage,
@@ -1704,11 +1748,11 @@ describe('Orchestrator — run persistence', () => {
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    runs.set('idea-001', makeRun({ stage: 'reviewing_spec' }));
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
     mockRunStore.save.mockClear();
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback() });
-    await vi.waitUntil(() => runs.get('idea-001')?.impl_feedback_ref === 'new-feedback-page', { timeout: 3000 });
+    await vi.waitUntil(() => runs.get('request-001')?.impl_feedback_ref === 'new-feedback-page', { timeout: 3000 });
     await orch.stop();
 
     expect(mockRunStore.save).toHaveBeenCalled();
@@ -1724,7 +1768,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: sg,
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_feedback'),
+        intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
         repo_url: 'r',
@@ -1733,13 +1777,13 @@ describe('Orchestrator — run persistence', () => {
     );
     await orch.start();
 
-    adapter._emit({ type: 'new_idea', payload: makeIdea() });
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 100));
     await orch.stop();
 
     // Verify normal operation still works
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
-    expect(runs.get('idea-001')?.stage).toBe('reviewing_spec');
+    expect(runs.get('request-001')?.stage).toBe('reviewing_spec');
   });
 
   it('Slack restart notification: posts "Server restarted" to channel/thread of demoted runs', async () => {
@@ -1753,7 +1797,8 @@ describe('Orchestrator — run persistence', () => {
 
     const persistedRun: Run = {
       id: 'run-restart',
-      idea_id: 'idea-restart',
+      request_id: 'request-restart',
+      intent: 'idea',
       stage: 'implementing',
       workspace_path: workspacePath,
       branch: 'feat/restart',
@@ -1779,7 +1824,7 @@ describe('Orchestrator — run persistence', () => {
         workspaceManager: makeWorkspaceManager(),
         specGenerator: makeSpecGenerator(),
         specPublisher: makeSpecPublisher(),
-        intentClassifier: makeIntentClassifier('spec_feedback'),
+        intentClassifier: makeIntentClassifier('feedback'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
         repo_url: 'r',

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -9,6 +9,7 @@ import type { FeedbackSource } from '../../src/adapters/notion/notion-feedback-s
 import type { NotionComment, NotionCommentResponse } from '../../src/adapters/agent/spec-generator.js';
 import type { Run } from '../../src/types/runs.js';
 import type { IntentClassifier } from '../../src/adapters/agent/intent-classifier.js';
+import type { QuestionAnswerer } from '../../src/adapters/agent/question-answerer.js';
 import type { SpecCommitter } from '../../src/adapters/notion/spec-committer.js';
 import type { Implementer, ImplementationResult } from '../../src/adapters/agent/implementer.js';
 import type { ImplementationFeedbackPage } from '../../src/adapters/notion/implementation-feedback-page.js';
@@ -104,6 +105,12 @@ function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
 function makeIntentClassifier(intent = 'feedback'): IntentClassifier {
   return {
     classify: vi.fn().mockResolvedValue(intent),
+  };
+}
+
+function makeQuestionAnswerer(response = 'Here is your answer.'): QuestionAnswerer {
+  return {
+    answer: vi.fn().mockResolvedValue(response),
   };
 }
 
@@ -1841,5 +1848,122 @@ describe('Orchestrator — run persistence', () => {
     await orch.stop();
 
     expect(postMessage).toHaveBeenCalledWith('C999', '9999.0000', expect.stringContaining('Server restarted'));
+  });
+});
+
+describe('Orchestrator — question intent', () => {
+  it('new_request with question intent: questionAnswerer.answer called with content, response posted', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    const qa = makeQuestionAnswerer('You can submit ideas by @mentioning me.');
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: makeSpecGenerator(),
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('question'),
+        questionAnswerer: qa,
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    const request = makeRequest({ content: 'How do I submit a feature request?' });
+    adapter._emit({ type: 'new_request', payload: request });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    expect(qa.answer).toHaveBeenCalledWith('How do I submit a feature request?');
+    expect(postMessage).toHaveBeenCalledWith('C123', '100.0', 'You can submit ideas by @mentioning me.');
+  });
+
+  it('thread_message with question intent: questionAnswerer.answer called with feedback content, stage unchanged', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    const qa = makeQuestionAnswerer('Great question about the auth flow.');
+    const ic = makeIntentClassifier('question');
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: makeSpecGenerator(),
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: ic,
+        questionAnswerer: qa,
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
+    adapter._emit({ type: 'thread_message', payload: makeFeedback({ content: 'How does auth work?' }) });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    expect(qa.answer).toHaveBeenCalledWith('How does auth work?');
+    expect(postMessage).toHaveBeenCalledWith(expect.any(String), expect.any(String), 'Great question about the auth flow.');
+    expect(runs.get('request-001')!.stage).toBe('reviewing_spec');
+  });
+
+  it('questionAnswerer throws: fallback response posted, run does not fail', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    const postError = vi.fn().mockResolvedValue(undefined);
+    const qa: QuestionAnswerer = { answer: vi.fn().mockRejectedValue(new Error('API down')) };
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: makeSpecGenerator(),
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('question'),
+        questionAnswerer: qa,
+        postError,
+        postMessage,
+        repo_url: 'r',
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    adapter._emit({ type: 'new_request', payload: makeRequest({ content: 'what can you do?' }) });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    expect(postMessage).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining("wasn't able"));
+    expect(postError).not.toHaveBeenCalled();
+  });
+
+  it('no questionAnswerer configured: fallback text posted', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: makeSpecGenerator(),
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('question'),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    expect(postMessage).toHaveBeenCalledWith('C123', '100.0', expect.any(String));
   });
 });

--- a/tests/core/run-store.test.ts
+++ b/tests/core/run-store.test.ts
@@ -27,7 +27,8 @@ function parseLogs(lines: string[]): Record<string, unknown>[] {
 function makeRun(overrides: Partial<Run> = {}): Run {
   return {
     id: randomUUID(),
-    idea_id: randomUUID(),
+    request_id: randomUUID(),
+    intent: 'idea',
     stage: 'reviewing_spec',
     workspace_path: '/tmp/placeholder',
     branch: 'spec/test',
@@ -122,7 +123,7 @@ describe('FileRunStore.load — non-array JSON', () => {
 // ─────────────────────────────────────────────
 
 describe('FileRunStore.load — workspace_path missing', () => {
-  it('drops run with non-existent workspace_path and emits run_store.run_dropped with idea_id', () => {
+  it('drops run with non-existent workspace_path and emits run_store.run_dropped with request_id', () => {
     const run = makeRun({
       workspace_path: path.join(tmpDir, 'nonexistent-workspace'),
     });
@@ -140,7 +141,7 @@ describe('FileRunStore.load — workspace_path missing', () => {
     const logs = parseLogs(lines);
     const dropped = logs.find(l => l['event'] === 'run_store.run_dropped');
     expect(dropped).toBeDefined();
-    expect(dropped!['idea_id']).toBe(run.idea_id);
+    expect(dropped!['request_id']).toBe(run.request_id);
   });
 });
 
@@ -359,7 +360,7 @@ describe('FileRunStore.save — creates directory', () => {
     const store = new FileRunStore(tmpDir, { logDestination: dest });
 
     const run = makeRun({ workspace_path: tmpDir });
-    const runs = new Map<string, Run>([[run.idea_id, run]]);
+    const runs = new Map<string, Run>([[run.request_id, run]]);
     store.save(runs);
 
     const filePath = path.join(tmpDir, '.autocatalyst', 'runs.json');
@@ -387,7 +388,7 @@ describe('FileRunStore.save — round-trip', () => {
       attempt: 3,
     });
 
-    const runs = new Map<string, Run>([[run.idea_id, run]]);
+    const runs = new Map<string, Run>([[run.request_id, run]]);
     store.save(runs);
 
     const { dest: dest2 } = makeLogCapture();
@@ -397,7 +398,7 @@ describe('FileRunStore.save — round-trip', () => {
     expect(loaded).toHaveLength(1);
     const loaded0 = loaded[0];
     expect(loaded0.id).toBe(run.id);
-    expect(loaded0.idea_id).toBe(run.idea_id);
+    expect(loaded0.request_id).toBe(run.request_id);
     expect(loaded0.stage).toBe(run.stage);
     expect(loaded0.workspace_path).toBe(run.workspace_path);
     expect(loaded0.branch).toBe(run.branch);
@@ -426,7 +427,7 @@ describe('FileRunStore.save — write failure non-fatal', () => {
     const store = new FileRunStore(tmpDir, { logDestination: dest });
 
     const run = makeRun({ workspace_path: tmpDir });
-    const runs = new Map<string, Run>([[run.idea_id, run]]);
+    const runs = new Map<string, Run>([[run.request_id, run]]);
 
     expect(() => store.save(runs)).not.toThrow();
 
@@ -447,7 +448,7 @@ describe('FileRunStore.demotedIds', () => {
     expect(store.demotedIds.size).toBe(0);
   });
 
-  it('is populated after load() with the demoted run idea_id', () => {
+  it('is populated after load() with the demoted run request_id', () => {
     const workspacePath = path.join(tmpDir, 'ws-demote');
     fs.mkdirSync(workspacePath, { recursive: true });
 
@@ -464,7 +465,7 @@ describe('FileRunStore.demotedIds', () => {
     const store = new FileRunStore(tmpDir, { logDestination: dest });
     store.load();
 
-    expect(store.demotedIds.has(run.idea_id)).toBe(true);
+    expect(store.demotedIds.has(run.request_id)).toBe(true);
   });
 
   it('is empty when no runs are demoted', () => {

--- a/tests/core/workspace-manager.test.ts
+++ b/tests/core/workspace-manager.test.ts
@@ -88,7 +88,7 @@ describe('WorkspaceManager.create', () => {
     expect(existsSync(join(tempRoot, 'idea-xyz'))).toBe(false);
   });
 
-  it('two ideas with different idea_ids produce non-overlapping paths', async () => {
+  it('two requests with different request_ids produce non-overlapping paths', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
     const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
 
@@ -98,19 +98,19 @@ describe('WorkspaceManager.create', () => {
     expect(r1.workspace_path).not.toBe(r2.workspace_path);
   });
 
-  it('throws on invalid idea_id containing path separator', async () => {
+  it('throws on invalid request_id containing path separator', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
     const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
 
-    await expect(wm.create('idea/evil', 'https://github.com/org/repo.git')).rejects.toThrow(/Invalid idea_id/);
+    await expect(wm.create('req/evil', 'https://github.com/org/repo.git')).rejects.toThrow(/Invalid request_id/);
     expect(execFn).not.toHaveBeenCalled();
   });
 
-  it('throws on invalid idea_id containing dot-dot traversal', async () => {
+  it('throws on invalid request_id containing dot-dot traversal', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
     const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
 
-    await expect(wm.create('idea..evil', 'https://github.com/org/repo.git')).rejects.toThrow(/Invalid idea_id/);
+    await expect(wm.create('req..evil', 'https://github.com/org/repo.git')).rejects.toThrow(/Invalid request_id/);
     expect(execFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Refactors `IntentClassifier` to a unified taxonomy (`idea | bug | question | feedback | approval | ignore`) keyed by `ClassificationContext = 'new_thread' | RunStage`, replacing the old stage-specific intent types (`spec_feedback`, `spec_approval`, etc.)
- Renames `Idea`/`idea_id`/`new_idea` → `Request`/`request_id`/`new_request` throughout all source and test files
- Updates `classifyMessage` in the Slack classifier with tighter ignore rules: in-thread messages that don't mention the bot are now ignored; multi-mention (bot + another user) correctly routes as `thread_message`
- Collapses orchestrator's top-level dispatch into a single `_handleRequest` entry point with intent × stage routing: `idea` starts spec pipeline, `bug`/`question` answered via Agent SDK, `ignore` discards; existing approval/implementation handlers preserved intact

Closes #27
Closes #37
Closes #41
Closes #43
Closes #44

**BREAKING CHANGE:** Run store serialization format changed — existing `.autocatalyst/runs.json` files with `idea_id` fields are incompatible. Delete `runs.json` to reset on next startup.

## Test Plan

- [x] All 427 tests pass (`npm test`)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] No remaining `idea_id`, `new_idea`, `spec_feedback`, `spec_approval`, `implementation_feedback`, `implementation_approval` as type/field references in `src/` or `tests/`
- [ ] Verify Slack bot correctly routes top-level @mentions as `new_request`
- [ ] Verify questions get AI-powered answers via Agent SDK
- [ ] Verify bugs get stub acknowledgements
- [ ] Verify in-thread messages without bot @mention are ignored
- [ ] Verify spec feedback flow still works end-to-end
- [ ] Verify approval and implementation pipeline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
