### PR TITLE
fix: expand tilde in workspaceRoot and FileRunStore constructor

### DIFF
--- a/src/core/run-store.ts
+++ b/src/core/run-store.ts
@@ -1,6 +1,7 @@
 // src/core/run-store.ts
 import * as fs from 'fs';
 import * as path from 'path';
+import { homedir } from 'node:os';
 import type pino from 'pino';
 import { createLogger } from './logger.js';
 import type { Run } from '../types/runs.js';
@@ -22,7 +23,7 @@ export class FileRunStore implements RunStore {
   public demotedIds: Set<string> = new Set();
 
   constructor(workspaceRoot: string, options?: FileRunStoreOptions) {
-    this.filePath = path.join(workspaceRoot, '.autocatalyst', 'runs.json');
+    this.filePath = path.join(workspaceRoot.replace(/^~/, homedir()), '.autocatalyst', 'runs.json');
     this.logger = createLogger('run-store', { destination: options?.logDestination });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { Service } from './core/service.js';
 import { registerSignalHandlers } from './core/signals.js';
 import { createLogger } from './core/logger.js';
 import { execSync } from 'node:child_process';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { App } from '@slack/bolt';
 import { SlackAdapter } from './adapters/slack/slack-adapter.js';
@@ -113,11 +114,12 @@ try {
   const repo_name = repoNameFromUrl(repo_url);
 
   // Validate workspace.root
-  const workspaceRoot = currentConfig.config.workspace?.root;
-  if (!workspaceRoot || typeof workspaceRoot !== 'string' || workspaceRoot.trim() === '') {
+  const rawWorkspaceRoot = currentConfig.config.workspace?.root;
+  if (!rawWorkspaceRoot || typeof rawWorkspaceRoot !== 'string' || rawWorkspaceRoot.trim() === '') {
     logger.error({ event: 'config.parse_error', error: 'workspace.root is not set in WORKFLOW.md' }, 'workspace.root is required');
     process.exit(1);
   }
+  const workspaceRoot = rawWorkspaceRoot.replace(/^~/, homedir());
 
   // Validate Slack tokens
   const botToken = currentConfig.config.slack?.bot_token;

--- a/tests/core/run-store.test.ts
+++ b/tests/core/run-store.test.ts
@@ -520,3 +520,52 @@ describe('FileRunStore.demotedIds', () => {
     expect(store.demotedIds.size).toBe(0);
   });
 });
+
+// ─────────────────────────────────────────────
+// constructor — tilde expansion
+// ─────────────────────────────────────────────
+
+describe('FileRunStore constructor — tilde expansion', () => {
+  it('expands ~/some/path to $HOME/some/path/.autocatalyst/runs.json', () => {
+    const { dest } = makeLogCapture();
+    const store = new FileRunStore('~/some/path', { logDestination: dest });
+    const expected = path.join(os.homedir(), 'some', 'path', '.autocatalyst', 'runs.json');
+    // Access the private filePath via type assertion for testing
+    expect((store as unknown as { filePath: string }).filePath).toBe(expected);
+  });
+
+  it('absolute path is unchanged', () => {
+    const { dest } = makeLogCapture();
+    const store = new FileRunStore('/absolute/path', { logDestination: dest });
+    const expected = path.join('/absolute/path', '.autocatalyst', 'runs.json');
+    expect((store as unknown as { filePath: string }).filePath).toBe(expected);
+  });
+
+  it('~/path and equivalent $HOME/path produce identical filePath', () => {
+    const { dest } = makeLogCapture();
+    const tildeStore = new FileRunStore('~/myroot', { logDestination: dest });
+    const absStore = new FileRunStore(path.join(os.homedir(), 'myroot'), { logDestination: dest });
+    expect(
+      (tildeStore as unknown as { filePath: string }).filePath
+    ).toBe(
+      (absStore as unknown as { filePath: string }).filePath
+    );
+  });
+
+  it('FileRunStore with tilde root saves to expanded path (integration)', () => {
+    const tildeEquivalent = path.join(os.tmpdir(), `tilde-test-${randomUUID()}`);
+    fs.mkdirSync(tildeEquivalent, { recursive: true });
+
+    try {
+      const { dest } = makeLogCapture();
+      const store = new FileRunStore(tildeEquivalent, { logDestination: dest });
+      const run = makeRun({ workspace_path: tildeEquivalent, stage: 'reviewing_spec' });
+      store.save(new Map([[run.request_id, run]]));
+      const loaded = store.load();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].request_id).toBe(run.request_id);
+    } finally {
+      fs.rmSync(tildeEquivalent, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixed tilde expansion bug in FileRunStore and src/index.ts. Two-layer defense-in-depth fix: (1) src/index.ts now expands ~ in workspaceRoot immediately after validation, before passing to any consumer; (2) FileRunStore constructor also expands ~ defensively. Added 4 new tests covering tilde expansion, absolute path regression, equivalence guard, and integration round-trip. All 24 run-store tests pass.

## Testing

Branch: spec/92768ed1-967e-401e-9fdb-8f0a466b9d46
Setup: npm install (if needed)
Test: npx vitest run tests/core/run-store.test.ts --reporter=verbose
Expect: 24/24 tests pass, including the 4 new 'FileRunStore constructor — tilde expansion' tests
Note: 3 pre-existing failures in tests/adapters/agent/spec-generator.test.ts are unrelated to this fix

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/92768ed1-967e-401e-9fdb-8f0a466b9d46/.autocatalyst/triage/triage-bug-tilde-not-expanded-filerunstore.md`
Closes #56