### PR TITLE
feat: enhancement: agent progress updates during long-running operations

### DIFF
--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -476,7 +476,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `tsc --noEmit` passes
 			- [ ] All existing tests pass
 		- **Dependencies**: None
-	- [ ] **Task: Add ****`parseRelayMessage`**** helper and augment implementation prompts**
+	- [x] **Task: Add ****`parseRelayMessage`**** helper and augment implementation prompts**
 		- **Description**: Add module-local helper `parseRelayMessage(content: BetaMessage['content']): string | null` to `src/adapters/agent/implementer.ts`. The function iterates each text block's lines, matches the first line of the form `/^\[Relay\]\s+(.+)$/`, and returns the capture group trimmed, or `null` if none found. Update `buildPrompt` and `buildFeedbackPrompt` to append the goal-oriented checkpoint instruction block.
 		- **Acceptance criteria**:
 			- [ ] `parseRelayMessage` handles all cases in the §6 unit test matrix

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -1,10 +1,10 @@
 ---
 created: 2026-04-15
 last_updated: 2026-04-16
-status: approved
+status: complete
 issue: 23
 specced_by: markdstafford
-implemented_by: null
+implemented_by: markdstafford
 superseded_by: null
 ---
 # Enhancement: Agent progress updates during long-running operations
@@ -471,101 +471,101 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 	- [x] **Task: Add ****`onProgress`**** parameter to ****`Implementer`**** interface**
 		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the fourth positional parameter to `Implementer.implement()` in `src/adapters/agent/implementer.ts`. Interface change only — no implementation logic yet.
 		- **Acceptance criteria**:
-			- [ ] `Implementer.implement()` signature includes the optional `onProgress` parameter
-			- [ ] `AgentSDKImplementer.implement()` signature updated to match (no body changes yet)
-			- [ ] `tsc --noEmit` passes
-			- [ ] All existing tests pass
+			- [x] `Implementer.implement()` signature includes the optional `onProgress` parameter
+			- [x] `AgentSDKImplementer.implement()` signature updated to match (no body changes yet)
+			- [x] `tsc --noEmit` passes
+			- [x] All existing tests pass
 		- **Dependencies**: None
 	- [x] **Task: Add ****`parseRelayMessage`**** helper and augment implementation prompts**
 		- **Description**: Add module-local helper `parseRelayMessage(content: BetaMessage['content']): string | null` to `src/adapters/agent/implementer.ts`. The function iterates each text block's lines, matches the first line of the form `/^\[Relay\]\s+(.+)$/`, and returns the capture group trimmed, or `null` if none found. Update `buildPrompt` and `buildFeedbackPrompt` to append the goal-oriented checkpoint instruction block.
 		- **Acceptance criteria**:
-			- [ ] `parseRelayMessage` handles all cases in the §6 unit test matrix
-			- [ ] Both `buildPrompt` and `buildFeedbackPrompt` output includes the checkpoint instruction block
-			- [ ] `tsc --noEmit` passes
+			- [x] `parseRelayMessage` handles all cases in the §6 unit test matrix
+			- [x] Both `buildPrompt` and `buildFeedbackPrompt` output includes the checkpoint instruction block
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `onProgress` parameter to `Implementer` interface
 	- [x] **Task: Implement relay detection in ****`AgentSDKImplementer.implement()`**** drain loop**
 		- **Description**: Update `AgentSDKImplementer.implement()` drain loop. When `onProgress` is defined and the message is `type === 'assistant'`, call `parseRelayMessage(message.message.content)`. If non-null, call `onProgress(relayMessage).then(() => logger.info(...)).catch(err => logger.warn(...))`. Do not await.
 		- **Acceptance criteria**:
-			- [ ] `onProgress` called when agent emits a `[Relay]` line
-			- [ ] `onProgress` not called for non-relay turns or non-assistant messages
-			- [ ] Success: `progress_update` logged at info with `phase: 'implementation'`
-			- [ ] Failure: `progress_failed` logged at warn with `phase: 'implementation'`; `implement()` resolves normally
-			- [ ] When `onProgress` omitted, behavior identical to before
-			- [ ] `tsc --noEmit` passes
+			- [x] `onProgress` called when agent emits a `[Relay]` line
+			- [x] `onProgress` not called for non-relay turns or non-assistant messages
+			- [x] Success: `progress_update` logged at info with `phase: 'implementation'`
+			- [x] Failure: `progress_failed` logged at warn with `phase: 'implementation'`; `implement()` resolves normally
+			- [x] When `onProgress` omitted, behavior identical to before
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment implementation prompts
 - [x] **Story: Update ****`Speccer`**** interface and ****`AgentSDKSpeccer`**
 	- [x] **Task: Add ****`onProgress`**** parameter to ****`Speccer`**** interface**
 		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the last optional parameter to both `Speccer.generateSpec()` and `Speccer.reviseSpec()` in `src/adapters/agent/speccer.ts`. Interface change only.
 		- **Acceptance criteria**:
-			- [ ] Both method signatures include the optional `onProgress` parameter
-			- [ ] `AgentSDKSpeccer` implementations updated to match (no body changes yet)
-			- [ ] `tsc --noEmit` passes
-			- [ ] All existing tests pass
+			- [x] Both method signatures include the optional `onProgress` parameter
+			- [x] `AgentSDKSpeccer` implementations updated to match (no body changes yet)
+			- [x] `tsc --noEmit` passes
+			- [x] All existing tests pass
 		- **Dependencies**: None
 	- [x] **Task: Add ****`parseRelayMessage`**** helper and augment spec gen prompts**
 		- **Description**: Add `parseRelayMessage` helper to `src/adapters/agent/speccer.ts` (same implementation as in `implementer.ts`). Update `buildSpecPrompt` and `buildSpecRevisionPrompt` to append the checkpoint instruction block.
 		- **Acceptance criteria**:
-			- [ ] `parseRelayMessage` handles all cases in the §6 unit test matrix
-			- [ ] Both `buildSpecPrompt` and `buildSpecRevisionPrompt` output includes the checkpoint instruction block
-			- [ ] `tsc --noEmit` passes
+			- [x] `parseRelayMessage` handles all cases in the §6 unit test matrix
+			- [x] Both `buildSpecPrompt` and `buildSpecRevisionPrompt` output includes the checkpoint instruction block
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `onProgress` parameter to `Speccer` interface
 	- [x] **Task: Implement relay detection in ****`AgentSDKSpeccer`**** drain loop**
 		- **Description**: Apply the same relay detection and logging pattern to both `generateSpec()` and `reviseSpec()` drain loops using `phase: 'spec_generation'`. Do not await `onProgress`.
 		- **Acceptance criteria**:
-			- [ ] `onProgress` called correctly in both `generateSpec` and `reviseSpec` when a `[Relay]` line is present
-			- [ ] `onProgress` not called for non-relay turns or non-assistant messages in either method
-			- [ ] Success: `progress_update` logged at info with `phase: 'spec_generation'`
-			- [ ] Failure: `progress_failed` logged at warn with `phase: 'spec_generation'`; the spec method resolves normally
-			- [ ] When `onProgress` omitted, behavior identical to before in both methods
-			- [ ] `tsc --noEmit` passes
+			- [x] `onProgress` called correctly in both `generateSpec` and `reviseSpec` when a `[Relay]` line is present
+			- [x] `onProgress` not called for non-relay turns or non-assistant messages in either method
+			- [x] Success: `progress_update` logged at info with `phase: 'spec_generation'`
+			- [x] Failure: `progress_failed` logged at warn with `phase: 'spec_generation'`; the spec method resolves normally
+			- [x] When `onProgress` omitted, behavior identical to before in both methods
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment spec gen prompts
 - [x] **Story: Wire ****`onProgress`**** in the orchestrator**
 	- [x] **Task: Pass ****`onProgress`**** callback to ****`implement()`**** in ****`_runImplementation`**
 		- **Description**: In `src/core/orchestrator.ts`, update `_runImplementation` to construct an `onProgress` callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`. Replace the current ternary with a single `implement()` call passing `additional_context` (which may be `undefined`) and `onProgress`.
 		- **Acceptance criteria**:
-			- [ ] Both call paths (with and without `additional_context`) pass `onProgress`
-			- [ ] Callback calls `deps.postMessage` with correct args
-			- [ ] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'implementation'`, `run_id`, `error`; run continues
-			- [ ] `tsc --noEmit` passes
+			- [x] Both call paths (with and without `additional_context`) pass `onProgress`
+			- [x] Callback calls `deps.postMessage` with correct args
+			- [x] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'implementation'`, `run_id`, `error`; run continues
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKImplementer.implement()` drain loop
 	- [x] **Task: Pass ****`onProgress`**** callback in ****`_runSpecGeneration`**
 		- **Description**: Apply the same `onProgress` wiring to `_runSpecGeneration` in `src/core/orchestrator.ts`. Construct the callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`, and pass it to both the `speccer.generateSpec()` and `speccer.reviseSpec()` call sites in the method. Use `phase: 'spec_generation'` in the warn log.
 		- **Acceptance criteria**:
-			- [ ] `onProgress` passed to both `generateSpec()` and `reviseSpec()` call sites within `_runSpecGeneration`
-			- [ ] Callback calls `deps.postMessage` with the run's `channel_id`, `thread_ts`, and message
-			- [ ] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, `error`; run continues
-			- [ ] `tsc --noEmit` passes
+			- [x] `onProgress` passed to both `generateSpec()` and `reviseSpec()` call sites within `_runSpecGeneration`
+			- [x] Callback calls `deps.postMessage` with the run's `channel_id`, `thread_ts`, and message
+			- [x] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, `error`; run continues
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKSpeccer` drain loop
 - [x] **Story: Tests**
 	- [x] **Task: Add ****`parseRelayMessage`**** unit tests**
 		- **Description**: Add unit tests covering the full §6 test matrix to both `tests/adapters/agent/implementer.test.ts` and `tests/adapters/agent/speccer.test.ts`.
 		- **Acceptance criteria**:
-			- [ ] All 8 matrix cases covered in both test files
+			- [x] All 8 matrix cases covered in both test files
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment implementation prompts; Task: Add `parseRelayMessage` helper and augment spec gen prompts
 	- [x] **Task: Add ****`AgentSDKImplementer`**** drain loop tests**
 		- **Description**: Add all 8 drain loop test cases from §6 to `tests/adapters/agent/implementer.test.ts`.
 		- **Acceptance criteria**:
-			- [ ] All 8 cases covered
-			- [ ] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream)
-			- [ ] All existing implementer tests pass
+			- [x] All 8 cases covered
+			- [x] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream)
+			- [x] All existing implementer tests pass
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKImplementer.implement()` drain loop
 	- [x] **Task: Add ****`AgentSDKSpeccer`**** drain loop tests**
 		- **Description**: Mirror of the implementer drain loop tests for `tests/adapters/agent/speccer.test.ts`. Both `generateSpec()` and `reviseSpec()` must be covered independently, each with all 8 cases from §6 substituting `phase: 'spec_generation'`.
 		- **Acceptance criteria**:
-			- [ ] All 8 cases covered independently for both `generateSpec()` and `reviseSpec()`
-			- [ ] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream) for both methods
-			- [ ] All existing speccer tests pass
+			- [x] All 8 cases covered independently for both `generateSpec()` and `reviseSpec()`
+			- [x] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream) for both methods
+			- [x] All existing speccer tests pass
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKSpeccer` drain loop
 	- [x] **Task: Add orchestrator ****`_runImplementation`**** progress tests**
 		- **Description**: Add the three test cases from §6 to `tests/core/orchestrator.test.ts`.
 		- **Acceptance criteria**:
-			- [ ] Callback wired for both call paths; `postMessage` invocation verified; failure handling confirmed with log event
-			- [ ] All existing orchestrator tests pass
+			- [x] Callback wired for both call paths; `postMessage` invocation verified; failure handling confirmed with log event
+			- [x] All existing orchestrator tests pass
 		- **Dependencies**: Task: Pass `onProgress` callback in `_runImplementation`
 	- [x] **Task: Add orchestrator ****`_runSpecGeneration`**** progress tests**
 		- **Description**: Mirror of the `_runImplementation` orchestrator tests for the spec gen path, substituting `deps.speccer` (or equivalent) and `phase: 'spec_generation'`.
 		- **Acceptance criteria**:
-			- [ ] Callback wired to speccer call site(s); `postMessage` invocation verified with correct `channel_id`, `thread_ts`, and message
-			- [ ] `postMessage` failure does not fail the run; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, and `error`
-			- [ ] All existing orchestrator tests pass
+			- [x] Callback wired to speccer call site(s); `postMessage` invocation verified with correct `channel_id`, `thread_ts`, and message
+			- [x] `postMessage` failure does not fail the run; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, and `error`
+			- [x] All existing orchestrator tests pass
 		- **Dependencies**: Task: Pass `onProgress` callback in `_runSpecGeneration`

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -1,0 +1,571 @@
+---
+created: 2026-04-15
+last_updated: 2026-04-16
+status: approved
+issue: 23
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+# Enhancement: Agent progress updates during long-running operations
+
+## Parent feature
+
+`feature-approval-to-implementation.md`
+## What
+
+During spec generation and implementation runs, the agent posts progress updates to the Slack thread at interesting intervals. The agent is prompted with instructions to emit specially-tagged `[Relay]` lines whenever it has something worth reporting to a human — phase transitions, current focus, task starts, or anything a human watching would find useful. When the speccer or implementer detects a `[Relay]`-tagged line in an assistant turn, the message is forwarded to the Slack thread. All progress posts are best-effort — a failed post never interrupts or fails the run.
+## Why
+
+Spec generation and implementation runs can take 20 minutes or longer with no visible activity in the Slack thread. The human has no way to tell whether the agent is making progress, waiting on a dependency, or silently failing. Early visibility enables course-correction before a long run concludes on a wrong path and builds confidence that the system is actively working.
+## User stories
+
+- During a long implementation run, Phoebe can see what the agent is currently working on in the Slack thread without waiting for the run to complete
+- During a spec generation run, Phoebe can see which comment the agent is currently processing or which section it is drafting
+- If a Slack notification fails during any run, the run continues and completes normally
+- When no `onProgress` callback is provided, agent behavior is identical to before this change
+## Design changes
+
+*(No UI changes — this is a backend-only enhancement to the speccer, implementer, and orchestrator.)*
+Example progress updates visible in the Slack thread during a spec generation run:
+```javascript
+autocatalyst  10:00 AM
+Analyzing requirements and reviewing existing specs
+
+autocatalyst  10:03 AM
+Processing feedback comment 3 of 8 — authentication design section
+
+autocatalyst  10:07 AM
+Drafting technical design section
+
+autocatalyst  10:11 AM
+Spec draft complete — reviewing for consistency
+```
+Example progress updates visible in the Slack thread during an implementation run:
+```javascript
+autocatalyst  10:00 AM
+Planning started — analyzing spec and generating task list
+
+autocatalyst  10:01 AM
+Planning complete — 7 tasks identified. Starting implementation.
+
+autocatalyst  10:04 AM
+Task 3 of 7: Implementing the parseRelayMessage helper
+
+autocatalyst  10:17 AM
+Starting final code review
+```
+## Technical changes
+
+### Affected files
+
+- `src/adapters/agent/speccer.ts` — add optional `onProgress` callback to `Speccer` interface and `AgentSDKSpeccer` methods; augment spec gen prompts with checkpoint instructions; detect `[Relay]` lines in the drain loop
+- `src/adapters/agent/implementer.ts` — add optional `onProgress` callback to `Implementer` interface and `AgentSDKImplementer.implement()` signature; add `parseRelayMessage` helper; augment agent prompt with checkpoint instructions; detect `[Relay]` lines in the drain loop
+- `src/core/orchestrator.ts` — construct `onProgress` callbacks and pass them into `_runSpecGeneration` and `_runImplementation` call sites
+- `tests/adapters/agent/speccer.test.ts` — add tests for relay message detection and best-effort failure handling
+- `tests/adapters/agent/implementer.test.ts` — add tests for relay message detection and best-effort failure handling
+- `tests/core/orchestrator.test.ts` — add tests for callback wiring and `postMessage` delegation for both run paths
+### Changes
+
+### 1. Introduction and overview
+
+**Prerequisites and assumptions**
+- Depends on `feature-approval-to-implementation.md` (complete) — establishes `AgentSDKSpeccer`, `AgentSDKImplementer`, the `query()` drain loop, and `_runSpecGeneration`/`_runImplementation` in the orchestrator
+- Both `Speccer` and `Implementer` interfaces are shared by their respective implementations and all test doubles; the signature change is non-breaking because the new parameter is optional
+- The `onProgress` callback is always invoked with best-effort semantics: errors are caught and logged at warn level, never rethrown
+**Technical goals**
+- The agent prompts (spec gen and implementation) are augmented with checkpoint instructions to emit `[Relay]`-tagged lines when the agent has something meaningful to report to a human watching; the LLM determines what is worth reporting and the specific wording, but must use the `[Relay]` prefix so the adapters require no heuristic text parsing
+- Checkpoint-tagged messages provide structured, actionable progress signal at interesting intervals without requiring the speccer or implementer to parse or interpret free-form assistant output
+- When the drain loop detects a `[Relay]` line in an assistant turn, it calls `onProgress` with the relay message content
+- A failure in `onProgress` (including a rejected `postMessage` call) does not propagate to the drain loop or fail the run
+- When `onProgress` is omitted, behavior is identical to the current implementation — zero changes in observable behavior for callers that do not pass the callback
+**Non-goals**
+- Progress during question answering or PR creation (only `_runSpecGeneration` and `_runImplementation` are affected)
+- Delivery guarantees — posts are fire-and-forget; a missed update is acceptable
+### 2. System design and architecture
+
+**Modified components**
+- `src/adapters/agent/speccer.ts` — the `Speccer` interface, `AgentSDKSpeccer` method signatures, prompt construction, and drain loop body change; no other methods are affected
+- `src/adapters/agent/implementer.ts` — the `Implementer` interface, `AgentSDKImplementer.implement()` signature, the prompt construction, and the drain loop body change; no other methods are affected
+- `src/core/orchestrator.ts` — `_runSpecGeneration` and `_runImplementation` are the only methods that change; relevant call sites are updated in place
+**High-level flow (unchanged externally)**
+```mermaid
+flowchart LR
+    Orchestrator -->|"implement(spec, ws, ctx, onProgress)"| AgentSDKImplementer
+    AgentSDKImplementer -->|query| ClaudeAgentSDK
+    ClaudeAgentSDK -->|SDKMessage stream| AgentSDKImplementer
+    AgentSDKImplementer -->|"onProgress(relayMsg)"| Orchestrator
+    Orchestrator -->|"postMessage(channel, thread, relayMsg)"| Slack
+```
+*(The same pattern applies for **`AgentSDKSpeccer`** and **`_runSpecGeneration`**.)*
+**Sequence — progress post during implementation**
+```mermaid
+sequenceDiagram
+    participant Orchestrator
+    participant AgentSDKImplementer
+    participant ClaudeAgentSDK
+    participant Slack
+
+    Orchestrator->>AgentSDKImplementer: implement(spec_path, workspace_path, ctx, onProgress)
+    loop for each SDKMessage
+        ClaudeAgentSDK-->>AgentSDKImplementer: SDKAssistantMessage (text content)
+        AgentSDKImplementer->>AgentSDKImplementer: parseRelayMessage → check for [Relay] line
+        opt [Relay] line found
+            AgentSDKImplementer-->>Orchestrator: onProgress("Task 3 of 7: ...")
+            Orchestrator->>Slack: postMessage(channel_id, thread_ts, relay message)
+            Slack-->>Orchestrator: ok / error
+            Note over AgentSDKImplementer: error swallowed — run continues
+        end
+    end
+    AgentSDKImplementer->>Orchestrator: ImplementationResult
+```
+*(The speccer sequence is identical, substituting **`AgentSDKSpeccer`**, **`specPath`**, and **`SpecResult`**.)*
+### 3. Detailed design
+
+**Updated ****`Implementer`**** interface**
+```typescript
+export interface Implementer {
+  implement(
+    spec_path: string,
+    workspace_path: string,
+    additional_context?: string,
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<ImplementationResult>;
+}
+```
+Adding `onProgress` as the fourth positional parameter preserves backwards compatibility: all existing call sites pass two or three arguments and continue to work without modification.
+**Updated ****`Speccer`**** interface**
+```typescript
+export interface Speccer {
+  generateSpec(
+    request: SpecRequest,
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<SpecResult>;
+
+  reviseSpec(
+    spec_path: string,
+    feedback: string,
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<SpecResult>;
+}
+```
+Adding `onProgress` as the last optional parameter preserves backwards compatibility for all existing call sites.
+**Prompt augmentation**
+The goal is for the agent to emit `[Relay]` messages whenever it has something genuinely worth reporting to the human watching — phase transitions, current focus, an interesting finding, a meaningful milestone. Examples orient the agent; the agent uses its judgment about what's worth reporting and when.
+The following checkpoint instruction block is appended to each prompt:
+```javascript
+At any point during your work, if you have something worth reporting to the human watching —
+a phase transition, your current focus, something interesting you found, or a meaningful
+milestone — emit it on its own line using this exact format:
+
+[Relay] <your message here>
+
+Examples of good checkpoints:
+- [Relay] Planning started — analyzing spec and requirements
+- [Relay] Planning complete — 7 tasks identified
+- [Relay] Task 3 of 7: Implementing the parseRelayMessage helper
+- [Relay] Found a potential issue with the existing auth middleware — investigating
+- [Relay] Starting final code review
+- [Relay] Processing feedback comment 3 of 8 — authentication design section
+- [Relay] Drafting technical design section
+
+The goal is to keep a human informed at intervals they'd find interesting. You decide what's
+worth reporting and when.
+```
+**Full prompts with additions marked**
+The following shows the structure of each prompt with this spec's additions marked `// [ADDED]`. The existing body is summarized for brevity; the actual file content is authoritative.
+*Spec generation — initial prompt (**`buildSpecPrompt`** in **`speccer.ts`**):*
+```javascript
+You are an expert software architect generating a technical specification.
+
+<system_context>
+[... existing context: repo description, spec format, conventions ...]
+</system_context>
+
+<request>
+{{request_description}}
+</request>
+
+[... existing instructions: output format, required sections, style ...]
+
+// [ADDED] — checkpoint instruction block
+At any point during your work, if you have something worth reporting to the human watching...
+[Relay] <your message here>
+[examples as above]
+```
+*Spec generation — revision prompt (**`buildSpecRevisionPrompt`** in **`speccer.ts`**):*
+```javascript
+You are an expert software architect revising a technical specification based on feedback.
+
+<system_context>
+[... existing context ...]
+</system_context>
+
+<spec>
+{{existing_spec_content}}
+</spec>
+
+<feedback>
+{{feedback}}
+</feedback>
+
+[... existing revision instructions ...]
+
+// [ADDED] — checkpoint instruction block
+At any point during your work, if you have something worth reporting...
+[Relay] <your message here>
+[examples as above]
+```
+*Implementation — initial prompt (**`buildPrompt`** in **`implementer.ts`**):*
+```javascript
+You are an expert software engineer implementing a technical specification.
+
+<system_context>
+[... existing context: repo description, coding conventions, tool instructions ...]
+</system_context>
+
+<spec>
+{{spec_content}}
+</spec>
+
+{{#if additional_context}}
+<additional_context>
+{{additional_context}}
+</additional_context>
+{{/if}}
+
+[... existing implementation instructions: task output format, tool use, result file ...]
+
+// [ADDED] — checkpoint instruction block
+At any point during your work, if you have something worth reporting...
+[Relay] <your message here>
+[examples as above]
+```
+*Implementation — feedback prompt (**`buildFeedbackPrompt`** in **`implementer.ts`**):*
+```javascript
+You are an expert software engineer addressing feedback on an implementation.
+
+<system_context>
+[... existing context ...]
+</system_context>
+
+<spec>
+{{spec_content}}
+</spec>
+
+<feedback>
+{{feedback}}
+</feedback>
+
+[... existing instructions ...]
+
+// [ADDED] — checkpoint instruction block
+At any point during your work, if you have something worth reporting...
+[Relay] <your message here>
+[examples as above]
+```
+**New module-local helper in ****`implementer.ts`**** (same pattern for ****`speccer.ts`****)**
+```typescript
+// BetaMessage is the assistant message type from @anthropic-ai/sdk (beta channel).
+// Its content field is an array of content blocks — text blocks, tool-use blocks, etc.
+function parseRelayMessage(content: BetaMessage['content']): string | null {
+  for (const block of content) {
+    if (block.type === 'text') {
+      for (const line of block.text.split('\n')) {
+        const match = line.match(/^\[Relay\]\s+(.+)$/);
+        if (match) return match[1].trim();
+      }
+    }
+  }
+  return null;
+}
+```
+`parseRelayMessage` scans each text block line by line for the `[Relay]` prefix and returns the message content after the tag. Returns `null` if no relay line is found (including tool-use-only content and assistant turns without a relay line). The same function is added to both `implementer.ts` and `speccer.ts`; extraction to a shared module is at implementer's discretion.
+**Updated ****`AgentSDKImplementer.implement()`**** drain loop**
+```typescript
+async implement(
+  spec_path: string,
+  workspace_path: string,
+  additional_context?: string,
+  onProgress?: (message: string) => Promise<void>,
+): Promise<ImplementationResult> {
+  // ...existing setup (resultFilePath, prompt augmented with checkpoint instructions, logger.debug)...
+
+  try {
+    for await (const message of this.queryFn({ prompt, options: { ... } })) {
+      if (onProgress && message.type === 'assistant') {
+        const relayMessage = parseRelayMessage(message.message.content);
+        if (relayMessage) {
+          onProgress(relayMessage)
+            .then(() => {
+              this.logger.info(
+                { event: 'progress_update', phase: 'implementation', message: relayMessage },
+                'Progress update posted',
+              );
+            })
+            .catch(err => {
+              this.logger.warn(
+                { event: 'progress_failed', phase: 'implementation', error: String(err) },
+                'Failed to post progress update',
+              );
+            });
+        }
+      }
+    }
+  } catch (err) {
+    // ...existing error handling unchanged...
+  }
+
+  // ...existing result file read unchanged...
+}
+```
+The `.then`/`.catch` on the `onProgress` call is non-blocking: the drain loop does not await the callback, so a slow or failing `postMessage` call never delays message processing.
+**Updated ****`AgentSDKSpeccer`**** drain loop (same pattern)**
+```typescript
+// Applied to both generateSpec() and reviseSpec() drain loops:
+if (onProgress && message.type === 'assistant') {
+  const relayMessage = parseRelayMessage(message.message.content);
+  if (relayMessage) {
+    onProgress(relayMessage)
+      .then(() => {
+        this.logger.info(
+          { event: 'progress_update', phase: 'spec_generation', message: relayMessage },
+          'Progress update posted',
+        );
+      })
+      .catch(err => {
+        this.logger.warn(
+          { event: 'progress_failed', phase: 'spec_generation', error: String(err) },
+          'Failed to post progress update',
+        );
+      });
+  }
+}
+```
+**Updated ****`_runImplementation`**** in ****`orchestrator.ts`**
+Construct the callback once and pass it to the unified `implement()` call:
+```typescript
+private async _runImplementation(feedback: ThreadMessage, run: Run, additional_context?: string): Promise<void> {
+  const onProgress = (message: string): Promise<void> =>
+    this.deps.postMessage(feedback.channel_id, feedback.thread_ts, message).catch(err => {
+      this.logger.warn(
+        { event: 'progress_failed', phase: 'implementation', run_id: run.id, error: String(err) },
+        'Failed to post progress update',
+      );
+    });
+
+  let result;
+  try {
+    result = await this.deps.implementer!.implement(
+      run.spec_path!,
+      run.workspace_path,
+      additional_context,
+      onProgress,
+    );
+  } catch (err) {
+    await this.failRun(run, feedback.channel_id, feedback.thread_ts, err);
+    return;
+  }
+
+  // ...rest of method unchanged...
+}
+```
+Passing `additional_context` directly (which may be `undefined`) replaces the current ternary that called `implement()` with two different signatures. `buildPrompt` already handles `undefined` via its `if (additionalContext)` guard, so this is a safe simplification.
+**Updated ****`_runSpecGeneration`**** in ****`orchestrator.ts`**** (same pattern)**
+```typescript
+private async _runSpecGeneration(feedback: ThreadMessage, run: Run): Promise<void> {
+  const onProgress = (message: string): Promise<void> =>
+    this.deps.postMessage(feedback.channel_id, feedback.thread_ts, message).catch(err => {
+      this.logger.warn(
+        { event: 'progress_failed', phase: 'spec_generation', run_id: run.id, error: String(err) },
+        'Failed to post progress update',
+      );
+    });
+
+  // pass onProgress to speccer.generateSpec() / speccer.reviseSpec() call...
+}
+```
+### 4. Security, privacy, and compliance
+
+No authentication or authorization changes. The `onProgress` callback receives the content of `[Relay]`-tagged lines — agent-authored checkpoint messages rather than arbitrary assistant output. No new data category leaves the system boundary.
+### 5. Observability
+
+**New log events**
+<table header-row="true">
+<tr>
+<td>Event</td>
+<td>Level</td>
+<td>Fields</td>
+<td>Notes</td>
+</tr>
+<tr>
+<td>`progress_update`</td>
+<td>info</td>
+<td>`phase` (`spec_generation` \| `implementation`), `message`</td>
+<td>Emitted in the adapter (implementer/speccer) when `onProgress` resolves successfully</td>
+</tr>
+<tr>
+<td>`progress_failed`</td>
+<td>warn</td>
+<td>`phase`, `error` (in adapter); `phase`, `run_id`, `error` (in orchestrator wrapper)</td>
+<td>Emitted when `onProgress` throws or the underlying `postMessage` rejects; run continues normally</td>
+</tr>
+</table>
+A single `progress_update` / `progress_failed` event pair is used rather than phase-prefixed variants (`impl.progress_update`, `spec.progress_update`). The `phase` field carries enough context for log filtering, and this avoids proliferating event names as more phases are added.
+No new metrics are required.
+### 6. Testing plan
+
+All tests use Vitest. Existing tests continue to pass without modification; all new cases are additive.
+#### `parseRelayMessage` unit tests (in both `implementer.test.ts` and `speccer.test.ts`)
+
+- **Single relay line**: one text block with one `[Relay]` line — assert returns the text after `[Relay]`, trimmed
+- **First of multiple relay lines**: text block with two `[Relay]` lines — assert only the first is returned
+- **Relay line among non-relay lines**: text block with regular lines before and after a `[Relay]` line — assert correct extraction
+- **No relay line**: text block with no `[Relay]` line — assert `null`
+- **Tool-use block only**: content array has only a tool-use block, no text block — assert `null`
+- **Empty content array**: content is `[]` — assert `null`
+- **Case-sensitive prefix**: content has `[relay]` (lowercase) or `[Relay]:` (with colon) — assert `null` (no match)
+- **Multi-block content**: two text blocks, relay line only in the second — assert relay message is found
+#### `AgentSDKImplementer` drain loop tests (`tests/adapters/agent/implementer.test.ts`)
+
+- **Relay line forwarded**: query yields one `SDKAssistantMessage` containing a `[Relay]` line — assert `onProgress` called once with the extracted text; assert `progress_update` logged at info with `phase: 'implementation'` and the message
+- **Non-relay assistant turn ignored**: `SDKAssistantMessage` with no `[Relay]` line — assert `onProgress` not called
+- **Non-assistant messages ignored**: query yields `SDKToolProgressMessage` and `SDKResultMessage` — assert `onProgress` not called
+- **Tool-use-only assistant message ignored**: `SDKAssistantMessage` with only tool-use blocks, no text — assert `onProgress` not called
+- **Failed callback does not throw**: `onProgress` returns a rejected promise — assert `implement()` resolves normally with result file contents; assert `progress_failed` logged at warn with `phase: 'implementation'` and `error` field
+- **No callback — behavior unchanged**: `onProgress` omitted — assert drain loop completes, result file is read, `ImplementationResult` returned, no `progress_update` or `progress_failed` events logged
+- **Multiple relay lines in one turn**: `SDKAssistantMessage` contains two `[Relay]` lines — assert `onProgress` called once (first relay only)
+- **Relay across multiple messages**: two `SDKAssistantMessage`s each with a `[Relay]` line — assert `onProgress` called twice
+#### `AgentSDKSpeccer` drain loop tests (`tests/adapters/agent/speccer.test.ts`)
+
+Mirror of the implementer tests above for both `generateSpec()` and `reviseSpec()`, substituting `phase: 'spec_generation'`. Each method must be tested independently.
+#### `_runImplementation` orchestrator tests (`tests/core/orchestrator.test.ts`)
+
+- **Callback wired (both call paths)**: spy on `deps.implementer.implement`; invoke `_runImplementation` with `additional_context` defined and with it `undefined` — assert `implement` receives an `onProgress` function in both cases
+- **Callback invokes ****`postMessage`**: capture `onProgress` from the spy; call it with a message string — assert `deps.postMessage` called with the run's `channel_id`, `thread_ts`, and the exact message string
+- **`postMessage`**** failure does not fail the run**: `deps.postMessage` rejects inside `onProgress` — assert implementation result propagates to caller; assert `_runImplementation` does not throw; assert `progress_failed` logged at warn with `phase: 'implementation'`, `run_id`, and `error`
+#### `_runSpecGeneration` orchestrator tests (`tests/core/orchestrator.test.ts`)
+
+Mirror of the `_runImplementation` tests above, substituting `deps.speccer` (or equivalent) and `phase: 'spec_generation'`.
+### 7. Alternatives considered
+
+**Poll every assistant text turn (rate-limited)**
+Sample any assistant text turn and rate-limit to one post per 60 seconds. Rejected: free-text excerpts are often mid-thought and lack context for the reader; rate limiting is arbitrary and may suppress useful checkpoints or surface irrelevant output. Instructing the LLM to emit explicit checkpoints produces more meaningful messages with no parsing heuristics required.
+**Inspect tool-use blocks instead of text turns**
+Tool-use blocks expose the tool name and input (e.g., `bash` with a command string), which could yield more targeted messages like "Running: npm test". Rejected for this iteration: parsing tool inputs introduces coupling to Claude Code tool names and input schemas, and the utility of the resulting messages is unclear until tested in production.
+**Push callback into ****`OrchestratorOptions`**** rather than ****`implement()`**** signature**
+Makes the callback a property of the orchestrator configuration, available to any adapter method. Rejected: the callback is per-run (it closes over `feedback.channel_id` and `feedback.thread_ts`), not per-orchestrator. It must be constructed at call time, not at construction time.
+**Await ****`onProgress`**** in the drain loop**
+Awaiting the callback would block the drain loop until each Slack post completes (including network round-trip). Rejected: this adds latency to every iteration of the loop and means a slow Slack API call holds up the agent. Fire-and-forget with `.then`/`.catch` is the right model for a best-effort notification.
+**Differentiate event names by phase (****`impl.progress_update`**** vs ****`spec.progress_update`****)**
+Rejected in favor of a single `progress_update` / `progress_failed` event pair with a `phase` field. The `phase` field makes filtering equally straightforward and avoids proliferating event names as more phases are added in the future.
+### 8. Risks
+
+**Agent may not always emit checkpoints**
+If the agent omits a `[Relay]` line, the Slack thread simply receives no update for that moment. This is acceptable: the feature is best-effort by design, and the agent is unlikely to omit checkpoints consistently if the prompt instructions are clear.
+**`[Relay]`**** tag appears in non-checkpoint text**
+If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code block or explanation), it would generate a spurious Slack post. This is low-risk given explicit prompt instructions and the goal-oriented framing.
+## Task list
+
+- [ ] **Story: Update ****`Implementer`**** interface and ****`AgentSDKImplementer`**
+	- [ ] **Task: Add ****`onProgress`**** parameter to ****`Implementer`**** interface**
+		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the fourth positional parameter to `Implementer.implement()` in `src/adapters/agent/implementer.ts`. Interface change only — no implementation logic yet.
+		- **Acceptance criteria**:
+			- [ ] `Implementer.implement()` signature includes the optional `onProgress` parameter
+			- [ ] `AgentSDKImplementer.implement()` signature updated to match (no body changes yet)
+			- [ ] `tsc --noEmit` passes
+			- [ ] All existing tests pass
+		- **Dependencies**: None
+	- [ ] **Task: Add ****`parseRelayMessage`**** helper and augment implementation prompts**
+		- **Description**: Add module-local helper `parseRelayMessage(content: BetaMessage['content']): string | null` to `src/adapters/agent/implementer.ts`. The function iterates each text block's lines, matches the first line of the form `/^\[Relay\]\s+(.+)$/`, and returns the capture group trimmed, or `null` if none found. Update `buildPrompt` and `buildFeedbackPrompt` to append the goal-oriented checkpoint instruction block.
+		- **Acceptance criteria**:
+			- [ ] `parseRelayMessage` handles all cases in the §6 unit test matrix
+			- [ ] Both `buildPrompt` and `buildFeedbackPrompt` output includes the checkpoint instruction block
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `onProgress` parameter to `Implementer` interface
+	- [ ] **Task: Implement relay detection in ****`AgentSDKImplementer.implement()`**** drain loop**
+		- **Description**: Update `AgentSDKImplementer.implement()` drain loop. When `onProgress` is defined and the message is `type === 'assistant'`, call `parseRelayMessage(message.message.content)`. If non-null, call `onProgress(relayMessage).then(() => logger.info(...)).catch(err => logger.warn(...))`. Do not await.
+		- **Acceptance criteria**:
+			- [ ] `onProgress` called when agent emits a `[Relay]` line
+			- [ ] `onProgress` not called for non-relay turns or non-assistant messages
+			- [ ] Success: `progress_update` logged at info with `phase: 'implementation'`
+			- [ ] Failure: `progress_failed` logged at warn with `phase: 'implementation'`; `implement()` resolves normally
+			- [ ] When `onProgress` omitted, behavior identical to before
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment implementation prompts
+- [ ] **Story: Update ****`Speccer`**** interface and ****`AgentSDKSpeccer`**
+	- [ ] **Task: Add ****`onProgress`**** parameter to ****`Speccer`**** interface**
+		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the last optional parameter to both `Speccer.generateSpec()` and `Speccer.reviseSpec()` in `src/adapters/agent/speccer.ts`. Interface change only.
+		- **Acceptance criteria**:
+			- [ ] Both method signatures include the optional `onProgress` parameter
+			- [ ] `AgentSDKSpeccer` implementations updated to match (no body changes yet)
+			- [ ] `tsc --noEmit` passes
+			- [ ] All existing tests pass
+		- **Dependencies**: None
+	- [ ] **Task: Add ****`parseRelayMessage`**** helper and augment spec gen prompts**
+		- **Description**: Add `parseRelayMessage` helper to `src/adapters/agent/speccer.ts` (same implementation as in `implementer.ts`). Update `buildSpecPrompt` and `buildSpecRevisionPrompt` to append the checkpoint instruction block.
+		- **Acceptance criteria**:
+			- [ ] `parseRelayMessage` handles all cases in the §6 unit test matrix
+			- [ ] Both `buildSpecPrompt` and `buildSpecRevisionPrompt` output includes the checkpoint instruction block
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `onProgress` parameter to `Speccer` interface
+	- [ ] **Task: Implement relay detection in ****`AgentSDKSpeccer`**** drain loop**
+		- **Description**: Apply the same relay detection and logging pattern to both `generateSpec()` and `reviseSpec()` drain loops using `phase: 'spec_generation'`. Do not await `onProgress`.
+		- **Acceptance criteria**:
+			- [ ] `onProgress` called correctly in both `generateSpec` and `reviseSpec` when a `[Relay]` line is present
+			- [ ] `onProgress` not called for non-relay turns or non-assistant messages in either method
+			- [ ] Success: `progress_update` logged at info with `phase: 'spec_generation'`
+			- [ ] Failure: `progress_failed` logged at warn with `phase: 'spec_generation'`; the spec method resolves normally
+			- [ ] When `onProgress` omitted, behavior identical to before in both methods
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment spec gen prompts
+- [ ] **Story: Wire ****`onProgress`**** in the orchestrator**
+	- [ ] **Task: Pass ****`onProgress`**** callback to ****`implement()`**** in ****`_runImplementation`**
+		- **Description**: In `src/core/orchestrator.ts`, update `_runImplementation` to construct an `onProgress` callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`. Replace the current ternary with a single `implement()` call passing `additional_context` (which may be `undefined`) and `onProgress`.
+		- **Acceptance criteria**:
+			- [ ] Both call paths (with and without `additional_context`) pass `onProgress`
+			- [ ] Callback calls `deps.postMessage` with correct args
+			- [ ] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'implementation'`, `run_id`, `error`; run continues
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Implement relay detection in `AgentSDKImplementer.implement()` drain loop
+	- [ ] **Task: Pass ****`onProgress`**** callback in ****`_runSpecGeneration`**
+		- **Description**: Apply the same `onProgress` wiring to `_runSpecGeneration` in `src/core/orchestrator.ts`. Construct the callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`, and pass it to both the `speccer.generateSpec()` and `speccer.reviseSpec()` call sites in the method. Use `phase: 'spec_generation'` in the warn log.
+		- **Acceptance criteria**:
+			- [ ] `onProgress` passed to both `generateSpec()` and `reviseSpec()` call sites within `_runSpecGeneration`
+			- [ ] Callback calls `deps.postMessage` with the run's `channel_id`, `thread_ts`, and message
+			- [ ] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, `error`; run continues
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Implement relay detection in `AgentSDKSpeccer` drain loop
+- [ ] **Story: Tests**
+	- [ ] **Task: Add ****`parseRelayMessage`**** unit tests**
+		- **Description**: Add unit tests covering the full §6 test matrix to both `tests/adapters/agent/implementer.test.ts` and `tests/adapters/agent/speccer.test.ts`.
+		- **Acceptance criteria**:
+			- [ ] All 8 matrix cases covered in both test files
+		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment implementation prompts; Task: Add `parseRelayMessage` helper and augment spec gen prompts
+	- [ ] **Task: Add ****`AgentSDKImplementer`**** drain loop tests**
+		- **Description**: Add all 8 drain loop test cases from §6 to `tests/adapters/agent/implementer.test.ts`.
+		- **Acceptance criteria**:
+			- [ ] All 8 cases covered
+			- [ ] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream)
+			- [ ] All existing implementer tests pass
+		- **Dependencies**: Task: Implement relay detection in `AgentSDKImplementer.implement()` drain loop
+	- [ ] **Task: Add ****`AgentSDKSpeccer`**** drain loop tests**
+		- **Description**: Mirror of the implementer drain loop tests for `tests/adapters/agent/speccer.test.ts`. Both `generateSpec()` and `reviseSpec()` must be covered independently, each with all 8 cases from §6 substituting `phase: 'spec_generation'`.
+		- **Acceptance criteria**:
+			- [ ] All 8 cases covered independently for both `generateSpec()` and `reviseSpec()`
+			- [ ] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream) for both methods
+			- [ ] All existing speccer tests pass
+		- **Dependencies**: Task: Implement relay detection in `AgentSDKSpeccer` drain loop
+	- [ ] **Task: Add orchestrator ****`_runImplementation`**** progress tests**
+		- **Description**: Add the three test cases from §6 to `tests/core/orchestrator.test.ts`.
+		- **Acceptance criteria**:
+			- [ ] Callback wired for both call paths; `postMessage` invocation verified; failure handling confirmed with log event
+			- [ ] All existing orchestrator tests pass
+		- **Dependencies**: Task: Pass `onProgress` callback in `_runImplementation`
+	- [ ] **Task: Add orchestrator ****`_runSpecGeneration`**** progress tests**
+		- **Description**: Mirror of the `_runImplementation` orchestrator tests for the spec gen path, substituting `deps.speccer` (or equivalent) and `phase: 'spec_generation'`.
+		- **Acceptance criteria**:
+			- [ ] Callback wired to speccer call site(s); `postMessage` invocation verified with correct `channel_id`, `thread_ts`, and message
+			- [ ] `postMessage` failure does not fail the run; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, and `error`
+			- [ ] All existing orchestrator tests pass
+		- **Dependencies**: Task: Pass `onProgress` callback in `_runSpecGeneration`

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -520,7 +520,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment spec gen prompts
 - [ ] **Story: Wire ****`onProgress`**** in the orchestrator**
-	- [ ] **Task: Pass ****`onProgress`**** callback to ****`implement()`**** in ****`_runImplementation`**
+	- [x] **Task: Pass ****`onProgress`**** callback to ****`implement()`**** in ****`_runImplementation`**
 		- **Description**: In `src/core/orchestrator.ts`, update `_runImplementation` to construct an `onProgress` callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`. Replace the current ternary with a single `implement()` call passing `additional_context` (which may be `undefined`) and `onProgress`.
 		- **Acceptance criteria**:
 			- [ ] Both call paths (with and without `additional_context`) pass `onProgress`
@@ -556,7 +556,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream) for both methods
 			- [ ] All existing speccer tests pass
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKSpeccer` drain loop
-	- [ ] **Task: Add orchestrator ****`_runImplementation`**** progress tests**
+	- [x] **Task: Add orchestrator ****`_runImplementation`**** progress tests**
 		- **Description**: Add the three test cases from §6 to `tests/core/orchestrator.test.ts`.
 		- **Acceptance criteria**:
 			- [ ] Callback wired for both call paths; `postMessage` invocation verified; failure handling confirmed with log event

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -493,8 +493,8 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] When `onProgress` omitted, behavior identical to before
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment implementation prompts
-- [ ] **Story: Update ****`Speccer`**** interface and ****`AgentSDKSpeccer`**
-	- [ ] **Task: Add ****`onProgress`**** parameter to ****`Speccer`**** interface**
+- [x] **Story: Update ****`Speccer`**** interface and ****`AgentSDKSpeccer`**
+	- [x] **Task: Add ****`onProgress`**** parameter to ****`Speccer`**** interface**
 		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the last optional parameter to both `Speccer.generateSpec()` and `Speccer.reviseSpec()` in `src/adapters/agent/speccer.ts`. Interface change only.
 		- **Acceptance criteria**:
 			- [ ] Both method signatures include the optional `onProgress` parameter
@@ -502,7 +502,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `tsc --noEmit` passes
 			- [ ] All existing tests pass
 		- **Dependencies**: None
-	- [ ] **Task: Add ****`parseRelayMessage`**** helper and augment spec gen prompts**
+	- [x] **Task: Add ****`parseRelayMessage`**** helper and augment spec gen prompts**
 		- **Description**: Add `parseRelayMessage` helper to `src/adapters/agent/speccer.ts` (same implementation as in `implementer.ts`). Update `buildSpecPrompt` and `buildSpecRevisionPrompt` to append the checkpoint instruction block.
 		- **Acceptance criteria**:
 			- [ ] `parseRelayMessage` handles all cases in the §6 unit test matrix

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -467,7 +467,7 @@ If the agent omits a `[Relay]` line, the Slack thread simply receives no update 
 If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code block or explanation), it would generate a spurious Slack post. This is low-risk given explicit prompt instructions and the goal-oriented framing.
 ## Task list
 
-- [ ] **Story: Update ****`Implementer`**** interface and ****`AgentSDKImplementer`**
+- [x] **Story: Update ****`Implementer`**** interface and ****`AgentSDKImplementer`**
 	- [x] **Task: Add ****`onProgress`**** parameter to ****`Implementer`**** interface**
 		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the fourth positional parameter to `Implementer.implement()` in `src/adapters/agent/implementer.ts`. Interface change only — no implementation logic yet.
 		- **Acceptance criteria**:
@@ -483,7 +483,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] Both `buildPrompt` and `buildFeedbackPrompt` output includes the checkpoint instruction block
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `onProgress` parameter to `Implementer` interface
-	- [ ] **Task: Implement relay detection in ****`AgentSDKImplementer.implement()`**** drain loop**
+	- [x] **Task: Implement relay detection in ****`AgentSDKImplementer.implement()`**** drain loop**
 		- **Description**: Update `AgentSDKImplementer.implement()` drain loop. When `onProgress` is defined and the message is `type === 'assistant'`, call `parseRelayMessage(message.message.content)`. If non-null, call `onProgress(relayMessage).then(() => logger.info(...)).catch(err => logger.warn(...))`. Do not await.
 		- **Acceptance criteria**:
 			- [ ] `onProgress` called when agent emits a `[Relay]` line
@@ -542,7 +542,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 		- **Acceptance criteria**:
 			- [ ] All 8 matrix cases covered in both test files
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment implementation prompts; Task: Add `parseRelayMessage` helper and augment spec gen prompts
-	- [ ] **Task: Add ****`AgentSDKImplementer`**** drain loop tests**
+	- [x] **Task: Add ****`AgentSDKImplementer`**** drain loop tests**
 		- **Description**: Add all 8 drain loop test cases from §6 to `tests/adapters/agent/implementer.test.ts`.
 		- **Acceptance criteria**:
 			- [ ] All 8 cases covered

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -468,7 +468,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 ## Task list
 
 - [ ] **Story: Update ****`Implementer`**** interface and ****`AgentSDKImplementer`**
-	- [ ] **Task: Add ****`onProgress`**** parameter to ****`Implementer`**** interface**
+	- [x] **Task: Add ****`onProgress`**** parameter to ****`Implementer`**** interface**
 		- **Description**: Add `onProgress?: (message: string) => Promise<void>` as the fourth positional parameter to `Implementer.implement()` in `src/adapters/agent/implementer.ts`. Interface change only — no implementation logic yet.
 		- **Acceptance criteria**:
 			- [ ] `Implementer.implement()` signature includes the optional `onProgress` parameter

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -536,8 +536,8 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'spec_generation'`, `run_id`, `error`; run continues
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKSpeccer` drain loop
-- [ ] **Story: Tests**
-	- [ ] **Task: Add ****`parseRelayMessage`**** unit tests**
+- [x] **Story: Tests**
+	- [x] **Task: Add ****`parseRelayMessage`**** unit tests**
 		- **Description**: Add unit tests covering the full §6 test matrix to both `tests/adapters/agent/implementer.test.ts` and `tests/adapters/agent/speccer.test.ts`.
 		- **Acceptance criteria**:
 			- [ ] All 8 matrix cases covered in both test files

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -519,7 +519,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] When `onProgress` omitted, behavior identical to before in both methods
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `parseRelayMessage` helper and augment spec gen prompts
-- [ ] **Story: Wire ****`onProgress`**** in the orchestrator**
+- [x] **Story: Wire ****`onProgress`**** in the orchestrator**
 	- [x] **Task: Pass ****`onProgress`**** callback to ****`implement()`**** in ****`_runImplementation`**
 		- **Description**: In `src/core/orchestrator.ts`, update `_runImplementation` to construct an `onProgress` callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`. Replace the current ternary with a single `implement()` call passing `additional_context` (which may be `undefined`) and `onProgress`.
 		- **Acceptance criteria**:
@@ -528,7 +528,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `postMessage` rejection handled; `progress_failed` logged at warn with `phase: 'implementation'`, `run_id`, `error`; run continues
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKImplementer.implement()` drain loop
-	- [ ] **Task: Pass ****`onProgress`**** callback in ****`_runSpecGeneration`**
+	- [x] **Task: Pass ****`onProgress`**** callback in ****`_runSpecGeneration`**
 		- **Description**: Apply the same `onProgress` wiring to `_runSpecGeneration` in `src/core/orchestrator.ts`. Construct the callback closing over `feedback.channel_id`, `feedback.thread_ts`, and `run.id`, and pass it to both the `speccer.generateSpec()` and `speccer.reviseSpec()` call sites in the method. Use `phase: 'spec_generation'` in the warn log.
 		- **Acceptance criteria**:
 			- [ ] `onProgress` passed to both `generateSpec()` and `reviseSpec()` call sites within `_runSpecGeneration`
@@ -562,7 +562,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] Callback wired for both call paths; `postMessage` invocation verified; failure handling confirmed with log event
 			- [ ] All existing orchestrator tests pass
 		- **Dependencies**: Task: Pass `onProgress` callback in `_runImplementation`
-	- [ ] **Task: Add orchestrator ****`_runSpecGeneration`**** progress tests**
+	- [x] **Task: Add orchestrator ****`_runSpecGeneration`**** progress tests**
 		- **Description**: Mirror of the `_runImplementation` orchestrator tests for the spec gen path, substituting `deps.speccer` (or equivalent) and `phase: 'spec_generation'`.
 		- **Acceptance criteria**:
 			- [ ] Callback wired to speccer call site(s); `postMessage` invocation verified with correct `channel_id`, `thread_ts`, and message

--- a/context-human/specs/enhancement-agent-progress-updates.md
+++ b/context-human/specs/enhancement-agent-progress-updates.md
@@ -509,7 +509,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] Both `buildSpecPrompt` and `buildSpecRevisionPrompt` output includes the checkpoint instruction block
 			- [ ] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `onProgress` parameter to `Speccer` interface
-	- [ ] **Task: Implement relay detection in ****`AgentSDKSpeccer`**** drain loop**
+	- [x] **Task: Implement relay detection in ****`AgentSDKSpeccer`**** drain loop**
 		- **Description**: Apply the same relay detection and logging pattern to both `generateSpec()` and `reviseSpec()` drain loops using `phase: 'spec_generation'`. Do not await `onProgress`.
 		- **Acceptance criteria**:
 			- [ ] `onProgress` called correctly in both `generateSpec` and `reviseSpec` when a `[Relay]` line is present
@@ -549,7 +549,7 @@ If the agent emits `[Relay]` outside a checkpoint context (e.g., inside a code b
 			- [ ] `progress_update` (info) and `progress_failed` (warn) log events asserted via structured JSON capture (logDestination stream)
 			- [ ] All existing implementer tests pass
 		- **Dependencies**: Task: Implement relay detection in `AgentSDKImplementer.implement()` drain loop
-	- [ ] **Task: Add ****`AgentSDKSpeccer`**** drain loop tests**
+	- [x] **Task: Add ****`AgentSDKSpeccer`**** drain loop tests**
 		- **Description**: Mirror of the implementer drain loop tests for `tests/adapters/agent/speccer.test.ts`. Both `generateSpec()` and `reviseSpec()` must be covered independently, each with all 8 cases from §6 substituting `phase: 'spec_generation'`.
 		- **Acceptance criteria**:
 			- [ ] All 8 cases covered independently for both `generateSpec()` and `reviseSpec()`

--- a/src/adapters/agent/implementer.ts
+++ b/src/adapters/agent/implementer.ts
@@ -4,6 +4,7 @@ import { readFile as _readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
+import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 
 type QueryFn = typeof _query;
 
@@ -118,6 +119,34 @@ export class AgentSDKImplementer implements Implementer {
   }
 }
 
+const CHECKPOINT_INSTRUCTIONS = `At any point during your work, if you have something worth reporting to the human watching —
+a phase transition, your current focus, something interesting you found, or a meaningful
+milestone — emit it on its own line using this exact format:
+
+[Relay] <your message here>
+
+Examples of good checkpoints:
+- [Relay] Planning started — analyzing spec and requirements
+- [Relay] Planning complete — 7 tasks identified
+- [Relay] Task 3 of 7: Implementing the parseRelayMessage helper
+- [Relay] Found a potential issue with the existing auth middleware — investigating
+- [Relay] Starting final code review
+
+The goal is to keep a human informed at intervals they'd find interesting. You decide what's
+worth reporting and when.`;
+
+function parseRelayMessage(content: BetaMessage['content']): string | null {
+  for (const block of content) {
+    if (block.type === 'text') {
+      for (const line of block.text.split('\n')) {
+        const match = line.match(/^\[Relay\]\s+(.+)$/);
+        if (match) return match[1].trim();
+      }
+    }
+  }
+  return null;
+}
+
 function buildPrompt(spec_path: string, result_file_path: string, additionalContext?: string): string {
   const lines: string[] = [];
 
@@ -168,5 +197,11 @@ function buildPrompt(spec_path: string, result_file_path: string, additionalCont
   lines.push('and where a wrong choice would require significant rework.');
   lines.push('Do not signal completion until the result file has been written.');
 
+  lines.push('');
+  lines.push(CHECKPOINT_INSTRUCTIONS);
+
   return lines.join('\n');
 }
+
+// Exported for testing only
+export { parseRelayMessage };

--- a/src/adapters/agent/implementer.ts
+++ b/src/adapters/agent/implementer.ts
@@ -1,5 +1,6 @@
 // src/adapters/agent/implementer.ts
 import { query as _query } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import { readFile as _readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type pino from 'pino';
@@ -82,7 +83,7 @@ export class AgentSDKImplementer implements Implementer {
     );
 
     try {
-      for await (const _message of this.queryFn({
+      for await (const message of this.queryFn({
         prompt,
         options: {
           cwd: workspace_path,
@@ -93,7 +94,25 @@ export class AgentSDKImplementer implements Implementer {
           systemPrompt: { type: 'preset', preset: 'claude_code' },
         },
       })) {
-        // drain iterator — agent writes result to file on completion
+        if (onProgress && (message as SDKMessage).type === 'assistant') {
+          const assistantMsg = message as Extract<SDKMessage, { type: 'assistant' }>;
+          const relayMessage = parseRelayMessage(assistantMsg.message.content);
+          if (relayMessage) {
+            onProgress(relayMessage)
+              .then(() => {
+                this.logger.info(
+                  { event: 'progress_update', phase: 'implementation', message: relayMessage },
+                  'Progress update posted',
+                );
+              })
+              .catch(err => {
+                this.logger.warn(
+                  { event: 'progress_failed', phase: 'implementation', error: String(err) },
+                  'Failed to post progress update',
+                );
+              });
+          }
+        }
       }
     } catch (err) {
       this.logger.error(

--- a/src/adapters/agent/implementer.ts
+++ b/src/adapters/agent/implementer.ts
@@ -22,6 +22,7 @@ export interface Implementer {
     spec_path: string,
     workspace_path: string,
     additional_context?: string,
+    onProgress?: (message: string) => Promise<void>,
   ): Promise<ImplementationResult>;
 }
 
@@ -69,7 +70,7 @@ export class AgentSDKImplementer implements Implementer {
     this.readFileFn = options?.readFile ?? ((path, enc) => _readFile(path, enc));
   }
 
-  async implement(spec_path: string, workspace_path: string, additional_context?: string): Promise<ImplementationResult> {
+  async implement(spec_path: string, workspace_path: string, additional_context?: string, onProgress?: (message: string) => Promise<void>): Promise<ImplementationResult> {
     const resultFilePath = join(workspace_path, '.autocatalyst', 'impl-result.json');
     const hasAdditionalContext = Boolean(additional_context);
     const prompt = buildPrompt(spec_path, resultFilePath, additional_context);

--- a/src/adapters/agent/spec-generator.ts
+++ b/src/adapters/agent/spec-generator.ts
@@ -1,5 +1,6 @@
 // src/adapters/agent/spec-generator.ts
 import { query as _query } from '@anthropic-ai/claude-agent-sdk';
+import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 import { readFile as _readFile } from 'node:fs/promises';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -26,13 +27,18 @@ export interface ReviseResult {
 }
 
 export interface SpecGenerator {
-  create(request: Request, workspace_path: string): Promise<string>;
+  create(
+    request: Request,
+    workspace_path: string,
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<string>;
   revise(
     feedback: ThreadMessage,
     notion_comments: NotionComment[],
     spec_path: string,
     workspace_path: string,
     current_page_markdown?: string,
+    onProgress?: (message: string) => Promise<void>,
   ): Promise<ReviseResult>;
 }
 
@@ -85,7 +91,7 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     this.readFileFn = options?.readFile ?? ((path, enc) => _readFile(path, enc));
   }
 
-  async create(request: Request, workspace_path: string): Promise<string> {
+  async create(request: Request, workspace_path: string, onProgress?: (message: string) => Promise<void>): Promise<string> {
     const createResultPath = join(workspace_path, '.autocatalyst', 'spec-create-result.json');
     const specDir = join(workspace_path, 'context-human', 'specs');
     const prompt = buildCreatePrompt(request, specDir, createResultPath);
@@ -150,6 +156,7 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     spec_path: string,
     workspace_path: string,
     current_page_markdown?: string,
+    onProgress?: (message: string) => Promise<void>,
   ): Promise<ReviseResult> {
     const reviseResultPath = join(workspace_path, '.autocatalyst', 'spec-revise-result.json');
     const originalSpans = current_page_markdown ? extractCommentSpans(current_page_markdown) : [];
@@ -220,6 +227,33 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
   }
 }
 
+function parseRelayMessage(content: BetaMessage['content']): string | null {
+  for (const block of content) {
+    if (block.type === 'text') {
+      for (const line of block.text.split('\n')) {
+        const match = line.match(/^\[Relay\]\s+(.+)$/);
+        if (match) return match[1].trim();
+      }
+    }
+  }
+  return null;
+}
+
+const CHECKPOINT_INSTRUCTIONS = `At any point during your work, if you have something worth reporting to the human watching —
+a phase transition, your current focus, something interesting you found, or a meaningful
+milestone — emit it on its own line using this exact format:
+
+[Relay] <your message here>
+
+Examples of good checkpoints:
+- [Relay] Analyzing requirements and reviewing existing specs
+- [Relay] Processing feedback comment 3 of 8 — authentication design section
+- [Relay] Drafting technical design section
+- [Relay] Spec draft complete — reviewing for consistency
+
+The goal is to keep a human informed at intervals they'd find interesting. You decide what's
+worth reporting and when.`;
+
 function buildCreatePrompt(request: Request, specDir: string, createResultPath: string): string {
   return [
     `Use the /mm:planning skill to create a complete product spec for the following request.`,
@@ -238,6 +272,8 @@ function buildCreatePrompt(request: Request, specDir: string, createResultPath: 
     `  Content must be: { "spec_path": "<absolute path to the spec file you wrote>" }`,
     ``,
     `Do not signal completion until both files have been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
   ].join('\n');
 }
 
@@ -307,5 +343,10 @@ function buildRevisePrompt(
     `<<<`,
     currentSpec,
     `>>>`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
   ].filter(line => line !== undefined).join('\n');
 }
+
+// Exported for testing only
+export { parseRelayMessage };

--- a/src/adapters/agent/spec-generator.ts
+++ b/src/adapters/agent/spec-generator.ts
@@ -1,5 +1,6 @@
 // src/adapters/agent/spec-generator.ts
 import { query as _query } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 import { readFile as _readFile } from 'node:fs/promises';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -99,7 +100,7 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     this.logger.debug({ event: 'spec.agent_invoked', request_id: request.id }, 'Invoking Agent SDK for spec creation');
 
     try {
-      for await (const _message of this.queryFn({
+      for await (const message of this.queryFn({
         prompt,
         options: {
           cwd: workspace_path,
@@ -110,7 +111,25 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
           systemPrompt: { type: 'preset', preset: 'claude_code' },
         },
       })) {
-        // drain iterator — agent writes spec and result file on completion
+        if (onProgress && (message as SDKMessage).type === 'assistant') {
+          const assistantMsg = message as Extract<SDKMessage, { type: 'assistant' }>;
+          const relayMessage = parseRelayMessage(assistantMsg.message.content);
+          if (relayMessage) {
+            onProgress(relayMessage)
+              .then(() => {
+                this.logger.info(
+                  { event: 'progress_update', phase: 'spec_generation', message: relayMessage },
+                  'Progress update posted',
+                );
+              })
+              .catch(err => {
+                this.logger.warn(
+                  { event: 'progress_failed', phase: 'spec_generation', error: String(err) },
+                  'Failed to post progress update',
+                );
+              });
+          }
+        }
       }
     } catch (err) {
       this.logger.error(
@@ -172,7 +191,7 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
     this.logger.debug({ event: 'spec.agent_invoked', request_id: feedback.request_id }, 'Invoking Agent SDK for spec revision');
 
     try {
-      for await (const _message of this.queryFn({
+      for await (const message of this.queryFn({
         prompt,
         options: {
           cwd: workspace_path,
@@ -183,7 +202,25 @@ export class AgentSDKSpecGenerator implements SpecGenerator {
           systemPrompt: { type: 'preset', preset: 'claude_code' },
         },
       })) {
-        // drain iterator — agent writes revised spec and result file on completion
+        if (onProgress && (message as SDKMessage).type === 'assistant') {
+          const assistantMsg = message as Extract<SDKMessage, { type: 'assistant' }>;
+          const relayMessage = parseRelayMessage(assistantMsg.message.content);
+          if (relayMessage) {
+            onProgress(relayMessage)
+              .then(() => {
+                this.logger.info(
+                  { event: 'progress_update', phase: 'spec_generation', message: relayMessage },
+                  'Progress update posted',
+                );
+              })
+              .catch(err => {
+                this.logger.warn(
+                  { event: 'progress_failed', phase: 'spec_generation', error: String(err) },
+                  'Failed to post progress update',
+                );
+              });
+          }
+        }
       }
     } catch (err) {
       this.logger.error(

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -353,12 +353,22 @@ export class OrchestratorImpl implements Orchestrator {
   }
 
   private async _runImplementation(feedback: ThreadMessage, run: Run, additional_context?: string): Promise<void> {
-    // Invoke the implementer
+    const onProgress = (message: string): Promise<void> =>
+      this.deps.postMessage(feedback.channel_id, feedback.thread_ts, message).catch(err => {
+        this.logger.warn(
+          { event: 'progress_failed', phase: 'implementation', run_id: run.id, error: String(err) },
+          'Failed to post progress update',
+        );
+      });
+
     let result;
     try {
-      result = additional_context !== undefined
-        ? await this.deps.implementer!.implement(run.spec_path!, run.workspace_path, additional_context)
-        : await this.deps.implementer!.implement(run.spec_path!, run.workspace_path);
+      result = await this.deps.implementer!.implement(
+        run.spec_path!,
+        run.workspace_path,
+        additional_context,
+        onProgress,
+      );
     } catch (err) {
       await this.failRun(run, feedback.channel_id, feedback.thread_ts, err);
       return;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -586,9 +586,17 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     // Step 2: Generate spec
+    const specCreateProgress = (message: string): Promise<void> =>
+      this.deps.postMessage(request.channel_id, request.thread_ts, message).catch(err => {
+        this.logger.warn(
+          { event: 'progress_failed', phase: 'spec_generation', run_id: run.id, error: String(err) },
+          'Failed to post progress update',
+        );
+      });
+
     let spec_path: string;
     try {
-      spec_path = await this.deps.specGenerator.create(request, workspace_path);
+      spec_path = await this.deps.specGenerator.create(request, workspace_path, specCreateProgress);
       run.spec_path = spec_path;
     } catch (err) {
       await this.deps.workspaceManager.destroy(workspace_path);
@@ -652,9 +660,17 @@ export class OrchestratorImpl implements Orchestrator {
     }, 'Revision enriched with feedback sources');
 
     // Step 2: Revise spec
+    const specReviseProgress = (message: string): Promise<void> =>
+      this.deps.postMessage(feedback.channel_id, feedback.thread_ts, message).catch(err => {
+        this.logger.warn(
+          { event: 'progress_failed', phase: 'spec_generation', run_id: run.id, error: String(err) },
+          'Failed to post progress update',
+        );
+      });
+
     let result: ReviseResult;
     try {
-      result = await this.deps.specGenerator.revise(feedback, notionComments, run.spec_path, run.workspace_path, pageMarkdown);
+      result = await this.deps.specGenerator.revise(feedback, notionComments, run.spec_path, run.workspace_path, pageMarkdown, specReviseProgress);
     } catch (err) {
       await this.failRun(run, feedback.channel_id, feedback.thread_ts, err);
       return;

--- a/tests/adapters/agent/implementer.test.ts
+++ b/tests/adapters/agent/implementer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { AgentSDKImplementer } from '../../../src/adapters/agent/implementer.js';
+import { AgentSDKImplementer, parseRelayMessage } from '../../../src/adapters/agent/implementer.js';
 
 const nullDest = { write: () => {} };
 
@@ -289,5 +289,49 @@ describe('AgentSDKImplementer — logging', () => {
 
     const failed = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'impl.agent_failed');
     expect(failed).toBeDefined();
+  });
+});
+
+describe('parseRelayMessage', () => {
+  it('single relay line: returns text after [Relay], trimmed', () => {
+    const content = [{ type: 'text' as const, text: '[Relay] Planning started' }];
+    expect(parseRelayMessage(content as never)).toBe('Planning started');
+  });
+
+  it('first of multiple relay lines: returns only the first', () => {
+    const content = [{ type: 'text' as const, text: '[Relay] First\n[Relay] Second' }];
+    expect(parseRelayMessage(content as never)).toBe('First');
+  });
+
+  it('relay line among non-relay lines: returns correct extraction', () => {
+    const content = [{ type: 'text' as const, text: 'line one\n[Relay] Found it\nline three' }];
+    expect(parseRelayMessage(content as never)).toBe('Found it');
+  });
+
+  it('no relay line: returns null', () => {
+    const content = [{ type: 'text' as const, text: 'just regular text' }];
+    expect(parseRelayMessage(content as never)).toBeNull();
+  });
+
+  it('tool-use block only: returns null', () => {
+    const content = [{ type: 'tool_use' as const, id: 'x', name: 'bash', input: {} }];
+    expect(parseRelayMessage(content as never)).toBeNull();
+  });
+
+  it('empty content array: returns null', () => {
+    expect(parseRelayMessage([])).toBeNull();
+  });
+
+  it('case-sensitive prefix: [relay] lowercase and [Relay]: with colon do not match', () => {
+    const content = [{ type: 'text' as const, text: '[relay] lowercase\n[Relay]: with colon' }];
+    expect(parseRelayMessage(content as never)).toBeNull();
+  });
+
+  it('multi-block content: relay line in second block is found', () => {
+    const content = [
+      { type: 'text' as const, text: 'no relay here' },
+      { type: 'text' as const, text: '[Relay] In second block' },
+    ];
+    expect(parseRelayMessage(content as never)).toBe('In second block');
   });
 });

--- a/tests/adapters/agent/implementer.test.ts
+++ b/tests/adapters/agent/implementer.test.ts
@@ -25,6 +25,16 @@ function makeImpl(result: object, queryFn = makeQueryFn()) {
   };
 }
 
+function makeAssistantMsg(text: string): object {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+function makeQueryFnWithMessages(messages: unknown[]) {
+  return vi.fn().mockReturnValue((async function* () {
+    for (const msg of messages) yield msg;
+  })());
+}
+
 let tmpDir: string;
 let specPath: string;
 
@@ -333,5 +343,145 @@ describe('parseRelayMessage', () => {
       { type: 'text' as const, text: '[Relay] In second block' },
     ];
     expect(parseRelayMessage(content as never)).toBe('In second block');
+  });
+});
+
+describe('AgentSDKImplementer — drain loop relay detection', () => {
+  it('relay line forwarded: onProgress called once with extracted text', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const impl = new AgentSDKImplementer({
+      logDestination: dest,
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Task 1 of 3: Starting')]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith('Task 1 of 3: Starting');
+    const progressLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_update');
+    expect(progressLog).toBeDefined();
+    expect(progressLog!['phase']).toBe('implementation');
+    expect(progressLog!['message']).toBe('Task 1 of 3: Starting');
+  });
+
+  it('non-relay assistant turn: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const impl = new AgentSDKImplementer({
+      logDestination: nullDest,
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('Just a regular message')]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('non-assistant messages ignored: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const nonAssistantMessages = [
+      { type: 'tool_progress', content: 'something' },
+      { type: 'result', subtype: 'success', total_cost_usd: 0, duration_ms: 0, num_turns: 1, result: '', session_id: 'x', is_error: false },
+    ];
+    const impl = new AgentSDKImplementer({
+      logDestination: nullDest,
+      queryFn: makeQueryFnWithMessages(nonAssistantMessages),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('tool-use-only assistant message: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const toolUseMsg = { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'x', name: 'bash', input: { command: 'ls' } }] } };
+    const impl = new AgentSDKImplementer({
+      logDestination: nullDest,
+      queryFn: makeQueryFnWithMessages([toolUseMsg]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('failed callback does not throw: implement resolves normally, progress_failed logged', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const onProgress = vi.fn().mockRejectedValue(new Error('Slack down'));
+    const impl = new AgentSDKImplementer({
+      logDestination: dest,
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Starting')]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    const result = await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(result.status).toBe('complete');
+    const failLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_failed');
+    expect(failLog).toBeDefined();
+    expect(failLog!['phase']).toBe('implementation');
+    expect(failLog!['error']).toContain('Slack down');
+  });
+
+  it('no callback: behavior unchanged, no progress events logged', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const impl = new AgentSDKImplementer({
+      logDestination: dest,
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Something')]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    const result = await impl.implement(specPath, tmpDir);
+
+    expect(result.status).toBe('complete');
+    const progressLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_update' || l['event'] === 'progress_failed');
+    expect(progressLog).toBeUndefined();
+  });
+
+  it('multiple relay lines in one turn: onProgress called once (first relay only)', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const impl = new AgentSDKImplementer({
+      logDestination: nullDest,
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] First\n[Relay] Second')]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith('First');
+  });
+
+  it('relay across multiple messages: onProgress called twice', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const impl = new AgentSDKImplementer({
+      logDestination: nullDest,
+      queryFn: makeQueryFnWithMessages([
+        makeAssistantMsg('[Relay] First message'),
+        makeAssistantMsg('[Relay] Second message'),
+      ]),
+      readFile: makeReadFileFn({ status: 'complete', summary: 'Done.', testing_instructions: 'Run tests' }),
+    });
+
+    await impl.implement(specPath, tmpDir, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 'First message');
+    expect(onProgress).toHaveBeenNthCalledWith(2, 'Second message');
   });
 });

--- a/tests/adapters/agent/spec-generator.test.ts
+++ b/tests/adapters/agent/spec-generator.test.ts
@@ -57,6 +57,16 @@ function makeReadFileFn(result: object) {
   return vi.fn().mockResolvedValue(JSON.stringify(result));
 }
 
+function makeAssistantMsg(text: string): object {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+function makeQueryFnWithMessages(messages: unknown[]) {
+  return vi.fn().mockReturnValue((async function* () {
+    for (const msg of messages) yield msg;
+  })());
+}
+
 let tempRoot: string;
 
 beforeEach(() => {
@@ -676,5 +686,300 @@ describe('parseRelayMessage (spec-generator)', () => {
       { type: 'text' as const, text: '[Relay] In second block' },
     ];
     expect(parseRelayMessage(content as never)).toBe('In second block');
+  });
+});
+
+describe('AgentSDKSpecGenerator.create — drain loop relay detection', () => {
+  it('relay line forwarded: onProgress called once with extracted text', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Analyzing requirements')]),
+      logDestination: dest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith('Analyzing requirements');
+    const progressLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_update');
+    expect(progressLog).toBeDefined();
+    expect(progressLog!['phase']).toBe('spec_generation');
+    expect(progressLog!['message']).toBe('Analyzing requirements');
+  });
+
+  it('non-relay assistant turn: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('Just thinking')]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('non-assistant messages ignored: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([{ type: 'tool_progress', content: 'x' }]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('tool-use-only assistant message: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const toolUseMsg = { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'x', name: 'bash', input: {} }] } };
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([toolUseMsg]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('failed callback does not throw: create resolves normally, progress_failed logged', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const onProgress = vi.fn().mockRejectedValue(new Error('network error'));
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Starting')]),
+      logDestination: dest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    const result = await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(result).toBe(specPath);
+    const failLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_failed');
+    expect(failLog).toBeDefined();
+    expect(failLog!['phase']).toBe('spec_generation');
+    expect(failLog!['error']).toContain('network error');
+  });
+
+  it('no callback: behavior unchanged, no progress events logged', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Something')]),
+      logDestination: dest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    const result = await sg.create(makeRequest(), tempRoot);
+
+    expect(result).toBe(specPath);
+    const progressLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_update' || l['event'] === 'progress_failed');
+    expect(progressLog).toBeUndefined();
+  });
+
+  it('multiple relay lines in one turn: onProgress called once (first relay only)', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] First\n[Relay] Second')]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith('First');
+  });
+
+  it('relay across multiple messages: onProgress called twice', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-wizard.md');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([
+        makeAssistantMsg('[Relay] First message'),
+        makeAssistantMsg('[Relay] Second message'),
+      ]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ spec_path: specPath }),
+    });
+
+    await sg.create(makeRequest(), tempRoot, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 'First message');
+    expect(onProgress).toHaveBeenNthCalledWith(2, 'Second message');
+  });
+});
+
+describe('AgentSDKSpecGenerator.revise — drain loop relay detection', () => {
+  it('relay line forwarded: onProgress called once with extracted text', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Processing comment 1 of 3')]),
+      logDestination: dest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith('Processing comment 1 of 3');
+    const progressLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_update');
+    expect(progressLog).toBeDefined();
+    expect(progressLog!['phase']).toBe('spec_generation');
+  });
+
+  it('non-relay assistant turn: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('Regular text')]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('non-assistant messages ignored: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([{ type: 'tool_progress', content: 'x' }]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('tool-use-only assistant message: onProgress not called', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const toolUseMsg = { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'x', name: 'bash', input: {} }] } };
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([toolUseMsg]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('failed callback does not throw: revise resolves normally, progress_failed logged', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const onProgress = vi.fn().mockRejectedValue(new Error('slack error'));
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Starting revision')]),
+      logDestination: dest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(result.comment_responses).toEqual([]);
+    const failLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_failed');
+    expect(failLog).toBeDefined();
+    expect(failLog!['phase']).toBe('spec_generation');
+    expect(failLog!['error']).toContain('slack error');
+  });
+
+  it('no callback: behavior unchanged, no progress events logged', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { logs.push(JSON.parse(line)); } };
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] Something')]),
+      logDestination: dest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    const result = await sg.revise(makeFeedback(), [], specPath, tempRoot);
+
+    expect(result.comment_responses).toEqual([]);
+    const progressLog = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'progress_update' || l['event'] === 'progress_failed');
+    expect(progressLog).toBeUndefined();
+  });
+
+  it('multiple relay lines in one turn: onProgress called once (first relay only)', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([makeAssistantMsg('[Relay] First\n[Relay] Second')]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith('First');
+  });
+
+  it('relay across multiple messages: onProgress called twice', async () => {
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+    const specPath = join(tempRoot, 'context-human', 'specs', 'feature-test.md');
+    writeFileSync(specPath, '# Spec', 'utf-8');
+    const sg = new AgentSDKSpecGenerator({
+      queryFn: makeQueryFnWithMessages([
+        makeAssistantMsg('[Relay] First message'),
+        makeAssistantMsg('[Relay] Second message'),
+      ]),
+      logDestination: nullDest,
+      readFile: makeReadFileFn({ comment_responses: [] }),
+    });
+
+    await sg.revise(makeFeedback(), [], specPath, tempRoot, undefined, onProgress);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 'First message');
+    expect(onProgress).toHaveBeenNthCalledWith(2, 'Second message');
   });
 });

--- a/tests/adapters/agent/spec-generator.test.ts
+++ b/tests/adapters/agent/spec-generator.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { AgentSDKSpecGenerator } from '../../../src/adapters/agent/spec-generator.js';
+import { AgentSDKSpecGenerator, parseRelayMessage } from '../../../src/adapters/agent/spec-generator.js';
 import type { Request, ThreadMessage } from '../../../src/types/events.js';
 
 const nullDest = { write: () => {} };
@@ -632,5 +632,49 @@ describe('AgentSDKSpecGenerator.revise — span passthrough', () => {
     const call = queryFn.mock.calls[0][0] as { prompt: string };
     expect(call.prompt).toContain('# Disk Spec Content');
     expect(result.page_content).toBeUndefined();
+  });
+});
+
+describe('parseRelayMessage (spec-generator)', () => {
+  it('single relay line: returns text after [Relay], trimmed', () => {
+    const content = [{ type: 'text' as const, text: '[Relay] Analyzing requirements' }];
+    expect(parseRelayMessage(content as never)).toBe('Analyzing requirements');
+  });
+
+  it('first of multiple relay lines: returns only the first', () => {
+    const content = [{ type: 'text' as const, text: '[Relay] First\n[Relay] Second' }];
+    expect(parseRelayMessage(content as never)).toBe('First');
+  });
+
+  it('relay line among non-relay lines: returns correct extraction', () => {
+    const content = [{ type: 'text' as const, text: 'thinking...\n[Relay] Processing comment 2\ndone' }];
+    expect(parseRelayMessage(content as never)).toBe('Processing comment 2');
+  });
+
+  it('no relay line: returns null', () => {
+    const content = [{ type: 'text' as const, text: 'just writing the spec' }];
+    expect(parseRelayMessage(content as never)).toBeNull();
+  });
+
+  it('tool-use block only: returns null', () => {
+    const content = [{ type: 'tool_use' as const, id: 'x', name: 'bash', input: {} }];
+    expect(parseRelayMessage(content as never)).toBeNull();
+  });
+
+  it('empty content array: returns null', () => {
+    expect(parseRelayMessage([])).toBeNull();
+  });
+
+  it('case-sensitive prefix: [relay] lowercase and [Relay]: with colon do not match', () => {
+    const content = [{ type: 'text' as const, text: '[relay] lowercase\n[Relay]: with colon' }];
+    expect(parseRelayMessage(content as never)).toBeNull();
+  });
+
+  it('multi-block content: relay line in second block is found', () => {
+    const content = [
+      { type: 'text' as const, text: 'no relay here' },
+      { type: 'text' as const, text: '[Relay] In second block' },
+    ];
+    expect(parseRelayMessage(content as never)).toBe('In second block');
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -241,7 +241,7 @@ describe('Orchestrator — new_request happy path', () => {
     await orch.stop();
 
     expect(wm.create).toHaveBeenCalledWith('request-001', 'https://github.com/org/repo');
-    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001');
+    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function));
     expect(cp.create).toHaveBeenCalledWith('C123', '100.0', '/ws/request-001/context-human/specs/feature-test.md');
   });
 
@@ -370,6 +370,7 @@ describe('Orchestrator — feedback happy path', () => {
       '/ws/request-001/context-human/specs/feature-test.md',
       '/ws/request-001',
       undefined,
+      expect.any(Function),
     );
     expect(cp.update).toHaveBeenCalledWith('CANVAS001', '/ws/request-001/context-human/specs/feature-test.md', undefined);
   });
@@ -602,6 +603,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
       expect.any(String),
       expect.any(String),
       undefined,
+      expect.any(Function),
     );
     expect(fs.reply).toHaveBeenCalledTimes(2);
     expect(fs.reply).toHaveBeenCalledWith('CANVAS001', 'disc-1', 'Updated per Phoebe');
@@ -630,6 +632,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
       expect.any(String),
       expect.any(String),
       undefined,
+      expect.any(Function),
     );
     expect(fs.reply).not.toHaveBeenCalled();
   });
@@ -655,6 +658,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
       expect.any(String),
       expect.any(String),
       undefined,
+      expect.any(Function),
     );
   });
 
@@ -3371,5 +3375,252 @@ describe('observability — log field correctness', () => {
     expect(typeof log!['error']).toBe('string');
     expect(log!['error']).toContain('oops');
     await orch.stop();
+  });
+});
+
+describe('Orchestrator — _startSpecPipeline onProgress wiring', () => {
+  it('specGenerator.create() receives an onProgress function', async () => {
+    const adapter = makeMockAdapter();
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const createFn = vi.fn().mockImplementation(async (_req: unknown, _wp: string, onProg?: (m: string) => Promise<void>) => {
+      capturedOnProgress = onProg;
+      return '/ws/request-001/context-human/specs/feature-test.md';
+    });
+    const sg = makeSpecGenerator({ create: createFn });
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: sg,
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('idea'),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        repo_url: 'r',
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    const event = makeEventFixture('new_request');
+    adapter._emit(event);
+    await vi.waitUntil(() => {
+      const runs = (orch as unknown as { runs: Map<string, unknown> }).runs;
+      const run = [...runs.values()][0] as { stage: string } | undefined;
+      return run?.stage === 'reviewing_spec';
+    }, { timeout: 3000 });
+    await orch.stop();
+
+    expect(capturedOnProgress).toBeTypeOf('function');
+  });
+
+  it('create() onProgress invokes postMessage with correct channel_id, thread_ts, and message', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const createFn = vi.fn().mockImplementation(async (_req: unknown, _wp: string, onProg?: (m: string) => Promise<void>) => {
+      capturedOnProgress = onProg;
+      return '/ws/request-001/context-human/specs/feature-test.md';
+    });
+    const sg = makeSpecGenerator({ create: createFn });
+    const event = makeEventFixture('new_request');
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: sg,
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('idea'),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit(event);
+    await vi.waitUntil(() => {
+      const runs = (orch as unknown as { runs: Map<string, unknown> }).runs;
+      const run = [...runs.values()][0] as { stage: string } | undefined;
+      return run?.stage === 'reviewing_spec';
+    }, { timeout: 3000 });
+    await orch.stop();
+
+    await capturedOnProgress!('Analyzing requirements');
+
+    const progressCalls = (postMessage as ReturnType<typeof vi.fn>).mock.calls.filter((c: unknown[]) => c[2] === 'Analyzing requirements');
+    expect(progressCalls).toHaveLength(1);
+    expect(progressCalls[0][0]).toBe(event.payload.channel_id);
+    expect(progressCalls[0][1]).toBe(event.payload.thread_ts);
+  });
+
+  it('postMessage rejection in create() onProgress does not fail the run, progress_failed logged at warn', async () => {
+    const adapter = makeMockAdapter();
+    const { records, destination } = makeLogCapture();
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const createFn = vi.fn().mockImplementation(async (_req: unknown, _wp: string, onProg?: (m: string) => Promise<void>) => {
+      capturedOnProgress = onProg;
+      return '/ws/request-001/context-human/specs/feature-test.md';
+    });
+    const sg = makeSpecGenerator({ create: createFn });
+    const postMessage = vi.fn().mockImplementation((_ch: string, _ts: string, msg: string) => {
+      if (msg === 'spec progress relay') return Promise.reject(new Error('slack unavailable'));
+      return Promise.resolve();
+    });
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: sg,
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('idea'),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      } as never,
+      { logDestination: destination },
+    );
+    await orch.start();
+    adapter._emit(makeEventFixture('new_request'));
+    await vi.waitUntil(() => {
+      const runs = (orch as unknown as { runs: Map<string, unknown> }).runs;
+      const run = [...runs.values()][0] as { stage: string } | undefined;
+      return run?.stage === 'reviewing_spec';
+    }, { timeout: 3000 });
+    await orch.stop();
+
+    if (capturedOnProgress) {
+      await capturedOnProgress('spec progress relay').catch(() => {});
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    const failLog = records.find(r => r['event'] === 'progress_failed' && r['phase'] === 'spec_generation');
+    expect(failLog).toBeDefined();
+    expect(String(failLog!['error'])).toContain('slack unavailable');
+  });
+});
+
+describe('Orchestrator — _handleSpecFeedback onProgress wiring', () => {
+  it('specGenerator.revise() receives an onProgress function', async () => {
+    const adapter = makeMockAdapter();
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const reviseFn = vi.fn().mockImplementation(async (...args: unknown[]) => {
+      capturedOnProgress = args[5] as ((m: string) => Promise<void>) | undefined;
+      return { comment_responses: [] };
+    });
+    const sg = makeSpecGenerator({ revise: reviseFn });
+    const ic = makeIntentClassifier('feedback');
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: sg,
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: ic,
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        repo_url: 'r',
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
+    adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'reviewing_spec' && reviseFn.mock.calls.length > 0,
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    expect(capturedOnProgress).toBeTypeOf('function');
+  });
+
+  it('revise() onProgress invokes postMessage with correct channel_id, thread_ts, and message', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const reviseFn = vi.fn().mockImplementation(async (...args: unknown[]) => {
+      capturedOnProgress = args[5] as ((m: string) => Promise<void>) | undefined;
+      return { comment_responses: [] };
+    });
+    const sg = makeSpecGenerator({ revise: reviseFn });
+    const ic = makeIntentClassifier('feedback');
+    const feedback = makeFeedback();
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: sg,
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: ic,
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
+    adapter._emit({ type: 'thread_message', payload: feedback });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'reviewing_spec' && reviseFn.mock.calls.length > 0,
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    await capturedOnProgress!('Drafting technical section');
+
+    const progressCalls = (postMessage as ReturnType<typeof vi.fn>).mock.calls.filter((c: unknown[]) => c[2] === 'Drafting technical section');
+    expect(progressCalls).toHaveLength(1);
+    expect(progressCalls[0][0]).toBe(feedback.channel_id);
+    expect(progressCalls[0][1]).toBe(feedback.thread_ts);
+  });
+
+  it('postMessage rejection in revise() onProgress does not fail the run, progress_failed logged at warn', async () => {
+    const adapter = makeMockAdapter();
+    const { records, destination } = makeLogCapture();
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const reviseFn = vi.fn().mockImplementation(async (...args: unknown[]) => {
+      capturedOnProgress = args[5] as ((m: string) => Promise<void>) | undefined;
+      return { comment_responses: [] };
+    });
+    const sg = makeSpecGenerator({ revise: reviseFn });
+    const ic = makeIntentClassifier('feedback');
+    const postMessage = vi.fn().mockImplementation((_ch: string, _ts: string, msg: string) => {
+      if (msg === 'revise progress relay') return Promise.reject(new Error('connection reset'));
+      return Promise.resolve();
+    });
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: sg,
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: ic,
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'r',
+      } as never,
+      { logDestination: destination },
+    );
+    await orch.start();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
+    adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'reviewing_spec' && reviseFn.mock.calls.length > 0,
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    if (capturedOnProgress) {
+      await capturedOnProgress('revise progress relay').catch(() => {});
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    const failLog = records.find(r => r['event'] === 'progress_failed' && r['phase'] === 'spec_generation');
+    expect(failLog).toBeDefined();
+    expect(String(failLog!['error'])).toContain('connection reset');
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -1052,6 +1052,8 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     expect(implementFn).toHaveBeenCalledWith(
       '/ws/request-001/context-human/specs/feature-test.md',
       '/ws/request-001',
+      undefined,
+      expect.any(Function),
     );
   });
 
@@ -1128,6 +1130,91 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const messages = (postMessage as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[2] as string);
     expect(messages.some(m => m.includes('Which approach do you prefer?'))).toBe(true);
     expect(implFeedbackPage.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('Orchestrator — _runImplementation onProgress wiring', () => {
+  it('implement() receives an onProgress function', async () => {
+    const adapter = makeMockAdapter();
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const implementFn = vi.fn().mockImplementation(async (_sp: string, _wp: string, _ctx: string | undefined, onProg?: (m: string) => Promise<void>) => {
+      capturedOnProgress = onProg;
+      return { status: 'complete', summary: 'Done', testing_instructions: 'Test' };
+    });
+    const impl = { implement: implementFn };
+    const orch = makeApprovalOrch({ adapter, implementer: impl as Implementer });
+    await orch.start();
+    await approveSpec(orch, adapter);
+    await orch.stop();
+
+    expect(capturedOnProgress).toBeTypeOf('function');
+  });
+
+  it('onProgress callback invokes postMessage with channel_id, thread_ts, and message', async () => {
+    const adapter = makeMockAdapter();
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const implementFn = vi.fn().mockImplementation(async (_sp: string, _wp: string, _ctx: string | undefined, onProg?: (m: string) => Promise<void>) => {
+      capturedOnProgress = onProg;
+      return { status: 'complete', summary: 'Done', testing_instructions: 'Test' };
+    });
+    const impl = { implement: implementFn };
+    const orch = makeApprovalOrch({ adapter, implementer: impl as Implementer, postMessage });
+    await orch.start();
+    await approveSpec(orch, adapter);
+    await orch.stop();
+
+    // Invoke the captured callback
+    await capturedOnProgress!('Task 3 of 7: Implementing the helper');
+
+    const progressCalls = (postMessage as ReturnType<typeof vi.fn>).mock.calls.filter((c: unknown[]) => c[2] === 'Task 3 of 7: Implementing the helper');
+    expect(progressCalls).toHaveLength(1);
+    expect(progressCalls[0][0]).toBe('C123');
+    expect(progressCalls[0][1]).toBe('100.0');
+  });
+
+  it('postMessage rejection inside onProgress does not fail the run, progress_failed logged at warn', async () => {
+    const adapter = makeMockAdapter();
+    const { records, destination } = makeLogCapture();
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const implementFn = vi.fn().mockImplementation(async (_sp: string, _wp: string, _ctx: string | undefined, onProg?: (m: string) => Promise<void>) => {
+      capturedOnProgress = onProg;
+      return { status: 'complete', summary: 'Done', testing_instructions: 'Test' };
+    });
+    const impl = { implement: implementFn };
+    const postMessage = vi.fn().mockImplementation((_ch: string, _ts: string, msg: string) => {
+      if (msg === 'progress relay msg') return Promise.reject(new Error('slack timeout'));
+      return Promise.resolve();
+    });
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        specGenerator: makeSpecGenerator(),
+        specPublisher: makeSpecPublisher(),
+        intentClassifier: makeIntentClassifier('approval'),
+        specCommitter: makeSpecCommitter(),
+        implementer: impl as Implementer,
+        implFeedbackPage: makeImplFeedbackPage(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage,
+        repo_url: 'https://github.com/org/repo',
+      } as never,
+      { logDestination: destination },
+    );
+    await orch.start();
+    await approveSpec(orch, adapter);
+    await orch.stop();
+
+    // Invoke the captured callback with a message that will make postMessage reject
+    if (capturedOnProgress) {
+      await capturedOnProgress('progress relay msg').catch(() => {});
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    const failLog = records.find(r => r['event'] === 'progress_failed' && r['phase'] === 'implementation');
+    expect(failLog).toBeDefined();
+    expect(String(failLog!['error'])).toContain('slack timeout');
   });
 });
 


### PR DESCRIPTION
## Summary

Implements mid-run progress updates from the agent to Slack during spec generation and implementation runs. Closes #23.

During long-running operations (spec generation, spec revision, implementation), the orchestrator now wires an `onProgress` callback into the speccer and implementer. The agent is prompted to emit `[Relay]`-tagged lines at meaningful intervals; the drain loop detects these and forwards them to the Slack thread as best-effort notifications — a failed post never interrupts the run.

- Added `onProgress?: (message: string) => Promise<void>` to `Implementer.implement()`, `SpecGenerator.create()`, and `SpecGenerator.revise()`
- Added `parseRelayMessage` helper (plus checkpoint prompt instructions) to both `implementer.ts` and `spec-generator.ts`
- Relay detection wired into all three Agent SDK drain loops (`AgentSDKImplementer`, `AgentSDKSpecGenerator.create`, `AgentSDKSpecGenerator.revise`)
- Orchestrator constructs per-run `onProgress` callbacks (closing over `channel_id`/`thread_ts`) and passes them in `_runImplementation`, `_startSpecPipeline`, and `_handleSpecFeedback`
- Fire-and-forget pattern: `.then`/`.catch` on every `onProgress` call; `progress_update` logged at info on success, `progress_failed` at warn on failure

## Test coverage

- 8 `parseRelayMessage` unit tests in each of `implementer.test.ts` and `spec-generator.test.ts` (16 total)
- 8 drain loop tests for `AgentSDKImplementer`
- 8 drain loop tests each for `AgentSDKSpecGenerator.create()` and `.revise()` (16 total)
- 3 orchestrator tests for `_runImplementation` progress wiring
- 3 orchestrator tests for spec gen progress wiring

521 tests passing.

## Spec

`context-human/specs/enhancement-agent-progress-updates.md` — status: complete, all tasks and acceptance criteria checked off.