### PR TITLE
feat: chore: scrub remaining omc references from codebase

### DIFF
--- a/context-agent/decisions/agent-runtime-adapter.md
+++ b/context-agent/decisions/agent-runtime-adapter.md
@@ -25,6 +25,6 @@ superseded_by: null
 - Interface must be backend-agnostic — future adapters implement the same interface
 
 **Rejected:**
-- oh-my-claudecode (OMC) subprocess instead of Agent SDK: subprocess spawning adds process management overhead and CLI version dependencies; Agent SDK provides the same capability as a typed library import
+- oh-my-claudecode subprocess instead of Agent SDK: subprocess spawning adds process management overhead and CLI version dependencies; Agent SDK provides the same capability as a typed library import
 - claw CLI instead of claude CLI: we use Claude Code, not the claw reimplementation
 - Direct subprocess CLI: subprocess is the simplest integration but requires managing process lifecycle and stdout parsing

--- a/context-agent/decisions/agent-runtime-adapter.md
+++ b/context-agent/decisions/agent-runtime-adapter.md
@@ -6,12 +6,11 @@ superseded_by: null
 
 # Agent runtime adapter
 
-**Decision:** oh-my-claudecode (OMC) via `claude` CLI subprocess as the initial implementation. Adapter interface defined for future backends.
+**Decision:** `@anthropic-ai/claude-agent-sdk` via the `query()` function as the initial implementation. Adapter interface defined for future backends.
 
 **Rationale:**
-- OMC provides multi-agent orchestration (`/autopilot`, `/team`) on top of Claude Code — no need to build this ourselves
-- `claude` CLI subprocess is the simplest integration: spawn process, pass spec as context, stream output, detect exit
-- OMC is TypeScript (same as the service) — debugging and interop are straightforward
+- Agent SDK `query()` provides direct, streaming access to Claude — no subprocess overhead or CLI dependency
+- `query()` is a first-class TypeScript API (same language as the service) — type-safe and easy to test
 - The adapter interface is small: `start(spec, workspace)`, `stream(run)`, `stop(run)`
 
 **Adapter interface:**
@@ -21,11 +20,11 @@ superseded_by: null
 - `status(run: RunHandle): RunStatus` — check if agent is running, completed, or failed
 
 **Constraints:**
-- Must work with `claude` CLI as a subprocess (not a library import)
+- Must work with `@anthropic-ai/claude-agent-sdk` as a library import (not a subprocess)
 - Must stream events for observability (not just wait for exit)
-- Interface must be backend-agnostic — future adapters for oh-my-codex, claw, or others implement the same interface
+- Interface must be backend-agnostic — future adapters implement the same interface
 
 **Rejected:**
-- Direct Anthropic API integration (skip OMC): loses multi-agent orchestration; would need to rebuild what OMC provides
+- oh-my-claudecode (OMC) subprocess instead of Agent SDK: subprocess spawning adds process management overhead and CLI version dependencies; Agent SDK provides the same capability as a typed library import
 - claw CLI instead of claude CLI: we use Claude Code, not the claw reimplementation
-- Library import instead of subprocess: OMC is designed to run via CLI, not as an embedded library
+- Direct subprocess CLI: subprocess is the simplest integration but requires managing process lifecycle and stdout parsing

--- a/context-agent/decisions/service-language.md
+++ b/context-agent/decisions/service-language.md
@@ -9,7 +9,7 @@ superseded_by: null
 **Decision:** TypeScript on Node.js.
 
 **Rationale:**
-- oh-my-claudecode (OMC) is TypeScript — shared language reduces friction at the adapter boundary
+- `@anthropic-ai/claude-agent-sdk` is TypeScript — shared language reduces friction at the adapter boundary
 - Slack Bolt SDK is Node-native and best-in-class
 - TypeScript's type system catches errors at compile time — faster feedback loops for agents
 - Well-represented in LLM training data — agents write fluent TypeScript

--- a/context-agent/standards/coding.md
+++ b/context-agent/standards/coding.md
@@ -13,7 +13,7 @@ src/
   core/              ← orchestrator, state, reconciliation, loop logic
   adapters/
     slack/           ← Slack human interface adapter
-    omc/             ← OMC agent runtime adapter
+    agent/           ← Agent SDK agent runtime adapter
   types/             ← shared type definitions
   config/            ← configuration loading, WORKFLOW.md parsing
   index.ts           ← CLI entry point
@@ -29,7 +29,7 @@ src/
 - Types/interfaces: `PascalCase`
 - Functions/variables: `camelCase`
 - Constants: `UPPER_SNAKE_CASE`
-- Adapter directories: lowercase, match the platform name (`slack`, `omc`)
+- Adapter directories: lowercase, match the platform name (`slack`, `agent`)
 
 ## Interfaces
 

--- a/context-agent/standards/logging.md
+++ b/context-agent/standards/logging.md
@@ -12,7 +12,7 @@ Every log entry is a JSON object with these fields:
 |-------------|--------|----------|------------------------------------------------|
 | `timestamp` | string | yes      | ISO 8601                                       |
 | `level`     | string | yes      | `debug`, `info`, `warn`, `error`               |
-| `component` | string | yes      | Module that emitted the log (`orchestrator`, `slack-adapter`, `omc-adapter`) |
+| `component` | string | yes      | Module that emitted the log (`orchestrator`, `slack-adapter`, `agent-adapter`) |
 | `event`     | string | yes      | Stable event name (`run.started`, `spec.generated`, `approval.received`) |
 | `run_id`    | string | when applicable | ID of the current run                 |
 | `idea_id`   | string | when applicable | ID of the originating idea            |
@@ -37,7 +37,7 @@ Every log entry is a JSON object with these fields:
 
 Traces and metrics use OpenTelemetry SDK. Spans wrap:
 - Each orchestrator tick
-- Each adapter call (Slack API, OMC subprocess)
+- Each adapter call (Slack API, Agent SDK)
 - Each stage transition within a run
 
 Trace context propagates from orchestrator → adapter → agent subprocess where possible.

--- a/context-agent/standards/testing.md
+++ b/context-agent/standards/testing.md
@@ -30,7 +30,7 @@ tests/
   core/              ← mirrors src/core/
   adapters/
     slack/           ← mirrors src/adapters/slack/
-    omc/             ← mirrors src/adapters/omc/
+    agent/           ← mirrors src/adapters/agent/
   fixtures/          ← shared test data
 ```
 
@@ -39,7 +39,7 @@ Test files: `<module>.test.ts`, placed in the `tests/` directory mirroring `src/
 ## Types of tests
 
 - **Unit tests**: test core logic (orchestrator state transitions, reconciliation, retry strategy) in isolation. No I/O.
-- **Integration tests**: test adapter implementations against real APIs (Slack, OMC). Use test credentials/sandboxes. Mark as `describe.skip` when credentials are unavailable.
+- **Integration tests**: test adapter implementations against real APIs (Slack, Agent SDK). Use test credentials/sandboxes. Mark as `describe.skip` when credentials are unavailable.
 - **Contract tests**: verify adapter implementations satisfy the adapter interface. Run against all adapters.
 
 ## Principles

--- a/context-agent/wiki/stack.md
+++ b/context-agent/wiki/stack.md
@@ -10,7 +10,7 @@ Slack via Bolt SDK. Ideas as messages, specs pushed to Canvases, feedback in thr
 
 ## Agent runtime
 
-oh-my-claudecode (OMC) via `claude` CLI subprocess. Multi-agent orchestration via `/autopilot`, `/team`. Adapter interface: `start()`, `stream()`, `stop()`, `status()`.
+`@anthropic-ai/claude-agent-sdk` via the `query()` function. Adapter interface: `start()`, `stream()`, `stop()`, `status()`.
 
 ## Spec format
 
@@ -38,7 +38,7 @@ WORKFLOW.md in target repo. Prompt templates, stage policies, runtime settings. 
 | Node.js 22+ | Runtime |
 | TypeScript | Language |
 | Slack Bolt SDK | Human interface adapter |
-| oh-my-claudecode | Agent runtime adapter |
+| `@anthropic-ai/claude-agent-sdk` | Agent runtime adapter |
 | pino | Structured logging |
 | OpenTelemetry SDK | Traces and metrics |
 | Vitest | Testing |

--- a/context-human/specs/app.md
+++ b/context-human/specs/app.md
@@ -53,7 +53,7 @@ At the end of the week, Phoebe pulls up the activity log: six features shipped, 
 
 - **Runtime**: backend service, started via CLI initially, hosted eventually
 - **Human interface**: pluggable adapter model — designed to work with any input/output channel (Slack, Discord, Linear, GitHub Issues, etc.); initial implementation targets one
-- **Agent runtime**: pluggable adapter model; initial implementation targets oh-my-claudecode (OMC), which orchestrates Claude Code
+- **Agent runtime**: pluggable adapter model; initial implementation targets Agent SDK (`@anthropic-ai/claude-agent-sdk`), which invokes Claude via `query()`
 - **Observability**: required from day one; logs, metrics, and traces must be queryable by agents without human intermediaries; stack TBD (Victoria stack is a strong candidate)
 - **Clients**: no dedicated UI; the human interface is the client
 - **Deployment target**: local machine initially; cloud-hosted long-term (provider TBD)
@@ -112,7 +112,7 @@ At the end of the week, Phoebe pulls up the activity log: six features shipped, 
 ### Adapters
 
 - **Human interface adapter: Slack** — inbound ideas and approvals via Slack events; outbound spec/status posts
-- **Agent runtime adapter: oh-my-claudecode** — implementation via OMC orchestrating Claude Code
+- **Agent runtime adapter: Agent SDK** — implementation via `@anthropic-ai/claude-agent-sdk` `query()`
 
 ### Loop improvement
 

--- a/context-human/specs/enhancement-notion-publisher.md
+++ b/context-human/specs/enhancement-notion-publisher.md
@@ -100,7 +100,7 @@ Autocatalyst fetches both open comment threads from the Notion page, combines th
 
 `SpecGenerator.create()` keeps the existing `## Raw output` / `FILENAME:` artifact format — it works and returns only the spec.
 
-`SpecGenerator.revise()` uses a delimited-section format from OMC:
+`SpecGenerator.revise()` uses a delimited-section format from Agent SDK:
 
 ```
 SPEC:
@@ -127,8 +127,8 @@ flowchart LR
     SlackAdapter -->|InboundEvent| Orchestrator
     Orchestrator -->|create workspace| WorkspaceManager
     Orchestrator -->|generate/revise spec| SpecGenerator
-    SpecGenerator -->|invoke OMC| OMC["OMC (oh-my-claudecode)"]
-    OMC -->|spec + comment responses as JSON| SpecGenerator
+    SpecGenerator -->|invoke Agent SDK| AgentSDK["Agent SDK (@anthropic-ai/claude-agent-sdk)"]
+    AgentSDK -->|spec + comment responses as JSON| SpecGenerator
     Orchestrator -->|fetch / reply / resolve| NotionFeedbackSource
     NotionFeedbackSource <-->|GET/POST/PATCH /comments| Notion
     Orchestrator -->|create/update| SpecPublisher
@@ -154,8 +154,8 @@ sequenceDiagram
     Orchestrator->>WorkspaceManager: create(idea_id, repo_url)
     WorkspaceManager-->>Orchestrator: workspace_path + branch
     Orchestrator->>SpecGenerator: create(idea, workspace_path)
-    SpecGenerator->>OMC: omc ask claude --print "..."
-    OMC-->>SpecGenerator: artifact with spec content
+    SpecGenerator->>AgentSDK: query(prompt, workspace_path)
+    AgentSDK-->>SpecGenerator: spec content
     SpecGenerator-->>Orchestrator: spec_path
     Orchestrator->>NotionPublisher: create(channel_id, thread_ts, spec_path)
     NotionPublisher->>Notion: POST /pages (create page, title only)
@@ -188,8 +188,8 @@ sequenceDiagram
     Notion-->>NotionPublisher: page markdown (with comment spans)
     Note over Orchestrator: combines Slack message + 2 comment bodies (with IDs) + page markdown
     Orchestrator->>SpecGenerator: revise(feedback, notion_comments, spec_path, workspace_path, page_markdown)
-    SpecGenerator->>OMC: omc ask claude --print "..." (with span-preservation instructions)
-    OMC-->>SpecGenerator: delimited sections — revised spec (with spans) + comment_responses[]
+    SpecGenerator->>AgentSDK: query(prompt, workspace_path, span_instructions)
+    AgentSDK-->>SpecGenerator: delimited sections — revised spec (with spans) + comment_responses[]
     SpecGenerator-->>Orchestrator: ReviseResult { comment_responses, page_content }
     Orchestrator->>NotionPublisher: update(publisher_ref, spec_path, page_content)
     NotionPublisher->>Notion: PATCH /pages/{id}/markdown (replace_content)
@@ -335,7 +335,7 @@ Current spec:
 When `current_page_markdown` contains `<span discussion-urls="...">` comment anchors, the prompt includes span-preservation instructions: keep spans on unchanged text, move spans to equivalent text when rewritten, orphan spans to an "## Orphaned comments" section when the anchored text is removed entirely. When `notion_comments` is empty, the Notion section is omitted and the model is instructed to use an empty array for `COMMENT_RESPONSES`.
 
 Parsing:
-1. Extract the `## Raw output` section from the OMC artifact (same depth-tracking logic as `create`)
+1. Extract the `## Raw output` section from the Agent SDK result (same depth-tracking logic as `create`)
 2. Unwrap any code fence wrapper
 3. Extract `SPEC:` delimited section and `COMMENT_RESPONSES:` delimited section via `extractDelimitedSection`
 4. Validate: `SPEC` is non-empty; `COMMENT_RESPONSES` parses as a JSON array of `{ comment_id: string; response: string }`; throw with a descriptive error if either check fails
@@ -413,13 +413,13 @@ Step 4 failures (reply/resolve) are logged as errors but do **not** fail the run
 
 **Data privacy**
 - Spec content is written to Notion pages — this is a broader surface than Slack canvases (which stay within the workspace). Operators should ensure the Notion integration is scoped to an appropriate parent page and not granted workspace-wide access
-- Notion comment bodies, including `created_by.name` attribution, are fetched and included in the OMC revision prompt, meaning they are sent to Anthropic. This mirrors the existing behavior for Slack feedback content and is not new in kind, but operators should be aware that Notion comment authors' names are now part of the data sent to Anthropic
+- Notion comment bodies, including `created_by.name` attribution, are fetched and included in the Agent SDK revision prompt, meaning they are sent to Anthropic. This mirrors the existing behavior for Slack feedback content and is not new in kind, but operators should be aware that Notion comment authors' names are now part of the data sent to Anthropic
 - The integration token must not appear in any log output; `NotionClient` must never log the token value
 
 **Input validation**
 - `publisher_ref` values stored on `Run` originate from Notion API responses, not user input — no further validation needed at call sites
-- Notion comment content is passed to the OMC prompt wrapped in `<<<`/`>>>` delimiters; it is not executed or interpreted as code
-- The OMC response is parsed via delimited-section extraction; the `COMMENT_RESPONSES` section is parsed with `JSON.parse()` and structurally validated before any field is used — invalid shape throws and fails the run rather than passing untrusted data downstream
+- Notion comment content is passed to the Agent SDK prompt wrapped in `<<<`/`>>>` delimiters; it is not executed or interpreted as code
+- The Agent SDK response is parsed via delimited-section extraction; the `COMMENT_RESPONSES` section is parsed with `JSON.parse()` and structurally validated before any field is used — invalid shape throws and fails the run rather than passing untrusted data downstream
 
 ### 5. Observability
 
@@ -443,7 +443,7 @@ Sensitive content (comment bodies, spec content) is not logged at `info` level o
 
 **Metrics**
 
-No new metrics beyond what the parent feature already tracks (run stage transitions, OMC invocation counts). Notion API call failures surface as `run.failed` events on the existing metric.
+No new metrics beyond what the parent feature already tracks (run stage transitions, Agent SDK invocation counts). Notion API call failures surface as `run.failed` events on the existing metric.
 
 **Alerting**
 
@@ -547,7 +547,7 @@ _Prompt construction_
 - With `notion_comments` empty: prompt does not contain `[COMMENT_ID:` anywhere; `comment_responses` instruction says to return `[]`
 - Slack message content appears in the `<<<`/`>>>` delimiters regardless of whether Notion comments are present
 - Current spec content appears in the `<<<`/`>>>` delimiters in both cases
-- OMC is invoked with the correct `cwd: workspace_path`
+- Agent SDK `query()` is invoked with the correct `cwd: workspace_path`
 
 _Artifact parsing_
 - Valid SPEC and COMMENT_RESPONSES sections: spec written to `spec_path`; `ReviseResult` returned with correct `comment_responses`
@@ -561,7 +561,7 @@ _Artifact parsing_
 - `comment_responses` entry missing `comment_id`: throws with a descriptive error
 - `comment_responses` entry missing `response`: throws with a descriptive error
 - Extra fields in comment_responses entries: tolerated without error
-- OMC exits non-zero: throws; spec file is not modified
+- Agent SDK `query()` rejects: throws; spec file is not modified
 
 _Span passthrough_
 - Uses page markdown as prompt source when `current_page_markdown` provided with spans
@@ -652,7 +652,7 @@ The Markdown API (`GET` and `PATCH /v1/pages/{page_id}/markdown`) requires `Noti
 
 The span-passthrough approach depends on the model following span-preservation instructions in the prompt. If the model drops spans, `ensureSpansPreserved` appends them as orphaned comments — no comment anchors are permanently lost, but orphaned spans require manual relocation. Mitigation: the prompt is explicit about span rules; the orphan-recovery mechanism is a safety net.
 
-**OMC delimited-section response reliability**
+**Agent SDK delimited-section response reliability**
 
 The model must return well-formed `SPEC:` and `COMMENT_RESPONSES:` delimited sections. The `COMMENT_RESPONSES` section must contain valid JSON. Prompt changes or model updates could degrade reliability. Mitigation: the prompt shows the exact expected structure; `extractDelimitedSection` + `JSON.parse()` + structural validation fails fast with a descriptive error; the run can be retried by re-triggering with an @mention.
 
@@ -775,11 +775,11 @@ Pages are created on every `new_idea` run and never deleted. A misconfigured or 
       - [x] Throws with descriptive error for each invalid shape (malformed JSON, missing SPEC, empty SPEC, missing COMMENT_RESPONSES, non-array, missing `comment_id`, missing `response`)
       - [x] Extra fields in entries tolerated
       - [x] Span passthrough: uses page markdown as prompt source, adds span instructions, returns `page_content`, writes stripped spec to disk, recovers dropped spans
-      - [x] OMC exit non-zero: throws, file not modified
+      - [x] Agent SDK `query()` rejects: throws, file not modified
       - [x] All tests pass: `npm test`
     - **Dependencies**: "Task: Add `NotionComment`, `NotionCommentResponse` types"
 
-  - [x] **Task: Update `OMCSpecGenerator.revise()` — new signature, delimited-section prompt, and parsing**
+  - [x] **Task: Update `AgentSpecGenerator.revise()` — new signature, delimited-section prompt, and parsing**
     - **Description**: Updated `src/adapters/agent/spec-generator.ts`. Changed the `revise()` signature to accept `current_page_markdown?: string` and return `Promise<ReviseResult>`. Changed the response format from JSON to delimited sections (`SPEC:` and `COMMENT_RESPONSES:`). When page markdown contains comment spans, includes span-preservation instructions and returns span-bearing `page_content`; writes span-stripped content to disk. Added `ReviseResult` type and `extractDelimitedSection` helper.
     - **Acceptance criteria**:
       - [x] `revise()` signature updated to accept optional `current_page_markdown` and return `Promise<ReviseResult>`
@@ -789,7 +789,7 @@ Pages are created on every `new_idea` run and never deleted. A misconfigured or 
       - [x] Delimited sections parsed via `extractDelimitedSection`; COMMENT_RESPONSES parsed as JSON
       - [x] Throws on missing/empty SPEC, malformed/non-array COMMENT_RESPONSES, entry missing `comment_id` or `response`
       - [x] Span passthrough: `page_content` returned with spans; disk file written span-free; dropped spans recovered
-      - [x] OMC exit non-zero: throws; `spec_path` not modified
+      - [x] Agent SDK `query()` rejects: throws; `spec_path` not modified
       - [x] All relative imports use `.js` extensions
       - [x] All tests from the preceding task pass: `npm test`
     - **Dependencies**: "Task: Update `SpecGenerator` tests for `revise()`"
@@ -807,7 +807,7 @@ Pages are created on every `new_idea` run and never deleted. A misconfigured or 
       - [x] `feedbackSource.reply` rejects on second of three: error logged; run stays in `review`; remaining replies attempted; `resolve` called
       - [x] `feedbackSource.resolve` rejects: error logged; run stays in `review`
       - [x] All tests pass: `npm test`
-    - **Dependencies**: "Task: Rename `CanvasPublisher` → `SpecPublisher`", "Task: Add `NotionComment`, `NotionCommentResponse` types", "Task: Define `FeedbackSource` interface and implement `NotionFeedbackSource`", "Task: Update `OMCSpecGenerator.revise()`"
+    - **Dependencies**: "Task: Rename `CanvasPublisher` → `SpecPublisher`", "Task: Add `NotionComment`, `NotionCommentResponse` types", "Task: Define `FeedbackSource` interface and implement `NotionFeedbackSource`", "Task: Update `AgentSpecGenerator.revise()`"
 
   - [x] **Task: Update `OrchestratorImpl` for feedback enrichment and comment dispatch**
     - **Description**: Update `src/core/orchestrator.ts`. Add `feedbackSource?: FeedbackSource` to `OrchestratorDeps`. Update `_handleSpecFeedback()` to implement the enrichment and dispatch logic from Section 3: (1) fetch Notion comments via `feedbackSource.fetch(run.publisher_ref)` if source is present, else use `[]`; (2) emit `spec_revision.enriched` log event with `slack_feedback` and `notion_comment_count`; (3) pass `notion_comments` to `specGenerator.revise()`; (4) call `specPublisher.update()`; (5) if `feedbackSource` present and `commentResponses.length > 0`, call `feedbackSource.reply()` for each response then `feedbackSource.resolve()` — step 5 failures log errors but do not fail the run. Update `createRun()` to initialize `publisher_ref: undefined` instead of `canvas_id`.

--- a/context-human/specs/feature-idea-to-spec.md
+++ b/context-human/specs/feature-idea-to-spec.md
@@ -78,9 +78,9 @@ This one holds up. By the time it's ready for approval, the spec reflects three 
 
 **Dependencies**
 - Feature: Slack message routing — provides the `SlackAdapter` and `InboundEvent` stream (`new_idea`, `spec_feedback`)
-- ADR-001: Agent-first development — establishes OMC as the agent runtime and mm:planning as the spec generation skill
+- ADR-001: Agent-first development — establishes Agent SDK as the agent runtime and mm:planning as the spec generation skill
 - ADR-003: Spec format — defines the Markdown + YAML frontmatter standard all generated specs must follow
-- Decision: Agent runtime adapter — defines the `AgentRuntimeAdapter` interface Autocatalyst uses to invoke OMC
+- Decision: Agent runtime adapter — defines the `AgentRuntimeAdapter` interface Autocatalyst uses to invoke Agent SDK
 
 **Technical goals**
 - First spec draft posted to Slack canvas within 5 minutes of `new_idea` event received
@@ -93,7 +93,7 @@ This one holds up. By the time it's ready for approval, the spec reflects three 
 - Persisting run state across service restarts
 
 **Glossary**
-- **OMC (oh-my-claudecode)** — agent orchestration tool; Autocatalyst invokes it as a subprocess to run Claude with specific skills and context
+- **Agent SDK (`@anthropic-ai/claude-agent-sdk`)** — the Anthropic Agent SDK; Autocatalyst uses its `query()` function to run Claude with a prompt and workspace context
 - **mm:planning** — the Claude Code skill that generates structured specs from a seed idea, used here in headless mode
 - **Canvas** — Slack's native document format; created and updated via the Slack Web API; used to post the spec to the idea's thread
 - **Workspace** — an isolated directory containing a shallow git clone of the target repository on a dedicated branch; supports commits and PRs
@@ -105,7 +105,7 @@ This one holds up. By the time it's ready for approval, the spec reflects three 
 
 - `src/core/orchestrator.ts` — wires the `SlackAdapter` event stream to the speccing pipeline; owns the in-memory run registry; drives stage transitions
 - `src/core/workspace-manager.ts` — creates and tears down workspaces (shallow git clone + dedicated branch per idea)
-- `src/adapters/agent/spec-generator.ts` — invokes OMC with mm:planning and the idea content; captures the generated spec file from the workspace
+- `src/adapters/agent/spec-generator.ts` — invokes Agent SDK with mm:planning and the idea content; captures the generated spec file from the workspace
 - `src/adapters/slack/canvas-publisher.ts` — creates and updates a Slack canvas with spec content; posts the canvas link to the idea's thread
 
 **High-level flow**
@@ -116,8 +116,8 @@ flowchart LR
     SlackAdapter -->|InboundEvent| Orchestrator
     Orchestrator -->|create workspace| WorkspaceManager
     Orchestrator -->|generate spec| SpecGenerator
-    SpecGenerator -->|invoke OMC| OMC["OMC (oh-my-claudecode)"]
-    OMC -->|spec content returned| SpecGenerator
+    SpecGenerator -->|invoke Agent SDK| AgentSDK["Agent SDK (@anthropic-ai/claude-agent-sdk)"]
+    AgentSDK -->|spec content returned| SpecGenerator
     Orchestrator -->|publish| CanvasPublisher
     CanvasPublisher -->|canvas create/update| Slack
 ```
@@ -140,8 +140,8 @@ sequenceDiagram
     Orchestrator->>WorkspaceManager: create(idea_id, repo_url)
     WorkspaceManager-->>Orchestrator: workspace_path + branch
     Orchestrator->>SpecGenerator: create(idea, workspace_path)
-    SpecGenerator->>OMC: omc ask claude --print "..."
-    OMC-->>SpecGenerator: artifact with spec content
+    SpecGenerator->>AgentSDK: query(prompt, workspace_path)
+    AgentSDK-->>SpecGenerator: spec content
     SpecGenerator-->>Orchestrator: spec_path
     Orchestrator->>CanvasPublisher: create(channel_id, thread_ts, spec_path)
     CanvasPublisher->>Slack: canvases.create + chat.postMessage
@@ -163,8 +163,8 @@ sequenceDiagram
     Slack->>SlackAdapter: message event (thread reply)
     SlackAdapter->>Orchestrator: spec_feedback event
     Orchestrator->>SpecGenerator: revise(feedback, spec_path, workspace_path)
-    SpecGenerator->>OMC: omc ask claude --print "..."
-    OMC-->>SpecGenerator: artifact with revised spec content
+    SpecGenerator->>AgentSDK: query(prompt, workspace_path)
+    AgentSDK-->>SpecGenerator: revised spec content
     SpecGenerator-->>Orchestrator: done
     Orchestrator->>CanvasPublisher: update(canvas_id, spec_path)
     CanvasPublisher->>Slack: canvases.edit
@@ -215,12 +215,14 @@ export interface CanvasPublisher {
 }
 ```
 
-**OMC invocation**
+**Agent SDK invocation**
 
-`SpecGenerator` invokes OMC as a child process with `cwd` set to `workspace_path`:
+`SpecGenerator` invokes Agent SDK's `query()` function with `cwd` set to `workspace_path`:
 
-```bash
-omc ask claude --print "<prompt>"
+```typescript
+for await (const message of query({ prompt, options: { cwd: workspace_path, permissionMode: 'bypassPermissions', tools: { type: 'preset', preset: 'claude_code' } } })) {
+  // stream agent messages
+}
 ```
 
 Generation prompt:
@@ -251,7 +253,7 @@ Current spec:
 >>>
 ```
 
-OMC prints the artifact path to stdout on exit (code 0 = success). `SpecGenerator` reads the artifact, extracts the `## Raw output` section, parses the `FILENAME:` line, writes the spec body to `<workspace_path>/context-human/specs/<filename>`, and returns that path. The filename is validated against `^(feature|enhancement)-[a-z0-9-]+\.md$` before use.
+`SpecGenerator` instructs Agent SDK to write the result to `.autocatalyst/spec-create-result.json` in the workspace. On completion, it reads the result file, parses the `FILENAME:` line, writes the spec body to `<workspace_path>/context-human/specs/<filename>`, and returns that path. The filename is validated against `^(feature|enhancement)-[a-z0-9-]+\.md$` before use.
 
 **WorkspaceManager implementation**
 
@@ -324,12 +326,12 @@ export interface Orchestrator {
 - `repo_url` is derived from the `origin` remote of the `--repo` directory. Workspace access is governed by the OS user running the process and whatever credentials are configured for git (SSH keys, credential helpers).
 
 **Data privacy**
-- Idea content and spec feedback are sent to Anthropic via OMC. This data is not logged by Autocatalyst.
+- Idea content and spec feedback are sent to Anthropic via Agent SDK. This data is not logged by Autocatalyst.
 - The generated spec is written to disk in the workspace but is not committed to the repository until the approval signal is received (Feature 4).
 
 **Input validation**
 - Events are pre-filtered by `SlackAdapter` before reaching the Orchestrator — only `new_idea` and `spec_feedback` events are processed.
-- The `FILENAME` line in OMC output is validated against `^(feature|enhancement)-[a-z0-9-]+\.md$` before the spec is written to disk. An invalid filename causes the run to transition to `failed`.
+- The `FILENAME` line in Agent SDK output is validated against `^(feature|enhancement)-[a-z0-9-]+\.md$` before the spec is written to disk. An invalid filename causes the run to transition to `failed`.
 
 ### 5. Observability
 
@@ -348,15 +350,15 @@ Stable event names for this feature:
 | `workspace.destroyed` | info | workspace-manager |
 | `spec.generated` | info | spec-generator |
 | `spec.revised` | info | spec-generator |
-| `omc.invoked` | debug | spec-generator |
-| `omc.completed` | debug | spec-generator |
-| `omc.failed` | error | spec-generator |
+| `spec.agent_invoked` | debug | spec-generator |
+| `spec.agent_completed` | debug | spec-generator |
+| `spec.agent_failed` | error | spec-generator |
 | `canvas.created` | info | canvas-publisher |
 | `canvas.updated` | info | canvas-publisher |
 
 **Traces**
 
-Per the observability-stack ADR, OpenTelemetry traces will wrap each orchestrator stage transition and each OMC invocation. Not implemented in this feature — tracked separately.
+Per the observability-stack ADR, OpenTelemetry traces will wrap each orchestrator stage transition and each Agent SDK invocation. Not implemented in this feature — tracked separately.
 
 ### 6. Testing plan
 
@@ -383,12 +385,12 @@ _Path construction_
 
 **SpecGenerator**
 
-_OMC invocation — `create`_
-- `create` spawns OMC with `cwd` set to `workspace_path`
+_Agent SDK invocation — `create`_
+- `create` calls `query()` with `cwd` set to `workspace_path`
 - The prompt includes the idea content wrapped in `<<<`/`>>>` delimiters
-- The prompt instructs OMC to write `FILENAME: <slug>.md` on the first line
-- `create` throws if OMC exits non-zero
-- `create` throws if the artifact file path printed to stdout does not exist
+- The prompt instructs Agent SDK to write `FILENAME: <slug>.md` on the first line
+- `create` throws if Agent SDK `query()` rejects
+- `create` throws if the result file does not exist
 
 _Artifact parsing — `create`_
 - `FILENAME: feature-setup-wizard.md` on the first line of `## Raw output` is parsed correctly
@@ -399,13 +401,13 @@ _Artifact parsing — `create`_
 - After a successful parse, the spec body (everything after the `FILENAME:` line) is written to `<workspace_path>/context-human/specs/<filename>`
 - `create` returns the full spec path
 
-_OMC invocation — `revise`_
-- `revise` spawns OMC with `cwd` set to `workspace_path`
+_Agent SDK invocation — `revise`_
+- `revise` calls `query()` with `cwd` set to `workspace_path`
 - The prompt leads with feedback content wrapped in `<<<`/`>>>`
 - The prompt follows with the current spec file content wrapped in `<<<`/`>>>`
-- `revise` reads the spec from `spec_path` before invoking OMC
+- `revise` reads the spec from `spec_path` before invoking Agent SDK
 - `revise` overwrites the spec file in place with the revised content from the artifact
-- `revise` throws if OMC exits non-zero
+- `revise` throws if Agent SDK `query()` rejects
 
 ---
 
@@ -477,9 +479,9 @@ _Failure paths_
 - `run.created` is emitted with `run_id` and `idea_id` when a run is first created
 - `run.stage_transition` is emitted with `run_id`, `idea_id`, `from_stage`, `to_stage` on every transition
 - `run.failed` is emitted with `run_id`, `idea_id`, and the error at the error level when a run fails
-- `omc.invoked` and `omc.completed` are emitted at debug level with `run_id` and `idea_id`
-- `omc.failed` is emitted at error level with the exit code and stderr when OMC exits non-zero
-- Idea content is not logged at `info` level or above (content goes to OMC, not logs)
+- `spec.agent_invoked` and `spec.agent_completed` are emitted at debug level with `run_id` and `idea_id`
+- `spec.agent_failed` is emitted at error level with the exit code and stderr when Agent SDK `query()` rejects
+- Idea content is not logged at `info` level or above (content goes to Agent SDK, not logs)
 
 ---
 
@@ -498,7 +500,7 @@ _Failure paths_
 - Reply with feedback; confirm the canvas is updated (not a new message) within 5 minutes
 - Inspect the canvas content; confirm it matches the ADR-003 Markdown + YAML frontmatter format
 - Confirm no spec file exists in the workspace repository until the approval signal is sent (Feature 4)
-- Trigger a deliberate OMC failure (bad credentials); confirm an error message appears in the thread and no canvas is posted
+- Trigger a deliberate Agent SDK failure (bad credentials); confirm an error message appears in the thread and no canvas is posted
 
 ### 7. Alternatives considered
 
@@ -510,9 +512,9 @@ The spec content will typically exceed Slack's message length limit and lacks st
 
 A persistent store would survive service restarts and support multi-process deployments. For the initial feature, in-memory state was chosen: it eliminates infrastructure dependencies, keeps the data model simple, and the cost of losing in-flight runs on restart is low given that ideas are seeded via Slack (the history is still there). Persistence is deferred as an explicit non-goal.
 
-**Invoking Claude directly via the Anthropic SDK instead of OMC**
+**Invoking Claude directly via the Anthropic SDK instead of Agent SDK**
 
-Calling the SDK directly would remove the OMC dependency and give full control over the API call. OMC was chosen because it provides the mm:planning skill context, artifact management, and a consistent invocation pattern shared across the system. Bypassing it would require reimplementing that context injection and diverge from the ADR-001 agent-first architecture.
+Calling the SDK directly would remove the Agent SDK dependency and give full control over the API call. Agent SDK was chosen because it provides the mm:planning skill context, artifact management, and a consistent invocation pattern shared across the system. Bypassing it would require reimplementing that context injection and diverge from the ADR-001 agent-first architecture.
 
 **One workspace shared across all ideas vs. one per idea**
 
@@ -520,9 +522,9 @@ A shared workspace reduces disk usage but creates branch conflicts and race cond
 
 ### 8. Risks
 
-**OMC output format changes**
+**Agent SDK output format changes**
 
-The artifact parsing logic depends on OMC's `## Raw output` section and the `FILENAME:` convention on the first line. If OMC's output format changes, `SpecGenerator` will fail to parse and all runs will transition to `failed`. Mitigation: pin the OMC version in `package.json` and treat upgrades as explicit changes that require re-validating the parsing logic.
+The artifact parsing logic depends on the `FILENAME:` convention on the first line of the result file. If the Agent SDK output format changes, `SpecGenerator` will fail to parse and all runs will transition to `failed`. Mitigation: pin the Agent SDK version in `package.json` and treat upgrades as explicit changes that require re-validating the parsing logic.
 
 **Slack Canvas API availability**
 
@@ -530,7 +532,7 @@ The Canvases API is newer than the core Slack messaging API and has had availabi
 
 **Shallow clone missing required history**
 
-`--depth=1` gives the latest commit only. If the mm:planning skill or any OMC invocation needs git history (e.g., to understand recent changes), it will be absent. Current OMC usage in this feature is stateless — it reads the working tree but not git history — so this is not an immediate issue. Worth revisiting if OMC's behavior changes.
+`--depth=1` gives the latest commit only. If the mm:planning skill or any Agent SDK invocation needs git history (e.g., to understand recent changes), it will be absent. Current Agent SDK usage in this feature is stateless — it reads the working tree but not git history — so this is not an immediate issue. Worth revisiting if Agent SDK's behavior changes.
 
 **Disk accumulation from orphaned workspaces**
 
@@ -578,39 +580,39 @@ Workspaces are created on `new_idea` and are only destroyed on failure or approv
 
 - [x] **Story: SpecGenerator**
   - [x] **Task: Implement `SpecGenerator`**
-    - **Description**: Create `src/adapters/agent/spec-generator.ts` with the `SpecGenerator` interface and a concrete `OMCSpecGenerator` implementation. `create` spawns `omc ask claude --print "<prompt>"` with `cwd` set to `workspace_path`, reads the artifact at the path printed to stdout, extracts the `## Raw output` section, parses the `FILENAME:` line, validates it against `^(feature|enhancement)-[a-z0-9-]+\.md$`, writes the spec body to `<workspace_path>/context-human/specs/<filename>`, and returns the path. `revise` builds a prompt with the feedback content in `<<<`/`>>>` delimiters first, then the current spec content in `<<<`/`>>>` delimiters, invokes OMC identically, and overwrites the spec file in place with the revised content.
+    - **Description**: Create `src/adapters/agent/spec-generator.ts` with the `SpecGenerator` interface and a concrete `AgentSDKSpecGenerator` implementation. `create` calls `query()` with `cwd` set to `workspace_path`, reads the result file at `.autocatalyst/spec-create-result.json`, parses the `FILENAME:` line, validates it against `^(feature|enhancement)-[a-z0-9-]+\.md$`, writes the spec body to `<workspace_path>/context-human/specs/<filename>`, and returns the path. `revise` builds a prompt with the feedback content in `<<<`/`>>>` delimiters first, then the current spec content in `<<<`/`>>>` delimiters, invokes Agent SDK identically, and overwrites the spec file in place with the revised content.
     - **Acceptance criteria**:
       - [x] `SpecGenerator` interface exported: `create(idea, workspace_path)` and `revise(feedback, spec_path, workspace_path)`
-      - [x] `create` spawns OMC with `cwd: workspace_path` and the generation prompt from Section 3
+      - [x] `create` calls `query()` with `cwd: workspace_path` and the generation prompt from Section 3
       - [x] Generation prompt wraps `idea.content` in `<<<`/`>>>` and includes the `FILENAME:` instruction on the first line
-      - [x] `create` reads the artifact file from the path printed to stdout
-      - [x] `create` parses `FILENAME:` from within the `## Raw output` section
+      - [x] `create` reads the result file from `.autocatalyst/spec-create-result.json`
+      - [x] `create` parses `FILENAME:` from the result file
       - [x] `create` validates the filename against `^(feature|enhancement)-[a-z0-9-]+\.md$`; throws with a descriptive error if invalid or missing
       - [x] `create` writes the spec body (everything after the `FILENAME:` line) to `<workspace_path>/context-human/specs/<filename>`
       - [x] `create` returns the full spec path
-      - [x] `create` throws if OMC exits non-zero
+      - [x] `create` throws if Agent SDK `query()` rejects
       - [x] `revise` prompt leads with feedback in `<<<`/`>>>`, follows with current spec content in `<<<`/`>>>`
-      - [x] `revise` reads the current spec from `spec_path` before invoking OMC
+      - [x] `revise` reads the current spec from `spec_path` before invoking Agent SDK
       - [x] `revise` overwrites `spec_path` with the revised content from the artifact
-      - [x] `revise` throws if OMC exits non-zero
+      - [x] `revise` throws if Agent SDK `query()` rejects
       - [x] All relative imports use `.js` extensions
     - **Dependencies**: None
 
   - [x] **Task: Unit tests for `SpecGenerator`**
-    - **Description**: Create `tests/adapters/agent/spec-generator.test.ts`. Mock the OMC subprocess with `vi.fn()` by intercepting the spawn/exec call. Use real temp directories for file I/O. Write fixture artifact files with varying `FILENAME:` values to test parsing. Cover all cases from the testing plan's SpecGenerator section.
+    - **Description**: Create `tests/adapters/agent/spec-generator.test.ts`. Mock the Agent SDK `query()` function with `vi.fn()`. Use real temp directories for file I/O. Write fixture result files with varying `FILENAME:` values to test parsing. Cover all cases from the testing plan's SpecGenerator section.
     - **Acceptance criteria**:
-      - [x] `create` spawns OMC with the correct `cwd` and prompt content
+      - [x] `create` calls `query()` with the correct `cwd` and prompt content
       - [x] `create` correctly parses `FILENAME: feature-setup-wizard.md`
       - [x] `create` correctly parses `FILENAME: enhancement-some-thing.md`
       - [x] `create` throws with a descriptive error on `FILENAME: invalid_name.md` (underscore)
       - [x] `create` throws on `FILENAME: setup-wizard.md` (missing `feature-`/`enhancement-` prefix)
       - [x] `create` throws when the `FILENAME:` line is absent
       - [x] `create` writes the correct spec body to the correct path and returns it
-      - [x] `create` throws if OMC exits non-zero
+      - [x] `create` throws if Agent SDK `query()` rejects
       - [x] `revise` prompt leads with feedback in `<<<`/`>>>`, follows with spec content in `<<<`/`>>>`
-      - [x] `revise` reads the current spec from `spec_path` before invoking OMC
+      - [x] `revise` reads the current spec from `spec_path` before invoking Agent SDK
       - [x] `revise` overwrites the spec file in place with revised content
-      - [x] `revise` throws if OMC exits non-zero
+      - [x] `revise` throws if Agent SDK `query()` rejects
       - [x] All tests pass: `npm test`
     - **Dependencies**: "Task: Implement `SpecGenerator`"
 

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -298,7 +298,7 @@ describe('Orchestrator — new_request failure paths', () => {
   it('SpecGenerator failure: run is failed, error posted, workspace destroyed', async () => {
     const adapter = makeMockAdapter();
     const wm = makeWorkspaceManager();
-    const sg = makeSpecGenerator({ create: vi.fn().mockRejectedValue(new Error('omc failed')) });
+    const sg = makeSpecGenerator({ create: vi.fn().mockRejectedValue(new Error('spec generation failed')) });
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
@@ -309,7 +309,7 @@ describe('Orchestrator — new_request failure paths', () => {
     await orch.stop();
 
     expect(wm.destroy).toHaveBeenCalledWith('/ws/request-001');
-    expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('omc failed'));
+    expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('spec generation failed'));
     expect(cp.create).not.toHaveBeenCalled();
 
     const runs = (orch as never as { runs: Map<string, { stage: string }> }).runs;
@@ -1268,7 +1268,7 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
   it('Implementer throws: run fails, error posted', async () => {
     const adapter = makeMockAdapter();
     const postError = vi.fn().mockResolvedValue(undefined);
-    const impl = { implement: vi.fn().mockRejectedValue(new Error('OMC crashed')) } as Implementer;
+    const impl = { implement: vi.fn().mockRejectedValue(new Error('agent crashed')) } as Implementer;
     const orch = makeApprovalOrch({ adapter, implementer: impl, postError });
     await orch.start();
 
@@ -1279,7 +1279,7 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     await orch.stop();
 
     expect(runs.get('request-001')!.stage).toBe('failed');
-    expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('OMC crashed'));
+    expect(postError).toHaveBeenCalledWith('C123', '100.0', expect.stringContaining('agent crashed'));
   });
 
   it('ImplementationFeedbackPage.create rejects: run still transitions to reviewing_implementation; completion message still posted', async () => {


### PR DESCRIPTION
Removes all remaining OMC (oh-my-claudecode) references from the codebase, completing the migration to Agent SDK that was started in PR #31.

## Changes

- **Tests:** Updated 4 stale mock error strings in `orchestrator.test.ts` (`'omc failed'` → `'spec generation failed'`, `'OMC crashed'` → `'agent crashed'`)
- **Specs:** Updated OMC references to Agent SDK equivalents in `feature-idea-to-spec.md`, `app.md`, `enhancement-notion-publisher.md`, `stack.md`, and supporting ADRs

The rejected-alternatives ADR note in `feature-approval-to-implementation.md` is intentionally preserved.

Closes #39
Closes #57