### PR TITLE
feat: enhancement: intent classification probe (`:ac-classify-intent:`)

### DIFF
--- a/context-human/specs/enhancement-classify-command.md
+++ b/context-human/specs/enhancement-classify-command.md
@@ -215,13 +215,13 @@ The handler accepts `IntentClassifier`, not `IntentClassifier | undefined`. In `
 ## Task list
 
 - [ ] **Story: Wire ****`:ac-classify-intent:`**** into the command table and register the handler**
-	- [ ] **Task: Add ****`:ac-classify-intent:`**** to ****`EMOJI_COMMAND_TABLE`**** in ****`classifier.ts`**
+	- [x] **Task: Add ****`:ac-classify-intent:`**** to ****`EMOJI_COMMAND_TABLE`**** in ****`classifier.ts`**
 		- **Description**: Add `'ac-classify-intent': 'classify-intent'` to the `EMOJI_COMMAND_TABLE` record in `src/adapters/slack/classifier.ts`. No other changes to the module.
 		- **Acceptance criteria**:
-			- [ ] `EMOJI_COMMAND_TABLE['ac-classify-intent']` equals `'classify-intent'`
-			- [ ] `:ac-classify-intent: hello world` passes through `classifyMessage()` as `{ intent: 'command', command: 'classify-intent', args: ['hello', 'world'] }`
-			- [ ] All existing `classifyMessage` tests pass
-			- [ ] `tsc --noEmit` passes
+			- [x] `EMOJI_COMMAND_TABLE['ac-classify-intent']` equals `'classify-intent'`
+			- [x] `:ac-classify-intent: hello world` passes through `classifyMessage()` as `{ intent: 'command', command: 'classify-intent', args: ['hello', 'world'] }`
+			- [x] All existing `classifyMessage` tests pass
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: None
 	- [ ] **Task: Implement ****`makeClassifyIntentHandler`**** in ****`classify-intent-command.ts`**
 		- **Description**: Create `src/core/commands/classify-intent-command.ts`. Export `makeClassifyIntentHandler(intentClassifier: IntentClassifier): CommandHandler`. The handler: (1) returns usage message if args is empty; (2) checks if `args[0]` is a key in `VALID_INTENTS_BY_CONTEXT` — if so, uses it as the context override and joins the remaining args as message text; otherwise joins all args as message text with context defaulting to `new_thread`; (3) returns usage message if text is empty after context extraction; (4) calls `intentClassifier.classify(text, context)`; (5) posts the formatted reply as specified in §2. Write unit tests in `tests/core/commands/classify-intent-command.test.ts` covering all cases in §6.

--- a/context-human/specs/enhancement-classify-command.md
+++ b/context-human/specs/enhancement-classify-command.md
@@ -1,0 +1,244 @@
+---
+created: 2026-04-21
+last_updated: 2026-04-22
+status: implementing
+issue: 65
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Intent classification probe (`:ac-classify-intent:`)
+
+## Parent feature
+
+`feature-command-mode.md`
+## What
+
+Adds the `:ac-classify-intent:` command — the first of two testing utilities planned but deferred in the initial command mode release. The command runs any message text through `AnthropicIntentClassifier.classify()` and posts the result in-thread: the intent and the context used. An optional context override lets callers test classification in any stage context. No run, workspace, or persistent state is created.
+## Why
+
+Diagnosing intent misclassifications requires starting a full pipeline run and watching how the message is routed. There is no way to test the classifier in isolation — against a known input, in a specific context, without side effects. This makes it slow and noisy to validate prompt changes or reproduce a reported misclassification. The probe closes that gap: any message can be tested in any context with a single command, with a result in under a second.
+## User stories
+
+- Phoebe can use `:ac-``classify-intent``: what's the status of the onboarding work` to see how a message would be classified before sending it as a real request, without starting a run
+- Phoebe can use `:ac-classify-intent: ``reviewing_spec`` looks good` to test how a message would be classified in a specific stage context (e.g., to confirm an approval message is recognized as `approval` during spec review)
+- Enzo can use the probe to confirm that a known message receives the expected intent after a classifier prompt change, without triggering the pipeline
+- Existing classification for all normal messages is unaffected
+## Design changes
+
+No UI — the reply is plain Slack text.
+## Technical changes
+
+### Affected files
+
+- `src/adapters/slack/classifier.ts` — add `'ac-classify-intent': 'classify-intent'` to `EMOJI_COMMAND_TABLE`
+- `src/core/commands/classify-intent-command.ts` — new file; `makeClassifyIntentHandler(intentClassifier: IntentClassifier)` implementation
+- `src/index.ts` — register `classify-intent` command with `makeClassifyIntentHandler(intentClassifier)` and a usage string
+### No changes needed
+
+- `src/adapters/agent/intent-classifier.ts` — called as-is; no changes
+- `src/core/orchestrator.ts` — command dispatch is already in place via `_launchCommand` and `CommandRegistry`
+- `src/adapters/slack/slack-adapter.ts` — command detection and `CommandEvent` emission already handle any registered emoji in the table
+### Changes
+
+#### 1. Introduction and overview
+
+**Prerequisites and assumptions**
+- Depends on `feature-command-mode.md` (complete) — `CommandRegistry`, `CommandEvent`, `CommandHandler` types; `_launchCommand` dispatch in `OrchestratorImpl`; `EMOJI_COMMAND_TABLE` in `classifier.ts`; command registration pattern in `src/index.ts`
+- Depends on `enhancement-intent-classifier-routing.md` (complete) — `AnthropicIntentClassifier`, `IntentClassifier` interface, `ClassificationContext` type, `VALID_INTENTS_BY_CONTEXT`
+- No new ADRs, database changes, or API surface required
+**Technical goals**
+- `:ac-classify-intent:` is dispatched through the existing `CommandRegistry` — no new event types, no changes to the `classifyMessage()` detection logic beyond adding one entry to `EMOJI_COMMAND_TABLE`
+- The handler treats `args[0]` as a context override if it matches a key in `VALID_INTENTS_BY_CONTEXT`; otherwise the full args are joined as message text and `new_thread` is used
+- No run, workspace, `ThreadRegistry` entry, or any persistent state is created
+**Non-goals**
+- Implementing `:ac-route:` (the other deferred testing utility from `feature-command-mode.md`)
+- Logging or persisting probe results
+- Restricting probe access to specific users or channels
+#### 2. System design and architecture
+
+No architectural changes. The classify-intent probe is a pure addition within the existing command infrastructure:
+```javascript
+User: :ac-classify-intent: reviewing_spec looks good
+  → classifyMessage() matches 'ac-classify-intent' in EMOJI_COMMAND_TABLE
+  → { intent: 'command', command: 'classify-intent', args: ['reviewing_spec', 'looks', 'good'] }
+  → SlackAdapter builds and emits CommandEvent
+  → OrchestratorImpl._runLoop detects type: 'command' → _launchCommand
+  → CommandRegistry.dispatch('classify-intent', event, reply)
+  → makeClassifyIntentHandler: 'reviewing_spec' found in VALID_INTENTS_BY_CONTEXT → context override
+  → intentClassifier.classify('looks good', 'reviewing_spec')
+  → reply: *Classification result* / Context: `reviewing_spec` / Intent: `approval`
+```
+**Context argument syntax**
+If `args[0]` is a key in `VALID_INTENTS_BY_CONTEXT`, it is treated as a context override and the remaining args are joined as the message text. Otherwise, all args are joined as the message text and the context defaults to `new_thread`.
+Examples:
+- `:ac-classify-intent: the login button is broken` → context = `new_thread`, text = `the login button is broken`
+- `:ac-classify-intent: reviewing_spec is this the right approach?` → context = `reviewing_spec`, text = `is this the right approach?`
+**Reply format**
+```javascript
+*Classification result*
+Context: `new_thread`
+Intent: `question`
+```
+#### 3. Detailed design
+
+**`src/adapters/slack/classifier.ts`**
+Add one entry to `EMOJI_COMMAND_TABLE`:
+```typescript
+'ac-classify-intent': 'classify-intent',
+```
+No other changes to the module.
+---
+**`src/core/commands/classify-intent-command.ts`** (new file)
+```typescript
+import type { CommandHandler } from '../../types/commands.js';
+import type { IntentClassifier, ClassificationContext } from '../../adapters/agent/intent-classifier.js';
+import { VALID_INTENTS_BY_CONTEXT } from '../../adapters/agent/intent-classifier.js';
+
+export function makeClassifyIntentHandler(intentClassifier: IntentClassifier): CommandHandler {
+  return async (event, reply) => {
+    const { args } = event;
+
+    if (args.length === 0) {
+      await reply('Usage: `:ac-classify-intent: ` or `:ac-classify-intent:  `');
+      return;
+    }
+
+    let context: ClassificationContext = 'new_thread';
+    let text: string;
+
+    if (args[0] in VALID_INTENTS_BY_CONTEXT) {
+      context = args[0] as ClassificationContext;
+      text = args.slice(1).join(' ');
+    } else {
+      text = args.join(' ');
+    }
+
+    if (!text.trim()) {
+      await reply('Usage: `:ac-classify-intent: ` or `:ac-classify-intent:  `');
+      return;
+    }
+
+    const intent = await intentClassifier.classify(text, context);
+
+    await reply(`*Classification result*\nContext: \`${context}\`\nIntent: \`${intent}\``);
+  };
+}
+```
+---
+**`src/index.ts`** (addition)
+After the existing command registrations, add:
+```typescript
+import { makeClassifyIntentHandler } from './core/commands/classify-intent-command.js';
+
+// ...
+
+commandRegistry.register(
+  'classify-intent',
+  makeClassifyIntentHandler(intentClassifier),
+  'Test how a message would be classified. Usage: `:ac-classify-intent: ` or `:ac-classify-intent:  `',
+);
+```
+#### 4. Security, privacy, and compliance
+
+**Input handling**
+- `event.args` values are not logged — consistent with the existing args-not-logged policy from `feature-command-mode.md`. Only `event.command`, `event.author`, and the extracted context name are logged.
+- The message text is passed to `AnthropicIntentClassifier.classify()` as an opaque string, which is the same call path used for all normal message classification. No new data sharing model is introduced.
+**No side effects**
+- The handler creates no runs, workspaces, `ThreadRegistry` entries, or persistent state. All side effects are confined to posting a single reply message.
+#### 5. Observability
+
+The classify-intent command inherits all command-level observability from the existing infrastructure:
+
+Event
+Level
+Fields
+
+`command.dispatched`
+info
+`command: 'classify-intent'`, `author`
+
+`command.succeeded`
+info
+`command: 'classify-intent'`, `author`
+
+`command.failed`
+error
+`command: 'classify-intent'`, `error`
+
+`intent.classified`
+info
+`context`, `classified_intent`, `message_length` (from `AnthropicIntentClassifier`)
+
+Metrics inherited from command infrastructure:
+- `command.received` counter with `command: 'classify-intent'` label
+- `command.succeeded` / `command.failed` counters with `command: 'classify-intent'` label
+No new metrics are required.
+#### 6. Testing plan
+
+**`classifier.ts`**** — unit tests (classify-intent entry in EMOJI_COMMAND_TABLE)**
+- `:ac-classify-intent: hello world` → `{ intent: 'command', command: 'classify-intent', args: ['hello', 'world'] }`
+- `:ac-classify-intent:` with no trailing text → `{ intent: 'command', command: 'classify-intent', args: [] }`
+- `:ac-classify-intent: reviewing_spec looks good` → `{ intent: 'command', command: 'classify-intent', args: ['reviewing_spec', 'looks', 'good'] }`
+- All existing `classifyMessage` tests still pass
+- `tsc --noEmit` passes
+**`classify-intent-command.ts`**** — unit tests**
+*Normal classification:*
+- Args `['the', 'login', 'button', 'is', 'broken']` → `classify('the login button is broken', 'new_thread')` called; reply contains `Context: \`new_thread\`` and `Intent: \`\\`\`
+- Args `['reviewing_spec', 'is', 'this', 'right?']` → `classify('is this right?', 'reviewing_spec')` called; reply contains `Context: \`reviewing_spec\`\`
+- Args `['awaiting_impl_input', 'more', 'context']` → valid context; `classify('more context', 'awaiting_impl_input')` called
+*Context detection:*
+- Args `['foo', 'message']` → `foo` not in `VALID_INTENTS_BY_CONTEXT`; `classify('foo message', 'new_thread')` called
+- Args `['new_thread', 'message']` → `new_thread` is valid; `classify('message', 'new_thread')` called
+*Edge cases:*
+- Empty args `[]` → usage message posted; `classify()` not called
+- Args `['reviewing_spec']` with no message text after context → usage message posted; `classify()` not called
+- `classify()` throws → error propagates to `_launchCommand`, which posts the standard command-failed fallback reply; handler does not swallow the error
+*Reply format:*
+- Reply is exactly `*Classification result*\nContext: \`new_thread\`nIntent: \`question\`\` (or actual intent)
+**`src/index.ts`**** — integration smoke test**
+- `commandRegistry.has('classify-intent')` returns `true` after startup
+- `commandRegistry.getUsage('classify-intent')` returns a non-empty usage string
+- `:ac-help:` output includes `classify-intent`
+#### 7. Alternatives considered
+
+**Text-prefix approach (****`@ac classify: message`****)**
+The issue proposes detecting a `classify:` text prefix in `classifyMessage()` after the `@mention`, rather than using a `:ac-classify-intent:` emoji token. This avoids requiring a custom emoji but introduces a parallel detection path in `classifyMessage()` with different logic and a new `InboundEvent` handling branch in the adapter. Rejected because the parent feature spec (`feature-command-mode.md`) explicitly names `:ac-classify:` as the intended command format, and the emoji approach requires zero changes beyond adding a table entry and implementing the handler — all routing infrastructure already exists.
+**Route through the orchestrator as a new event type**
+The issue also proposes routing through a new `probe_classify` event type in `InboundEvent` rather than through the command registry. Rejected for the same reason: the command registry exists precisely for deterministic, non-pipeline operations that post a reply without creating a run. A new event type would require changes to `classifyMessage()`, `SlackAdapter`, and the orchestrator's main dispatch loop, all of which are avoided by using the existing command path.
+#### 8. Risks
+
+**`:ac-classify-intent:`**** custom Slack emoji must exist in the workspace**
+Like all `:ac-*:` commands, `:ac-classify-intent:` requires a custom emoji to be created in the Slack workspace. If the emoji does not exist, the command cannot be triggered. Mitigation: document the emoji alongside the other required `:ac-*:` emojis in the project README. No code change required.
+**`intentClassifier`**** is required (not optional)**
+The handler accepts `IntentClassifier`, not `IntentClassifier | undefined`. In `src/index.ts`, `intentClassifier` is always constructed before command registration, so this is not a runtime risk. Tests that construct the handler must supply a mock; the non-optional type signature enforces this at compile time.
+## Task list
+
+- [ ] **Story: Wire ****`:ac-classify-intent:`**** into the command table and register the handler**
+	- [ ] **Task: Add ****`:ac-classify-intent:`**** to ****`EMOJI_COMMAND_TABLE`**** in ****`classifier.ts`**
+		- **Description**: Add `'ac-classify-intent': 'classify-intent'` to the `EMOJI_COMMAND_TABLE` record in `src/adapters/slack/classifier.ts`. No other changes to the module.
+		- **Acceptance criteria**:
+			- [ ] `EMOJI_COMMAND_TABLE['ac-classify-intent']` equals `'classify-intent'`
+			- [ ] `:ac-classify-intent: hello world` passes through `classifyMessage()` as `{ intent: 'command', command: 'classify-intent', args: ['hello', 'world'] }`
+			- [ ] All existing `classifyMessage` tests pass
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: None
+	- [ ] **Task: Implement ****`makeClassifyIntentHandler`**** in ****`classify-intent-command.ts`**
+		- **Description**: Create `src/core/commands/classify-intent-command.ts`. Export `makeClassifyIntentHandler(intentClassifier: IntentClassifier): CommandHandler`. The handler: (1) returns usage message if args is empty; (2) checks if `args[0]` is a key in `VALID_INTENTS_BY_CONTEXT` — if so, uses it as the context override and joins the remaining args as message text; otherwise joins all args as message text with context defaulting to `new_thread`; (3) returns usage message if text is empty after context extraction; (4) calls `intentClassifier.classify(text, context)`; (5) posts the formatted reply as specified in §2. Write unit tests in `tests/core/commands/classify-intent-command.test.ts` covering all cases in §6.
+		- **Acceptance criteria**:
+			- [ ] Empty args → usage message posted; `classify()` not called
+			- [ ] `['reviewing_spec', 'is', 'this', 'right?']` → `classify('is this right?', 'reviewing_spec')` called; reply includes `Context: \`reviewing_spec\`\`
+			- [ ] `['reviewing_spec']` only → usage message posted; `classify()` not called
+			- [ ] `['hello', 'world']` (no valid context as first arg) → `classify('hello world', 'new_thread')` called
+			- [ ] Reply format matches spec
+			- [ ] All unit tests pass
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `:ac-classify-intent:` to `EMOJI_COMMAND_TABLE`
+	- [ ] **Task: Register ****`classify-intent`**** command in ****`src/index.ts`**
+		- **Description**: Import `makeClassifyIntentHandler` from `./core/commands/classify-intent-command.js`. After the existing command registrations, call `commandRegistry.register('classify-intent', makeClassifyIntentHandler(intentClassifier), '')`. Use usage string: `Test how a message would be classified. Usage: \`:ac-classify-intent: \\` or \`:ac-classify-intent: \ \\`\`.
+		- **Acceptance criteria**:
+			- [ ] `commandRegistry.has('classify-intent')` returns `true` at startup
+			- [ ] `commandRegistry.getUsage('classify-intent')` returns a non-empty string
+			- [ ] `:ac-help:` lists `classify-intent` in its output
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Implement `makeClassifyIntentHandler` in `classify-intent-command.ts`

--- a/context-human/specs/enhancement-classify-command.md
+++ b/context-human/specs/enhancement-classify-command.md
@@ -223,16 +223,16 @@ The handler accepts `IntentClassifier`, not `IntentClassifier | undefined`. In `
 			- [x] All existing `classifyMessage` tests pass
 			- [x] `tsc --noEmit` passes
 		- **Dependencies**: None
-	- [ ] **Task: Implement ****`makeClassifyIntentHandler`**** in ****`classify-intent-command.ts`**
+	- [x] **Task: Implement ****`makeClassifyIntentHandler`**** in ****`classify-intent-command.ts`**
 		- **Description**: Create `src/core/commands/classify-intent-command.ts`. Export `makeClassifyIntentHandler(intentClassifier: IntentClassifier): CommandHandler`. The handler: (1) returns usage message if args is empty; (2) checks if `args[0]` is a key in `VALID_INTENTS_BY_CONTEXT` — if so, uses it as the context override and joins the remaining args as message text; otherwise joins all args as message text with context defaulting to `new_thread`; (3) returns usage message if text is empty after context extraction; (4) calls `intentClassifier.classify(text, context)`; (5) posts the formatted reply as specified in §2. Write unit tests in `tests/core/commands/classify-intent-command.test.ts` covering all cases in §6.
 		- **Acceptance criteria**:
-			- [ ] Empty args → usage message posted; `classify()` not called
-			- [ ] `['reviewing_spec', 'is', 'this', 'right?']` → `classify('is this right?', 'reviewing_spec')` called; reply includes `Context: \`reviewing_spec\`\`
-			- [ ] `['reviewing_spec']` only → usage message posted; `classify()` not called
-			- [ ] `['hello', 'world']` (no valid context as first arg) → `classify('hello world', 'new_thread')` called
-			- [ ] Reply format matches spec
-			- [ ] All unit tests pass
-			- [ ] `tsc --noEmit` passes
+			- [x] Empty args → usage message posted; `classify()` not called
+			- [x] `['reviewing_spec', 'is', 'this', 'right?']` → `classify('is this right?', 'reviewing_spec')` called; reply includes `Context: \`reviewing_spec\`\`
+			- [x] `['reviewing_spec']` only → usage message posted; `classify()` not called
+			- [x] `['hello', 'world']` (no valid context as first arg) → `classify('hello world', 'new_thread')` called
+			- [x] Reply format matches spec
+			- [x] All unit tests pass
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `:ac-classify-intent:` to `EMOJI_COMMAND_TABLE`
 	- [ ] **Task: Register ****`classify-intent`**** command in ****`src/index.ts`**
 		- **Description**: Import `makeClassifyIntentHandler` from `./core/commands/classify-intent-command.js`. After the existing command registrations, call `commandRegistry.register('classify-intent', makeClassifyIntentHandler(intentClassifier), '')`. Use usage string: `Test how a message would be classified. Usage: \`:ac-classify-intent: \\` or \`:ac-classify-intent: \ \\`\`.

--- a/context-human/specs/enhancement-classify-command.md
+++ b/context-human/specs/enhancement-classify-command.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-21
 last_updated: 2026-04-22
-status: implementing
+status: complete
 issue: 65
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-classify-command.md
+++ b/context-human/specs/enhancement-classify-command.md
@@ -214,7 +214,7 @@ Like all `:ac-*:` commands, `:ac-classify-intent:` requires a custom emoji to be
 The handler accepts `IntentClassifier`, not `IntentClassifier | undefined`. In `src/index.ts`, `intentClassifier` is always constructed before command registration, so this is not a runtime risk. Tests that construct the handler must supply a mock; the non-optional type signature enforces this at compile time.
 ## Task list
 
-- [ ] **Story: Wire ****`:ac-classify-intent:`**** into the command table and register the handler**
+- [x] **Story: Wire ****`:ac-classify-intent:`**** into the command table and register the handler**
 	- [x] **Task: Add ****`:ac-classify-intent:`**** to ****`EMOJI_COMMAND_TABLE`**** in ****`classifier.ts`**
 		- **Description**: Add `'ac-classify-intent': 'classify-intent'` to the `EMOJI_COMMAND_TABLE` record in `src/adapters/slack/classifier.ts`. No other changes to the module.
 		- **Acceptance criteria**:
@@ -234,11 +234,11 @@ The handler accepts `IntentClassifier`, not `IntentClassifier | undefined`. In `
 			- [x] All unit tests pass
 			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `:ac-classify-intent:` to `EMOJI_COMMAND_TABLE`
-	- [ ] **Task: Register ****`classify-intent`**** command in ****`src/index.ts`**
+	- [x] **Task: Register ****`classify-intent`**** command in ****`src/index.ts`**
 		- **Description**: Import `makeClassifyIntentHandler` from `./core/commands/classify-intent-command.js`. After the existing command registrations, call `commandRegistry.register('classify-intent', makeClassifyIntentHandler(intentClassifier), '')`. Use usage string: `Test how a message would be classified. Usage: \`:ac-classify-intent: \\` or \`:ac-classify-intent: \ \\`\`.
 		- **Acceptance criteria**:
-			- [ ] `commandRegistry.has('classify-intent')` returns `true` at startup
-			- [ ] `commandRegistry.getUsage('classify-intent')` returns a non-empty string
-			- [ ] `:ac-help:` lists `classify-intent` in its output
-			- [ ] `tsc --noEmit` passes
+			- [x] `commandRegistry.has('classify-intent')` returns `true` at startup
+			- [x] `commandRegistry.getUsage('classify-intent')` returns a non-empty string
+			- [x] `:ac-help:` lists `classify-intent` in its output
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Implement `makeClassifyIntentHandler` in `classify-intent-command.ts`

--- a/src/adapters/slack/classifier.ts
+++ b/src/adapters/slack/classifier.ts
@@ -20,6 +20,7 @@ export const EMOJI_COMMAND_TABLE: Record<string, string> = {
   'ac-run-logs': 'run.logs',
   'ac-health': 'health',
   'ac-help': 'help',
+  'ac-classify-intent': 'classify-intent',
 };
 
 export function classifyMessage(

--- a/src/core/commands/classify-intent-command.ts
+++ b/src/core/commands/classify-intent-command.ts
@@ -1,0 +1,33 @@
+import type { CommandHandler } from '../../types/commands.js';
+import type { IntentClassifier, ClassificationContext } from '../../adapters/agent/intent-classifier.js';
+import { VALID_INTENTS_BY_CONTEXT } from '../../adapters/agent/intent-classifier.js';
+
+export function makeClassifyIntentHandler(intentClassifier: IntentClassifier): CommandHandler {
+  return async (event, reply) => {
+    const { args } = event;
+
+    if (args.length === 0) {
+      await reply('Usage: `:ac-classify-intent: <message>` or `:ac-classify-intent: <context> <message>`');
+      return;
+    }
+
+    let context: ClassificationContext = 'new_thread';
+    let text: string;
+
+    if (args[0] in VALID_INTENTS_BY_CONTEXT) {
+      context = args[0] as ClassificationContext;
+      text = args.slice(1).join(' ');
+    } else {
+      text = args.join(' ');
+    }
+
+    if (!text.trim()) {
+      await reply('Usage: `:ac-classify-intent: <message>` or `:ac-classify-intent: <context> <message>`');
+      return;
+    }
+
+    const intent = await intentClassifier.classify(text, context);
+
+    await reply(`*Classification result*\nContext: \`${context}\`\nIntent: \`${intent}\``);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { OrchestratorImpl } from './core/orchestrator.js';
 import { CommandRegistryImpl } from './core/command-registry.js';
 import { makeRunStatusHandler, makeRunListHandler, makeRunCancelHandler, makeRunLogsHandler } from './core/commands/run-commands.js';
 import { makeHealthHandler, makeHelpHandler } from './core/commands/meta-commands.js';
+import { makeClassifyIntentHandler } from './core/commands/classify-intent-command.js';
 import { FileRunStore } from './core/run-store.js';
 import { NotionClientImpl } from './adapters/notion/notion-client.js';
 import { NotionPublisher } from './adapters/notion/notion-publisher.js';
@@ -297,6 +298,11 @@ try {
     'help',
     makeHelpHandler(commandRegistry),
     'Show available commands. Usage: `:ac-help:` or `:ac-help: <command>`',
+  );
+  commandRegistry.register(
+    'classify-intent',
+    makeClassifyIntentHandler(intentClassifier),
+    'Test how a message would be classified. Usage: `:ac-classify-intent: <message>` or `:ac-classify-intent: <context> <message>`',
   );
 
   const service = new Service(currentConfig, { orchestrator });

--- a/tests/adapters/slack/classifier.test.ts
+++ b/tests/adapters/slack/classifier.test.ts
@@ -236,3 +236,44 @@ describe('classifyMessage — command detection', () => {
     expect(result.intent).toBe('ignore');
   });
 });
+
+describe('classifyMessage — classify-intent command', () => {
+  it(':ac-classify-intent: hello world → command classify-intent with args [hello, world]', () => {
+    const result = classifyMessage(
+      { text: ':ac-classify-intent: hello world', user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    );
+    expect(result.intent).toBe('command');
+    if (result.intent === 'command') {
+      expect(result.command).toBe('classify-intent');
+      expect(result.args).toEqual(['hello', 'world']);
+    }
+  });
+
+  it(':ac-classify-intent: with no trailing text → command classify-intent with empty args', () => {
+    const result = classifyMessage(
+      { text: ':ac-classify-intent:', user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    );
+    expect(result.intent).toBe('command');
+    if (result.intent === 'command') {
+      expect(result.command).toBe('classify-intent');
+      expect(result.args).toEqual([]);
+    }
+  });
+
+  it(':ac-classify-intent: reviewing_spec looks good → args include context and message tokens', () => {
+    const result = classifyMessage(
+      { text: ':ac-classify-intent: reviewing_spec looks good', user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    );
+    expect(result.intent).toBe('command');
+    if (result.intent === 'command') {
+      expect(result.command).toBe('classify-intent');
+      expect(result.args).toEqual(['reviewing_spec', 'looks', 'good']);
+    }
+  });
+});

--- a/tests/core/commands/classify-intent-command.test.ts
+++ b/tests/core/commands/classify-intent-command.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { CommandEvent } from '../../../src/types/commands.js';
+import type { IntentClassifier } from '../../../src/adapters/agent/intent-classifier.js';
+import { makeClassifyIntentHandler } from '../../../src/core/commands/classify-intent-command.js';
+
+function makeEvent(overrides: Partial<CommandEvent> = {}): CommandEvent {
+  return {
+    command: 'classify-intent',
+    args: [],
+    source: 'slack',
+    channel_id: 'C001',
+    thread_ts: '1000.0',
+    author: 'U001',
+    received_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeClassifier(classifyImpl?: (msg: string, ctx: string) => Promise<string>) {
+  return {
+    classify: classifyImpl
+      ? vi.fn().mockImplementation(classifyImpl)
+      : vi.fn().mockResolvedValue('question'),
+  } as unknown as IntentClassifier & { classify: ReturnType<typeof vi.fn> };
+}
+
+describe('makeClassifyIntentHandler — empty args', () => {
+  it('posts usage message and does not call classify()', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: [] }), reply);
+
+    expect(reply).toHaveBeenCalledOnce();
+    expect(reply.mock.calls[0][0] as string).toContain('Usage');
+    expect(classifier.classify).not.toHaveBeenCalled();
+  });
+});
+
+describe('makeClassifyIntentHandler — context override', () => {
+  it('args [reviewing_spec, is, this, right?] → classify("is this right?", "reviewing_spec")', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['reviewing_spec', 'is', 'this', 'right?'] }), reply);
+
+    expect(classifier.classify).toHaveBeenCalledWith('is this right?', 'reviewing_spec');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('Context: `reviewing_spec`');
+  });
+
+  it('args [awaiting_impl_input, more, context] → classify("more context", "awaiting_impl_input")', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['awaiting_impl_input', 'more', 'context'] }), reply);
+
+    expect(classifier.classify).toHaveBeenCalledWith('more context', 'awaiting_impl_input');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('Context: `awaiting_impl_input`');
+  });
+
+  it('args [reviewing_spec] with no message text → usage message, classify() not called', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['reviewing_spec'] }), reply);
+
+    expect(reply).toHaveBeenCalledOnce();
+    expect(reply.mock.calls[0][0] as string).toContain('Usage');
+    expect(classifier.classify).not.toHaveBeenCalled();
+  });
+});
+
+describe('makeClassifyIntentHandler — no context override (defaults to new_thread)', () => {
+  it('args [hello, world] → classify("hello world", "new_thread")', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['hello', 'world'] }), reply);
+
+    expect(classifier.classify).toHaveBeenCalledWith('hello world', 'new_thread');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('Context: `new_thread`');
+  });
+
+  it('args [foo, message] where "foo" is not a valid context → classify("foo message", "new_thread")', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['foo', 'message'] }), reply);
+
+    expect(classifier.classify).toHaveBeenCalledWith('foo message', 'new_thread');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('Context: `new_thread`');
+  });
+
+  it('args [new_thread, message] → "new_thread" is valid → classify("message", "new_thread")', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['new_thread', 'message'] }), reply);
+
+    expect(classifier.classify).toHaveBeenCalledWith('message', 'new_thread');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('Context: `new_thread`');
+  });
+});
+
+describe('makeClassifyIntentHandler — reply format', () => {
+  it('reply is exactly *Classification result*\\nContext: `new_thread`\\nIntent: `question`', async () => {
+    const classifier = makeClassifier();
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ args: ['hello', 'world'] }), reply);
+
+    expect(reply).toHaveBeenCalledOnce();
+    expect(reply.mock.calls[0][0]).toBe(
+      '*Classification result*\nContext: `new_thread`\nIntent: `question`',
+    );
+  });
+});
+
+describe('makeClassifyIntentHandler — error propagation', () => {
+  it('classify() throws → error propagates out of handler; reply not called', async () => {
+    const error = new Error('API failure');
+    const classifier = makeClassifier(() => Promise.reject(error));
+    const handler = makeClassifyIntentHandler(classifier);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await expect(handler(makeEvent({ args: ['hello'] }), reply)).rejects.toThrow('API failure');
+    expect(reply).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implemented the :ac-classify-intent: command. Added 'ac-classify-intent': 'classify-intent' to EMOJI_COMMAND_TABLE in src/adapters/slack/classifier.ts, created src/core/commands/classify-intent-command.ts with makeClassifyIntentHandler (context override detection via VALID_INTENTS_BY_CONTEXT, formatted reply, error propagation), and registered the command in src/index.ts. 9 new unit tests added for the handler, 3 new classifier table tests. 806/809 tests pass; the 3 failures are pre-existing in spec-generator.test.ts and unrelated to this feature.

## Testing

Branch: spec/a0fa5f35-38e5-4255-9c76-a797e4d60061
Setup: npm install && npm run build
Test: npm test — 806 tests pass; 3 pre-existing failures in tests/adapters/agent/spec-generator.test.ts are unrelated to this feature

Manual smoke test (requires running Autocatalyst with Slack):
1. Send :ac-classify-intent: the login button is broken in any channel — expect reply: *Classification result* / Context: `new_thread` / Intent: `bug` (or similar)
2. Send :ac-classify-intent: reviewing_spec looks good — expect reply with Context: `reviewing_spec` and Intent: `approval`
3. Send :ac-classify-intent: (no text) — expect usage message
4. Send :ac-help: — verify classify-intent appears in the command list

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/a0fa5f35-38e5-4255-9c76-a797e4d60061/context-human/specs/enhancement-classify-command.md`
Closes #65