### PR TITLE
fix: replace databases.query with dataSources.query for @notionhq/client@5 compatibility

### DIFF
--- a/context-human/specs/enhancement-notion-database-publishing.md
+++ b/context-human/specs/enhancement-notion-database-publishing.md
@@ -313,7 +313,7 @@ export interface NotionClient {
 }
 ```
 `pages.updateProperties` sends `PATCH /v1/pages/{page_id}` with `{ properties }`. Implemented via the Notion SDK's `pages.update()` method.
-`databases.query` sends `POST /v1/databases/{database_id}/query` with an optional filter body. Implemented via the SDK's `databases.query()` method.
+`dataSources.query` sends `POST /v1/databases/{database_id}/query` with an optional filter body. Implemented via the SDK's `dataSources.query()` method.
 **SpecPublisher interface extension**
 ```typescript
 // src/adapters/slack/canvas-publisher.ts
@@ -562,8 +562,8 @@ All tests use Vitest. `NotionClient` is injectable and mocked with `vi.fn()`. Ex
 **`NotionClient`**** additions**
 - `pages.updateProperties` calls `pages.update()` with the page_id and properties payload; the exact payload is passed through unchanged
 - `pages.updateProperties` propagates rejection from the SDK `pages.update()` call
-- `databases.query` calls `databases.query()` with the database_id and filter; returns the `results` array from the SDK response
-- `databases.query` called without a filter: passes an empty or absent body (does not error)
+- `dataSources.query` calls `dataSources.query()` with the data_source_id and filter; returns the `results` array from the SDK response
+- `dataSources.query` called without a filter: passes an empty or absent body (does not error)
 - `databases.query` propagates rejection from the SDK
 ---
 **`NotionPublisher`**
@@ -708,7 +708,7 @@ These tests live in the `src/index.ts` config block or a dedicated unit for the 
 			- [x] Unit tests added to `tests/adapters/notion/notion-client.test.ts`
 		- **Dependencies**: None
 	- [x] **Task: Add ****`databases.query()`**** to ****`NotionClient`**
-		- **Description**: Add a `databases` namespace to `NotionClient` with `query(database_id: string, filter?: unknown): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>`. Implement in `NotionClientImpl` via the Notion SDK's `databases.query()` method. Calling without a filter must not error.
+		- **Description**: Add a `dataSources` namespace to `NotionClient` with `query(data_source_id: string, filter?: unknown): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>`. Implement in `NotionClientImpl` via the Notion SDK's `dataSources.query()` method. Calling without a filter must not error.
 		- **Acceptance criteria**:
 			- [x] Method added to `NotionClient` interface
 			- [x] `NotionClientImpl.databases.query` calls the SDK and returns the `results` array shaped as specified

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -33,9 +33,9 @@ export interface NotionClient {
   users: {
     me(): Promise<{ id: string }>;
   };
-  databases: {
+  dataSources: {
     query(
-      database_id: string,
+      data_source_id: string,
       filter?: unknown,
     ): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }>;
   };
@@ -105,17 +105,17 @@ export class NotionClientImpl implements NotionClient {
     },
   };
 
-  readonly databases = {
+  readonly dataSources = {
     query: async (
-      database_id: string,
+      data_source_id: string,
       filter?: unknown,
     ): Promise<{ results: Array<{ id: string; properties: Record<string, unknown> }> }> => {
       const response = await (this.client as unknown as {
-        databases: {
-          query: (args: { database_id: string; filter?: unknown }) => Promise<{ results: unknown[] }>;
+        dataSources: {
+          query: (args: { data_source_id: string; filter?: unknown }) => Promise<{ results: unknown[] }>;
         };
-      }).databases.query({
-        database_id,
+      }).dataSources.query({
+        data_source_id,
         ...(filter !== undefined ? { filter } : {}),
       });
       return {

--- a/src/adapters/notion/notion-publisher.ts
+++ b/src/adapters/notion/notion-publisher.ts
@@ -175,7 +175,7 @@ export class NotionPublisher implements SpecPublisher {
   }
 
   private async resolveFilenameToPageId(filename: string): Promise<string | undefined> {
-    const result = await this.client.databases.query(this.specs_database_id, {
+    const result = await this.client.dataSources.query(this.specs_database_id, {
       filter: { property: 'Filename', rich_text: { equals: filename } },
     });
     if (result.results.length === 0) {

--- a/tests/adapters/notion/notion-client.test.ts
+++ b/tests/adapters/notion/notion-client.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NotionClient } from '../../../src/adapters/notion/notion-client.js';
+import { NotionClientImpl } from '../../../src/adapters/notion/notion-client.js';
+
+// Mock the Notion SDK Client so we can inspect what NotionClientImpl passes to it
+const mockSdkQuery = vi.fn();
+vi.mock('@notionhq/client', () => ({
+  Client: vi.fn(() => ({
+    dataSources: { query: mockSdkQuery },
+  })),
+}));
 
 describe('NotionClient interface', () => {
   it('users.me is defined on the interface', () => {
@@ -13,7 +22,7 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
-      databases: { query: async () => ({ results: [] }) },
+      dataSources: { query: async () => ({ results: [] }) },
     };
     expect(typeof client.users.me).toBe('function');
   });
@@ -29,12 +38,12 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
-      databases: { query: async () => ({ results: [] }) },
+      dataSources: { query: async () => ({ results: [] }) },
     };
     expect(typeof client.pages.updateProperties).toBe('function');
   });
 
-  it('databases.query is defined on the interface', () => {
+  it('dataSources.query is defined on the interface', () => {
     const mockQuery = vi.fn().mockResolvedValue({ results: [{ id: 'page-id', properties: {} }] });
     const client: NotionClient = {
       pages: {
@@ -46,12 +55,12 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
-      databases: { query: mockQuery },
+      dataSources: { query: mockQuery },
     };
-    expect(typeof client.databases.query).toBe('function');
+    expect(typeof client.dataSources.query).toBe('function');
   });
 
-  it('databases.query called without a filter does not error', async () => {
+  it('dataSources.query called without a filter does not error', async () => {
     const mockQuery = vi.fn().mockResolvedValue({ results: [] });
     const client: NotionClient = {
       pages: {
@@ -63,8 +72,55 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
-      databases: { query: mockQuery },
+      dataSources: { query: mockQuery },
     };
-    await expect(client.databases.query('db-id')).resolves.toEqual({ results: [] });
+    await expect(client.dataSources.query('db-id')).resolves.toEqual({ results: [] });
+  });
+});
+
+describe('NotionClientImpl.dataSources.query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls SDK dataSources.query with data_source_id', async () => {
+    mockSdkQuery.mockResolvedValue({ results: [] });
+    const impl = new NotionClientImpl({ integration_token: 'test-token' });
+
+    await impl.dataSources.query('ds-abc');
+
+    expect(mockSdkQuery).toHaveBeenCalledWith({ data_source_id: 'ds-abc' });
+  });
+
+  it('passes filter through to SDK when provided', async () => {
+    mockSdkQuery.mockResolvedValue({ results: [] });
+    const impl = new NotionClientImpl({ integration_token: 'test-token' });
+    const filter = { property: 'Filename', rich_text: { equals: 'spec.md' } };
+
+    await impl.dataSources.query('ds-abc', filter);
+
+    expect(mockSdkQuery).toHaveBeenCalledWith({ data_source_id: 'ds-abc', filter });
+  });
+
+  it('omits filter key when filter not provided', async () => {
+    mockSdkQuery.mockResolvedValue({ results: [] });
+    const impl = new NotionClientImpl({ integration_token: 'test-token' });
+
+    await impl.dataSources.query('ds-abc');
+
+    expect(mockSdkQuery).toHaveBeenCalledWith(
+      expect.not.objectContaining({ filter: expect.anything() }),
+    );
+  });
+
+  it('returns results from SDK response shaped as { id, properties } array', async () => {
+    mockSdkQuery.mockResolvedValue({
+      results: [{ id: 'page-1', properties: { Name: {} } }],
+    });
+    const impl = new NotionClientImpl({ integration_token: 'test-token' });
+
+    const result = await impl.dataSources.query('ds-abc');
+
+    expect(result).toEqual({ results: [{ id: 'page-1', properties: { Name: {} } }] });
   });
 });

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -54,7 +54,7 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
       create: vi.fn().mockResolvedValue({}),
     },
     users: { me: vi.fn() },
-    databases: {
+    dataSources: {
       query: vi.fn().mockResolvedValue({ results: [] }),
     },
   };
@@ -405,7 +405,7 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via create)', ()
   it('supersedes set and found: relation property included in create call', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (client.dataSources.query as ReturnType<typeof vi.fn>).mockResolvedValue({
       results: [{ id: 'old-spec-page-id', properties: {} }],
     });
     const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
@@ -414,7 +414,7 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via create)', ()
       'feature-new-spec.md',
     );
     await publisher.create('C123', '100.0', specPath);
-    expect(client.databases.query).toHaveBeenCalledWith('db-specs-id', {
+    expect(client.dataSources.query).toHaveBeenCalledWith('db-specs-id', {
       filter: { property: 'Filename', rich_text: { equals: 'feature-old-spec.md' } },
     });
     const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
@@ -425,7 +425,7 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via create)', ()
     const { records, destination } = makeLogCapture();
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
+    (client.dataSources.query as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
     const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
     const specPath = makeSpecFile(
       '---\nspecced_by: alice\nlast_updated: 2026-04-16\nsupersedes: feature-missing.md\n---\n# Spec',
@@ -441,7 +441,7 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via create)', ()
   it('multiple results: returns first result id', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (client.dataSources.query as ReturnType<typeof vi.fn>).mockResolvedValue({
       results: [
         { id: 'first-page-id', properties: {} },
         { id: 'second-page-id', properties: {} },
@@ -565,7 +565,7 @@ describe('NotionPublisher.update — property sync', () => {
   it('superseded_by set and resolves: Status=Superseded and relation set', async () => {
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (client.dataSources.query as ReturnType<typeof vi.fn>).mockResolvedValue({
       results: [{ id: 'superseding-page-id', properties: {} }],
     });
     const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: nullDest });
@@ -583,7 +583,7 @@ describe('NotionPublisher.update — property sync', () => {
     const { records, destination } = makeLogCapture();
     const client = makeMockNotionClient();
     const app = makeMockApp();
-    (client.databases.query as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
+    (client.dataSources.query as ReturnType<typeof vi.fn>).mockResolvedValue({ results: [] });
     const publisher = new NotionPublisher(client, app as unknown as App, 'db-specs-id', { logDestination: destination });
     const specPath = makeSpecFile(
       '---\nlast_updated: 2026-04-16\nsuperseded_by: feature-missing.md\n---\n# Spec',


### PR DESCRIPTION
Fixes #54

Fixed TypeError caused by `@notionhq/client@5` removing `databases.query`. Renamed `databases` → `dataSources` throughout `NotionClient` interface, `NotionClientImpl`, and all callers/tests. Added 4 new unit tests for `NotionClientImpl.dataSources.query` that mock the underlying SDK Client and verify correct argument passing (`data_source_id`, filter passthrough, filter omission, return shape). Updated 6 mock references in `notion-publisher.test.ts`. Updated 3 spec-doc references in `enhancement-notion-database-publishing.md`. All 826 tests pass (3 pre-existing failures in `spec-generator.test.ts` are unrelated to this fix).

## Testing

Branch: spec/8b8080fc-54d9-47e5-8781-1f7c8826d4fd
Setup: `npm install`
Test: `npm test`
Expected: 826 tests pass, 3 pre-existing failures in `tests/adapters/agent/spec-generator.test.ts` (unrelated to this fix)
Key test files: `tests/adapters/notion/notion-client.test.ts` (8 tests including 4 new `NotionClientImpl.dataSources.query` unit tests), `tests/adapters/notion/notion-publisher.test.ts` (45 tests)