### PR TITLE
feat: enhancement: notion database publishing

### DIFF
--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -801,15 +801,15 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] Unit tests cover all valid `TestingGuideStatus` values, PR link passthrough, and rejection cases
 		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface", "Task: Add `pages.updateProperties()` to `NotionClient`"
 - [ ] **Story: Orchestrator status transitions**
-	- [ ] **Task: Wire spec lifecycle status update call-sites**
+	- [x] **Task: Wire spec lifecycle status update call-sites**
 		- **Description**: In `src/core/orchestrator.ts`, add best-effort `specPublisher.updateStatus?.()` calls using optional chaining + `.catch()` at three points: after `transition(run, 'reviewing_spec')` in `_startSpecPipeline` (→ "Waiting on feedback"), after `transition(run, 'speccing')` in `_handleSpecFeedback` (→ "Speccing"), and after successful `specCommitter.commit()` in `_handleSpecApproval` (→ "Approved"). Each failure logs `run.status_update_failed` with `run_id` and target `status` but does not abort the run.
 		- **Acceptance criteria**:
-			- [ ] `updateStatus('Waiting on feedback')` called after `reviewing_spec` transition
-			- [ ] `updateStatus('Speccing')` called after `speccing` transition
-			- [ ] `updateStatus('Approved')` called after successful `specCommitter.commit()`
-			- [ ] Each rejection logs `run.status_update_failed` with `run_id` and `status`; rejection does not propagate to the run state machine
-			- [ ] When `specPublisher` is `SlackCanvasPublisher` (no `updateStatus`), optional chaining short-circuits with no error
-			- [ ] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and for rejection behavior
+			- [x] `updateStatus('Waiting on feedback')` called after `reviewing_spec` transition
+			- [x] `updateStatus('Speccing')` called after `speccing` transition
+			- [x] `updateStatus('Approved')` called after successful `specCommitter.commit()`
+			- [x] Each rejection logs `run.status_update_failed` with `run_id` and `status`; rejection does not propagate to the run state machine
+			- [x] When `specPublisher` is `SlackCanvasPublisher` (no `updateStatus`), optional chaining short-circuits with no error
+			- [x] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and for rejection behavior
 		- **Dependencies**: "Task: Add `updateStatus()` to `NotionPublisher`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
 	- [ ] **Task: Wire implementation lifecycle status update call-sites**
 		- **Description**: In `src/core/orchestrator.ts`, add best-effort `implFeedbackPage.updateStatus?.()` calls: before `implementer.implement()` in `_runImplementation` (→ "In progress", only if `impl_feedback_ref` is set), and after implementation completes before `transition(run, 'reviewing_implementation')` (→ "Waiting on feedback"). Add a `Promise.allSettled` block in `_handleImplementationApproval` after a successful PR creation that calls `setPRLink`, `implFeedbackPage.updateStatus('Approved')`, and `specPublisher.updateStatus('Complete')`; log each rejection individually.

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -772,7 +772,7 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] Throws if `pages.updateProperties` rejects
 			- [x] Unit tests cover all valid `SpecEntryStatus` values and rejection propagation
 		- **Dependencies**: "Task: Add `pages.updateProperties()` to `NotionClient`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
-- [ ] **Story: ImplementationFeedbackPage database publishing**
+- [x] **Story: ImplementationFeedbackPage database publishing**
 	- [x] **Task: Add ****`TestingGuideStatus`**** type and update ****`ImplementationFeedbackPage`**** interface**
 		- **Description**: In `src/adapters/notion/implementation-feedback-page.ts`, export `TestingGuideStatus` as `'Not started' | 'In progress' | 'Waiting on feedback' | 'Approved'`. Update the `ImplementationFeedbackPage` interface: add `spec_title: string` as the third parameter to `create()`; add optional `updateStatus?(page_id: string, status: TestingGuideStatus): Promise<void>` and `setPRLink?(page_id: string, pr_url: string): Promise<void>`.
 		- **Acceptance criteria**:
@@ -791,14 +791,14 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] Returns `page_id` from the Notion response
 			- [x] Unit tests cover all cases in the Testing plan section
 		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface"
-	- [ ] **Task: Implement ****`updateStatus()`**** and ****`setPRLink()`**** on ****`NotionImplementationFeedbackPage`**
+	- [x] **Task: Implement ****`updateStatus()`**** and ****`setPRLink()`**** on ****`NotionImplementationFeedbackPage`**
 		- **Description**: Implement `updateStatus(page_id, status)` by calling `pages.updateProperties(page_id, { Status: { status: { name: status } } })` and logging `notion_testing_guide.status_updated`. Implement `setPRLink(page_id, pr_url)` by calling `pages.updateProperties(page_id, { 'PR link': { url: pr_url } })` and logging `notion_testing_guide.pr_link_set`. Both throw if `pages.updateProperties` rejects.
 		- **Acceptance criteria**:
-			- [ ] `updateStatus()` calls `pages.updateProperties` with the correct Status payload
-			- [ ] `setPRLink()` calls `pages.updateProperties` with the correct `PR link` payload
-			- [ ] Both log the appropriate event on success
-			- [ ] Both throw on rejection from `pages.updateProperties`
-			- [ ] Unit tests cover all valid `TestingGuideStatus` values, PR link passthrough, and rejection cases
+			- [x] `updateStatus()` calls `pages.updateProperties` with the correct Status payload
+			- [x] `setPRLink()` calls `pages.updateProperties` with the correct `PR link` payload
+			- [x] Both log the appropriate event on success
+			- [x] Both throw on rejection from `pages.updateProperties`
+			- [x] Unit tests cover all valid `TestingGuideStatus` values, PR link passthrough, and rejection cases
 		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface", "Task: Add `pages.updateProperties()` to `NotionClient`"
 - [ ] **Story: Orchestrator status transitions**
 	- [ ] **Task: Wire spec lifecycle status update call-sites**

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -781,15 +781,15 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] Optional `updateStatus?()` and `setPRLink?()` added to the interface
 			- [x] TypeScript compiles with no errors
 		- **Dependencies**: None
-	- [ ] **Task: Update ****`NotionImplementationFeedbackPage`**** constructor and ****`create()`**** for Testing guides database**
+	- [x] **Task: Update ****`NotionImplementationFeedbackPage`**** constructor and ****`create()`**** for Testing guides database**
 		- **Description**: Add `testing_guides_database_id: string` as the second positional constructor parameter (before `options`). Update `create()` to post with `parent: { type: 'database_id', database_id: testing_guides_database_id }` and set typed properties: Title (`"Testing guide: {spec_title}"`), Spec relation (`[{ id: spec_page_id }]`), Status (`"Not started"`). Page body `children` (bookmark, Summary, Testing instructions, Feedback sections) are unchanged.
 		- **Acceptance criteria**:
-			- [ ] Constructor signature is `(client, testing_guides_database_id, options?)`
-			- [ ] `create()` posts to database parent with the three required properties
-			- [ ] Title passes `spec_title` through verbatim (special characters not escaped)
-			- [ ] `children` blocks are unchanged from the current implementation
-			- [ ] Returns `page_id` from the Notion response
-			- [ ] Unit tests cover all cases in the Testing plan section
+			- [x] Constructor signature is `(client, testing_guides_database_id, options?)`
+			- [x] `create()` posts to database parent with the three required properties
+			- [x] Title passes `spec_title` through verbatim (special characters not escaped)
+			- [x] `children` blocks are unchanged from the current implementation
+			- [x] Returns `page_id` from the Notion response
+			- [x] Unit tests cover all cases in the Testing plan section
 		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface"
 	- [ ] **Task: Implement ****`updateStatus()`**** and ****`setPRLink()`**** on ****`NotionImplementationFeedbackPage`**
 		- **Description**: Implement `updateStatus(page_id, status)` by calling `pages.updateProperties(page_id, { Status: { status: { name: status } } })` and logging `notion_testing_guide.status_updated`. Implement `setPRLink(page_id, pr_url)` by calling `pages.updateProperties(page_id, { 'PR link': { url: pr_url } })` and logging `notion_testing_guide.pr_link_set`. Both throw if `pages.updateProperties` rejects.

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -682,12 +682,12 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 ## Task list
 
 - [ ] **Story: Configuration layer**
-	- [ ] **Task: Update ****`WorkflowConfig.notion`**** type**
+	- [x] **Task: Update ****`WorkflowConfig.notion`**** type**
 		- **Description**: In `src/types/config.ts`, replace the `parent_page_id: string` field with `specs_database_id: string` and `testing_guides_database_id: string`. Remove `parent_page_id` entirely.
 		- **Acceptance criteria**:
-			- [ ] `WorkflowConfig.notion` has `integration_token`, `specs_database_id`, and `testing_guides_database_id` fields
-			- [ ] `parent_page_id` field is removed
-			- [ ] TypeScript compiles with no errors after the change
+			- [x] `WorkflowConfig.notion` has `integration_token`, `specs_database_id`, and `testing_guides_database_id` fields
+			- [x] `parent_page_id` field is removed
+			- [x] TypeScript compiles with no errors after the change
 		- **Dependencies**: None
 	- [ ] **Task: Update startup validation, ****`repo_name`**** derivation, and constructors in ****`src/index.ts`**
 		- **Description**: Replace `parent_page_id` validation with `specs_database_id` + `testing_guides_database_id` validation (exit with a config error if either is missing). Derive `repo_name` from `repo_url` by stripping `.git` and taking the last two path segments joined by `/`. Update `NotionPublisher` and `NotionImplementationFeedbackPage` constructor calls to use the new IDs.

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -1,10 +1,10 @@
 ---
 created: 2026-04-16
 last_updated: 2026-04-16
-status: approved
-issue: null
+status: complete
+issue: 53
 specced_by: markdstafford
-implemented_by: null
+implemented_by: markdstafford
 superseded_by: null
 ---
 # Enhancement: Notion database publishing

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -800,7 +800,7 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] Both throw on rejection from `pages.updateProperties`
 			- [x] Unit tests cover all valid `TestingGuideStatus` values, PR link passthrough, and rejection cases
 		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface", "Task: Add `pages.updateProperties()` to `NotionClient`"
-- [ ] **Story: Orchestrator status transitions**
+- [x] **Story: Orchestrator status transitions**
 	- [x] **Task: Wire spec lifecycle status update call-sites**
 		- **Description**: In `src/core/orchestrator.ts`, add best-effort `specPublisher.updateStatus?.()` calls using optional chaining + `.catch()` at three points: after `transition(run, 'reviewing_spec')` in `_startSpecPipeline` (→ "Waiting on feedback"), after `transition(run, 'speccing')` in `_handleSpecFeedback` (→ "Speccing"), and after successful `specCommitter.commit()` in `_handleSpecApproval` (→ "Approved"). Each failure logs `run.status_update_failed` with `run_id` and target `status` but does not abort the run.
 		- **Acceptance criteria**:
@@ -811,20 +811,20 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] When `specPublisher` is `SlackCanvasPublisher` (no `updateStatus`), optional chaining short-circuits with no error
 			- [x] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and for rejection behavior
 		- **Dependencies**: "Task: Add `updateStatus()` to `NotionPublisher`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
-	- [ ] **Task: Wire implementation lifecycle status update call-sites**
+	- [x] **Task: Wire implementation lifecycle status update call-sites**
 		- **Description**: In `src/core/orchestrator.ts`, add best-effort `implFeedbackPage.updateStatus?.()` calls: before `implementer.implement()` in `_runImplementation` (→ "In progress", only if `impl_feedback_ref` is set), and after implementation completes before `transition(run, 'reviewing_implementation')` (→ "Waiting on feedback"). Add a `Promise.allSettled` block in `_handleImplementationApproval` after a successful PR creation that calls `setPRLink`, `implFeedbackPage.updateStatus('Approved')`, and `specPublisher.updateStatus('Complete')`; log each rejection individually.
 		- **Acceptance criteria**:
-			- [ ] `implFeedbackPage.updateStatus('In progress')` called before `implementer.implement()` when `impl_feedback_ref` is set; not called when unset
-			- [ ] `implFeedbackPage.updateStatus('Waiting on feedback')` called after implementation completes
-			- [ ] `Promise.allSettled` in `_handleImplementationApproval` calls all three updates; one rejection does not prevent the other two
-			- [ ] Each rejection individually logged with `run.status_update_failed`
-			- [ ] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and rejection behavior
+			- [x] `implFeedbackPage.updateStatus('In progress')` called before `implementer.implement()` when `impl_feedback_ref` is set; not called when unset
+			- [x] `implFeedbackPage.updateStatus('Waiting on feedback')` called after implementation completes
+			- [x] `Promise.allSettled` in `_handleImplementationApproval` calls all three updates; one rejection does not prevent the other two
+			- [x] Each rejection individually logged with `run.status_update_failed`
+			- [x] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and rejection behavior
 		- **Dependencies**: "Task: Implement `updateStatus()` and `setPRLink()` on `NotionImplementationFeedbackPage`", "Task: Add `updateStatus()` to `NotionPublisher`"
-	- [ ] **Task: Update ****`implFeedbackPage.create()`**** call with new ****`spec_title`**** parameter**
+	- [x] **Task: Update ****`implFeedbackPage.create()`**** call with new ****`spec_title`**** parameter**
 		- **Description**: In `_runImplementation` in `src/core/orchestrator.ts`, update the `implFeedbackPage.create()` call to pass `titleFromPath(run.spec_path!)` as the new third `spec_title` argument. Add a direct import for `titleFromPath` from `canvas-publisher.ts` if it is not already available in scope.
 		- **Acceptance criteria**:
-			- [ ] `implFeedbackPage.create()` called with `(run.publisher_ref!, specPageUrl, titleFromPath(run.spec_path!), result.summary ?? '', result.testing_instructions ?? '')`
-			- [ ] `titleFromPath` imported and available in `orchestrator.ts`
-			- [ ] TypeScript compiles with no errors
-			- [ ] Existing orchestrator tests updated to include `spec_title` in mock expectations
+			- [x] `implFeedbackPage.create()` called with `(run.publisher_ref!, specPageUrl, titleFromPath(run.spec_path!), result.summary ?? '', result.testing_instructions ?? '')`
+			- [x] `titleFromPath` imported and available in `orchestrator.ts`
+			- [x] TypeScript compiles with no errors
+			- [x] Existing orchestrator tests updated to include `spec_title` in mock expectations
 		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface"

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -726,51 +726,51 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] TypeScript compiles with no errors
 			- [x] Existing `canvas-publisher.test.ts` tests pass unchanged; no new tests required unless existing assertions break
 		- **Dependencies**: None
-- [ ] **Story: NotionPublisher database publishing**
-	- [ ] **Task: Implement ****`parseFrontmatter()`**** private helper**
+- [x] **Story: NotionPublisher database publishing**
+	- [x] **Task: Implement ****`parseFrontmatter()`**** private helper**
 		- **Description**: Add a private `parseFrontmatter(spec_path: string): Record<string, unknown>` method to `NotionPublisher`. Reads the file, extracts the YAML block between the first pair of `---` delimiters, and parses it with the `yaml` package. Returns `{}` when no frontmatter block is found, the block is empty, or YAML parsing fails.
 		- **Acceptance criteria**:
-			- [ ] Returns all frontmatter fields as a `Record<string, unknown>` when present
-			- [ ] Returns `{}` for files with no `---` delimiters, empty frontmatter block, or YAML parse error
-			- [ ] `issue: null` parses as `null`; `issue: 42` parses as the number `42` (not a string)
-			- [ ] Extra/unknown frontmatter fields are included in the returned map without filtering
-			- [ ] Unit tests cover all cases in the Testing plan section
+			- [x] Returns all frontmatter fields as a `Record<string, unknown>` when present
+			- [x] Returns `{}` for files with no `---` delimiters, empty frontmatter block, or YAML parse error
+			- [x] `issue: null` parses as `null`; `issue: 42` parses as the number `42` (not a string)
+			- [x] Extra/unknown frontmatter fields are included in the returned map without filtering
+			- [x] Unit tests cover all cases in the Testing plan section
 		- **Dependencies**: None
-	- [ ] **Task: Implement ****`resolveFilenameToPageId()`**** private helper**
+	- [x] **Task: Implement ****`resolveFilenameToPageId()`**** private helper**
 		- **Description**: Add a private `resolveFilenameToPageId(filename: string): Promise<string | undefined>` method to `NotionPublisher`. Queries the Specs database filtering by `Filename` equals `filename`. Returns `results[0].id` if found; returns `undefined` and logs `notion_spec.filename_lookup_failed` at warn if no results. Propagates rejection from `databases.query`.
 		- **Acceptance criteria**:
-			- [ ] Returns the first result's `id` when one or more results are found
-			- [ ] Returns `undefined` and logs `notion_spec.filename_lookup_failed` with the filename when results are empty
-			- [ ] Rejection from `databases.query` propagates to the caller (not swallowed)
-			- [ ] Unit tests cover all cases in the Testing plan section
+			- [x] Returns the first result's `id` when one or more results are found
+			- [x] Returns `undefined` and logs `notion_spec.filename_lookup_failed` with the filename when results are empty
+			- [x] Rejection from `databases.query` propagates to the caller (not swallowed)
+			- [x] Unit tests cover all cases in the Testing plan section
 		- **Dependencies**: "Task: Add `databases.query()` to `NotionClient`"
-	- [ ] **Task: Update ****`create()`**** to publish as Specs database entry with typed properties**
+	- [x] **Task: Update ****`create()`**** to publish as Specs database entry with typed properties**
 		- **Description**: Update `NotionPublisher.create()` to call `pages.create` with `parent: { database_id: specs_database_id }` and typed properties built from parsed frontmatter: Title, Filename, Status ("Speccing"), Specced by, Repo/Codebase (only if `repo_name` is in options), Issue # (only if non-null), Last updated, Implemented by (only if non-null), and Superseded by / Supersedes (resolved via `resolveFilenameToPageId()` if `supersedes` is set in frontmatter). Markdown write and Slack postMessage steps are unchanged.
 		- **Acceptance criteria**:
-			- [ ] `pages.create` called with `parent: { database_id: specs_database_id }`, not `page_id`
-			- [ ] All properties set as specified in the Design changes section
-			- [ ] Optional properties omitted (not set to null/empty) when their frontmatter values are absent
-			- [ ] When `supersedes` filename is not found in the database, `notion_spec.filename_lookup_failed` is logged and `pages.create` still succeeds without the relation property
-			- [ ] Unit tests cover all cases in the Testing plan section
+			- [x] `pages.create` called with `parent: { database_id: specs_database_id }`, not `page_id`
+			- [x] All properties set as specified in the Design changes section
+			- [x] Optional properties omitted (not set to null/empty) when their frontmatter values are absent
+			- [x] When `supersedes` filename is not found in the database, `notion_spec.filename_lookup_failed` is logged and `pages.create` still succeeds without the relation property
+			- [x] Unit tests cover all cases in the Testing plan section
 		- **Dependencies**: "Task: Implement `parseFrontmatter()` private helper", "Task: Implement `resolveFilenameToPageId()` private helper", "Task: Update `WorkflowConfig.notion` type"
-	- [ ] **Task: Update ****`update()`**** to sync frontmatter properties**
+	- [x] **Task: Update ****`update()`**** to sync frontmatter properties**
 		- **Description**: After the existing Markdown write in `NotionPublisher.update()`, call `pages.updateProperties()` to sync `last_updated` and `implemented_by` from freshly-parsed frontmatter. If `superseded_by` is now set in frontmatter, also update Status to `"Superseded"` and set the Superseded by / Supersedes relation (resolved via `resolveFilenameToPageId()`). Always call `pages.updateProperties()` — no diffing.
 		- **Acceptance criteria**:
-			- [ ] `pages.updateProperties()` called after Markdown write with `last_updated` and `implemented_by`
-			- [ ] `implemented_by` key omitted from payload when absent from frontmatter
-			- [ ] `superseded_by` set in frontmatter: Status updated to `"Superseded"` and relation set when filename resolves
-			- [ ] `superseded_by` set but filename not found: `last_updated`/`implemented_by` still synced; Status not changed; `notion_spec.filename_lookup_failed` logged
-			- [ ] No diffing — `pages.updateProperties()` called even when frontmatter is unchanged
-			- [ ] Unit tests cover all cases in the Testing plan section
+			- [x] `pages.updateProperties()` called after Markdown write with `last_updated` and `implemented_by`
+			- [x] `implemented_by` key omitted from payload when absent from frontmatter
+			- [x] `superseded_by` set in frontmatter: Status updated to `"Superseded"` and relation set when filename resolves
+			- [x] `superseded_by` set but filename not found: `last_updated`/`implemented_by` still synced; Status not changed; `notion_spec.filename_lookup_failed` logged
+			- [x] No diffing — `pages.updateProperties()` called even when frontmatter is unchanged
+			- [x] Unit tests cover all cases in the Testing plan section
 		- **Dependencies**: "Task: Implement `parseFrontmatter()` private helper", "Task: Implement `resolveFilenameToPageId()` private helper", "Task: Add `pages.updateProperties()` to `NotionClient`"
-	- [ ] **Task: Add ****`updateStatus()`**** to ****`NotionPublisher`**
+	- [x] **Task: Add ****`updateStatus()`**** to ****`NotionPublisher`**
 		- **Description**: Add a public `updateStatus(page_id: string, status: SpecEntryStatus): Promise<void>` method to `NotionPublisher`. Calls `pages.updateProperties(page_id, { Status: { status: { name: status } } })` and logs `notion_spec.status_updated` with `page_id` and `status`. Throws if `pages.updateProperties` rejects.
 		- **Acceptance criteria**:
-			- [ ] Method satisfies the optional `updateStatus?()` signature on the `SpecPublisher` interface
-			- [ ] Calls `pages.updateProperties` with the correct Status payload structure
-			- [ ] Logs `notion_spec.status_updated` on success
-			- [ ] Throws if `pages.updateProperties` rejects
-			- [ ] Unit tests cover all valid `SpecEntryStatus` values and rejection propagation
+			- [x] Method satisfies the optional `updateStatus?()` signature on the `SpecPublisher` interface
+			- [x] Calls `pages.updateProperties` with the correct Status payload structure
+			- [x] Logs `notion_spec.status_updated` on success
+			- [x] Throws if `pages.updateProperties` rejects
+			- [x] Unit tests cover all valid `SpecEntryStatus` values and rejection propagation
 		- **Dependencies**: "Task: Add `pages.updateProperties()` to `NotionClient`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
 - [ ] **Story: ImplementationFeedbackPage database publishing**
 	- [x] **Task: Add ****`TestingGuideStatus`**** type and update ****`ImplementationFeedbackPage`**** interface**

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -698,23 +698,23 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [ ] `NotionImplementationFeedbackPage` constructed with `(notionClient, testingGuidesDatabaseId)`
 			- [ ] Unit tests cover: both IDs present (no exit), one absent (exit), both absent (exit), `notion` block absent entirely, all four `repo_url` format variants
 		- **Dependencies**: "Task: Update `WorkflowConfig.notion` type"
-- [ ] **Story: NotionClient API extensions**
-	- [ ] **Task: Add ****`pages.updateProperties()`**** to ****`NotionClient`**
+- [x] **Story: NotionClient API extensions**
+	- [x] **Task: Add ****`pages.updateProperties()`**** to ****`NotionClient`**
 		- **Description**: Add `updateProperties(page_id: string, properties: Record<string, unknown>): Promise<void>` to the `NotionClient` interface and implement it in `NotionClientImpl` via the Notion SDK's `pages.update()` method. The properties payload is passed through unchanged.
 		- **Acceptance criteria**:
-			- [ ] Method added to `NotionClient` interface in `src/adapters/notion/notion-client.ts`
-			- [ ] `NotionClientImpl.pages.updateProperties` calls `this.client.pages.update({ page_id, properties })` as a passthrough
-			- [ ] Rejection from the SDK propagates to the caller
-			- [ ] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
+			- [x] Method added to `NotionClient` interface in `src/adapters/notion/notion-client.ts`
+			- [x] `NotionClientImpl.pages.updateProperties` calls `this.client.pages.update({ page_id, properties })` as a passthrough
+			- [x] Rejection from the SDK propagates to the caller
+			- [x] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
 		- **Dependencies**: None
-	- [ ] **Task: Add ****`databases.query()`**** to ****`NotionClient`**
+	- [x] **Task: Add ****`databases.query()`**** to ****`NotionClient`**
 		- **Description**: Add a `databases` namespace to `NotionClient` with `query(database_id: string, filter?: unknown): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>`. Implement in `NotionClientImpl` via the Notion SDK's `databases.query()` method. Calling without a filter must not error.
 		- **Acceptance criteria**:
-			- [ ] Method added to `NotionClient` interface
-			- [ ] `NotionClientImpl.databases.query` calls the SDK and returns the `results` array shaped as specified
-			- [ ] Calling without a filter does not error
-			- [ ] Rejection from the SDK propagates to the caller
-			- [ ] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
+			- [x] Method added to `NotionClient` interface
+			- [x] `NotionClientImpl.databases.query` calls the SDK and returns the `results` array shaped as specified
+			- [x] Calling without a filter does not error
+			- [x] Rejection from the SDK propagates to the caller
+			- [x] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
 		- **Dependencies**: None
 - [x] **Story: SpecPublisher interface extension**
 	- [x] **Task: Export ****`SpecEntryStatus`**** type and add optional ****`updateStatus?()`**** to ****`SpecPublisher`**

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -773,13 +773,13 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [ ] Unit tests cover all valid `SpecEntryStatus` values and rejection propagation
 		- **Dependencies**: "Task: Add `pages.updateProperties()` to `NotionClient`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
 - [ ] **Story: ImplementationFeedbackPage database publishing**
-	- [ ] **Task: Add ****`TestingGuideStatus`**** type and update ****`ImplementationFeedbackPage`**** interface**
+	- [x] **Task: Add ****`TestingGuideStatus`**** type and update ****`ImplementationFeedbackPage`**** interface**
 		- **Description**: In `src/adapters/notion/implementation-feedback-page.ts`, export `TestingGuideStatus` as `'Not started' | 'In progress' | 'Waiting on feedback' | 'Approved'`. Update the `ImplementationFeedbackPage` interface: add `spec_title: string` as the third parameter to `create()`; add optional `updateStatus?(page_id: string, status: TestingGuideStatus): Promise<void>` and `setPRLink?(page_id: string, pr_url: string): Promise<void>`.
 		- **Acceptance criteria**:
-			- [ ] `TestingGuideStatus` type exported
-			- [ ] `ImplementationFeedbackPage.create()` signature updated with `spec_title` as third parameter
-			- [ ] Optional `updateStatus?()` and `setPRLink?()` added to the interface
-			- [ ] TypeScript compiles with no errors
+			- [x] `TestingGuideStatus` type exported
+			- [x] `ImplementationFeedbackPage.create()` signature updated with `spec_title` as third parameter
+			- [x] Optional `updateStatus?()` and `setPRLink?()` added to the interface
+			- [x] TypeScript compiles with no errors
 		- **Dependencies**: None
 	- [ ] **Task: Update ****`NotionImplementationFeedbackPage`**** constructor and ****`create()`**** for Testing guides database**
 		- **Description**: Add `testing_guides_database_id: string` as the second positional constructor parameter (before `options`). Update `create()` to post with `parent: { type: 'database_id', database_id: testing_guides_database_id }` and set typed properties: Title (`"Testing guide: {spec_title}"`), Spec relation (`[{ id: spec_page_id }]`), Status (`"Not started"`). Page body `children` (bookmark, Summary, Testing instructions, Feedback sections) are unchanged.

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -681,7 +681,7 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 **Select option auto-creation**: Notion's select property auto-creates new options when a value not already in the option list is used. If `repo_name` produces an unexpected value or the Repo/Codebase option list is locked, the `pages.create()` call may fail or create an unintended option. Mitigation: `repo_name` is derived deterministically from `repo_url` in `org/repo` format; operators should confirm the value matches an existing option or allow auto-creation.
 ## Task list
 
-- [ ] **Story: Configuration layer**
+- [x] **Story: Configuration layer**
 	- [x] **Task: Update ****`WorkflowConfig.notion`**** type**
 		- **Description**: In `src/types/config.ts`, replace the `parent_page_id: string` field with `specs_database_id: string` and `testing_guides_database_id: string`. Remove `parent_page_id` entirely.
 		- **Acceptance criteria**:
@@ -689,14 +689,14 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] `parent_page_id` field is removed
 			- [x] TypeScript compiles with no errors after the change
 		- **Dependencies**: None
-	- [ ] **Task: Update startup validation, ****`repo_name`**** derivation, and constructors in ****`src/index.ts`**
+	- [x] **Task: Update startup validation, ****`repo_name`**** derivation, and constructors in ****`src/index.ts`**
 		- **Description**: Replace `parent_page_id` validation with `specs_database_id` + `testing_guides_database_id` validation (exit with a config error if either is missing). Derive `repo_name` from `repo_url` by stripping `.git` and taking the last two path segments joined by `/`. Update `NotionPublisher` and `NotionImplementationFeedbackPage` constructor calls to use the new IDs.
 		- **Acceptance criteria**:
-			- [ ] Process exits with a config error if either `specs_database_id` or `testing_guides_database_id` is missing from the `notion` block
-			- [ ] `repo_name` is derived as `org/repo` from HTTPS and SSH `repo_url` formats, with and without `.git` suffix
-			- [ ] `NotionPublisher` constructed with `(notionClient, boltApp, specsDatabaseId, { repo_name })`
-			- [ ] `NotionImplementationFeedbackPage` constructed with `(notionClient, testingGuidesDatabaseId)`
-			- [ ] Unit tests cover: both IDs present (no exit), one absent (exit), both absent (exit), `notion` block absent entirely, all four `repo_url` format variants
+			- [x] Process exits with a config error if either `specs_database_id` or `testing_guides_database_id` is missing from the `notion` block
+			- [x] `repo_name` is derived as `org/repo` from HTTPS and SSH `repo_url` formats, with and without `.git` suffix
+			- [x] `NotionPublisher` constructed with `(notionClient, boltApp, specsDatabaseId, { repo_name })`
+			- [x] `NotionImplementationFeedbackPage` constructed with `(notionClient, testingGuidesDatabaseId)`
+			- [x] Unit tests cover: both IDs present (no exit), one absent (exit), both absent (exit), `notion` block absent entirely, all four `repo_url` format variants
 		- **Dependencies**: "Task: Update `WorkflowConfig.notion` type"
 - [x] **Story: NotionClient API extensions**
 	- [x] **Task: Add ****`pages.updateProperties()`**** to ****`NotionClient`**

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -716,15 +716,15 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [ ] Rejection from the SDK propagates to the caller
 			- [ ] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
 		- **Dependencies**: None
-- [ ] **Story: SpecPublisher interface extension**
-	- [ ] **Task: Export ****`SpecEntryStatus`**** type and add optional ****`updateStatus?()`**** to ****`SpecPublisher`**
+- [x] **Story: SpecPublisher interface extension**
+	- [x] **Task: Export ****`SpecEntryStatus`**** type and add optional ****`updateStatus?()`**** to ****`SpecPublisher`**
 		- **Description**: In `src/adapters/slack/canvas-publisher.ts`, export `SpecEntryStatus` as `'Speccing' | 'Waiting on feedback' | 'Approved' | 'Complete' | 'Superseded'`. Add optional `updateStatus?(publisher_ref: string, status: SpecEntryStatus): Promise<void>` to the `SpecPublisher` interface. `SlackCanvasPublisher` must not declare this method — all call-sites use optional chaining.
 		- **Acceptance criteria**:
-			- [ ] `SpecEntryStatus` type exported from `canvas-publisher.ts`
-			- [ ] `SpecPublisher` interface has optional `updateStatus?()` with the correct signature
-			- [ ] `SlackCanvasPublisher` does not declare `updateStatus` (method absent on instances)
-			- [ ] TypeScript compiles with no errors
-			- [ ] Existing `canvas-publisher.test.ts` tests pass unchanged; no new tests required unless existing assertions break
+			- [x] `SpecEntryStatus` type exported from `canvas-publisher.ts`
+			- [x] `SpecPublisher` interface has optional `updateStatus?()` with the correct signature
+			- [x] `SlackCanvasPublisher` does not declare `updateStatus` (method absent on instances)
+			- [x] TypeScript compiles with no errors
+			- [x] Existing `canvas-publisher.test.ts` tests pass unchanged; no new tests required unless existing assertions break
 		- **Dependencies**: None
 - [ ] **Story: NotionPublisher database publishing**
 	- [ ] **Task: Implement ****`parseFrontmatter()`**** private helper**

--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -1,0 +1,830 @@
+---
+created: 2026-04-16
+last_updated: 2026-04-16
+status: approved
+issue: null
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+# Enhancement: Notion database publishing
+
+## Parent feature
+
+`enhancement-notion-publisher.md` — Notion publisher
+## What
+
+Instead of writing specs and testing guides as plain child pages under a configured parent page, Autocatalyst creates them as structured entries in two dedicated Notion databases: a "Specs" database and a "Testing guides" database. Each spec entry carries typed properties populated from the spec's frontmatter — title, filename, status, specced by, repo/codebase, and issue number. When a spec is committed (approved), its Specs database entry Status is updated to "Approved". Testing guide entries are created in the Testing guides database with a relation back to the corresponding Specs entry, wiring the dual-property link that Notion maintains automatically. The `parent_page_id` configuration field is replaced by `specs_database_id` and `testing_guides_database_id`.
+## Why
+
+The Specs and Testing guides databases exist to be the structured home for these artifacts — they have the right columns, relations, and views already in place. Writing to them as proper database entries makes the full corpus queryable: team members can filter by Status to find all in-progress specs, sort by creation date, and navigate from a spec entry directly to its testing guide via the built-in relation without hunting through a page tree. It also makes Autocatalyst a first-class contributor to the team's existing workflow rather than a parallel, unstructured pile of pages.
+## User stories
+
+- Phoebe can see a new spec entry appear in the Specs database with Status "Speccing" as soon as Autocatalyst generates it, without any manual steps
+- Phoebe can filter the Specs database by Status and immediately see which specs are actively being specced, waiting on feedback, or approved
+- Phoebe can see the spec entry Status change to "Approved" automatically when the spec is committed, and "Complete" when the implementation is approved
+- Phoebe can see the spec entry Status change to "Superseded" automatically when the spec is superseded
+- Enzo can open a spec entry and navigate to its linked testing guide directly from the Testing guide relation property
+- Enzo can open the Testing guides database and see the corresponding Spec relation on each entry pointing back to the source spec
+- Enzo can see the testing guide Status update automatically as implementation work progresses
+- Mark (operator) can wire up the integration by adding two database IDs and the integration token to [WORKFLOW.md](http://WORKFLOW.md) — no code changes required
+## Design changes
+
+This enhancement has no user-facing UI changes. The design changes describe the Notion artifact structure that team members see when browsing the two databases.
+### Specs database entry structure
+
+Each spec generates one entry in the Specs database. Autocatalyst sets the following properties at creation and updates them on revision:
+<table header-row="true">
+<tr>
+<td>Property</td>
+<td>Type</td>
+<td>Value set by Autocatalyst</td>
+</tr>
+<tr>
+<td>**Title**</td>
+<td>Title</td>
+<td>Spec title derived from the spec filename (same titleFromPath logic as today — e.g., `feature-setup-wizard.md` → "Setup wizard")</td>
+</tr>
+<tr>
+<td>**Filename**</td>
+<td>Rich text</td>
+<td>Basename of the spec file (e.g., `feature-setup-wizard.md`); used to resolve `supersedes` and `superseded_by` relation links from other spec entries</td>
+</tr>
+<tr>
+<td>**Status**</td>
+<td>Status</td>
+<td>"Speccing" on creation; see status lifecycle below</td>
+</tr>
+<tr>
+<td>**Specced by**</td>
+<td>Rich text</td>
+<td>Value of `specced_by` from spec frontmatter</td>
+</tr>
+<tr>
+<td>**Repo / Codebase**</td>
+<td>Select</td>
+<td>org/repo derived from the last two path segments of `repo_url` (e.g., `acme-org/autocatalyst`); omitted if `repo_name` is not provided in `NotionPublisherOptions`</td>
+</tr>
+<tr>
+<td>**Issue #**</td>
+<td>Number</td>
+<td>Value of `issue` from spec frontmatter, if set; omitted otherwise</td>
+</tr>
+<tr>
+<td>**Last updated**</td>
+<td>Date</td>
+<td>Value of `last_updated` from spec frontmatter</td>
+</tr>
+<tr>
+<td>**Implemented by**</td>
+<td>Rich text</td>
+<td>Value of `implemented_by` from spec frontmatter, if set; omitted otherwise</td>
+</tr>
+<tr>
+<td>**Superseded by / Supersedes**</td>
+<td>Relation</td>
+<td>Values of `superseded_by` and `supersedes` from spec frontmatter, if set; each is a spec filename resolved by querying the Specs database `Filename` property, then linked as a relation</td>
+</tr>
+</table>
+The following properties are **not set by Autocatalyst** — they are either auto-managed by Notion or populated manually by the team:
+<table header-row="true">
+<tr>
+<td>Property</td>
+<td>How it's populated</td>
+</tr>
+<tr>
+<td>**Created**</td>
+<td>Auto-set by Notion (created_time)</td>
+</tr>
+<tr>
+<td>**Testing guide**</td>
+<td>Populated automatically via the dual-property relation when a testing guide entry is created with the Spec relation pointing to this entry</td>
+</tr>
+<tr>
+<td>**Links**</td>
+<td>Set manually by the team</td>
+</tr>
+</table>
+**Status lifecycle**: The Status property reflects where the spec is in its lifecycle. Autocatalyst manages all transitions:
+<table header-row="true">
+<tr>
+<td>Event</td>
+<td>Status transition</td>
+</tr>
+<tr>
+<td>Spec created</td>
+<td>→ "Speccing"</td>
+</tr>
+<tr>
+<td>Agent stops working, spec not yet approved</td>
+<td>→ "Waiting on feedback"</td>
+</tr>
+<tr>
+<td>Agent resumes working on spec</td>
+<td>→ "Speccing"</td>
+</tr>
+<tr>
+<td>Spec committed (approved via `SpecCommitter`)</td>
+<td>→ "Approved"</td>
+</tr>
+<tr>
+<td>Implementation approved</td>
+<td>→ "Complete"</td>
+</tr>
+<tr>
+<td>Spec superseded (`superseded_by` set in frontmatter)</td>
+<td>→ "Superseded"</td>
+</tr>
+</table>
+**Entry page body**: The full spec Markdown including frontmatter is written to the entry's page body via the Notion Markdown API — identical to the current behavior. Inline comment anchors, span passthrough, and revision behavior are unchanged.
+---
+### Testing guides database entry structure
+
+Each testing guide generates one entry in the Testing guides database. Autocatalyst sets the following properties at creation:
+<table header-row="true">
+<tr>
+<td>Property</td>
+<td>Type</td>
+<td>Value set by Autocatalyst</td>
+</tr>
+<tr>
+<td>**Title**</td>
+<td>Title</td>
+<td>"Testing guide: \{spec title\}" — derived from the associated spec title</td>
+</tr>
+<tr>
+<td>**Spec**</td>
+<td>Relation</td>
+<td>The Notion page ID of the corresponding Specs database entry</td>
+</tr>
+<tr>
+<td>**Status**</td>
+<td>Status</td>
+<td>Set automatically by Autocatalyst; see status lifecycle below</td>
+</tr>
+<tr>
+<td>**PR link**</td>
+<td>URL</td>
+<td>Set automatically by Autocatalyst when the implementation PR is created</td>
+</tr>
+</table>
+All other properties are either auto-managed by Notion or populated manually:
+<table header-row="true">
+<tr>
+<td>Property</td>
+<td>How it's populated</td>
+</tr>
+<tr>
+<td>**Created**</td>
+<td>Auto-set by Notion (created_time)</td>
+</tr>
+<tr>
+<td>**Last updated**</td>
+<td>Auto-set by Notion on every edit (last_edited_time)</td>
+</tr>
+<tr>
+<td>**Implemented by**</td>
+<td>Set manually by the team</td>
+</tr>
+<tr>
+<td>**Test plan complete**</td>
+<td>Checked manually by the team</td>
+</tr>
+</table>
+**Status lifecycle**: Autocatalyst manages the testing guide Status to reflect the state of implementation work:
+<table header-row="true">
+<tr>
+<td>Event</td>
+<td>Status transition</td>
+</tr>
+<tr>
+<td>Testing guide created</td>
+<td>→ "Not started"</td>
+</tr>
+<tr>
+<td>Agent starts working on implementation</td>
+<td>→ "In progress"</td>
+</tr>
+<tr>
+<td>Agent stops working on implementation</td>
+<td>→ "Waiting on feedback"</td>
+</tr>
+<tr>
+<td>Implementation approved</td>
+<td>→ "Approved"</td>
+</tr>
+</table>
+**Spec relation and dual-property sync**: Setting the `Spec` relation on a testing guide entry automatically populates the `Testing guide` relation on the linked Specs entry — this is Notion's dual-property relation behavior and requires no additional API call from Autocatalyst.
+**Entry page body**: Same structure as today — a spec link bookmark, a Summary section, a Testing instructions section, and a Feedback section with to-do items. No changes to content or layout.
+---
+### Configuration delta
+
+`WORKFLOW.md` gains two new fields and the integration token under the `notion` block. The existing `parent_page_id` field is removed.
+**Before:**
+```yaml
+notion:
+  parent_page_id: <page-id>
+# Note: Set AC_NOTION_INTEGRATION_TOKEN as an environment variable (not in this file)
+
+```
+**After:**
+```yaml
+notion:
+  integration_token: ${AC_NOTION_INTEGRATION_TOKEN}
+  specs_database_id: <specs-database-id>
+  testing_guides_database_id: <testing-guides-database-id>
+```
+The integration token (`AC_NOTION_INTEGRATION_TOKEN`) is added to the `notion` block in [WORKFLOW.md](http://WORKFLOW.md) as `integration_token: ${AC_NOTION_INTEGRATION_TOKEN}`, following the same pattern as the Slack tokens.
+## Technical changes
+
+### Affected files
+
+- `src/types/config.ts` — `notion` block updated: `parent_page_id` replaced by `specs_database_id` + `testing_guides_database_id`
+- `src/adapters/notion/notion-client.ts` — add `pages.updateProperties()` and `databases.query()` methods
+- `src/adapters/slack/canvas-publisher.ts` — `SpecPublisher` interface gains optional `updateStatus?()` method; `SpecEntryStatus` type exported (note: markdstafford/autocatalyst#50 tracks extracting `SpecPublisher` to a neutral location — out of scope here)
+- `src/adapters/notion/notion-publisher.ts` — constructor updated; `create()` creates database entry with typed properties; `update()` also syncs frontmatter properties; `updateStatus()` added
+- `src/adapters/notion/implementation-feedback-page.ts` — constructor gains `testing_guides_database_id` as second positional parameter; `create()` signature updated; `updateStatus()` and `setPRLink()` added; `ImplementationFeedbackPage` interface updated
+- `src/core/orchestrator.ts` — status update calls added at lifecycle transitions; `implFeedbackPage.create()` call updated with new `spec_title` parameter
+- `src/index.ts` — config validation updated; `repo_name` derived from `repo_url`; constructors updated
+### Changes
+
+This enhancement is a delta on the parent feature (`enhancement-notion-publisher.md`). All changes are additive or substitutive within the Notion adapter layer — no new agent interactions, no new Slack interactions, no changes to the workspace or spec generation pipeline.
+The core substitution: `pages.create()` with `parent: { page_id }` → `pages.create()` with `parent: { database_id }` plus typed properties. The Markdown content write and revision flow are unchanged.
+## Tech spec
+
+### 1. Introduction and overview
+
+**Dependencies**
+- Enhancement: Notion publisher — provides all Notion infrastructure (NotionClient, NotionPublisher, NotionFeedbackSource, ImplementationFeedbackPage, spec committer, Markdown API, comment handling). This enhancement is a delta on top of it; all of that infrastructure is assumed to be in place.
+- The Specs and Testing guides databases must exist in Notion with the schema described in the Design changes section. Autocatalyst does not create or validate database schemas at startup.
+**Technical goals**
+- Specs created as entries in `specs_database_id` with typed properties sourced from spec frontmatter
+- Testing guides created as entries in `testing_guides_database_id` with a Spec relation pointing to the corresponding Specs entry
+- Status properties updated at each lifecycle event via the Orchestrator (Speccing, Waiting on feedback, Approved, Complete, Superseded)
+- `supersedes` / `superseded_by` frontmatter filenames resolved to Notion page IDs by querying the Specs database `Filename` property
+- `parent_page_id` config removed; `specs_database_id` and `testing_guides_database_id` take its place
+- Markdown content, span passthrough, comment handling, and revision flow unchanged
+**Non-goals**
+- Migrating existing Notion pages created under `parent_page_id` to the new databases
+- Validating the database schema at startup — Autocatalyst surfaces schema mismatches as Notion API errors on first run
+- Automating testing guide Status updates for teams not using the implementation workflow
+### 2. System design and architecture
+
+**Modified components**
+- `src/types/config.ts` — `WorkflowConfig.notion` updated
+- `src/adapters/notion/notion-client.ts` — two new methods on `NotionClient` interface and `NotionClientImpl`
+- `src/adapters/slack/canvas-publisher.ts` — `SpecPublisher` interface extended with optional `updateStatus?()`; `SpecEntryStatus` type added. `SpecPublisher` is currently defined in `canvas-publisher.ts` because that is where the `SlackCanvasPublisher` implementation lives. This is acknowledged as a sub-optimal placement; markdstafford/autocatalyst#50 tracks extracting it to a neutral location and is out of scope here.
+- `src/adapters/notion/notion-publisher.ts` — constructor, `create()`, `update()` updated; `updateStatus()` added
+- `src/adapters/notion/implementation-feedback-page.ts` — constructor, `create()` updated; `updateStatus()`, `setPRLink()` added
+- `src/core/orchestrator.ts` — status update call-sites added at each lifecycle transition
+- `src/index.ts` — config validation, `repo_name` derivation, constructor calls updated
+No new files.
+### 3. Detailed design
+
+**Updated config types**
+```typescript
+// src/types/config.ts
+export interface WorkflowConfig {
+  // ...existing fields unchanged
+  notion?: {
+    integration_token: string;
+    specs_database_id: string;          // replaces parent_page_id
+    testing_guides_database_id: string; // new
+  };
+}
+```
+**NotionClient additions**
+```typescript
+// src/adapters/notion/notion-client.ts — additions to interface and NotionClientImpl
+export interface NotionClient {
+  // ...existing methods unchanged
+  pages: {
+    create(args: CreatePageParameters): Promise<CreatePageResponse>;
+    getMarkdown(page_id: string): Promise<string>;
+    updateMarkdown(page_id: string, operation: MarkdownOperation): Promise<void>;
+    updateProperties(page_id: string, properties: Record<string, unknown>): Promise<void>; // new
+  };
+  databases: {
+    query(                                                                                  // new
+      database_id: string,
+      filter?: unknown,
+    ): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>;
+  };
+}
+```
+`pages.updateProperties` sends `PATCH /v1/pages/{page_id}` with `{ properties }`. Implemented via the Notion SDK's `pages.update()` method.
+`databases.query` sends `POST /v1/databases/{database_id}/query` with an optional filter body. Implemented via the SDK's `databases.query()` method.
+**SpecPublisher interface extension**
+```typescript
+// src/adapters/slack/canvas-publisher.ts
+export type SpecEntryStatus =
+  | 'Speccing'
+  | 'Waiting on feedback'
+  | 'Approved'
+  | 'Complete'
+  | 'Superseded';
+
+export interface SpecPublisher {
+  create(channel_id: string, thread_ts: string, spec_path: string): Promise<string>;
+  update(publisher_ref: string, spec_path: string, page_content?: string): Promise<void>;
+  getPageMarkdown(publisher_ref: string): Promise<string>;
+  updateStatus?(publisher_ref: string, status: SpecEntryStatus): Promise<void>; // new; not implemented by SlackCanvasPublisher
+}
+```
+`SlackCanvasPublisher` does not implement `updateStatus` (the method is absent on instances). All call-sites use optional chaining: `await this.deps.specPublisher.updateStatus?.(publisher_ref, status)`.
+**NotionPublisher changes**
+**What goes in options vs. positional**: `client`, `app`, and `specs_database_id` are positional — they are the core dependencies and the primary operational target the component needs to function. `repo_name` is a presentational configuration value (used only to populate the `Repo / Codebase` property); it goes in `NotionPublisherOptions`. This keeps the positional signature stable and consistent with the current `(client, app, parent_page_id)` shape.
+Constructor signature:
+```typescript
+constructor(
+  client: NotionClient,
+  app: App,
+  specs_database_id: string,  // replaces parent_page_id
+  options?: NotionPublisherOptions,
+)
+```
+`NotionPublisherOptions` gains `repo_name?: string` alongside the existing `logDestination`. If `repo_name` is absent, the `Repo / Codebase` property is omitted from the `pages.create()` call.
+`create()` changes:
+1. Read spec from `spec_path`; parse YAML frontmatter via private `parseFrontmatter()` helper
+2. Derive `title` via `titleFromPath(spec_path)` and `filename` via `basename(spec_path)`
+3. Build `properties` object for the Notion API call:
+	- `Title`: title property with derived title
+	- `Filename`: rich_text property with spec filename
+	- `Status`: status property set to `"Speccing"`
+	- `Specced by`: rich_text from `frontmatter['specced_by']`
+	- `Repo / Codebase`: select from `options.repo_name` (omit key if absent)
+	- `Issue #`: number from `frontmatter['issue']` (omit key if null/undefined)
+	- `Last updated`: date from `frontmatter['last_updated']`
+	- `Implemented by`: rich_text from `frontmatter['implemented_by']` (omit key if null/undefined)
+	- `Superseded by / Supersedes`: relation resolved via `resolveFilenameToPageId()` if `frontmatter['supersedes']` is set
+4. `POST /v1/pages` with `parent: { database_id: specs_database_id }` and properties — no children
+5. `PATCH /v1/pages/<page_id>/markdown` with `replace_content` (unchanged from parent feature)
+6. Post Slack message with Notion page URL (unchanged)
+7. Return `page_id`
+`update()` changes: after writing Markdown as today, additionally call `pages.updateProperties()` to sync the following from freshly-parsed frontmatter: `last_updated`, `implemented_by`. If `superseded_by` is now set in frontmatter, also call `pages.updateProperties()` with Status `"Superseded"` and the Superseded by / Supersedes relation (resolved via `resolveFilenameToPageId()`).
+`updateStatus(page_id, status)` (new):
+```typescript
+async updateStatus(page_id: string, status: SpecEntryStatus): Promise<void> {
+  await this.client.pages.updateProperties(page_id, {
+    Status: { status: { name: status } },
+  });
+}
+```
+`resolveFilenameToPageId(filename)` (private):
+1. Call `databases.query(specs_database_id, { filter: { property: 'Filename', rich_text: { equals: filename } } })`
+2. Return `results[0].id` if found
+3. Return `undefined` and log `notion_spec.filename_lookup_failed` at `warn` level if not found; callers skip the relation update gracefully
+`parseFrontmatter(spec_path)` (private): reads the file, extracts the YAML block between `---` delimiters, parses with the `yaml` package (already a project dependency). Returns a map (`Record<string, unknown>`) of all YAML frontmatter fields. Callers access specific keys by name with appropriate type coercion (e.g., `String(frontmatter['specced_by'] ?? '')`). Returns `{}` gracefully if frontmatter is absent or the YAML block is empty.
+**ImplementationFeedbackPage changes**
+`NotionImplementationFeedbackPage` constructor gains `testing_guides_database_id: string` as a **second positional parameter**, consistent with how `parent_page_id` was positional in `NotionPublisher`. The `options` parameter (currently `{ logDestination? }`) is unchanged.
+Updated interface:
+```typescript
+// src/adapters/notion/implementation-feedback-page.ts
+export type TestingGuideStatus =
+  | 'Not started'
+  | 'In progress'
+  | 'Waiting on feedback'
+  | 'Approved';
+
+export interface ImplementationFeedbackPage {
+  create(
+    spec_page_id: string,    // was parent_page_id; now sets the Spec relation
+    spec_page_url: string,
+    spec_title: string,      // new — for the Title property ("Testing guide: {spec_title}")
+    summary: string,
+    testing_instructions: string,
+  ): Promise<string>;
+  readFeedback(page_id: string): Promise<FeedbackItem[]>;
+  update(
+    page_id: string,
+    options: {
+      summary?: string;
+      resolved_items?: Array<{ id: string; resolution_comment: string }>;
+    },
+  ): Promise<void>;
+  updateStatus?(page_id: string, status: TestingGuideStatus): Promise<void>; // new
+  setPRLink?(page_id: string, pr_url: string): Promise<void>;                // new
+}
+```
+`create()` changes:
+- `parent` changes to `{ type: 'database_id', database_id: testing_guides_database_id }`
+- `properties` set: `Title` (title: "Testing guide: \{spec_title\}"), `Spec` (relation: `[{ id: spec_page_id }]`), `Status` (status: `"Not started"`)
+- `children` (page body blocks) unchanged: bookmark, Summary, Testing instructions, Feedback sections
+`updateStatus(page_id, status)` (new): calls `pages.updateProperties(page_id, { Status: { status: { name: status } } })`.
+`setPRLink(page_id, pr_url)` (new): calls `pages.updateProperties(page_id, { 'PR link': { url: pr_url } })`.
+**Orchestrator changes**
+All new `updateStatus` and `setPRLink` calls are best-effort: errors are logged at `error` level but do not transition the run to `failed` and do not abort subsequent steps.
+In `_startSpecPipeline`, after `transition(run, 'reviewing_spec')`:
+```typescript
+await this.deps.specPublisher.updateStatus?.(publisher_ref, 'Waiting on feedback').catch(err =>
+  this.logger.error({ event: 'run.status_update_failed', run_id: run.id, status: 'Waiting on feedback', error: String(err) }, 'Failed to update spec status'),
+);
+```
+In `_handleSpecFeedback`, after `transition(run, 'speccing')`:
+```typescript
+await this.deps.specPublisher.updateStatus?.(run.publisher_ref, 'Speccing').catch(err =>
+  this.logger.error({ event: 'run.status_update_failed', run_id: run.id, status: 'Speccing', error: String(err) }, 'Failed to update spec status'),
+);
+```
+In `_handleSpecApproval`, after `specCommitter.commit()` succeeds:
+```typescript
+await this.deps.specPublisher.updateStatus?.(run.publisher_ref, 'Approved').catch(err =>
+  this.logger.error({ event: 'run.status_update_failed', run_id: run.id, status: 'Approved', error: String(err) }, 'Failed to update spec status'),
+);
+```
+In `_runImplementation`, before `implementer.implement()`:
+```typescript
+if (run.impl_feedback_ref) {
+  await this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'In progress').catch(err =>
+    this.logger.error({ event: 'run.status_update_failed', run_id: run.id, status: 'In progress', error: String(err) }, 'Failed to update testing guide status'),
+  );
+}
+```
+In `_runImplementation`, after implementation completes (before `transition(run, 'reviewing_implementation')`):
+```typescript
+if (run.impl_feedback_ref) {
+  await this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'Waiting on feedback').catch(err =>
+    this.logger.error({ event: 'run.status_update_failed', run_id: run.id, status: 'Waiting on feedback', error: String(err) }, 'Failed to update testing guide status'),
+  );
+}
+```
+In `_handleImplementationApproval`, after `prCreator.createPR()` succeeds:
+```typescript
+if (run.impl_feedback_ref) {
+  await Promise.allSettled([
+    this.deps.implFeedbackPage?.setPRLink?.(run.impl_feedback_ref, prUrl),
+    this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'Approved'),
+    this.deps.specPublisher.updateStatus?.(run.publisher_ref!, 'Complete'),
+  ]).then(results => {
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        this.logger.error({ event: 'run.status_update_failed', run_id: run.id, error: String(r.reason) }, 'Failed to update status on implementation approval');
+      }
+    }
+  });
+}
+```
+Updated `implFeedbackPage.create()` call in `_runImplementation` (adds `spec_title`):
+```typescript
+const pageId = await this.deps.implFeedbackPage!.create(
+  run.publisher_ref!,             // spec_page_id — for Spec relation
+  specPageUrl,
+  titleFromPath(run.spec_path!),  // spec_title — new parameter
+  result.summary ?? '',
+  result.testing_instructions ?? '',
+);
+```
+`titleFromPath` is already imported from `canvas-publisher.ts` in `orchestrator.ts` via the `SpecPublisher` import chain; add the direct import if not already present.
+**`src/index.ts`**** changes**
+Replace `parent_page_id` validation with:
+```typescript
+const specsDatabaseId = currentConfig.config.notion.specs_database_id;
+const testingGuidesDatabaseId = currentConfig.config.notion.testing_guides_database_id;
+if (!specsDatabaseId || !testingGuidesDatabaseId) {
+  logger.error(
+    { event: 'config.parse_error' },
+    'notion.specs_database_id and notion.testing_guides_database_id are required in WORKFLOW.md',
+  );
+  process.exit(1);
+}
+```
+Derive `repo_name` from the already-resolved `repo_url`, taking the last two path segments to produce the `org/repo` format:
+```typescript
+const segments = repo_url.replace(/\.git$/, '').split('/');
+const repo_name = segments.slice(-2).join('/') || 'unknown';
+```
+For example: `https://github.com/acme-org/autocatalyst` → `acme-org/autocatalyst`; `git@github.com:acme-org/autocatalyst.git` → `acme-org/autocatalyst`.
+Updated constructors:
+```typescript
+specPublisher = new NotionPublisher(notionClient, boltApp, specsDatabaseId, { repo_name });
+implFeedbackPage = new NotionImplementationFeedbackPage(notionClient, testingGuidesDatabaseId);
+```
+### 4. Security, privacy, and compliance
+
+No new secrets or credentials. `specs_database_id` and `testing_guides_database_id` are non-sensitive Notion database IDs stored plainly in `WORKFLOW.md` — they are workspace-internal identifiers, not authentication credentials.
+Frontmatter values written to Notion properties (`specced_by`, `implemented_by`) are already visible in the spec Markdown body; writing them to structured properties does not expand the data surface.
+All other security, privacy, and compliance characteristics are inherited from the parent feature unchanged.
+### 5. Observability
+
+New stable log events (all components use `createLogger()` from `src/core/logger.ts`):
+<table header-row="true">
+<tr>
+<td>Event</td>
+<td>Level</td>
+<td>Component</td>
+</tr>
+<tr>
+<td>`notion_spec.properties_created`</td>
+<td>info</td>
+<td>notion-publisher</td>
+</tr>
+<tr>
+<td>`notion_spec.properties_updated`</td>
+<td>info</td>
+<td>notion-publisher</td>
+</tr>
+<tr>
+<td>`notion_spec.status_updated`</td>
+<td>info</td>
+<td>notion-publisher</td>
+</tr>
+<tr>
+<td>`notion_spec.filename_lookup_failed`</td>
+<td>warn</td>
+<td>notion-publisher</td>
+</tr>
+<tr>
+<td>`notion_testing_guide.created`</td>
+<td>info</td>
+<td>implementation-feedback-page</td>
+</tr>
+<tr>
+<td>`notion_testing_guide.status_updated`</td>
+<td>info</td>
+<td>implementation-feedback-page</td>
+</tr>
+<tr>
+<td>`notion_testing_guide.pr_link_set`</td>
+<td>info</td>
+<td>implementation-feedback-page</td>
+</tr>
+<tr>
+<td>`run.status_update_failed`</td>
+<td>error</td>
+<td>orchestrator</td>
+</tr>
+</table>
+`notion_spec.filename_lookup_failed` includes the `filename` that could not be resolved so operators can diagnose broken `supersedes` / `superseded_by` links. `run.status_update_failed` includes `run_id` and the target `status` so failed transitions are traceable without failing the run.
+### 6. Testing plan
+
+All tests use Vitest. `NotionClient` is injectable and mocked with `vi.fn()`. Existing test structure and helper patterns from the parent feature apply unchanged. The mock client helper in each test file must be extended to include the new `pages.updateProperties` and `databases.query` methods.
+---
+**`NotionClient`**** additions**
+- `pages.updateProperties` calls `pages.update()` with the page_id and properties payload; the exact payload is passed through unchanged
+- `pages.updateProperties` propagates rejection from the SDK `pages.update()` call
+- `databases.query` calls `databases.query()` with the database_id and filter; returns the `results` array from the SDK response
+- `databases.query` called without a filter: passes an empty or absent body (does not error)
+- `databases.query` propagates rejection from the SDK
+---
+**`NotionPublisher`**
+*`parseFrontmatter()`** — private helper*
+- File with all expected frontmatter fields present: returns `Record<string, unknown>` containing each field
+- File with no frontmatter block (no `---` delimiters): returns `{}`
+- File with empty frontmatter block (`---\n---`): returns `{}`
+- File with only some fields set: returns a map containing only the present fields; missing keys are absent from the map (callers coerce via `?? null`)
+- `issue: null` in YAML: value in map is `null`
+- `issue: 42` in YAML: value in map is the number `42` (not a string)
+- File with extra/unknown frontmatter fields: all fields appear in the returned map (flexible — no field list is hard-coded)
+- YAML parse error: throws or returns `{}`; `create()` continues with empty properties (no crash)
+*`create()`** — database entry*
+- Calls `pages.create` with `parent: { database_id: specs_database_id }`, not `page_id`
+- Title property derived from filename via `titleFromPath`
+- Filename property set to `basename(spec_path)` (e.g., `feature-setup-wizard.md`)
+- Status property set to `"Speccing"`
+- Specced by property set from `frontmatter['specced_by']`
+- `repo_name` provided in options: `Repo / Codebase` select property included with the provided value
+- `repo_name` absent from options: `Repo / Codebase` key omitted from `properties`
+- `issue` non-null in frontmatter: `Issue #` number property included
+- `issue` null in frontmatter: `Issue #` key omitted from `properties`
+- Last updated property set from `frontmatter['last_updated']`
+- `implemented_by` non-null in frontmatter: `Implemented by` rich_text property included
+- `implemented_by` null/absent: `Implemented by` key omitted
+- `supersedes` set in frontmatter: `resolveFilenameToPageId()` called; `Superseded by / Supersedes` relation set when found
+- `supersedes` filename not found in database: `notion_spec.filename_lookup_failed` logged at warn; relation key omitted; `pages.create` still called and succeeds
+- Markdown write and Slack postMessage behavior unchanged from parent feature tests
+*`update()`** — property sync*
+- After Markdown write, calls `pages.updateProperties()` with `last_updated` and `implemented_by` from updated frontmatter
+- `implemented_by` absent from frontmatter on update: `pages.updateProperties()` still called; `implemented_by` key omitted from properties payload
+- `superseded_by` newly set in frontmatter: calls `pages.updateProperties()` with Status `"Superseded"` and resolved relation
+- `superseded_by` set but filename not found in DB: `updateProperties` still called for `last_updated`/`implemented_by`; Status NOT set to `"Superseded"`; `notion_spec.filename_lookup_failed` logged
+- Frontmatter unchanged between calls: `pages.updateProperties()` is still called (no diffing — always syncs tracked fields)
+*`updateStatus()`*
+- Calls `pages.updateProperties(page_id, { Status: { status: { name: status } } })` with the provided status string
+- Throws if `pages.updateProperties` rejects
+- Logs `notion_spec.status_updated` with `page_id` and `status`
+- Called with each valid `SpecEntryStatus` value: correct name string passed through in each case
+*`resolveFilenameToPageId()`*
+- Returns page ID of first result when database query returns one or more matches
+- Multiple results: returns `results[0].id` (first match only)
+- Empty results array: returns `undefined` and logs `notion_spec.filename_lookup_failed` with the filename
+- `databases.query` rejects: exception propagates to the caller
+---
+**`NotionImplementationFeedbackPage`**
+*Constructor*
+- `testing_guides_database_id` passed as second positional argument: stored on instance and used in `create()`
+- Options still accepted as third argument: `logDestination` routed to logger as before
+*`create()`** — database entry*
+- Calls `pages.create` with `parent: { type: 'database_id', database_id: testing_guides_database_id }`
+- Title property set to `"Testing guide: {spec_title}"`
+- Spec relation property set to `[{ id: spec_page_id }]`
+- Status property set to `"Not started"`
+- `children` (page body blocks) unchanged: bookmark, Summary, Testing instructions, Feedback sections
+- Returns `page_id` from response
+- `spec_title` with special characters (e.g., colons, slashes): passed through to title without modification
+*`updateStatus()`*
+- Calls `pages.updateProperties(page_id, { Status: { status: { name: status } } })`
+- Throws if rejects; logs `notion_testing_guide.status_updated`
+- Called with each valid `TestingGuideStatus` value: correct name string passed through
+*`setPRLink()`*
+- Calls `pages.updateProperties(page_id, { 'PR link': { url: pr_url } })`
+- Throws if rejects; logs `notion_testing_guide.pr_link_set`
+- `pr_url` passed through verbatim
+---
+**`repo_name`**** derivation**
+These tests live in the `src/index.ts` config block or a dedicated unit for the derivation helper:
+- HTTPS URL without `.git`: `https://github.com/acme-org/autocatalyst` → `acme-org/autocatalyst`
+- HTTPS URL with `.git`: `https://github.com/acme-org/autocatalyst.git` → `acme-org/autocatalyst`
+- SSH URL with `.git`: `git@github.com:acme-org/autocatalyst.git` → `acme-org/autocatalyst`
+- SSH URL without `.git`: `git@github.com:acme-org/autocatalyst` → `acme-org/autocatalyst`
+- URL with only one path segment (e.g., `https://selfhosted/repo`): `slice(-2)` falls back gracefully; result is `repo` (single segment joined)
+**Config validation (startup)**
+- `specs_database_id` present, `testing_guides_database_id` absent: process exits with a config error naming both fields
+- `specs_database_id` absent, `testing_guides_database_id` present: same exit
+- Both absent: same exit
+- Both present: no exit; constructors called with correct IDs
+- `notion` block absent entirely: `SlackCanvasPublisher` used; no `NotionPublisher` or `NotionImplementationFeedbackPage` constructed
+---
+**`Orchestrator`**** — status update call-sites**
+- After `reviewing_spec` transition in `_startSpecPipeline`: `updateStatus('Waiting on feedback')` called; failure logged but run state machine continues to next step
+- After `speccing` transition in `_handleSpecFeedback`: `updateStatus('Speccing')` called; failure logged but run continues
+- After `specCommitter.commit()` succeeds in `_handleSpecApproval`: `updateStatus('Approved')` called; failure logged but run continues
+- In `_runImplementation` before `implementer.implement()`: `implFeedbackPage.updateStatus('In progress')` called if `impl_feedback_ref` is set; if `impl_feedback_ref` is not set, `updateStatus` is not called
+- `updateStatus` rejects at any call-site: `run.status_update_failed` logged with `run_id` and target `status`; the pipeline step that follows the `.catch()` still executes — the rejection does not propagate
+- In `_handleImplementationApproval` after PR created: `specPublisher.updateStatus('Complete')`, `implFeedbackPage.updateStatus('Approved')`, `implFeedbackPage.setPRLink(prUrl)` called via `Promise.allSettled`; one rejection does not prevent the other two from executing; each rejection individually logged
+- `specPublisher` is `SlackCanvasPublisher` (no `updateStatus` method): optional chaining short-circuits; `updateStatus` is never invoked; no error thrown; run behaves identically to before
+---
+**Manual acceptance testing**
+- Seed an idea; confirm: (1) a new entry appears in the Specs database with Status "Speccing", correct Title, Filename, Specced by, Repo/Codebase (in `org/repo` format), Last updated; (2) a link appears in the Slack thread as before
+- After Autocatalyst stops revising (goes to `reviewing_spec`): confirm Specs entry Status is now "Waiting on feedback"
+- @mention `@ac` with feedback; confirm: (1) Specs entry Status flips to "Speccing" while revising, then back to "Waiting on feedback" when done
+- Approve the spec; confirm: (1) Specs entry Status is "Approved"; (2) a new Testing guides database entry appears with Status "Not started", correct Title (`Testing guide: <spec title>`), and Spec relation pointing to the Specs entry; (3) Specs entry shows the Testing guide relation populated automatically (dual-property sync)
+- Seed a new spec with `supersedes: <old-spec-filename>` in its frontmatter; confirm: (1) the Superseded by / Supersedes relation is populated on both entries; (2) the old spec's Status is "Superseded" automatically on the next revision cycle
+- Seed a spec with no `issue` field in frontmatter; confirm: Issue # property is absent from the Specs database entry (not set to 0 or blank)
+- After spec approval, confirm `implemented_by` sync: set `implemented_by` in frontmatter and trigger a revision; confirm the Notion property updates
+- Approve implementation; confirm: (1) Testing guides entry PR link is set to the correct PR URL; (2) Testing guides entry Status is "Approved"; (3) Specs entry Status is "Complete"
+- Configure the service with an HTTPS `repo_url` (e.g., `https://github.com/acme-org/autocatalyst`); confirm Repo/Codebase reads `acme-org/autocatalyst`
+- Configure the service with an SSH `repo_url` (e.g., `git@github.com:acme-org/autocatalyst.git`); confirm same `acme-org/autocatalyst` value
+- Revoke the Notion integration token during an active run; confirm: `run.status_update_failed` appears in logs; the run continues and Slack interaction is unaffected
+- Configure the service without a `notion` block (fallback to `SlackCanvasPublisher`); confirm no status update calls are made and behavior is identical to before this enhancement
+### 7. Alternatives considered
+
+**Database IDs on the ****`Run`**** object**: Storing `specs_database_id` and `testing_guides_database_id` on the `Run` struct was considered to avoid passing them through constructors. Rejected — these are service-level configuration constants, not per-run values. Keeping them in constructors follows the existing `parent_page_id` pattern and avoids bloating the persisted run state.
+**Single ****`createInDatabase()`**** method on ****`SpecPublisher`**: Adding a `createInDatabase()` method to the `SpecPublisher` interface was considered to make the database-vs-page distinction explicit at the interface level. Rejected — `SpecPublisher` is implemented by `SlackCanvasPublisher`, which has no database concept. Confining the database logic to `NotionPublisher`'s `create()` keeps the shared interface stable.
+**Rolling status updates into ****`update()`**: Bundling all status transitions into `update()` was partially adopted — `"Superseded"` transitions are derived from frontmatter and handled there because the frontmatter is already being read. Point-in-time transitions (`"Speccing"`, `"Waiting on feedback"`, `"Approved"`, `"Complete"`) remain Orchestrator-driven because they depend on pipeline stage events, not content diffs.
+**Validating database schema at startup**: Querying the Notion database schema at startup to verify property names was considered. Rejected — adds latency at startup, creates a dependency on the schema query API, and would fail the service entirely on any schema drift. Surfacing mismatches as run-time errors (with clear log events) provides an equivalent operator signal without the startup cost.
+**`repo_name`**** as positional parameter on ****`NotionPublisher`**: Keeping `repo_name` as a fourth positional argument was considered. Rejected — `repo_name` is a presentational concern (one optional Notion property), not a core operational dependency. Placing it in options keeps the positional signature stable at `(client, app, specs_database_id)` and makes the constructor consistent with how `SlackCanvasPublisher` and `NotionPublisher` currently differ only by their third positional arg.
+### 8. Risks
+
+**Notion database schema drift**: If the Specs or Testing guides database schemas are modified (properties renamed or removed), `pages.create()` or `pages.updateProperties()` will return a 400 validation error from Notion. Mitigation: document the expected schema in the operator setup guide; schema errors surface as run failures with the Notion error message in the logs.
+**Filename uniqueness assumption**: `resolveFilenameToPageId()` uses the first result from the database query. If two Specs entries share the same `Filename` value (which should not occur by convention), the wrong entry is linked. Mitigation: spec filenames are unique by the workspace convention enforced by the spec generator; document this requirement for manual entries created directly in Notion.
+**Best-effort status updates**: All `updateStatus()` and `setPRLink()` calls in the Orchestrator are best-effort. A transient Notion API failure leaves an entry's Status stale without failing the run. Operators monitoring the database may see entries stuck at a prior status. Mitigation: `run.status_update_failed` logged at `error` level with `run_id` and target `status` for diagnosis; retrying the triggering Slack message will re-drive the status transition.
+**Select option auto-creation**: Notion's select property auto-creates new options when a value not already in the option list is used. If `repo_name` produces an unexpected value or the Repo/Codebase option list is locked, the `pages.create()` call may fail or create an unintended option. Mitigation: `repo_name` is derived deterministically from `repo_url` in `org/repo` format; operators should confirm the value matches an existing option or allow auto-creation.
+## Task list
+
+- [ ] **Story: Configuration layer**
+	- [ ] **Task: Update ****`WorkflowConfig.notion`**** type**
+		- **Description**: In `src/types/config.ts`, replace the `parent_page_id: string` field with `specs_database_id: string` and `testing_guides_database_id: string`. Remove `parent_page_id` entirely.
+		- **Acceptance criteria**:
+			- [ ] `WorkflowConfig.notion` has `integration_token`, `specs_database_id`, and `testing_guides_database_id` fields
+			- [ ] `parent_page_id` field is removed
+			- [ ] TypeScript compiles with no errors after the change
+		- **Dependencies**: None
+	- [ ] **Task: Update startup validation, ****`repo_name`**** derivation, and constructors in ****`src/index.ts`**
+		- **Description**: Replace `parent_page_id` validation with `specs_database_id` + `testing_guides_database_id` validation (exit with a config error if either is missing). Derive `repo_name` from `repo_url` by stripping `.git` and taking the last two path segments joined by `/`. Update `NotionPublisher` and `NotionImplementationFeedbackPage` constructor calls to use the new IDs.
+		- **Acceptance criteria**:
+			- [ ] Process exits with a config error if either `specs_database_id` or `testing_guides_database_id` is missing from the `notion` block
+			- [ ] `repo_name` is derived as `org/repo` from HTTPS and SSH `repo_url` formats, with and without `.git` suffix
+			- [ ] `NotionPublisher` constructed with `(notionClient, boltApp, specsDatabaseId, { repo_name })`
+			- [ ] `NotionImplementationFeedbackPage` constructed with `(notionClient, testingGuidesDatabaseId)`
+			- [ ] Unit tests cover: both IDs present (no exit), one absent (exit), both absent (exit), `notion` block absent entirely, all four `repo_url` format variants
+		- **Dependencies**: "Task: Update `WorkflowConfig.notion` type"
+- [ ] **Story: NotionClient API extensions**
+	- [ ] **Task: Add ****`pages.updateProperties()`**** to ****`NotionClient`**
+		- **Description**: Add `updateProperties(page_id: string, properties: Record<string, unknown>): Promise<void>` to the `NotionClient` interface and implement it in `NotionClientImpl` via the Notion SDK's `pages.update()` method. The properties payload is passed through unchanged.
+		- **Acceptance criteria**:
+			- [ ] Method added to `NotionClient` interface in `src/adapters/notion/notion-client.ts`
+			- [ ] `NotionClientImpl.pages.updateProperties` calls `this.client.pages.update({ page_id, properties })` as a passthrough
+			- [ ] Rejection from the SDK propagates to the caller
+			- [ ] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
+		- **Dependencies**: None
+	- [ ] **Task: Add ****`databases.query()`**** to ****`NotionClient`**
+		- **Description**: Add a `databases` namespace to `NotionClient` with `query(database_id: string, filter?: unknown): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>`. Implement in `NotionClientImpl` via the Notion SDK's `databases.query()` method. Calling without a filter must not error.
+		- **Acceptance criteria**:
+			- [ ] Method added to `NotionClient` interface
+			- [ ] `NotionClientImpl.databases.query` calls the SDK and returns the `results` array shaped as specified
+			- [ ] Calling without a filter does not error
+			- [ ] Rejection from the SDK propagates to the caller
+			- [ ] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
+		- **Dependencies**: None
+- [ ] **Story: SpecPublisher interface extension**
+	- [ ] **Task: Export ****`SpecEntryStatus`**** type and add optional ****`updateStatus?()`**** to ****`SpecPublisher`**
+		- **Description**: In `src/adapters/slack/canvas-publisher.ts`, export `SpecEntryStatus` as `'Speccing' | 'Waiting on feedback' | 'Approved' | 'Complete' | 'Superseded'`. Add optional `updateStatus?(publisher_ref: string, status: SpecEntryStatus): Promise<void>` to the `SpecPublisher` interface. `SlackCanvasPublisher` must not declare this method — all call-sites use optional chaining.
+		- **Acceptance criteria**:
+			- [ ] `SpecEntryStatus` type exported from `canvas-publisher.ts`
+			- [ ] `SpecPublisher` interface has optional `updateStatus?()` with the correct signature
+			- [ ] `SlackCanvasPublisher` does not declare `updateStatus` (method absent on instances)
+			- [ ] TypeScript compiles with no errors
+			- [ ] Existing `canvas-publisher.test.ts` tests pass unchanged; no new tests required unless existing assertions break
+		- **Dependencies**: None
+- [ ] **Story: NotionPublisher database publishing**
+	- [ ] **Task: Implement ****`parseFrontmatter()`**** private helper**
+		- **Description**: Add a private `parseFrontmatter(spec_path: string): Record<string, unknown>` method to `NotionPublisher`. Reads the file, extracts the YAML block between the first pair of `---` delimiters, and parses it with the `yaml` package. Returns `{}` when no frontmatter block is found, the block is empty, or YAML parsing fails.
+		- **Acceptance criteria**:
+			- [ ] Returns all frontmatter fields as a `Record<string, unknown>` when present
+			- [ ] Returns `{}` for files with no `---` delimiters, empty frontmatter block, or YAML parse error
+			- [ ] `issue: null` parses as `null`; `issue: 42` parses as the number `42` (not a string)
+			- [ ] Extra/unknown frontmatter fields are included in the returned map without filtering
+			- [ ] Unit tests cover all cases in the Testing plan section
+		- **Dependencies**: None
+	- [ ] **Task: Implement ****`resolveFilenameToPageId()`**** private helper**
+		- **Description**: Add a private `resolveFilenameToPageId(filename: string): Promise<string | undefined>` method to `NotionPublisher`. Queries the Specs database filtering by `Filename` equals `filename`. Returns `results[0].id` if found; returns `undefined` and logs `notion_spec.filename_lookup_failed` at warn if no results. Propagates rejection from `databases.query`.
+		- **Acceptance criteria**:
+			- [ ] Returns the first result's `id` when one or more results are found
+			- [ ] Returns `undefined` and logs `notion_spec.filename_lookup_failed` with the filename when results are empty
+			- [ ] Rejection from `databases.query` propagates to the caller (not swallowed)
+			- [ ] Unit tests cover all cases in the Testing plan section
+		- **Dependencies**: "Task: Add `databases.query()` to `NotionClient`"
+	- [ ] **Task: Update ****`create()`**** to publish as Specs database entry with typed properties**
+		- **Description**: Update `NotionPublisher.create()` to call `pages.create` with `parent: { database_id: specs_database_id }` and typed properties built from parsed frontmatter: Title, Filename, Status ("Speccing"), Specced by, Repo/Codebase (only if `repo_name` is in options), Issue # (only if non-null), Last updated, Implemented by (only if non-null), and Superseded by / Supersedes (resolved via `resolveFilenameToPageId()` if `supersedes` is set in frontmatter). Markdown write and Slack postMessage steps are unchanged.
+		- **Acceptance criteria**:
+			- [ ] `pages.create` called with `parent: { database_id: specs_database_id }`, not `page_id`
+			- [ ] All properties set as specified in the Design changes section
+			- [ ] Optional properties omitted (not set to null/empty) when their frontmatter values are absent
+			- [ ] When `supersedes` filename is not found in the database, `notion_spec.filename_lookup_failed` is logged and `pages.create` still succeeds without the relation property
+			- [ ] Unit tests cover all cases in the Testing plan section
+		- **Dependencies**: "Task: Implement `parseFrontmatter()` private helper", "Task: Implement `resolveFilenameToPageId()` private helper", "Task: Update `WorkflowConfig.notion` type"
+	- [ ] **Task: Update ****`update()`**** to sync frontmatter properties**
+		- **Description**: After the existing Markdown write in `NotionPublisher.update()`, call `pages.updateProperties()` to sync `last_updated` and `implemented_by` from freshly-parsed frontmatter. If `superseded_by` is now set in frontmatter, also update Status to `"Superseded"` and set the Superseded by / Supersedes relation (resolved via `resolveFilenameToPageId()`). Always call `pages.updateProperties()` — no diffing.
+		- **Acceptance criteria**:
+			- [ ] `pages.updateProperties()` called after Markdown write with `last_updated` and `implemented_by`
+			- [ ] `implemented_by` key omitted from payload when absent from frontmatter
+			- [ ] `superseded_by` set in frontmatter: Status updated to `"Superseded"` and relation set when filename resolves
+			- [ ] `superseded_by` set but filename not found: `last_updated`/`implemented_by` still synced; Status not changed; `notion_spec.filename_lookup_failed` logged
+			- [ ] No diffing — `pages.updateProperties()` called even when frontmatter is unchanged
+			- [ ] Unit tests cover all cases in the Testing plan section
+		- **Dependencies**: "Task: Implement `parseFrontmatter()` private helper", "Task: Implement `resolveFilenameToPageId()` private helper", "Task: Add `pages.updateProperties()` to `NotionClient`"
+	- [ ] **Task: Add ****`updateStatus()`**** to ****`NotionPublisher`**
+		- **Description**: Add a public `updateStatus(page_id: string, status: SpecEntryStatus): Promise<void>` method to `NotionPublisher`. Calls `pages.updateProperties(page_id, { Status: { status: { name: status } } })` and logs `notion_spec.status_updated` with `page_id` and `status`. Throws if `pages.updateProperties` rejects.
+		- **Acceptance criteria**:
+			- [ ] Method satisfies the optional `updateStatus?()` signature on the `SpecPublisher` interface
+			- [ ] Calls `pages.updateProperties` with the correct Status payload structure
+			- [ ] Logs `notion_spec.status_updated` on success
+			- [ ] Throws if `pages.updateProperties` rejects
+			- [ ] Unit tests cover all valid `SpecEntryStatus` values and rejection propagation
+		- **Dependencies**: "Task: Add `pages.updateProperties()` to `NotionClient`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
+- [ ] **Story: ImplementationFeedbackPage database publishing**
+	- [ ] **Task: Add ****`TestingGuideStatus`**** type and update ****`ImplementationFeedbackPage`**** interface**
+		- **Description**: In `src/adapters/notion/implementation-feedback-page.ts`, export `TestingGuideStatus` as `'Not started' | 'In progress' | 'Waiting on feedback' | 'Approved'`. Update the `ImplementationFeedbackPage` interface: add `spec_title: string` as the third parameter to `create()`; add optional `updateStatus?(page_id: string, status: TestingGuideStatus): Promise<void>` and `setPRLink?(page_id: string, pr_url: string): Promise<void>`.
+		- **Acceptance criteria**:
+			- [ ] `TestingGuideStatus` type exported
+			- [ ] `ImplementationFeedbackPage.create()` signature updated with `spec_title` as third parameter
+			- [ ] Optional `updateStatus?()` and `setPRLink?()` added to the interface
+			- [ ] TypeScript compiles with no errors
+		- **Dependencies**: None
+	- [ ] **Task: Update ****`NotionImplementationFeedbackPage`**** constructor and ****`create()`**** for Testing guides database**
+		- **Description**: Add `testing_guides_database_id: string` as the second positional constructor parameter (before `options`). Update `create()` to post with `parent: { type: 'database_id', database_id: testing_guides_database_id }` and set typed properties: Title (`"Testing guide: {spec_title}"`), Spec relation (`[{ id: spec_page_id }]`), Status (`"Not started"`). Page body `children` (bookmark, Summary, Testing instructions, Feedback sections) are unchanged.
+		- **Acceptance criteria**:
+			- [ ] Constructor signature is `(client, testing_guides_database_id, options?)`
+			- [ ] `create()` posts to database parent with the three required properties
+			- [ ] Title passes `spec_title` through verbatim (special characters not escaped)
+			- [ ] `children` blocks are unchanged from the current implementation
+			- [ ] Returns `page_id` from the Notion response
+			- [ ] Unit tests cover all cases in the Testing plan section
+		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface"
+	- [ ] **Task: Implement ****`updateStatus()`**** and ****`setPRLink()`**** on ****`NotionImplementationFeedbackPage`**
+		- **Description**: Implement `updateStatus(page_id, status)` by calling `pages.updateProperties(page_id, { Status: { status: { name: status } } })` and logging `notion_testing_guide.status_updated`. Implement `setPRLink(page_id, pr_url)` by calling `pages.updateProperties(page_id, { 'PR link': { url: pr_url } })` and logging `notion_testing_guide.pr_link_set`. Both throw if `pages.updateProperties` rejects.
+		- **Acceptance criteria**:
+			- [ ] `updateStatus()` calls `pages.updateProperties` with the correct Status payload
+			- [ ] `setPRLink()` calls `pages.updateProperties` with the correct `PR link` payload
+			- [ ] Both log the appropriate event on success
+			- [ ] Both throw on rejection from `pages.updateProperties`
+			- [ ] Unit tests cover all valid `TestingGuideStatus` values, PR link passthrough, and rejection cases
+		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface", "Task: Add `pages.updateProperties()` to `NotionClient`"
+- [ ] **Story: Orchestrator status transitions**
+	- [ ] **Task: Wire spec lifecycle status update call-sites**
+		- **Description**: In `src/core/orchestrator.ts`, add best-effort `specPublisher.updateStatus?.()` calls using optional chaining + `.catch()` at three points: after `transition(run, 'reviewing_spec')` in `_startSpecPipeline` (→ "Waiting on feedback"), after `transition(run, 'speccing')` in `_handleSpecFeedback` (→ "Speccing"), and after successful `specCommitter.commit()` in `_handleSpecApproval` (→ "Approved"). Each failure logs `run.status_update_failed` with `run_id` and target `status` but does not abort the run.
+		- **Acceptance criteria**:
+			- [ ] `updateStatus('Waiting on feedback')` called after `reviewing_spec` transition
+			- [ ] `updateStatus('Speccing')` called after `speccing` transition
+			- [ ] `updateStatus('Approved')` called after successful `specCommitter.commit()`
+			- [ ] Each rejection logs `run.status_update_failed` with `run_id` and `status`; rejection does not propagate to the run state machine
+			- [ ] When `specPublisher` is `SlackCanvasPublisher` (no `updateStatus`), optional chaining short-circuits with no error
+			- [ ] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and for rejection behavior
+		- **Dependencies**: "Task: Add `updateStatus()` to `NotionPublisher`", "Task: Export `SpecEntryStatus` type and add optional `updateStatus?()` to `SpecPublisher`"
+	- [ ] **Task: Wire implementation lifecycle status update call-sites**
+		- **Description**: In `src/core/orchestrator.ts`, add best-effort `implFeedbackPage.updateStatus?.()` calls: before `implementer.implement()` in `_runImplementation` (→ "In progress", only if `impl_feedback_ref` is set), and after implementation completes before `transition(run, 'reviewing_implementation')` (→ "Waiting on feedback"). Add a `Promise.allSettled` block in `_handleImplementationApproval` after a successful PR creation that calls `setPRLink`, `implFeedbackPage.updateStatus('Approved')`, and `specPublisher.updateStatus('Complete')`; log each rejection individually.
+		- **Acceptance criteria**:
+			- [ ] `implFeedbackPage.updateStatus('In progress')` called before `implementer.implement()` when `impl_feedback_ref` is set; not called when unset
+			- [ ] `implFeedbackPage.updateStatus('Waiting on feedback')` called after implementation completes
+			- [ ] `Promise.allSettled` in `_handleImplementationApproval` calls all three updates; one rejection does not prevent the other two
+			- [ ] Each rejection individually logged with `run.status_update_failed`
+			- [ ] Unit tests added to `tests/core/orchestrator.test.ts` for each call-site and rejection behavior
+		- **Dependencies**: "Task: Implement `updateStatus()` and `setPRLink()` on `NotionImplementationFeedbackPage`", "Task: Add `updateStatus()` to `NotionPublisher`"
+	- [ ] **Task: Update ****`implFeedbackPage.create()`**** call with new ****`spec_title`**** parameter**
+		- **Description**: In `_runImplementation` in `src/core/orchestrator.ts`, update the `implFeedbackPage.create()` call to pass `titleFromPath(run.spec_path!)` as the new third `spec_title` argument. Add a direct import for `titleFromPath` from `canvas-publisher.ts` if it is not already available in scope.
+		- **Acceptance criteria**:
+			- [ ] `implFeedbackPage.create()` called with `(run.publisher_ref!, specPageUrl, titleFromPath(run.spec_path!), result.summary ?? '', result.testing_instructions ?? '')`
+			- [ ] `titleFromPath` imported and available in `orchestrator.ts`
+			- [ ] TypeScript compiles with no errors
+			- [ ] Existing orchestrator tests updated to include `spec_title` in mock expectations
+		- **Dependencies**: "Task: Add `TestingGuideStatus` type and update `ImplementationFeedbackPage` interface"

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -47,26 +47,39 @@ interface NotionImplementationFeedbackPageOptions {
 
 export class NotionImplementationFeedbackPage implements ImplementationFeedbackPage {
   private readonly client: NotionClient;
+  private readonly testing_guides_database_id: string;
   private readonly logger: pino.Logger;
 
-  constructor(client: NotionClient, options?: NotionImplementationFeedbackPageOptions) {
+  constructor(
+    client: NotionClient,
+    testing_guides_database_id: string,
+    options?: NotionImplementationFeedbackPageOptions,
+  ) {
     this.client = client;
+    this.testing_guides_database_id = testing_guides_database_id;
     this.logger = createLogger('implementation-feedback-page', { destination: options?.logDestination });
   }
 
   async create(
-    parent_page_id: string,
+    spec_page_id: string,
     spec_page_url: string,
+    spec_title: string,
     summary: string,
     testing_instructions: string,
   ): Promise<string> {
     const response = await this.client.pages.create({
-      parent: { type: 'page_id', page_id: parent_page_id },
+      parent: { type: 'database_id', database_id: this.testing_guides_database_id } as never,
       properties: {
-        title: {
-          title: [{ text: { content: 'Implementation feedback' } }],
+        Title: {
+          title: [{ text: { content: `Testing guide: ${spec_title}` } }],
         },
-      },
+        Spec: {
+          relation: [{ id: spec_page_id }],
+        },
+        Status: {
+          status: { name: 'Not started' },
+        },
+      } as never,
       children: [
         // Spec link bookmark
         {
@@ -91,7 +104,7 @@ export class NotionImplementationFeedbackPage implements ImplementationFeedbackP
           type: 'paragraph',
           paragraph: { rich_text: [{ text: { content: testing_instructions } }] },
         } as never,
-        // Feedback section (empty to-do list)
+        // Feedback section
         {
           type: 'heading_2',
           heading_2: { rich_text: [{ text: { content: 'Feedback' } }] },
@@ -101,8 +114,8 @@ export class NotionImplementationFeedbackPage implements ImplementationFeedbackP
 
     const page_id = (response as { id: string }).id;
     this.logger.info(
-      { event: 'impl_feedback_page.created', page_id, parent_page_id },
-      'Implementation feedback page created',
+      { event: 'notion_testing_guide.created', page_id, spec_page_id },
+      'Testing guide database entry created',
     );
     return page_id;
   }

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -228,6 +228,26 @@ export class NotionImplementationFeedbackPage implements ImplementationFeedbackP
       'Implementation feedback page updated',
     );
   }
+
+  async updateStatus(page_id: string, status: TestingGuideStatus): Promise<void> {
+    await this.client.pages.updateProperties(page_id, {
+      Status: { status: { name: status } },
+    });
+    this.logger.info(
+      { event: 'notion_testing_guide.status_updated', page_id, status },
+      'Testing guide status updated',
+    );
+  }
+
+  async setPRLink(page_id: string, pr_url: string): Promise<void> {
+    await this.client.pages.updateProperties(page_id, {
+      'PR link': { url: pr_url },
+    });
+    this.logger.info(
+      { event: 'notion_testing_guide.pr_link_set', page_id, pr_url },
+      'Testing guide PR link set',
+    );
+  }
 }
 
 function escapeRegex(str: string): string {

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -2,6 +2,12 @@ import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 import type { NotionClient } from './notion-client.js';
 
+export type TestingGuideStatus =
+  | 'Not started'
+  | 'In progress'
+  | 'Waiting on feedback'
+  | 'Approved';
+
 export interface FeedbackItem {
   id: string;
   text: string;
@@ -11,8 +17,9 @@ export interface FeedbackItem {
 
 export interface ImplementationFeedbackPage {
   create(
-    parent_page_id: string,
+    spec_page_id: string,
     spec_page_url: string,
+    spec_title: string,
     summary: string,
     testing_instructions: string,
   ): Promise<string>;
@@ -29,6 +36,9 @@ export interface ImplementationFeedbackPage {
       }>;
     },
   ): Promise<void>;
+
+  updateStatus?(page_id: string, status: TestingGuideStatus): Promise<void>;
+  setPRLink?(page_id: string, pr_url: string): Promise<void>;
 }
 
 interface NotionImplementationFeedbackPageOptions {

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -19,6 +19,7 @@ export interface NotionClient {
     create(args: CreatePageParameters): Promise<CreatePageResponse>;
     getMarkdown(page_id: string): Promise<string>;
     updateMarkdown(page_id: string, operation: MarkdownOperation): Promise<void>;
+    updateProperties(page_id: string, properties: Record<string, unknown>): Promise<void>;
   };
   blocks: {
     children: {
@@ -31,6 +32,12 @@ export interface NotionClient {
   };
   users: {
     me(): Promise<{ id: string }>;
+  };
+  databases: {
+    query(
+      database_id: string,
+      filter?: unknown,
+    ): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>;
   };
 }
 
@@ -66,6 +73,10 @@ export class NotionClientImpl implements NotionClient {
         body: operation,
       });
     },
+
+    updateProperties: async (page_id: string, properties: Record<string, unknown>): Promise<void> => {
+      await this.client.pages.update({ page_id, properties: properties as never });
+    },
   };
 
   readonly blocks = {
@@ -90,8 +101,22 @@ export class NotionClientImpl implements NotionClient {
         path: 'users/me',
         method: 'GET',
       });
-      // Top-level `id` is the bot's own user ID — matches `created_by.id` on comments
       return { id: (response as { id: string }).id };
+    },
+  };
+
+  readonly databases = {
+    query: async (
+      database_id: string,
+      filter?: unknown,
+    ): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }> => {
+      const response = await this.client.databases.query({
+        database_id,
+        ...(filter !== undefined ? { filter: filter as never } : {}),
+      });
+      return {
+        results: response.results as Array<{ id: string; properties: Record<string, unknown> }>,
+      };
     },
   };
 }

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -110,9 +110,13 @@ export class NotionClientImpl implements NotionClient {
       database_id: string,
       filter?: unknown,
     ): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }> => {
-      const response = await this.client.databases.query({
+      const response = await (this.client as unknown as {
+        databases: {
+          query: (args: { database_id: string; filter?: unknown }) => Promise<{ results: unknown[] }>;
+        };
+      }).databases.query({
         database_id,
-        ...(filter !== undefined ? { filter: filter as never } : {}),
+        ...(filter !== undefined ? { filter } : {}),
       });
       return {
         results: response.results as Array<{ id: string; properties: Record<string, unknown> }>,

--- a/src/adapters/notion/notion-publisher.ts
+++ b/src/adapters/notion/notion-publisher.ts
@@ -1,48 +1,89 @@
 // src/adapters/notion/notion-publisher.ts
 import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { parse as parseYaml } from 'yaml';
 import type { App } from '@slack/bolt';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 import type { NotionClient } from './notion-client.js';
 import { titleFromPath } from '../slack/canvas-publisher.js';
-import type { SpecPublisher } from '../slack/canvas-publisher.js';
+import type { SpecPublisher, SpecEntryStatus } from '../slack/canvas-publisher.js';
 
 interface NotionPublisherOptions {
   logDestination?: pino.DestinationStream;
+  repo_name?: string;
 }
 
 export class NotionPublisher implements SpecPublisher {
   private readonly client: NotionClient;
   private readonly app: App;
-  private readonly parent_page_id: string;
+  private readonly specs_database_id: string;
+  private readonly options?: NotionPublisherOptions;
   private readonly logger: pino.Logger;
 
   constructor(
     client: NotionClient,
     app: App,
-    parent_page_id: string,
+    specs_database_id: string,
     options?: NotionPublisherOptions,
   ) {
     this.client = client;
     this.app = app;
-    this.parent_page_id = parent_page_id;
+    this.specs_database_id = specs_database_id;
+    this.options = options;
     this.logger = createLogger('notion-publisher', { destination: options?.logDestination });
   }
 
   async create(channel_id: string, thread_ts: string, spec_path: string): Promise<string> {
     const content = readFileSync(spec_path, 'utf-8');
     const title = titleFromPath(spec_path);
+    const filename = basename(spec_path);
+    const frontmatter = this.parseFrontmatter(spec_path);
+
+    // Resolve supersedes relation if set
+    let supersedingPageId: string | undefined;
+    const supersedes = frontmatter['supersedes'];
+    if (supersedes) {
+      supersedingPageId = await this.resolveFilenameToPageId(String(supersedes));
+    }
+
+    // Build typed properties
+    const properties: Record<string, unknown> = {
+      Title: { title: [{ type: 'text', text: { content: title } }] },
+      Filename: { rich_text: [{ type: 'text', text: { content: filename } }] },
+      Status: { status: { name: 'Speccing' } },
+      'Specced by': {
+        rich_text: [{ type: 'text', text: { content: String(frontmatter['specced_by'] ?? '') } }],
+      },
+      'Last updated': { date: { start: String(frontmatter['last_updated'] ?? '') } },
+    };
+
+    if (this.options?.repo_name) {
+      properties['Repo / Codebase'] = { select: { name: this.options.repo_name } };
+    }
+    if (frontmatter['issue'] != null) {
+      properties['Issue #'] = { number: frontmatter['issue'] as number };
+    }
+    if (frontmatter['implemented_by'] != null) {
+      properties['Implemented by'] = {
+        rich_text: [{ type: 'text', text: { content: String(frontmatter['implemented_by']) } }],
+      };
+    }
+    if (supersedingPageId) {
+      properties['Superseded by / Supersedes'] = { relation: [{ id: supersedingPageId }] };
+    }
 
     const page = await this.client.pages.create({
-      parent: { page_id: this.parent_page_id },
-      properties: {
-        title: [{ type: 'text', text: { content: title } }],
-      } as unknown as Parameters<NotionClient['pages']['create']>[0]['properties'],
+      parent: { database_id: this.specs_database_id } as unknown as Parameters<NotionClient['pages']['create']>[0]['parent'],
+      properties: properties as unknown as Parameters<NotionClient['pages']['create']>[0]['properties'],
     });
 
     const pageId = page.id;
 
-    await this.client.pages.updateMarkdown(pageId, { type: 'replace_content', replace_content: { new_str: content } });
+    await this.client.pages.updateMarkdown(pageId, {
+      type: 'replace_content',
+      replace_content: { new_str: content },
+    });
 
     const pageUrl = `https://notion.so/${pageId.replace(/-/g, '')}`;
 
@@ -52,7 +93,10 @@ export class NotionPublisher implements SpecPublisher {
       text: `Here's the spec: <${pageUrl}|View spec in Notion>`,
     });
 
-    this.logger.info({ event: 'notion_page.created', channel_id, thread_ts, page_id: pageId }, 'Notion page created');
+    this.logger.info(
+      { event: 'notion_spec.properties_created', channel_id, thread_ts, page_id: pageId },
+      'Spec database entry created',
+    );
     return pageId;
   }
 
@@ -68,6 +112,77 @@ export class NotionPublisher implements SpecPublisher {
       replace_content: { new_str: content },
     });
 
-    this.logger.info({ event: 'notion_page.updated', page_id: publisher_ref }, 'Notion page updated');
+    // Sync frontmatter properties from spec file on disk
+    const frontmatter = this.parseFrontmatter(spec_path);
+
+    const propertiesToUpdate: Record<string, unknown> = {
+      'Last updated': { date: { start: String(frontmatter['last_updated'] ?? '') } },
+    };
+
+    if (frontmatter['implemented_by'] != null) {
+      propertiesToUpdate['Implemented by'] = {
+        rich_text: [{ type: 'text', text: { content: String(frontmatter['implemented_by']) } }],
+      };
+    }
+
+    const superseded_by = frontmatter['superseded_by'];
+    if (superseded_by) {
+      const supersededByPageId = await this.resolveFilenameToPageId(String(superseded_by));
+      if (supersededByPageId) {
+        propertiesToUpdate['Status'] = { status: { name: 'Superseded' } };
+        propertiesToUpdate['Superseded by / Supersedes'] = { relation: [{ id: supersededByPageId }] };
+      }
+    }
+
+    await this.client.pages.updateProperties(publisher_ref, propertiesToUpdate);
+
+    this.logger.info(
+      { event: 'notion_spec.properties_updated', page_id: publisher_ref },
+      'Spec database entry updated',
+    );
+  }
+
+  async updateStatus(publisher_ref: string, status: SpecEntryStatus): Promise<void> {
+    await this.client.pages.updateProperties(publisher_ref, {
+      Status: { status: { name: status } },
+    });
+    this.logger.info(
+      { event: 'notion_spec.status_updated', page_id: publisher_ref, status },
+      'Spec status updated',
+    );
+  }
+
+  private parseFrontmatter(spec_path: string): Record<string, unknown> {
+    let content: string;
+    try {
+      content = readFileSync(spec_path, 'utf-8');
+    } catch {
+      return {};
+    }
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match || !match[1] || !match[1].trim()) return {};
+    try {
+      const parsed = parseYaml(match[1]);
+      if (parsed && typeof parsed === 'object') {
+        return parsed as Record<string, unknown>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  private async resolveFilenameToPageId(filename: string): Promise<string | undefined> {
+    const result = await this.client.databases.query(this.specs_database_id, {
+      filter: { property: 'Filename', rich_text: { equals: filename } },
+    });
+    if (result.results.length === 0) {
+      this.logger.warn(
+        { event: 'notion_spec.filename_lookup_failed', filename },
+        'Could not resolve spec filename to page ID',
+      );
+      return undefined;
+    }
+    return result.results[0].id;
   }
 }

--- a/src/adapters/slack/canvas-publisher.ts
+++ b/src/adapters/slack/canvas-publisher.ts
@@ -5,10 +5,18 @@ import type { App } from '@slack/bolt';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 
+export type SpecEntryStatus =
+  | 'Speccing'
+  | 'Waiting on feedback'
+  | 'Approved'
+  | 'Complete'
+  | 'Superseded';
+
 export interface SpecPublisher {
   create(channel_id: string, thread_ts: string, spec_path: string): Promise<string>;
   update(publisher_ref: string, spec_path: string, page_content?: string): Promise<void>;
   getPageMarkdown(publisher_ref: string): Promise<string>;
+  updateStatus?(publisher_ref: string, status: SpecEntryStatus): Promise<void>;
 }
 
 export function titleFromPath(spec_path: string): string {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -182,6 +182,13 @@ export function bootstrapWorkflow(repoPath: string): boolean {
   return true; // created
 }
 
+export function repoNameFromUrl(repo_url: string): string {
+  // Strip trailing .git, then normalize SSH colon separator to slash
+  const normalized = repo_url.replace(/\.git$/, '').replace(/^[^@]+@[^:]+:/, '/');
+  const segments = normalized.split('/').filter(Boolean);
+  return segments.slice(-2).join('/') || 'unknown';
+}
+
 /**
  * Resolves the effective AWS profile to use, applying config-level override
  * precedence over the environment variable.

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -5,6 +5,7 @@ import { createLogger } from './logger.js';
 import type { SlackAdapter } from '../adapters/slack/slack-adapter.js';
 import type { WorkspaceManager } from './workspace-manager.js';
 import type { SpecGenerator, ReviseResult } from '../adapters/agent/spec-generator.js';
+import { titleFromPath } from '../adapters/slack/canvas-publisher.js';
 import type { SpecPublisher } from '../adapters/slack/canvas-publisher.js';
 import type { Run, RunStage, RequestIntent } from '../types/runs.js';
 import type { Request, ThreadMessage, InboundEvent } from '../types/events.js';
@@ -369,6 +370,15 @@ export class OrchestratorImpl implements Orchestrator {
         );
       });
 
+    if (run.impl_feedback_ref) {
+      await this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'In progress').catch(err =>
+        this.logger.error(
+          { event: 'run.status_update_failed', run_id: run.id, status: 'In progress', error: String(err) },
+          'Failed to update testing guide status',
+        ),
+      );
+    }
+
     let result;
     try {
       result = await this.deps.implementer!.implement(
@@ -408,6 +418,7 @@ export class OrchestratorImpl implements Orchestrator {
       const pageId = await this.deps.implFeedbackPage!.create(
         run.publisher_ref!,
         specPageUrl,
+        titleFromPath(run.spec_path!),
         result.summary ?? '',
         result.testing_instructions ?? '',
       );
@@ -425,6 +436,15 @@ export class OrchestratorImpl implements Orchestrator {
       await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, completionMsg);
     } catch (err) {
       this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post completion notification');
+    }
+
+    if (run.impl_feedback_ref) {
+      await this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'Waiting on feedback').catch(err =>
+        this.logger.error(
+          { event: 'run.status_update_failed', run_id: run.id, status: 'Waiting on feedback', error: String(err) },
+          'Failed to update testing guide status',
+        ),
+      );
     }
 
     this.transition(run, 'reviewing_implementation');
@@ -520,6 +540,24 @@ export class OrchestratorImpl implements Orchestrator {
       await this.deps.postMessage(feedback.channel_id, feedback.thread_ts, `PR opened: ${prUrl}`);
     } catch (err) {
       this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post PR link');
+    }
+
+    // Step 3: Update statuses (best-effort, all in parallel)
+    if (run.impl_feedback_ref) {
+      await Promise.allSettled([
+        this.deps.implFeedbackPage?.setPRLink?.(run.impl_feedback_ref, prUrl),
+        this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'Approved'),
+        this.deps.specPublisher.updateStatus?.(run.publisher_ref!, 'Complete'),
+      ]).then(results => {
+        for (const r of results) {
+          if (r.status === 'rejected') {
+            this.logger.error(
+              { event: 'run.status_update_failed', run_id: run.id, error: String(r.reason) },
+              'Failed to update status on implementation approval',
+            );
+          }
+        }
+      });
     }
 
     this.transition(run, 'done');

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -348,7 +348,15 @@ export class OrchestratorImpl implements Orchestrator {
       return;
     }
 
-    // Step 3: Run implementation
+    // Step 3: Update status to Approved (best-effort)
+    await this.deps.specPublisher.updateStatus?.(run.publisher_ref!, 'Approved').catch(err =>
+      this.logger.error(
+        { event: 'run.status_update_failed', run_id: run.id, status: 'Approved', error: String(err) },
+        'Failed to update spec status',
+      ),
+    );
+
+    // Step 4: Run implementation
     await this._runImplementation(feedback, run);
   }
 
@@ -616,6 +624,12 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     this.transition(run, 'reviewing_spec');
+    await this.deps.specPublisher.updateStatus?.(run.publisher_ref!, 'Waiting on feedback').catch(err =>
+      this.logger.error(
+        { event: 'run.status_update_failed', run_id: run.id, status: 'Waiting on feedback', error: String(err) },
+        'Failed to update spec status',
+      ),
+    );
   }
 
   private async _handleSpecFeedback(feedback: ThreadMessage): Promise<void> {
@@ -628,6 +642,12 @@ export class OrchestratorImpl implements Orchestrator {
     }
 
     this.transition(run, 'speccing');
+    await this.deps.specPublisher.updateStatus?.(run.publisher_ref!, 'Speccing').catch(err =>
+      this.logger.error(
+        { event: 'run.status_update_failed', run_id: run.id, status: 'Speccing', error: String(err) },
+        'Failed to update spec status',
+      ),
+    );
     run.attempt += 1;
 
     // Step 1: Fetch Notion comments if a feedback source is configured

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { parseArgs, printUsage } from './core/cli.js';
-import { bootstrapWorkflow, loadConfig, redactConfig, resolveEnvVars, resolveAwsProfile } from './core/config.js';
+import { bootstrapWorkflow, loadConfig, redactConfig, resolveEnvVars, resolveAwsProfile, repoNameFromUrl } from './core/config.js';
 import { ConfigWatcher } from './core/config-watcher.js';
 import { Service } from './core/service.js';
 import { registerSignalHandlers } from './core/signals.js';
@@ -88,6 +88,7 @@ try {
     logger.error({ event: 'config.parse_error', error: String(err) }, 'Could not resolve git origin URL. Run: git remote add origin <url>');
     process.exit(1);
   }
+  const repo_name = repoNameFromUrl(repo_url);
 
   // Validate workspace.root
   const workspaceRoot = currentConfig.config.workspace?.root;
@@ -177,7 +178,15 @@ try {
       logger.error({ event: 'config.parse_error' }, 'AC_NOTION_INTEGRATION_TOKEN is required when notion config is present');
       process.exit(1);
     }
-    // TODO Task 14: add specs_database_id / testing_guides_database_id validation
+    const specsDatabaseId = currentConfig.config.notion.specs_database_id;
+    const testingGuidesDatabaseId = currentConfig.config.notion.testing_guides_database_id;
+    if (!specsDatabaseId || !testingGuidesDatabaseId) {
+      logger.error(
+        { event: 'config.parse_error' },
+        'notion.specs_database_id and notion.testing_guides_database_id are required in WORKFLOW.md',
+      );
+      process.exit(1);
+    }
     const notionClient = new NotionClientImpl({ integration_token: notionToken });
     let botUser: { id: string };
     try {
@@ -187,10 +196,10 @@ try {
       process.exit(1);
     }
     logger.info({ event: 'service.config', bot_user_id: botUser.id }, 'Detected Notion bot user ID');
-    specPublisher = new NotionPublisher(notionClient, boltApp, '');
+    specPublisher = new NotionPublisher(notionClient, boltApp, specsDatabaseId, { repo_name });
     feedbackSource = new NotionFeedbackSource(notionClient, { bot_user_id: botUser.id });
     specCommitter = new NotionSpecCommitter(specPublisher);
-    implFeedbackPage = new NotionImplementationFeedbackPage(notionClient);
+    implFeedbackPage = new NotionImplementationFeedbackPage(notionClient, testingGuidesDatabaseId);
     logger.info({ event: 'service.config', publisher: 'notion' }, 'Using Notion publisher');
   } else {
     specPublisher = new SlackCanvasPublisher(boltApp);

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,11 +177,7 @@ try {
       logger.error({ event: 'config.parse_error' }, 'AC_NOTION_INTEGRATION_TOKEN is required when notion config is present');
       process.exit(1);
     }
-    const parentPageId = currentConfig.config.notion.parent_page_id;
-    if (!parentPageId) {
-      logger.error({ event: 'config.parse_error' }, 'notion.parent_page_id is required in WORKFLOW.md');
-      process.exit(1);
-    }
+    // TODO Task 14: add specs_database_id / testing_guides_database_id validation
     const notionClient = new NotionClientImpl({ integration_token: notionToken });
     let botUser: { id: string };
     try {
@@ -191,7 +187,7 @@ try {
       process.exit(1);
     }
     logger.info({ event: 'service.config', bot_user_id: botUser.id }, 'Detected Notion bot user ID');
-    specPublisher = new NotionPublisher(notionClient, boltApp, parentPageId);
+    specPublisher = new NotionPublisher(notionClient, boltApp, '');
     feedbackSource = new NotionFeedbackSource(notionClient, { bot_user_id: botUser.id });
     specCommitter = new NotionSpecCommitter(specPublisher);
     implFeedbackPage = new NotionImplementationFeedbackPage(notionClient);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,7 +11,9 @@ export interface WorkflowConfig {
     channel_name?: string;
   };
   notion?: {
-    parent_page_id?: string;
+    integration_token: string;
+    specs_database_id: string;
+    testing_guides_database_id: string;
   };
   aws_profile?: string;
   [key: string]: unknown;

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -75,44 +75,113 @@ function makeBlocksChildrenListFn(
 }
 
 describe('NotionImplementationFeedbackPage — create', () => {
-  it('creates a page under the given parent_page_id', async () => {
+  it('creates a page in the testing_guides_database_id (not under a parent page)', async () => {
     const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
     const client = makeNotionClient({ pagesCreate });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
-    await page.create('parent-123', 'https://notion.so/spec', 'Summary text', 'Run npm test');
+    await page.create('spec-page-id', 'https://notion.so/spec', 'Setup wizard', 'the summary', 'run npm test');
 
-    expect(pagesCreate).toHaveBeenCalledOnce();
-    const args = pagesCreate.mock.calls[0][0];
-    expect(JSON.stringify(args)).toContain('parent-123');
+    const createCall = pagesCreate.mock.calls[0][0];
+    expect(createCall.parent).toEqual(
+      expect.objectContaining({ database_id: 'db-testing-guides-id' }),
+    );
+    expect(createCall.parent.page_id).toBeUndefined();
   });
 
-  it('returns the page_id from the created page', async () => {
-    const client = makeNotionClient({ pagesCreate: vi.fn().mockResolvedValue({ id: 'page-xyz' }) });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
-
-    const result = await page.create('parent', 'https://notion.so/spec', 'Summary', 'Test');
-    expect(result).toBe('page-xyz');
-  });
-
-  it('includes the spec link in the page content', async () => {
+  it('returns the page_id', async () => {
     const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
     const client = makeNotionClient({ pagesCreate });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
-    await page.create('parent', 'https://notion.so/spec-page', 'Summary', 'Test instructions');
+    const result = await page.create('spec-page-id', 'https://notion.so/spec', 'Setup wizard', 'sum', 'test');
 
-    const args = JSON.stringify(pagesCreate.mock.calls[0][0]);
-    expect(args).toContain('notion.so/spec-page');
+    expect(result).toBe('new-page-id');
+  });
+
+  it('sets Title to "Testing guide: {spec_title}"', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create('spec-page-id', 'https://notion.so/spec', 'Setup wizard', 'sum', 'test');
+
+    const createCall = pagesCreate.mock.calls[0][0];
+    expect(createCall.properties['Title'].title[0].text.content).toBe('Testing guide: Setup wizard');
+  });
+
+  it('sets Spec relation to spec_page_id', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create('spec-page-abc', 'https://notion.so/spec', 'Setup wizard', 'sum', 'test');
+
+    const createCall = pagesCreate.mock.calls[0][0];
+    expect(createCall.properties['Spec'].relation).toEqual([{ id: 'spec-page-abc' }]);
+  });
+
+  it('sets Status to "Not started"', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create('spec-page-id', 'https://notion.so/spec', 'Setup wizard', 'sum', 'test');
+
+    const createCall = pagesCreate.mock.calls[0][0];
+    expect(createCall.properties['Status'].status.name).toBe('Not started');
+  });
+
+  it('includes spec link bookmark in page children', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create('spec-page-id', 'https://notion.so/spec-url', 'Setup wizard', 'sum', 'test');
+
+    const createCall = pagesCreate.mock.calls[0][0];
+    const bookmarkBlock = createCall.children.find(
+      (b: { type: string }) => b.type === 'bookmark',
+    );
+    expect(bookmarkBlock?.bookmark?.url).toBe('https://notion.so/spec-url');
+  });
+
+  it('spec_title with special characters passes through verbatim', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create('spec-page-id', 'https://notion.so/spec', 'API: v2/beta', 'sum', 'test');
+
+    const createCall = pagesCreate.mock.calls[0][0];
+    expect(createCall.properties['Title'].title[0].text.content).toBe('Testing guide: API: v2/beta');
   });
 
   it('throws when pages.create rejects', async () => {
-    const client = makeNotionClient({
-      pagesCreate: vi.fn().mockRejectedValue(new Error('Notion API error')),
-    });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const pagesCreate = vi.fn().mockRejectedValue(new Error('Notion error'));
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
 
-    await expect(page.create('parent', 'https://url', 'Summary', 'Test')).rejects.toThrow();
+    await expect(
+      page.create('spec-page-id', 'https://notion.so/spec', 'Setup wizard', 'sum', 'test'),
+    ).rejects.toThrow('Notion error');
+  });
+
+  it('emits notion_testing_guide.created log event', async () => {
+    const records: Record<string, unknown>[] = [];
+    const logDest = {
+      write(msg: string) {
+        try { records.push(JSON.parse(msg) as Record<string, unknown>); } catch { /* ignore */ }
+      },
+    };
+    const client = makeNotionClient();
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', {
+      logDestination: logDest as unknown as import('pino').DestinationStream,
+    });
+
+    await page.create('spec-page-id', 'https://notion.so/spec', 'Setup wizard', 'sum', 'test');
+
+    expect(records.find(r => r['event'] === 'notion_testing_guide.created')).toBeDefined();
   });
 });
 
@@ -121,7 +190,7 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const client = makeNotionClient({
       blocksChildrenList: makeBlocksChildrenListFn([]),
     });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     const result = await page.readFeedback('page-id');
     expect(result).toEqual([]);
@@ -132,7 +201,7 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const client = makeNotionClient({
       blocksChildrenList: makeBlocksChildrenListFn([todoBlock]),
     });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     const result = await page.readFeedback('page-id');
     expect(result).toHaveLength(1);
@@ -146,7 +215,7 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const client = makeNotionClient({
       blocksChildrenList: makeBlocksChildrenListFn([todoBlock]),
     });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     const result = await page.readFeedback('page-id');
     expect(result[0].resolved).toBe(true);
@@ -164,7 +233,7 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     });
 
     const client = makeNotionClient({ blocksChildrenList });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     const result = await page.readFeedback('page-id');
     expect(result[0].conversation).toEqual(['Comment A', 'Comment B']);
@@ -177,7 +246,7 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const client = makeNotionClient({
       blocksChildrenList: makeBlocksChildrenListFn([block1, block2, block3]),
     });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     const result = await page.readFeedback('page-id');
     expect(result).toHaveLength(3);
@@ -193,7 +262,7 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const client = makeNotionClient({
       blocksChildrenList: makeBlocksChildrenListFn([heading, paragraph, todo]),
     });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     const result = await page.readFeedback('page-id');
     expect(result).toHaveLength(1);
@@ -219,7 +288,7 @@ describe('NotionImplementationFeedbackPage — update', () => {
       '',
     ].join('\n'));
     const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     await page.update('page-id', { summary: 'New summary text.' });
 
@@ -241,7 +310,7 @@ describe('NotionImplementationFeedbackPage — update', () => {
     ].join('\n'));
     const blocksChildrenList = vi.fn().mockResolvedValue({ results: [] });
     const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     await page.update('page-id', {
       resolved_items: [],
@@ -280,7 +349,7 @@ describe('NotionImplementationFeedbackPage — update', () => {
       return { results: [] };
     });
     const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     await page.update('page-id', {
       resolved_items: [{ id: 'todo-1', resolution_comment: 'Fixed the config validator' }],
@@ -298,22 +367,22 @@ describe('NotionImplementationFeedbackPage — update', () => {
     const pagesUpdateMarkdown = vi.fn().mockRejectedValue(new Error('API error'));
     const blocksChildrenList = vi.fn().mockResolvedValue({ results: [] });
     const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: nullDest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
     await expect(page.update('page-id', { summary: 'New summary' })).rejects.toThrow();
   });
 });
 
 describe('NotionImplementationFeedbackPage — logging', () => {
-  it('emits impl_feedback_page.created on successful create', async () => {
+  it('emits notion_testing_guide.created on successful create', async () => {
     const logs: unknown[] = [];
     const dest = { write: (line: string) => logs.push(JSON.parse(line)) };
     const client = makeNotionClient();
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: dest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: dest });
 
-    await page.create('parent', 'https://url', 'Summary', 'Test');
+    await page.create('spec-page-id', 'https://url', 'Test title', 'Summary', 'Test');
 
-    const created = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'impl_feedback_page.created');
+    const created = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'notion_testing_guide.created');
     expect(created).toBeDefined();
   });
 
@@ -323,7 +392,7 @@ describe('NotionImplementationFeedbackPage — logging', () => {
     const client = makeNotionClient({
       blocksChildrenList: makeBlocksChildrenListFn([]),
     });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: dest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: dest });
 
     await page.readFeedback('page-id');
 
@@ -338,7 +407,7 @@ describe('NotionImplementationFeedbackPage — logging', () => {
     const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
     const blocksChildrenList = vi.fn().mockResolvedValue({ results: [] });
     const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
-    const page = new NotionImplementationFeedbackPage(client, { logDestination: dest });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: dest });
 
     await page.update('page-id', { summary: 'New summary' });
 

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -415,3 +415,109 @@ describe('NotionImplementationFeedbackPage — logging', () => {
     expect(updated).toBeDefined();
   });
 });
+
+describe('NotionImplementationFeedbackPage — updateStatus', () => {
+  it('calls pages.updateProperties with Status payload', async () => {
+    const pagesUpdateProperties = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.updateStatus!('page-tg-id', 'In progress');
+
+    expect(pagesUpdateProperties).toHaveBeenCalledWith('page-tg-id', {
+      Status: { status: { name: 'In progress' } },
+    });
+  });
+
+  it.each([
+    ['Not started'],
+    ['In progress'],
+    ['Waiting on feedback'],
+    ['Approved'],
+  ] as const)('passes status "%s" through correctly', async (status) => {
+    const pagesUpdateProperties = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.updateStatus!('page-id', status);
+
+    expect(pagesUpdateProperties.mock.calls[0][1]['Status'].status.name).toBe(status);
+  });
+
+  it('throws if pages.updateProperties rejects', async () => {
+    const pagesUpdateProperties = vi.fn().mockRejectedValue(new Error('API error'));
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await expect(page.updateStatus!('page-id', 'Approved')).rejects.toThrow('API error');
+  });
+
+  it('logs notion_testing_guide.status_updated event', async () => {
+    const records: Record<string, unknown>[] = [];
+    const logDest = {
+      write(msg: string) {
+        try { records.push(JSON.parse(msg) as Record<string, unknown>); } catch { /* ignore */ }
+      },
+    };
+    const pagesUpdateProperties = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', {
+      logDestination: logDest as unknown as import('pino').DestinationStream,
+    });
+
+    await page.updateStatus!('page-id', 'Approved');
+
+    expect(records.find(r => r['event'] === 'notion_testing_guide.status_updated')).toBeDefined();
+  });
+});
+
+describe('NotionImplementationFeedbackPage — setPRLink', () => {
+  it('calls pages.updateProperties with PR link payload', async () => {
+    const pagesUpdateProperties = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.setPRLink!('page-tg-id', 'https://github.com/org/repo/pull/42');
+
+    expect(pagesUpdateProperties).toHaveBeenCalledWith('page-tg-id', {
+      'PR link': { url: 'https://github.com/org/repo/pull/42' },
+    });
+  });
+
+  it('passes pr_url through verbatim', async () => {
+    const pagesUpdateProperties = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const url = 'https://github.com/org/repo/pull/99?special=true&x=1';
+    await page.setPRLink!('page-id', url);
+
+    expect(pagesUpdateProperties.mock.calls[0][1]['PR link'].url).toBe(url);
+  });
+
+  it('throws if pages.updateProperties rejects', async () => {
+    const pagesUpdateProperties = vi.fn().mockRejectedValue(new Error('API error'));
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await expect(page.setPRLink!('page-id', 'https://example.com/pr')).rejects.toThrow('API error');
+  });
+
+  it('logs notion_testing_guide.pr_link_set event', async () => {
+    const records: Record<string, unknown>[] = [];
+    const logDest = {
+      write(msg: string) {
+        try { records.push(JSON.parse(msg) as Record<string, unknown>); } catch { /* ignore */ }
+      },
+    };
+    const pagesUpdateProperties = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({ pagesUpdateProperties });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', {
+      logDestination: logDest as unknown as import('pino').DestinationStream,
+    });
+
+    await page.setPRLink!('page-id', 'https://github.com/org/repo/pull/1');
+
+    expect(records.find(r => r['event'] === 'notion_testing_guide.pr_link_set')).toBeDefined();
+  });
+});

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -9,12 +9,14 @@ function makeNotionClient(overrides: Partial<{
   blocksChildrenList: ReturnType<typeof vi.fn>;
   pagesGetMarkdown: ReturnType<typeof vi.fn>;
   pagesUpdateMarkdown: ReturnType<typeof vi.fn>;
+  pagesUpdateProperties: ReturnType<typeof vi.fn>;
 }> = {}): NotionClient {
   return {
     pages: {
       create: overrides.pagesCreate ?? vi.fn().mockResolvedValue({ id: 'new-page-id' }),
       getMarkdown: overrides.pagesGetMarkdown ?? vi.fn().mockResolvedValue(''),
       updateMarkdown: overrides.pagesUpdateMarkdown ?? vi.fn().mockResolvedValue(undefined),
+      updateProperties: overrides.pagesUpdateProperties ?? vi.fn().mockResolvedValue(undefined),
     },
     blocks: {
       children: {
@@ -27,6 +29,9 @@ function makeNotionClient(overrides: Partial<{
     },
     users: {
       me: vi.fn().mockResolvedValue({ id: 'bot-id' }),
+    },
+    databases: {
+      query: vi.fn().mockResolvedValue({ results: [] }),
     },
   } as unknown as NotionClient;
 }

--- a/tests/adapters/notion/notion-client.test.ts
+++ b/tests/adapters/notion/notion-client.test.ts
@@ -1,15 +1,70 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { NotionClient } from '../../../src/adapters/notion/notion-client.js';
 
 describe('NotionClient interface', () => {
   it('users.me is defined on the interface', () => {
-    // Type-level check: this test verifies the interface shape compiles
     const client: NotionClient = {
-      pages: { create: async () => ({}) as never, getMarkdown: async () => '', updateMarkdown: async () => {} },
+      pages: {
+        create: async () => ({}) as never,
+        getMarkdown: async () => '',
+        updateMarkdown: async () => {},
+        updateProperties: async () => {},
+      },
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
+      databases: { query: async () => ({ results: [] }) },
     };
     expect(typeof client.users.me).toBe('function');
+  });
+
+  it('pages.updateProperties is defined on the interface', () => {
+    const client: NotionClient = {
+      pages: {
+        create: async () => ({}) as never,
+        getMarkdown: async () => '',
+        updateMarkdown: async () => {},
+        updateProperties: async () => {},
+      },
+      blocks: { children: { list: async () => ({}) as never } },
+      comments: { list: async () => ({}) as never, create: async () => ({}) as never },
+      users: { me: async () => ({ id: 'test' }) },
+      databases: { query: async () => ({ results: [] }) },
+    };
+    expect(typeof client.pages.updateProperties).toBe('function');
+  });
+
+  it('databases.query is defined on the interface', () => {
+    const mockQuery = vi.fn().mockResolvedValue({ results: [{ id: 'page-id', properties: {} }] });
+    const client: NotionClient = {
+      pages: {
+        create: async () => ({}) as never,
+        getMarkdown: async () => '',
+        updateMarkdown: async () => {},
+        updateProperties: async () => {},
+      },
+      blocks: { children: { list: async () => ({}) as never } },
+      comments: { list: async () => ({}) as never, create: async () => ({}) as never },
+      users: { me: async () => ({ id: 'test' }) },
+      databases: { query: mockQuery },
+    };
+    expect(typeof client.databases.query).toBe('function');
+  });
+
+  it('databases.query called without a filter does not error', async () => {
+    const mockQuery = vi.fn().mockResolvedValue({ results: [] });
+    const client: NotionClient = {
+      pages: {
+        create: async () => ({}) as never,
+        getMarkdown: async () => '',
+        updateMarkdown: async () => {},
+        updateProperties: async () => {},
+      },
+      blocks: { children: { list: async () => ({}) as never } },
+      comments: { list: async () => ({}) as never, create: async () => ({}) as never },
+      users: { me: async () => ({ id: 'test' }) },
+      databases: { query: mockQuery },
+    };
+    await expect(client.databases.query('db-id')).resolves.toEqual({ results: [] });
   });
 });

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -9,6 +9,16 @@ import { NotionPublisher } from '../../../src/adapters/notion/notion-publisher.j
 
 const nullDest = { write: () => {} };
 
+function makeLogCapture() {
+  const records: Record<string, unknown>[] = [];
+  const destination = {
+    write(msg: string) {
+      try { records.push(JSON.parse(msg) as Record<string, unknown>); } catch { /* ignore */ }
+    },
+  };
+  return { records, destination: destination as unknown as import('pino').DestinationStream };
+}
+
 let tempDir: string;
 
 beforeEach(() => {
@@ -64,13 +74,13 @@ describe('NotionPublisher.create', () => {
   it('calls pages.create with correct parent_page_id and title only (no children)', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
     const specPath = makeSpecFile();
 
     await publisher.create('C123', '100.0', specPath);
 
     expect(client.pages.create).toHaveBeenCalledWith(
-      expect.objectContaining({ parent: { page_id: 'parent-page-xyz' } }),
+      expect.objectContaining({ parent: expect.objectContaining({ database_id: 'db-specs-id' }) }),
     );
     // No children in pages.create — content set via markdown API
     const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
@@ -80,7 +90,7 @@ describe('NotionPublisher.create', () => {
   it('derives title from filename slug — feature-setup-wizard.md → "Setup wizard"', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
     const specPath = makeSpecFile('# spec', 'feature-setup-wizard.md');
 
     await publisher.create('C123', '100.0', specPath);
@@ -88,9 +98,11 @@ describe('NotionPublisher.create', () => {
     expect(client.pages.create).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: expect.objectContaining({
-          title: expect.arrayContaining([
-            expect.objectContaining({ text: expect.objectContaining({ content: 'Setup wizard' }) }),
-          ]),
+          Title: expect.objectContaining({
+            title: expect.arrayContaining([
+              expect.objectContaining({ text: expect.objectContaining({ content: 'Setup wizard' }) }),
+            ]),
+          }),
         }),
       }),
     );
@@ -99,7 +111,7 @@ describe('NotionPublisher.create', () => {
   it('derives title from enhancement slug — enhancement-notion-publisher.md → "Notion publisher"', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
     const specPath = makeSpecFile('# spec', 'enhancement-notion-publisher.md');
 
     await publisher.create('C123', '100.0', specPath);
@@ -107,9 +119,11 @@ describe('NotionPublisher.create', () => {
     expect(client.pages.create).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: expect.objectContaining({
-          title: expect.arrayContaining([
-            expect.objectContaining({ text: expect.objectContaining({ content: 'Notion publisher' }) }),
-          ]),
+          Title: expect.objectContaining({
+            title: expect.arrayContaining([
+              expect.objectContaining({ text: expect.objectContaining({ content: 'Notion publisher' }) }),
+            ]),
+          }),
         }),
       }),
     );
@@ -118,7 +132,7 @@ describe('NotionPublisher.create', () => {
   it('calls pages.updateMarkdown with replace_content after pages.create', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
     const specPath = makeSpecFile('# My Spec\n\ncontent');
 
     const callOrder: string[] = [];
@@ -142,7 +156,7 @@ describe('NotionPublisher.create', () => {
   it('calls postMessage after pages.create with Notion page URL', async () => {
     const client = makeMockNotionClient('page-abc-123-xyz');
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
     const specPath = makeSpecFile();
 
     const callOrder: string[] = [];
@@ -173,7 +187,7 @@ describe('NotionPublisher.create', () => {
   it('returns page_id', async () => {
     const client = makeMockNotionClient('returned-page-id');
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     const result = await publisher.create('C123', '100.0', makeSpecFile());
 
@@ -184,7 +198,7 @@ describe('NotionPublisher.create', () => {
     const client = makeMockNotionClient();
     (client.pages.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('API error'));
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await expect(publisher.create('C123', '100.0', makeSpecFile())).rejects.toThrow('API error');
     expect(client.pages.updateMarkdown).not.toHaveBeenCalled();
@@ -195,7 +209,7 @@ describe('NotionPublisher.create', () => {
     const client = makeMockNotionClient();
     (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Markdown error'));
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await expect(publisher.create('C123', '100.0', makeSpecFile())).rejects.toThrow('Markdown error');
     expect(app.client.chat.postMessage).not.toHaveBeenCalled();
@@ -205,7 +219,7 @@ describe('NotionPublisher.create', () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
     (app.client.chat.postMessage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Slack error'));
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await expect(publisher.create('C123', '100.0', makeSpecFile())).rejects.toThrow('Slack error');
   });
@@ -215,7 +229,7 @@ describe('NotionPublisher.update', () => {
   it('reads spec from disk and calls replace_content when no page_content provided', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await publisher.update('page-xyz', makeSpecFile('# My Spec\n\ncontent'));
 
@@ -228,7 +242,7 @@ describe('NotionPublisher.update', () => {
   it('uses page_content directly when provided (span-bearing)', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     const spanContent = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
     await publisher.update('page-xyz', makeSpecFile('# Spec\n\ntext'), spanContent);
@@ -242,7 +256,7 @@ describe('NotionPublisher.update', () => {
   it('does not call getMarkdown (no diff needed)', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await publisher.update('page-xyz', makeSpecFile('# Spec'));
 
@@ -253,7 +267,7 @@ describe('NotionPublisher.update', () => {
     const client = makeMockNotionClient();
     (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('patch error'));
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await expect(publisher.update('page-xyz', makeSpecFile('# New'))).rejects.toThrow('patch error');
   });
@@ -261,7 +275,7 @@ describe('NotionPublisher.update', () => {
   it('never calls postMessage during update', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await publisher.update('page-xyz', makeSpecFile('# New'));
 
@@ -273,7 +287,7 @@ describe('NotionPublisher.getPageMarkdown', () => {
   it('returns page markdown from client', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     const markdown = '# Spec\n\n<span discussion-urls="discussion://abc">text</span>';
     (client.pages.getMarkdown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(markdown);
@@ -287,7 +301,7 @@ describe('NotionPublisher.getPageMarkdown', () => {
   it('returns empty string when page has no content', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     (client.pages.getMarkdown as ReturnType<typeof vi.fn>).mockResolvedValueOnce('');
 
@@ -300,8 +314,309 @@ describe('NotionPublisher.getPageMarkdown', () => {
     const client = makeMockNotionClient();
     (client.pages.getMarkdown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('API error'));
     const app = makeMockApp();
-    const publisher = new NotionPublisher(client, app as unknown as App, 'parent-page-xyz', { logDestination: nullDest });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
 
     await expect(publisher.getPageMarkdown('page-xyz')).rejects.toThrow('API error');
+  });
+});
+
+describe('NotionPublisher — parseFrontmatter behavior (via create)', () => {
+  it('returns all frontmatter fields — create sets Specced by from frontmatter', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: alice\nlast_updated: 2026-04-16\n---\n# Spec\ncontent',
+      'feature-setup-wizard.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.properties['Specced by'].rich_text[0].text.content).toBe('alice');
+    expect(createCall.properties['Last updated'].date.start).toBe('2026-04-16');
+  });
+
+  it('no frontmatter: create still works without crashing', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile('# Spec with no frontmatter\ncontent', 'feature-no-fm.md');
+    await publisher.create('C123', '100.0', specPath);
+    expect(client.pages.create).toHaveBeenCalledOnce();
+  });
+
+  it('issue: null in frontmatter — Issue # omitted from properties', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: bob\nlast_updated: 2026-04-16\nissue: null\n---\n# Spec',
+      'feature-null-issue.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.properties['Issue #']).toBeUndefined();
+  });
+
+  it('issue: 42 in frontmatter — Issue # number property included', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: bob\nlast_updated: 2026-04-16\nissue: 42\n---\n# Spec',
+      'feature-with-issue.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.properties['Issue #'].number).toBe(42);
+  });
+});
+
+describe('NotionPublisher — resolveFilenameToPageId behavior (via create)', () => {
+  it('supersedes set and found: relation property included in create call', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [{ id: 'old-spec-page-id', properties: {} }],
+    });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: alice\nlast_updated: 2026-04-16\nsupersedes: feature-old-spec.md\n---\n# Spec',
+      'feature-new-spec.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    expect(client.databases.query).toHaveBeenCalledWith('db-specs-id', {
+      filter: { property: 'Filename', rich_text: { equals: 'feature-old-spec.md' } },
+    });
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.properties['Superseded by / Supersedes'].relation).toEqual([{ id: 'old-spec-page-id' }]);
+  });
+
+  it('supersedes filename not found: warn logged, relation omitted, create still called', async () => {
+    const { records, destination } = makeLogCapture();
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: alice\nlast_updated: 2026-04-16\nsupersedes: feature-missing.md\n---\n# Spec',
+      'feature-new-spec.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    expect(client.pages.create).toHaveBeenCalledOnce();
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.properties['Superseded by / Supersedes']).toBeUndefined();
+    expect(records.find(r => r['event'] === 'notion_spec.filename_lookup_failed')).toBeDefined();
+  });
+
+  it('multiple results: returns first result id', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [
+        { id: 'first-page-id', properties: {} },
+        { id: 'second-page-id', properties: {} },
+      ],
+    });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: alice\nlast_updated: 2026-04-16\nsupersedes: feature-old.md\n---\n# Spec',
+      'feature-new.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.properties['Superseded by / Supersedes'].relation).toEqual([{ id: 'first-page-id' }]);
+  });
+});
+
+describe('NotionPublisher.create — database entry with typed properties', () => {
+  it('calls pages.create with database_id parent (not page_id)', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile('---\nspecced_by: alice\nlast_updated: 2026-04-16\n---\n# Spec', 'feature-setup-wizard.md');
+    await publisher.create('C123', '100.0', specPath);
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.parent).toEqual(expect.objectContaining({ database_id: 'db-specs-id' }));
+    expect(createCall.parent.page_id).toBeUndefined();
+  });
+
+  it('sets all required typed properties', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', {
+      logDestination: nullDest,
+      repo_name: 'acme-org/autocatalyst',
+    });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: alice\nlast_updated: 2026-04-16\nissue: 7\nimplemented_by: bob\n---\n# Spec',
+      'feature-setup-wizard.md',
+    );
+    await publisher.create('C123', '100.0', specPath);
+    const p = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0].properties;
+    expect(p['Title'].title[0].text.content).toBe('Setup wizard');
+    expect(p['Filename'].rich_text[0].text.content).toBe('feature-setup-wizard.md');
+    expect(p['Status'].status.name).toBe('Speccing');
+    expect(p['Specced by'].rich_text[0].text.content).toBe('alice');
+    expect(p['Repo / Codebase'].select.name).toBe('acme-org/autocatalyst');
+    expect(p['Issue #'].number).toBe(7);
+    expect(p['Last updated'].date.start).toBe('2026-04-16');
+    expect(p['Implemented by'].rich_text[0].text.content).toBe('bob');
+  });
+
+  it('omits Repo/Codebase when repo_name absent from options', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile('---\nspecced_by: alice\nlast_updated: 2026-04-16\n---\n# Spec', 'feature-no-repo.md');
+    await publisher.create('C123', '100.0', specPath);
+    const p = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0].properties;
+    expect(p['Repo / Codebase']).toBeUndefined();
+  });
+
+  it('omits Implemented by when null/absent in frontmatter', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile('---\nspecced_by: alice\nlast_updated: 2026-04-16\nimplemented_by: null\n---\n# Spec', 'feature-no-impl.md');
+    await publisher.create('C123', '100.0', specPath);
+    const p = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0].properties;
+    expect(p['Implemented by']).toBeUndefined();
+  });
+
+  it('logs notion_spec.properties_created event', async () => {
+    const { records, destination } = makeLogCapture();
+    const client = makeMockNotionClient('page-xyz');
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
+    const specPath = makeSpecFile('---\nspecced_by: alice\nlast_updated: 2026-04-16\n---\n# Spec', 'feature-log-test.md');
+    await publisher.create('C123', '100.0', specPath);
+    expect(records.find(r => r['event'] === 'notion_spec.properties_created')).toBeDefined();
+  });
+});
+
+describe('NotionPublisher.update — property sync', () => {
+  it('calls pages.updateProperties after Markdown write with last_updated and implemented_by', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nspecced_by: alice\nlast_updated: 2026-04-17\nimplemented_by: bob\n---\n# Spec',
+      'feature-update-test.md',
+    );
+    await publisher.update('page-abc', specPath);
+    expect(client.pages.updateMarkdown).toHaveBeenCalledWith('page-abc', expect.any(Object));
+    expect(client.pages.updateProperties).toHaveBeenCalledWith('page-abc', expect.objectContaining({
+      'Last updated': { date: { start: '2026-04-17' } },
+      'Implemented by': { rich_text: [{ type: 'text', text: { content: 'bob' } }] },
+    }));
+  });
+
+  it('omits Implemented by when absent from frontmatter on update', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile('---\nspecced_by: alice\nlast_updated: 2026-04-17\n---\n# Spec', 'feature-no-impl.md');
+    await publisher.update('page-abc', specPath);
+    const call = (client.pages.updateProperties as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]['Implemented by']).toBeUndefined();
+    expect(call[1]['Last updated']).toBeDefined();
+  });
+
+  it('always calls updateProperties even when called twice (no diffing)', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile('---\nlast_updated: 2026-04-16\n---\n# Spec', 'feature-nodiff.md');
+    await publisher.update('page-abc', specPath);
+    await publisher.update('page-abc', specPath);
+    expect(client.pages.updateProperties).toHaveBeenCalledTimes(2);
+  });
+
+  it('superseded_by set and resolves: Status=Superseded and relation set', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+      results: [{ id: 'superseding-page-id', properties: {} }],
+    });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile(
+      '---\nlast_updated: 2026-04-16\nsuperseded_by: feature-new-spec.md\n---\n# Spec',
+      'feature-old-spec.md',
+    );
+    await publisher.update('page-abc', specPath);
+    const call = (client.pages.updateProperties as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]['Status'].status.name).toBe('Superseded');
+    expect(call[1]['Superseded by / Supersedes'].relation).toEqual([{ id: 'superseding-page-id' }]);
+  });
+
+  it('superseded_by set but not found: last_updated synced, Status NOT changed', async () => {
+    const { records, destination } = makeLogCapture();
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
+    const specPath = makeSpecFile(
+      '---\nlast_updated: 2026-04-16\nsuperseded_by: feature-missing.md\n---\n# Spec',
+      'feature-old-spec.md',
+    );
+    await publisher.update('page-abc', specPath);
+    const call = (client.pages.updateProperties as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]['Last updated']).toBeDefined();
+    expect(call[1]['Status']).toBeUndefined();
+    expect(records.find(r => r['event'] === 'notion_spec.filename_lookup_failed')).toBeDefined();
+  });
+
+  it('logs notion_spec.properties_updated event', async () => {
+    const { records, destination } = makeLogCapture();
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
+    const specPath = makeSpecFile('---\nlast_updated: 2026-04-16\n---\n# Spec', 'feature-logtest.md');
+    await publisher.update('page-abc', specPath);
+    expect(records.find(r => r['event'] === 'notion_spec.properties_updated')).toBeDefined();
+  });
+});
+
+describe('NotionPublisher.updateStatus', () => {
+  it('calls pages.updateProperties with Status payload', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    await publisher.updateStatus!('page-abc', 'Approved');
+    expect(client.pages.updateProperties).toHaveBeenCalledWith('page-abc', {
+      Status: { status: { name: 'Approved' } },
+    });
+  });
+
+  it.each([
+    ['Speccing'],
+    ['Waiting on feedback'],
+    ['Approved'],
+    ['Complete'],
+    ['Superseded'],
+  ] as const)('passes status "%s" through correctly', async (status) => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    await publisher.updateStatus!('page-abc', status);
+    const call = (client.pages.updateProperties as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]['Status'].status.name).toBe(status);
+  });
+
+  it('throws if pages.updateProperties rejects', async () => {
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    (client.pages.updateProperties as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Notion API error'));
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
+    await expect(publisher.updateStatus!('page-abc', 'Approved')).rejects.toThrow('Notion API error');
+  });
+
+  it('logs notion_spec.status_updated event on success', async () => {
+    const { records, destination } = makeLogCapture();
+    const client = makeMockNotionClient();
+    const app = makeMockApp();
+    const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
+    await publisher.updateStatus!('page-abc', 'Complete');
+    expect(records.find(r => r['event'] === 'notion_spec.status_updated')).toBeDefined();
   });
 });

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -32,6 +32,7 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
       create: vi.fn().mockResolvedValue({ id: pageId }),
       getMarkdown: vi.fn().mockResolvedValue(''),
       updateMarkdown: vi.fn().mockResolvedValue(undefined),
+      updateProperties: vi.fn().mockResolvedValue(undefined),
     },
     blocks: {
       children: {
@@ -43,6 +44,9 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
       create: vi.fn().mockResolvedValue({}),
     },
     users: { me: vi.fn() },
+    databases: {
+      query: vi.fn().mockResolvedValue({ results: [] }),
+    },
   };
 }
 

--- a/tests/core/config-types.test.ts
+++ b/tests/core/config-types.test.ts
@@ -32,6 +32,21 @@ describe('WorkflowConfig type', () => {
     };
     expect(config.aws_profile).toBeUndefined();
   });
+
+  it('notion block has specs_database_id and testing_guides_database_id (no parent_page_id)', () => {
+    const config: WorkflowConfig = {
+      notion: {
+        integration_token: 'tok_abc',
+        specs_database_id: 'db-specs-id',
+        testing_guides_database_id: 'db-tg-id',
+      },
+    };
+    expect(config.notion?.specs_database_id).toBe('db-specs-id');
+    expect(config.notion?.testing_guides_database_id).toBe('db-tg-id');
+    expect(config.notion?.integration_token).toBe('tok_abc');
+    // @ts-expect-error parent_page_id should not exist
+    expect(config.notion?.parent_page_id).toBeUndefined();
+  });
 });
 
 describe('LoadedConfig type', () => {

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { parseWorkflow, resolveEnvVars, validateConfig, redactConfig, resolveAwsProfile } from '../../src/core/config.js';
+import { parseWorkflow, resolveEnvVars, validateConfig, redactConfig, resolveAwsProfile, repoNameFromUrl } from '../../src/core/config.js';
 import type { WorkflowConfig } from '../../src/types/config.js';
 
 const fixture = (name: string) =>
@@ -291,5 +291,28 @@ describe('resolveAwsProfile', () => {
   it('trims leading and trailing whitespace from config aws_profile', () => {
     const result = resolveAwsProfile({ aws_profile: '  trimmed-profile  ' }, {});
     expect(result).toBe('trimmed-profile');
+  });
+});
+
+describe('repoNameFromUrl', () => {
+  it('HTTPS URL without .git', () => {
+    expect(repoNameFromUrl('https://github.com/acme-org/autocatalyst')).toBe('acme-org/autocatalyst');
+  });
+
+  it('HTTPS URL with .git', () => {
+    expect(repoNameFromUrl('https://github.com/acme-org/autocatalyst.git')).toBe('acme-org/autocatalyst');
+  });
+
+  it('SSH URL with .git', () => {
+    expect(repoNameFromUrl('git@github.com:acme-org/autocatalyst.git')).toBe('acme-org/autocatalyst');
+  });
+
+  it('SSH URL without .git', () => {
+    expect(repoNameFromUrl('git@github.com:acme-org/autocatalyst')).toBe('acme-org/autocatalyst');
+  });
+
+  it('URL with only one path segment falls back gracefully', () => {
+    const result = repoNameFromUrl('https://selfhosted/repo');
+    expect(result).toMatch(/repo/);
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -3624,3 +3624,92 @@ describe('Orchestrator — _handleSpecFeedback onProgress wiring', () => {
     expect(String(failLog!['error'])).toContain('connection reset');
   });
 });
+
+describe('Orchestrator — spec lifecycle status updates', () => {
+  it('calls updateStatus("Waiting on feedback") after reviewing_spec transition in _startSpecPipeline', async () => {
+    const adapter = makeMockAdapter();
+    const wm = makeWorkspaceManager();
+    const sg = makeSpecGenerator();
+    const updateStatus = vi.fn().mockResolvedValue(undefined);
+    const cp = makeSpecPublisher({ updateStatus });
+    const ic = makeIntentClassifier('idea');
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    expect(updateStatus).toHaveBeenCalledWith('CANVAS001', 'Waiting on feedback');
+  });
+
+  it('updateStatus rejection after reviewing_spec transition: run still reaches reviewing_spec', async () => {
+    const adapter = makeMockAdapter();
+    const wm = makeWorkspaceManager();
+    const sg = makeSpecGenerator();
+    const updateStatus = vi.fn().mockRejectedValue(new Error('Notion down'));
+    const cp = makeSpecPublisher({ updateStatus });
+    const ic = makeIntentClassifier('idea');
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
+    expect(runs.get('request-001')!.stage).toBe('reviewing_spec');
+  });
+
+  it('calls updateStatus("Speccing") after speccing transition in _handleSpecFeedback', async () => {
+    const adapter = makeMockAdapter();
+    const wm = makeWorkspaceManager();
+    const sg = makeSpecGenerator();
+    const updateStatus = vi.fn().mockResolvedValue(undefined);
+    const cp = makeSpecPublisher({ updateStatus });
+    const ic = makeIntentClassifier('idea');
+    (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
+    await new Promise(r => setTimeout(r, 50));
+    adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    const statusCalls = (updateStatus as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[1]);
+    expect(statusCalls).toContain('Speccing');
+    expect(statusCalls).toContain('Waiting on feedback');
+  });
+
+  it('when specPublisher has no updateStatus (SlackCanvasPublisher pattern), optional chaining short-circuits, run reaches reviewing_spec', async () => {
+    const adapter = makeMockAdapter();
+    const wm = makeWorkspaceManager();
+    const sg = makeSpecGenerator();
+    // makeSpecPublisher() without updateStatus — simulates SlackCanvasPublisher
+    const cp = makeSpecPublisher();
+    const ic = makeIntentClassifier('idea');
+
+    const orch = new OrchestratorImpl(
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest() });
+    await new Promise(r => setTimeout(r, 50));
+    await orch.stop();
+
+    const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
+    expect(runs.get('request-001')!.stage).toBe('reviewing_spec');
+  });
+});

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -213,7 +213,10 @@ function makeImplementer(resultOverrides: Partial<ImplementationResult> = {}): I
   };
 }
 
-function makeImplFeedbackPage(overrides: Partial<ImplementationFeedbackPage> = {}): ImplementationFeedbackPage {
+function makeImplFeedbackPage(overrides: Partial<ImplementationFeedbackPage> & {
+  updateStatus?: ReturnType<typeof vi.fn>;
+  setPRLink?: ReturnType<typeof vi.fn>;
+} = {}): ImplementationFeedbackPage {
   return {
     create: vi.fn().mockResolvedValue('feedback-page-id'),
     readFeedback: vi.fn().mockResolvedValue([]),
@@ -1071,8 +1074,9 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
 
     expect(implFeedbackPage.create).toHaveBeenCalledOnce();
     const createArgs = (implFeedbackPage.create as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(createArgs[2]).toBe('Implemented the feature successfully.');
-    expect(createArgs[3]).toBe('npm install && npm test');
+    expect(createArgs[2]).toBe('Test'); // spec_title derived from spec_path
+    expect(createArgs[3]).toBe('Implemented the feature successfully.');
+    expect(createArgs[4]).toBe('npm install && npm test');
   });
 
   it('complete result: stores impl_feedback_ref on run after page creation', async () => {
@@ -3622,6 +3626,197 @@ describe('Orchestrator — _handleSpecFeedback onProgress wiring', () => {
     const failLog = records.find(r => r['event'] === 'progress_failed' && r['phase'] === 'spec_generation');
     expect(failLog).toBeDefined();
     expect(String(failLog!['error'])).toContain('connection reset');
+  });
+});
+
+describe('Orchestrator — implementation lifecycle status updates', () => {
+  function makeOrchestratorWithNotionDeps(overrides: {
+    specPublisherUpdateStatus?: ReturnType<typeof vi.fn>;
+    implFeedbackPageUpdateStatus?: ReturnType<typeof vi.fn>;
+    implFeedbackPageSetPRLink?: ReturnType<typeof vi.fn>;
+    implFeedbackPageCreate?: ReturnType<typeof vi.fn>;
+  } = {}) {
+    const adapter = makeMockAdapter();
+    const wm = makeWorkspaceManager();
+    const sg = makeSpecGenerator();
+    const updateStatus = overrides.specPublisherUpdateStatus ?? vi.fn().mockResolvedValue(undefined);
+    const cp = makeSpecPublisher({ updateStatus });
+    const sc = makeSpecCommitter();
+    const impl = makeImplementer();
+    const implFbUpdateStatus = overrides.implFeedbackPageUpdateStatus ?? vi.fn().mockResolvedValue(undefined);
+    const implFbSetPRLink = overrides.implFeedbackPageSetPRLink ?? vi.fn().mockResolvedValue(undefined);
+    const implFbCreate = overrides.implFeedbackPageCreate ?? vi.fn().mockResolvedValue('feedback-page-id');
+    const implFb = makeImplFeedbackPage({
+      create: implFbCreate,
+      updateStatus: implFbUpdateStatus,
+      setPRLink: implFbSetPRLink,
+    });
+    const prCreator = { createPR: vi.fn().mockResolvedValue('https://github.com/org/repo/pull/1') };
+    return {
+      adapter, wm, sg, cp, sc, impl, implFb, prCreator,
+      specPublisherUpdateStatus: updateStatus,
+      implFeedbackPageUpdateStatus: implFbUpdateStatus,
+      implFeedbackPageSetPRLink: implFbSetPRLink,
+      implFeedbackPageCreate: implFbCreate,
+    };
+  }
+
+  it('calls implFeedbackPage.updateStatus("In progress") and ("Waiting on feedback") during first implementation', async () => {
+    const deps = makeOrchestratorWithNotionDeps();
+    const ic = makeIntentClassifier('approval');
+
+    const orch = new OrchestratorImpl(
+      {
+        adapter: deps.adapter as never,
+        workspaceManager: deps.wm,
+        specGenerator: deps.sg,
+        specPublisher: deps.cp,
+        postError: vi.fn(),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        repo_url: 'https://github.com/org/repo',
+        intentClassifier: ic,
+        specCommitter: deps.sc,
+        implementer: deps.impl,
+        implFeedbackPage: deps.implFb,
+        prCreator: deps.prCreator as never,
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    // Inject run with existing impl_feedback_ref to test 'In progress' call
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec', impl_feedback_ref: 'existing-feedback-id' }));
+    deps.adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'reviewing_implementation' || runs.get('request-001')?.stage === 'failed',
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    const statusCalls = (deps.implFeedbackPageUpdateStatus as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[1]);
+    expect(statusCalls).toContain('In progress');
+    expect(statusCalls).toContain('Waiting on feedback');
+  });
+
+  it('calls implFeedbackPage.updateStatus("Approved"), specPublisher.updateStatus("Complete"), and setPRLink on implementation approval', async () => {
+    const deps = makeOrchestratorWithNotionDeps();
+    const ic = makeIntentClassifier('approval');
+
+    const orch = new OrchestratorImpl(
+      {
+        adapter: deps.adapter as never,
+        workspaceManager: deps.wm,
+        specGenerator: deps.sg,
+        specPublisher: deps.cp,
+        postError: vi.fn(),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        repo_url: 'https://github.com/org/repo',
+        intentClassifier: ic,
+        specCommitter: deps.sc,
+        implementer: deps.impl,
+        implFeedbackPage: deps.implFb,
+        prCreator: deps.prCreator as never,
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    // Inject run in reviewing_implementation with impl_feedback_ref set
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id', publisher_ref: 'CANVAS001' }));
+    deps.adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'done' || runs.get('request-001')?.stage === 'failed',
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    const implStatusCalls = (deps.implFeedbackPageUpdateStatus as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[1]);
+    expect(implStatusCalls).toContain('Approved');
+    const specStatusCalls = (deps.specPublisherUpdateStatus as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[1]);
+    expect(specStatusCalls).toContain('Complete');
+    expect(deps.implFeedbackPageSetPRLink).toHaveBeenCalledWith('feedback-page-id', 'https://github.com/org/repo/pull/1');
+  });
+
+  it('implFeedbackPage.create() called with spec_title derived from spec_path', async () => {
+    const deps = makeOrchestratorWithNotionDeps();
+    const ic = makeIntentClassifier('approval');
+
+    const orch = new OrchestratorImpl(
+      {
+        adapter: deps.adapter as never,
+        workspaceManager: deps.wm,
+        specGenerator: deps.sg,
+        specPublisher: deps.cp,
+        postError: vi.fn(),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        repo_url: 'https://github.com/org/repo',
+        intentClassifier: ic,
+        specCommitter: deps.sc,
+        implementer: deps.impl,
+        implFeedbackPage: deps.implFb,
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    // spec_path from makeRun is '/ws/request-001/context-human/specs/feature-test.md'
+    // titleFromPath('feature-test.md') -> 'Test'
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
+    deps.adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'reviewing_implementation' || runs.get('request-001')?.stage === 'failed',
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    const createCall = (deps.implFeedbackPageCreate as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(createCall[2]).toBe('Test'); // spec_title is 3rd argument
+  });
+
+  it('one rejection in Promise.allSettled on implementation approval does not prevent others', async () => {
+    const deps = makeOrchestratorWithNotionDeps({
+      implFeedbackPageUpdateStatus: vi.fn().mockRejectedValue(new Error('status failed')),
+      implFeedbackPageSetPRLink: vi.fn().mockResolvedValue(undefined),
+      specPublisherUpdateStatus: vi.fn().mockResolvedValue(undefined),
+    });
+    const ic = makeIntentClassifier('approval');
+
+    const orch = new OrchestratorImpl(
+      {
+        adapter: deps.adapter as never,
+        workspaceManager: deps.wm,
+        specGenerator: deps.sg,
+        specPublisher: deps.cp,
+        postError: vi.fn(),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        repo_url: 'https://github.com/org/repo',
+        intentClassifier: ic,
+        specCommitter: deps.sc,
+        implementer: deps.impl,
+        implFeedbackPage: deps.implFb,
+        prCreator: deps.prCreator as never,
+      } as never,
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_implementation', impl_feedback_ref: 'feedback-page-id', publisher_ref: 'CANVAS001' }));
+    deps.adapter._emit({ type: 'thread_message', payload: makeFeedback() });
+    await vi.waitUntil(
+      () => runs.get('request-001')?.stage === 'done' || runs.get('request-001')?.stage === 'failed',
+      { timeout: 3000 },
+    );
+    await orch.stop();
+
+    // setPRLink and specPublisher.updateStatus('Complete') still called despite implFb.updateStatus rejection
+    expect(deps.implFeedbackPageSetPRLink).toHaveBeenCalled();
+    expect(deps.specPublisherUpdateStatus).toHaveBeenCalledWith(expect.any(String), 'Complete');
+    // Run reaches 'done' despite the rejection
+    expect(runs.get('request-001')!.stage).toBe('done');
   });
 });
 


### PR DESCRIPTION
Implements the spec: `context-human/specs/enhancement-notion-database-publishing.md`

Instead of writing specs and testing guides as plain child pages under a configured parent page, Autocatalyst now creates them as structured entries in two dedicated Notion databases. Each entry carries typed properties (title, filename, status, specced by, repo, issue number). The `parent_page_id` config field is replaced by `specs_database_id` and `testing_guides_database_id`.

Closes #53
Closes #8