### PR TITLE
feat: feature: multi-repo message routing

### DIFF
--- a/context-human/specs/enhancement-multi-repo-message-routing.md
+++ b/context-human/specs/enhancement-multi-repo-message-routing.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-23
-last_updated: 2026-04-23
-status: implemented
+last_updated: 2026-04-24
+status: complete
 issue: 33
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-multi-repo-message-routing.md
+++ b/context-human/specs/enhancement-multi-repo-message-routing.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-23
 last_updated: 2026-04-23
-status: implementing
+status: implemented
 issue: 33
 specced_by: markdstafford
 implemented_by: markdstafford
@@ -163,112 +163,112 @@ Integration
 ## Task list
 
 *(Added by task decomposition stage)*
-- [ ] **Story: CLI — multi-repo startup via ****`--repo`**** flag**
-	- [ ] **Task: Extend ****`--repo`**** to accept multiple space-separated paths**
+- [x] **Story: CLI — multi-repo startup via ****`--repo`**** flag**
+	- [x] **Task: Extend ****`--repo`**** to accept multiple space-separated paths**
 		- **Description**: Update argument parsing in `src/index.ts` to allow `--repo` to accept multiple space-separated paths. When multiple paths are provided, collect them as an array. Single `--repo /path` or no flag preserves existing behavior.
 		- **Acceptance criteria**:
-			- [ ] `--repo /a /b` parsed as `["/a", "/b"]`
-			- [ ] Single `--repo /a` or no flag → existing parse result unchanged
-			- [ ] `tsc --noEmit` passes
+			- [x] `--repo /a /b` parsed as `["/a", "/b"]`
+			- [x] Single `--repo /a` or no flag → existing parse result unchanged
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: None
-	- [ ] **Task: Add ****`loadConfigFromPath()`**** to ****`src/core/config.ts`**
+	- [x] **Task: Add ****`loadConfigFromPath()`**** to ****`src/core/config.ts`**
 		- **Description**: Add `loadConfigFromPath(repoPath: string): WorkflowConfig` that reads and validates [WORKFLOW.md](http://WORKFLOW.md) from the given directory path. Update the existing `loadConfig()` to delegate to this with `process.cwd()`. Update `src/index.ts` multi-repo startup to call `loadConfigFromPath()` for each path in `--repo`.
 		- **Acceptance criteria**:
-			- [ ] Valid [WORKFLOW.md](http://WORKFLOW.md) at given path → returns parsed `WorkflowConfig`
-			- [ ] Missing or invalid [WORKFLOW.md](http://WORKFLOW.md) → descriptive error including the path
-			- [ ] Existing `loadConfig()` behavior unchanged
-			- [ ] All config tests pass: `npm test`
+			- [x] Valid [WORKFLOW.md](http://WORKFLOW.md) at given path → returns parsed `WorkflowConfig`
+			- [x] Missing or invalid [WORKFLOW.md](http://WORKFLOW.md) → descriptive error including the path
+			- [x] Existing `loadConfig()` behavior unchanged
+			- [x] All config tests pass: `npm test`
 		- **Dependencies**: Task: Extend `--repo` to accept multiple space-separated paths
-	- [ ] **Task: Resolve repo URLs and build ****`ChannelRepoMap`**** at startup**
+	- [x] **Task: Resolve repo URLs and build ****`ChannelRepoMap`**** at startup**
 		- **Description**: For each repo path in multi-repo mode, run `git remote get-url origin` from that directory to get `repo_url`. Combine with `channel_name` and `workspace_root` from the repo's [WORKFLOW.md](http://WORKFLOW.md). Pass the full entry list to `SlackAdapter` for channel ID resolution. Log `service.starting` with mode and channel count.
 		- **Acceptance criteria**:
-			- [ ] Each repo's `repo_url` resolved via `git remote` in its directory
-			- [ ] `workspace_root` defaults to `~/.autocatalyst/workspaces/` when absent from [WORKFLOW.md](http://WORKFLOW.md)
-			- [ ] `service.starting` logged with `mode: "multi-repo"` and correct `channel_count`
-			- [ ] Single-repo startup logs `mode: "single-repo"` unchanged
-			- [ ] `tsc --noEmit` passes
+			- [x] Each repo's `repo_url` resolved via `git remote` in its directory
+			- [x] `workspace_root` defaults to `~/.autocatalyst/workspaces/` when absent from [WORKFLOW.md](http://WORKFLOW.md)
+			- [x] `service.starting` logged with `mode: "multi-repo"` and correct `channel_count`
+			- [x] Single-repo startup logs `mode: "single-repo"` unchanged
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Add `loadConfigFromPath()`
-	- [ ] **Task: Tests for conditional startup modes**
+	- [x] **Task: Tests for conditional startup modes**
 		- **Description**: Extend entry point startup helper tests: multi-repo mode reads each repo's [WORKFLOW.md](http://WORKFLOW.md) and runs `git remote` per repo; single-repo mode unchanged; missing [WORKFLOW.md](http://WORKFLOW.md) at a `--repo` path exits with code 1 and descriptive message.
 		- **Acceptance criteria**:
-			- [ ] Multi-repo mode: `loadConfigFromPath()` called once per repo path
-			- [ ] Multi-repo mode: `git remote get-url origin` called once per repo directory
-			- [ ] Multi-repo mode: `service.starting` logged with `mode: "multi-repo"`
-			- [ ] Single-repo mode: all existing startup tests pass unchanged
-			- [ ] Missing [WORKFLOW.md](http://WORKFLOW.md): exits code 1 with path in error message
-			- [ ] `npm test` passes
+			- [x] Multi-repo mode: `loadConfigFromPath()` called once per repo path
+			- [x] Multi-repo mode: `git remote get-url origin` called once per repo directory
+			- [x] Multi-repo mode: `service.starting` logged with `mode: "multi-repo"`
+			- [x] Single-repo mode: all existing startup tests pass unchanged
+			- [x] Missing [WORKFLOW.md](http://WORKFLOW.md): exits code 1 with path in error message
+			- [x] `npm test` passes
 		- **Dependencies**: Task: Resolve repo URLs and build ChannelRepoMap
-- [ ] **Story: Config — internal ****`RepoEntry`**** type**
-	- [ ] **Task: Add ****`RepoEntry`**** internal type**
+- [x] **Story: Config — internal ****`RepoEntry`**** type**
+	- [x] **Task: Add ****`RepoEntry`**** internal type**
 		- **Description**: Add `RepoEntry` interface to `src/types/config.ts` for internal `ChannelRepoMap` use. No changes to `WorkflowConfig`.
 		- **Acceptance criteria**:
-			- [ ] `RepoEntry` has `channel_id: string`, `repo_url: string`, `workspace_root: string`
-			- [ ] `WorkflowConfig` schema unchanged
-			- [ ] `tsc --noEmit` passes
+			- [x] `RepoEntry` has `channel_id: string`, `repo_url: string`, `workspace_root: string`
+			- [x] `WorkflowConfig` schema unchanged
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: None
-	- [ ] **Task: Unit tests for ****`loadConfigFromPath()`**
+	- [x] **Task: Unit tests for ****`loadConfigFromPath()`**
 		- **Description**: Extend `tests/core/config.test.ts`: valid path → parsed config; missing file → error with path; invalid [WORKFLOW.md](http://WORKFLOW.md) → validation error; existing `loadConfig()` tests unchanged.
 		- **Acceptance criteria**:
-			- [ ] All cases pass
-			- [ ] No existing config tests broken
-			- [ ] `npm test` passes
+			- [x] All cases pass
+			- [x] No existing config tests broken
+			- [x] `npm test` passes
 		- **Dependencies**: Task: Add `loadConfigFromPath()`
-- [ ] **Story: SlackAdapter — multi-channel startup**
-	- [ ] **Task: Resolve multiple channel IDs at startup**
+- [x] **Story: SlackAdapter — multi-channel startup**
+	- [x] **Task: Resolve multiple channel IDs at startup**
 		- **Description**: Update `SlackAdapter.start()` to accept repo entries in multi-repo mode. Resolve each channel name to its ID via `conversations.list`. Store as `Map`. Log `slack.startup.channels_resolved`. If any channel cannot be resolved, log `slack.startup.channel_resolution_failed` at error and fail startup. Preserve the existing single-channel path in single-repo mode.
 		- **Acceptance criteria**:
-			- [ ] All channel names resolved before any event handler is registered
-			- [ ] `slack.startup.channels_resolved` logged with `channels` array
-			- [ ] One unresolvable channel → `slack.startup.channel_resolution_failed` logged at error; startup fails with descriptive error
-			- [ ] Single-repo mode → existing `channel_name` resolution unchanged
-			- [ ] `tsc --noEmit` passes
+			- [x] All channel names resolved before any event handler is registered
+			- [x] `slack.startup.channels_resolved` logged with `channels` array
+			- [x] One unresolvable channel → `slack.startup.channel_resolution_failed` logged at error; startup fails with descriptive error
+			- [x] Single-repo mode → existing `channel_name` resolution unchanged
+			- [x] `tsc --noEmit` passes
 		- **Dependencies**: Task: Resolve repo URLs and build ChannelRepoMap
-	- [ ] **Task: Scope event handlers to configured channels**
+	- [x] **Task: Scope event handlers to configured channels**
 		- **Description**: Update `SlackAdapter` message and reaction handlers to drop events from channel IDs not in the resolved `ChannelRepoMap`. This check happens before the classifier is called. Dropped events are logged at debug level as `slack.event.channel_filtered`.
 		- **Acceptance criteria**:
-			- [ ] Message in unconfigured channel → `slack.event.channel_filtered` logged at debug; no classifier call, no event emitted
-			- [ ] Reaction in unconfigured channel → no event emitted
-			- [ ] Message in configured channel → existing classify+emit behavior unchanged
-			- [ ] All existing `SlackAdapter` integration tests pass: `npm test`
+			- [x] Message in unconfigured channel → `slack.event.channel_filtered` logged at debug; no classifier call, no event emitted
+			- [x] Reaction in unconfigured channel → no event emitted
+			- [x] Message in configured channel → existing classify+emit behavior unchanged
+			- [x] All existing `SlackAdapter` integration tests pass: `npm test`
 		- **Dependencies**: Task: Resolve multiple channel IDs at startup
-	- [ ] **Task: Integration tests for multi-channel adapter**
+	- [x] **Task: Integration tests for multi-channel adapter**
 		- **Description**: Extend `tests/adapters/slack/slack-adapter.test.ts` with multi-channel scenarios: two channels resolved at startup, ideas from each channel dispatched with correct `channel_id`, event from unconfigured channel logged as `slack.event.channel_filtered` and silently dropped, one unresolvable channel logs `slack.startup.channel_resolution_failed` and causes startup failure.
 		- **Acceptance criteria**:
-			- [ ] Two configured channels: each `new_idea` emits with the correct `channel_id`
-			- [ ] Event from unconfigured channel: `slack.event.channel_filtered` logged at debug; no event emitted
-			- [ ] Unknown channel at startup: `slack.startup.channel_resolution_failed` logged at error; startup throws
-			- [ ] All tests pass: `npm test`
+			- [x] Two configured channels: each `new_idea` emits with the correct `channel_id`
+			- [x] Event from unconfigured channel: `slack.event.channel_filtered` logged at debug; no event emitted
+			- [x] Unknown channel at startup: `slack.startup.channel_resolution_failed` logged at error; startup throws
+			- [x] All tests pass: `npm test`
 		- **Dependencies**: Task: Scope event handlers
-- [ ] **Story: WorkspaceManager — explicit workspace root**
-	- [ ] **Task: Add ****`workspace_root`**** parameter to ****`WorkspaceManager.create()`**
+- [x] **Story: WorkspaceManager — explicit workspace root**
+	- [x] **Task: Add ****`workspace_root`**** parameter to ****`WorkspaceManager.create()`**
 		- **Description**: Update `WorkspaceManager` interface and implementation to accept `workspace_root` as a third parameter to `create()`. Remove reliance on service-level config. Update `Orchestrator` and `src/index.ts` callers to pass the correct `workspace_root` from `ChannelRepoMap`.
 		- **Acceptance criteria**:
-			- [ ] `create(idea_id, repo_url, workspace_root)` compiles and routes workspace creation to the provided root
-			- [ ] Orchestrator passes per-channel `workspace_root` from `ChannelRepoMap`
-			- [ ] `src/index.ts` single-repo path passes `workspace_root` from config (unchanged behavior)
-			- [ ] All existing workspace manager tests pass: `npm test`
+			- [x] `create(idea_id, repo_url, workspace_root)` compiles and routes workspace creation to the provided root
+			- [x] Orchestrator passes per-channel `workspace_root` from `ChannelRepoMap`
+			- [x] `src/index.ts` single-repo path passes `workspace_root` from config (unchanged behavior)
+			- [x] All existing workspace manager tests pass: `npm test`
 		- **Dependencies**: None
-	- [ ] **Task: Unit tests for updated ****`WorkspaceManager`**
+	- [x] **Task: Unit tests for updated ****`WorkspaceManager`**
 		- **Description**: Update `tests/core/workspace-manager.test.ts` to pass `workspace_root` explicitly. Add a case verifying two calls with different roots produce non-overlapping paths.
 		- **Acceptance criteria**:
-			- [ ] All existing tests updated and passing
-			- [ ] Two distinct `workspace_root` values → non-overlapping `workspace_path`s
-			- [ ] `npm test` passes
+			- [x] All existing tests updated and passing
+			- [x] Two distinct `workspace_root` values → non-overlapping `workspace_path`s
+			- [x] `npm test` passes
 		- **Dependencies**: Task: Add `workspace_root` parameter
-- [ ] **Story: Orchestrator — per-channel repo resolution**
-	- [ ] **Task: Replace single ****`repo_url`**** with ****`ChannelRepoMap`**
+- [x] **Story: Orchestrator — per-channel repo resolution**
+	- [x] **Task: Replace single ****`repo_url`**** with ****`ChannelRepoMap`**
 		- **Description**: Update `OrchestratorImpl` constructor to accept `ChannelRepoMap` instead of `repo_url: string`. On `new_idea` and `spec_feedback`: look up `channel_id`; if not found, log `run.channel_unmapped` at warn and discard; if found, pass `repo_url` and `workspace_root` to the pipeline.
 		- **Acceptance criteria**:
-			- [ ] `new_idea` with mapped `channel_id` → `WorkspaceManager.create()` called with correct `repo_url` and `workspace_root`
-			- [ ] `new_idea` with unmapped `channel_id` → `run.channel_unmapped` logged at warn, no run created
-			- [ ] `spec_feedback` with unmapped `channel_id` → silently discarded
-			- [ ] All existing orchestrator tests updated and passing: `npm test`
+			- [x] `new_idea` with mapped `channel_id` → `WorkspaceManager.create()` called with correct `repo_url` and `workspace_root`
+			- [x] `new_idea` with unmapped `channel_id` → `run.channel_unmapped` logged at warn, no run created
+			- [x] `spec_feedback` with unmapped `channel_id` → silently discarded
+			- [x] All existing orchestrator tests updated and passing: `npm test`
 		- **Dependencies**: Task: Add `workspace_root` parameter
-	- [ ] **Task: Unit tests for multi-repo orchestrator dispatch**
+	- [x] **Task: Unit tests for multi-repo orchestrator dispatch**
 		- **Description**: Extend `tests/core/orchestrator.test.ts` with multi-repo cases: ideas from two different channels routed to different `repo_url`s, event from unmapped channel discarded, single-entry `ChannelRepoMap` matches existing behavior.
 		- **Acceptance criteria**:
-			- [ ] Channel A idea → channel A's `repo_url` and `workspace_root` passed to pipeline
-			- [ ] Channel B idea → channel B's values; no interference with A
-			- [ ] Unmapped channel → `run.channel_unmapped` warn log; no WorkspaceManager, SpecGenerator, or CanvasPublisher calls
-			- [ ] All tests pass: `npm test`
+			- [x] Channel A idea → channel A's `repo_url` and `workspace_root` passed to pipeline
+			- [x] Channel B idea → channel B's values; no interference with A
+			- [x] Unmapped channel → `run.channel_unmapped` warn log; no WorkspaceManager, SpecGenerator, or CanvasPublisher calls
+			- [x] All tests pass: `npm test`
 		- **Dependencies**: Task: Replace single `repo_url`

--- a/context-human/specs/enhancement-multi-repo-message-routing.md
+++ b/context-human/specs/enhancement-multi-repo-message-routing.md
@@ -1,0 +1,274 @@
+---
+created: 2026-04-23
+last_updated: 2026-04-23
+status: implementing
+issue: 33
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+# Feature: Multi-repo message routing
+
+## What
+
+This feature extends Slack message routing to support multiple repositories simultaneously. Where the service today binds to a single Slack channel and routes all messages to one repository — derived from the `--repo` flag at startup — this feature extends the `--repo` flag to accept multiple space-separated paths, so that each repository supplies its own channel binding and settings via its own [WORKFLOW.md](http://WORKFLOW.md). Existing single-repo deployments continue to work without modification.
+## Why
+
+Teams with multiple active repositories today must run one Autocatalyst instance per repo — separate processes, separate [WORKFLOW.md](http://WORKFLOW.md) files, and separate bots. The complexity grows linearly with the number of projects. Multi-repo routing collapses that overhead to a single process and a single bot, while each repository retains full ownership of its own [WORKFLOW.md](http://WORKFLOW.md).
+## User stories
+
+- Enzo can seed an idea in `#autocatalyst-amp` and receive a spec scoped to the AMP repository without specifying the repo in the message
+- Enzo can seed a separate idea in `#autocatalyst-search` in the same Slack workspace simultaneously, and Autocatalyst processes it against the Search repository independently within the same running instance
+- Phoebe can start Autocatalyst with `--repo /path/to/amp /path/to/search`, and the service reads each repository's own [WORKFLOW.md](http://WORKFLOW.md) for its channel name and settings — no shared configuration file required
+- Enzo can use run-scoped commands (`:ac-run-status:`, `:ac-run-cancel:`) in any configured channel and have them apply to that channel's runs only
+- Enzo can see a startup log entry listing each configured channel and its mapped repository, confirming the service is listening to the right channels before any messages arrive
+- Phoebe can send a message in a channel that is not mapped to any repository and have the service ignore it silently, with no error posted to that channel
+## Design changes
+
+*(Added by design specs stage — frame as delta on the parent feature's design spec)*
+## Technical changes
+
+### Affected files
+
+*(Populated during tech specs stage — list files that will change and why)*
+- `src/types/config.ts` — add internal `RepoEntry` type for `ChannelRepoMap`; no changes to `WorkflowConfig` schema
+- `src/core/config.ts` — add `loadConfigFromPath(repoPath)` to load and validate [WORKFLOW.md](http://WORKFLOW.md) from an arbitrary directory; delegate existing `loadConfig()` to it with `process.cwd()`
+- `src/adapters/slack/slack-adapter.ts` — resolve channel IDs for all repos at startup; attach message and reaction handlers scoped to each configured channel; log startup channel list
+- `src/core/orchestrator.ts` — replace the single `repo_url` constructor parameter with a `ChannelRepoMap`; resolve per-channel `repo_url` and `workspace_root` from each event's `channel_id`; discard events from unmapped channels with a warn log
+- `src/core/workspace-manager.ts` — add explicit `workspace_root` parameter to `create()`; remove reliance on service-level config for workspace root path
+- `src/index.ts` — parse `--repo` to accept multiple space-separated paths; load each repo's [WORKFLOW.md](http://WORKFLOW.md) via `loadConfigFromPath()`; resolve `repo_url` via `git remote get-url origin` per repo; build `ChannelRepoMap`; log startup mode and channel count
+### Changes
+
+*(Added by tech specs stage — frame as delta on the parent feature's tech spec)*
+**CLI interface**
+The `--repo` flag is extended to accept multiple space-separated paths. When more than one path is provided, the service starts in multi-repo mode:
+```bash
+# Existing single-repo form (unchanged)
+
+autocatalyst start
+
+# New multi-repo form
+
+autocatalyst start --repo /path/to/amp /path/to/search
+```
+Each path must point to a local repository containing a valid [WORKFLOW.md](http://WORKFLOW.md) with a `slack.channel_name` field. No new [WORKFLOW.md](http://WORKFLOW.md) fields are required.
+**Internal ****`RepoEntry`**** type**
+```typescript
+// src/types/config.ts — internal only; not reflected in WorkflowConfig
+export interface RepoEntry {
+  channel_id: string;      // resolved from WorkflowConfig.slack.channel_name at startup
+  repo_url: string;        // from git remote get-url origin in the repo directory
+  workspace_root: string;  // from WorkflowConfig or default (~/.autocatalyst/workspaces/)
+}
+```
+`WorkflowConfig` schema is unchanged. No `repos` array is added.
+**Startup logic in ****`src/index.ts`**
+```javascript
+If --repo is given multiple paths:
+  → For each repo path:
+    - Load /WORKFLOW.md via loadConfigFromPath()
+    - Run git remote get-url origin from  to obtain repo_url
+    - Extract channel_name and workspace_root from config
+  → Pass all entries to SlackAdapter for channel ID resolution
+  → Build ChannelRepoMap (channel_id resolved by SlackAdapter)
+  → Log { event: "service.starting", mode: "multi-repo", channel_count: N }
+Else (legacy single-repo):
+  → Existing startup sequence unchanged
+  → Log { event: "service.starting", mode: "single-repo" }
+```
+**`loadConfigFromPath()`**** in ****`src/core/config.ts`**
+```typescript
+export function loadConfigFromPath(repoPath: string): WorkflowConfig
+```
+Reads and validates [WORKFLOW.md](http://WORKFLOW.md) from the given directory. Existing `loadConfig()` delegates to this function with `process.cwd()`, preserving full backward compatibility.
+**`SlackAdapter`**** startup changes**
+`start()` iterates repo entries, calling `conversations.list` to resolve each channel name to its ID. Resolved mappings are stored as `Map`. If any channel name cannot be resolved, the adapter logs `slack.startup.channel_resolution_failed` at error level and throws — failing fast prevents the service from starting in a silently misconfigured state (e.g., a typo in `slack.channel_name` that would cause all messages in that repo's channel to be silently ignored). After resolving, the adapter registers `message` and `reaction_added` handlers scoped to configured channel IDs. Events from channels not in the map are dropped before the classifier is called and logged at debug level as `slack.event.channel_filtered`.
+> **Why filtering unmapped channels is necessary**: A Slack bot receives events from every channel it is a member of in the workspace — not only the channels it was configured to handle. Without explicit filtering, messages from any channel the bot happens to be in would reach the classifier and be processed against an unknown repository. The adapter is the primary filter; the orchestrator adds a secondary check as defense in depth (see below).
+**Orchestrator changes**
+Constructor signature changes from accepting `repo_url: string` and `workspace_root: string` to accepting a `ChannelRepoMap`:
+```typescript
+type ChannelRepoMap = Map;
+```
+On every `new_idea` or `spec_feedback` event, the orchestrator looks up `event.payload.channel_id` in the map. If no entry is found, it logs `run.channel_unmapped` at warn level and discards the event without creating a run. This secondary check exists as defense in depth: the `SlackAdapter` is the primary filter and should prevent unmapped channel events from reaching the orchestrator, but the orchestrator handles them gracefully in case the adapter is bypassed (e.g., in tests or future transport integrations that don't go through `SlackAdapter`). The single-repo startup path constructs a `ChannelRepoMap` with one entry, so the `Orchestrator` interface is uniform across both modes.
+**`WorkspaceManager.create()`**** signature change**
+```typescript
+// Before
+create(idea_id: string, repo_url: string): Promise
+
+// After
+create(idea_id: string, repo_url: string, workspace_root: string): Promise
+```
+`workspace_root` is supplied by the orchestrator from the per-channel `RepoEntry`. Path construction (`/`) is unchanged.
+**New log ****events**
+
+Event
+Level
+Fields
+
+`service.starting`
+info
+\`mode ("single-repo"\\
+
+`slack.startup.channels_resolved`
+info
+`channels: [{ channel_name, channel_id, repo_url }]`
+
+`slack.startup.channel_resolution_failed`
+error
+`channel_name, error`
+
+`slack.event.channel_filtered`
+debug
+`channel_id, event_type`
+
+`run.channel_unmapped`
+warn
+`channel_id`
+
+## Test plan
+
+### Automated
+
+Layer
+File
+What is verified
+
+Unit
+`tests/core/config.test.ts`
+`loadConfigFromPath()`: valid path returns parsed config; missing file throws with path in message; invalid schema throws with validation details; `loadConfig()` backward compatibility unchanged
+
+Unit
+`tests/core/workspace-manager.test.ts`
+`create(idea_id, repo_url, workspace_root)` routes to provided root; two distinct `workspace_root` values produce non-overlapping paths
+
+Unit
+`tests/core/orchestrator.test.ts`
+Mapped channel idea → correct `repo_url` and `workspace_root` passed to pipeline; unmapped channel → `run.channel_unmapped` at warn, no pipeline calls; single-entry `ChannelRepoMap` matches existing single-repo behavior
+
+Integration
+`tests/adapters/slack/slack-adapter.test.ts`
+Two channels resolved at startup with `slack.startup.channels_resolved` logged; unresolvable channel emits `slack.startup.channel_resolution_failed` and throws; event from unconfigured channel logs `slack.event.channel_filtered` at debug and emits nothing; ideas from each configured channel dispatched with correct `channel_id`
+
+Integration
+`tests/index.test.ts`
+`--repo /a /b` startup: `loadConfigFromPath()` and `git remote` called once per path; `service.starting` logged with `mode: "multi-repo"`; missing [WORKFLOW.md](http://WORKFLOW.md) at a path exits code 1 with path in message; single-repo startup logs `mode: "single-repo"` unchanged
+
+### Manual smoke test
+
+1. Start with `--repo /path/to/repo-a /path/to/repo-b` and confirm the startup log lists both channels with their mapped repos.
+2. Post a message in repo-a's channel; verify a spec is created in repo-a's workspace only.
+3. Post a message in repo-b's channel; verify it routes to repo-b's workspace with no interference with repo-a.
+4. Post a message in an unconfigured channel; verify nothing is posted back and no run is created.
+5. Start with a single repo (no `--repo`); verify behavior is identical to the pre-feature baseline.
+## Task list
+
+*(Added by task decomposition stage)*
+- [ ] **Story: CLI — multi-repo startup via ****`--repo`**** flag**
+	- [ ] **Task: Extend ****`--repo`**** to accept multiple space-separated paths**
+		- **Description**: Update argument parsing in `src/index.ts` to allow `--repo` to accept multiple space-separated paths. When multiple paths are provided, collect them as an array. Single `--repo /path` or no flag preserves existing behavior.
+		- **Acceptance criteria**:
+			- [ ] `--repo /a /b` parsed as `["/a", "/b"]`
+			- [ ] Single `--repo /a` or no flag → existing parse result unchanged
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: None
+	- [ ] **Task: Add ****`loadConfigFromPath()`**** to ****`src/core/config.ts`**
+		- **Description**: Add `loadConfigFromPath(repoPath: string): WorkflowConfig` that reads and validates [WORKFLOW.md](http://WORKFLOW.md) from the given directory path. Update the existing `loadConfig()` to delegate to this with `process.cwd()`. Update `src/index.ts` multi-repo startup to call `loadConfigFromPath()` for each path in `--repo`.
+		- **Acceptance criteria**:
+			- [ ] Valid [WORKFLOW.md](http://WORKFLOW.md) at given path → returns parsed `WorkflowConfig`
+			- [ ] Missing or invalid [WORKFLOW.md](http://WORKFLOW.md) → descriptive error including the path
+			- [ ] Existing `loadConfig()` behavior unchanged
+			- [ ] All config tests pass: `npm test`
+		- **Dependencies**: Task: Extend `--repo` to accept multiple space-separated paths
+	- [ ] **Task: Resolve repo URLs and build ****`ChannelRepoMap`**** at startup**
+		- **Description**: For each repo path in multi-repo mode, run `git remote get-url origin` from that directory to get `repo_url`. Combine with `channel_name` and `workspace_root` from the repo's [WORKFLOW.md](http://WORKFLOW.md). Pass the full entry list to `SlackAdapter` for channel ID resolution. Log `service.starting` with mode and channel count.
+		- **Acceptance criteria**:
+			- [ ] Each repo's `repo_url` resolved via `git remote` in its directory
+			- [ ] `workspace_root` defaults to `~/.autocatalyst/workspaces/` when absent from [WORKFLOW.md](http://WORKFLOW.md)
+			- [ ] `service.starting` logged with `mode: "multi-repo"` and correct `channel_count`
+			- [ ] Single-repo startup logs `mode: "single-repo"` unchanged
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `loadConfigFromPath()`
+	- [ ] **Task: Tests for conditional startup modes**
+		- **Description**: Extend entry point startup helper tests: multi-repo mode reads each repo's [WORKFLOW.md](http://WORKFLOW.md) and runs `git remote` per repo; single-repo mode unchanged; missing [WORKFLOW.md](http://WORKFLOW.md) at a `--repo` path exits with code 1 and descriptive message.
+		- **Acceptance criteria**:
+			- [ ] Multi-repo mode: `loadConfigFromPath()` called once per repo path
+			- [ ] Multi-repo mode: `git remote get-url origin` called once per repo directory
+			- [ ] Multi-repo mode: `service.starting` logged with `mode: "multi-repo"`
+			- [ ] Single-repo mode: all existing startup tests pass unchanged
+			- [ ] Missing [WORKFLOW.md](http://WORKFLOW.md): exits code 1 with path in error message
+			- [ ] `npm test` passes
+		- **Dependencies**: Task: Resolve repo URLs and build ChannelRepoMap
+- [ ] **Story: Config — internal ****`RepoEntry`**** type**
+	- [ ] **Task: Add ****`RepoEntry`**** internal type**
+		- **Description**: Add `RepoEntry` interface to `src/types/config.ts` for internal `ChannelRepoMap` use. No changes to `WorkflowConfig`.
+		- **Acceptance criteria**:
+			- [ ] `RepoEntry` has `channel_id: string`, `repo_url: string`, `workspace_root: string`
+			- [ ] `WorkflowConfig` schema unchanged
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: None
+	- [ ] **Task: Unit tests for ****`loadConfigFromPath()`**
+		- **Description**: Extend `tests/core/config.test.ts`: valid path → parsed config; missing file → error with path; invalid [WORKFLOW.md](http://WORKFLOW.md) → validation error; existing `loadConfig()` tests unchanged.
+		- **Acceptance criteria**:
+			- [ ] All cases pass
+			- [ ] No existing config tests broken
+			- [ ] `npm test` passes
+		- **Dependencies**: Task: Add `loadConfigFromPath()`
+- [ ] **Story: SlackAdapter — multi-channel startup**
+	- [ ] **Task: Resolve multiple channel IDs at startup**
+		- **Description**: Update `SlackAdapter.start()` to accept repo entries in multi-repo mode. Resolve each channel name to its ID via `conversations.list`. Store as `Map`. Log `slack.startup.channels_resolved`. If any channel cannot be resolved, log `slack.startup.channel_resolution_failed` at error and fail startup. Preserve the existing single-channel path in single-repo mode.
+		- **Acceptance criteria**:
+			- [ ] All channel names resolved before any event handler is registered
+			- [ ] `slack.startup.channels_resolved` logged with `channels` array
+			- [ ] One unresolvable channel → `slack.startup.channel_resolution_failed` logged at error; startup fails with descriptive error
+			- [ ] Single-repo mode → existing `channel_name` resolution unchanged
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Resolve repo URLs and build ChannelRepoMap
+	- [ ] **Task: Scope event handlers to configured channels**
+		- **Description**: Update `SlackAdapter` message and reaction handlers to drop events from channel IDs not in the resolved `ChannelRepoMap`. This check happens before the classifier is called. Dropped events are logged at debug level as `slack.event.channel_filtered`.
+		- **Acceptance criteria**:
+			- [ ] Message in unconfigured channel → `slack.event.channel_filtered` logged at debug; no classifier call, no event emitted
+			- [ ] Reaction in unconfigured channel → no event emitted
+			- [ ] Message in configured channel → existing classify+emit behavior unchanged
+			- [ ] All existing `SlackAdapter` integration tests pass: `npm test`
+		- **Dependencies**: Task: Resolve multiple channel IDs at startup
+	- [ ] **Task: Integration tests for multi-channel adapter**
+		- **Description**: Extend `tests/adapters/slack/slack-adapter.test.ts` with multi-channel scenarios: two channels resolved at startup, ideas from each channel dispatched with correct `channel_id`, event from unconfigured channel logged as `slack.event.channel_filtered` and silently dropped, one unresolvable channel logs `slack.startup.channel_resolution_failed` and causes startup failure.
+		- **Acceptance criteria**:
+			- [ ] Two configured channels: each `new_idea` emits with the correct `channel_id`
+			- [ ] Event from unconfigured channel: `slack.event.channel_filtered` logged at debug; no event emitted
+			- [ ] Unknown channel at startup: `slack.startup.channel_resolution_failed` logged at error; startup throws
+			- [ ] All tests pass: `npm test`
+		- **Dependencies**: Task: Scope event handlers
+- [ ] **Story: WorkspaceManager — explicit workspace root**
+	- [ ] **Task: Add ****`workspace_root`**** parameter to ****`WorkspaceManager.create()`**
+		- **Description**: Update `WorkspaceManager` interface and implementation to accept `workspace_root` as a third parameter to `create()`. Remove reliance on service-level config. Update `Orchestrator` and `src/index.ts` callers to pass the correct `workspace_root` from `ChannelRepoMap`.
+		- **Acceptance criteria**:
+			- [ ] `create(idea_id, repo_url, workspace_root)` compiles and routes workspace creation to the provided root
+			- [ ] Orchestrator passes per-channel `workspace_root` from `ChannelRepoMap`
+			- [ ] `src/index.ts` single-repo path passes `workspace_root` from config (unchanged behavior)
+			- [ ] All existing workspace manager tests pass: `npm test`
+		- **Dependencies**: None
+	- [ ] **Task: Unit tests for updated ****`WorkspaceManager`**
+		- **Description**: Update `tests/core/workspace-manager.test.ts` to pass `workspace_root` explicitly. Add a case verifying two calls with different roots produce non-overlapping paths.
+		- **Acceptance criteria**:
+			- [ ] All existing tests updated and passing
+			- [ ] Two distinct `workspace_root` values → non-overlapping `workspace_path`s
+			- [ ] `npm test` passes
+		- **Dependencies**: Task: Add `workspace_root` parameter
+- [ ] **Story: Orchestrator — per-channel repo resolution**
+	- [ ] **Task: Replace single ****`repo_url`**** with ****`ChannelRepoMap`**
+		- **Description**: Update `OrchestratorImpl` constructor to accept `ChannelRepoMap` instead of `repo_url: string`. On `new_idea` and `spec_feedback`: look up `channel_id`; if not found, log `run.channel_unmapped` at warn and discard; if found, pass `repo_url` and `workspace_root` to the pipeline.
+		- **Acceptance criteria**:
+			- [ ] `new_idea` with mapped `channel_id` → `WorkspaceManager.create()` called with correct `repo_url` and `workspace_root`
+			- [ ] `new_idea` with unmapped `channel_id` → `run.channel_unmapped` logged at warn, no run created
+			- [ ] `spec_feedback` with unmapped `channel_id` → silently discarded
+			- [ ] All existing orchestrator tests updated and passing: `npm test`
+		- **Dependencies**: Task: Add `workspace_root` parameter
+	- [ ] **Task: Unit tests for multi-repo orchestrator dispatch**
+		- **Description**: Extend `tests/core/orchestrator.test.ts` with multi-repo cases: ideas from two different channels routed to different `repo_url`s, event from unmapped channel discarded, single-entry `ChannelRepoMap` matches existing behavior.
+		- **Acceptance criteria**:
+			- [ ] Channel A idea → channel A's `repo_url` and `workspace_root` passed to pipeline
+			- [ ] Channel B idea → channel B's values; no interference with A
+			- [ ] Unmapped channel → `run.channel_unmapped` warn log; no WorkspaceManager, SpecGenerator, or CanvasPublisher calls
+			- [ ] All tests pass: `npm test`
+		- **Dependencies**: Task: Replace single `repo_url`

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -8,10 +8,11 @@ import { classifyMessage } from './classifier.js';
 import { EMOJI_COMMAND_TABLE } from './classifier.js';
 import type { CommandEvent } from '../../types/commands.js';
 import { ThreadRegistry } from './thread-registry.js';
+import type { RepoEntry, ChannelRepoMap, PreRepoEntry } from '../../types/config.js';
 
-interface SlackAdapterConfig {
-  channelName: string;
-}
+type SlackAdapterConfig =
+  | { channelName: string }
+  | { repoEntries: PreRepoEntry[] };
 
 interface SlackAdapterOptions {
   registry?: ThreadRegistry;
@@ -25,7 +26,9 @@ export class SlackAdapter implements HumanInterfaceAdapter {
   private readonly logger: pino.Logger;
 
   private botUserId: string | undefined;
-  private channelId: string | undefined;
+  private _resolvedChannelId: string | undefined;
+  private _resolvedChannelRepoMap: ChannelRepoMap | null = null;
+  private _channelsResolved = false;
 
   // AsyncIterable queue
   private readonly eventQueue: InboundEvent[] = [];
@@ -39,6 +42,97 @@ export class SlackAdapter implements HumanInterfaceAdapter {
     this.logger = createLogger('slack-adapter', { destination: options?.logDestination });
   }
 
+  /**
+   * Resolves configured channel name(s) to IDs using conversations.list.
+   * Idempotent — skips re-resolution on subsequent calls.
+   * Single-repo: caches channel_id; logs slack.startup.channel_resolved.
+   * Multi-repo: builds ChannelRepoMap; logs slack.startup.channels_resolved.
+   * Throws (logging slack.startup.channel_resolution_failed) if any channel can't be resolved.
+   */
+  async resolveChannels(): Promise<void> {
+    if (this._channelsResolved) return;
+
+    const listResult = await this.app.client.conversations.list({
+      types: 'public_channel',
+      limit: 1000,
+    });
+
+    if ((listResult as { response_metadata?: { next_cursor?: string } }).response_metadata?.next_cursor) {
+      this.logger.warn(
+        { event: 'slack.error', error: 'conversations.list result truncated — channel may not be found if workspace has >1000 channels' },
+        'Channel list truncated; consider paginating if channel is not found',
+      );
+    }
+
+    if ('channelName' in this.config) {
+      const channelName = this.config.channelName;
+      const channel = listResult.channels?.find(
+        (c: { name?: string }) => c.name === channelName,
+      );
+      if (!channel || !('id' in channel) || typeof channel.id !== 'string') {
+        this.logger.error(
+          { event: 'slack.startup.channel_resolution_failed', channel_name: channelName, error: `channel not found: ${channelName}` },
+          'Slack channel not found — adapter cannot start',
+        );
+        throw new Error(`Slack channel not found: ${channelName}`);
+      }
+      this._resolvedChannelId = channel.id;
+      this.logger.info(
+        { event: 'slack.startup.channel_resolved', channel_name: channelName, channel_id: this._resolvedChannelId },
+        'Channel resolved',
+      );
+    } else {
+      const repoEntries = this.config.repoEntries;
+      const channelRepoMap: ChannelRepoMap = new Map();
+      for (const entry of repoEntries) {
+        const channel = listResult.channels?.find(
+          (c: { name?: string }) => c.name === entry.channel_name,
+        );
+        if (!channel || !('id' in channel) || typeof channel.id !== 'string') {
+          this.logger.error(
+            { event: 'slack.startup.channel_resolution_failed', channel_name: entry.channel_name, error: `channel not found: ${entry.channel_name}` },
+            'Slack channel not found — adapter cannot start',
+          );
+          throw new Error(`Slack channel not found: ${entry.channel_name}`);
+        }
+        channelRepoMap.set(channel.id, {
+          channel_id: channel.id,
+          repo_url: entry.repo_url,
+          workspace_root: entry.workspace_root,
+        });
+      }
+      this._resolvedChannelRepoMap = channelRepoMap;
+      this.logger.info(
+        {
+          event: 'slack.startup.channels_resolved',
+          channels: [...channelRepoMap.values()].map(e => ({
+            channel_id: e.channel_id,
+            repo_url: e.repo_url,
+          })),
+        },
+        'All channels resolved',
+      );
+    }
+
+    this._channelsResolved = true;
+  }
+
+  /** Returns the resolved channel ID for single-repo mode. Valid after resolveChannels() or start(). */
+  getChannelId(): string {
+    if (this._resolvedChannelId === undefined) {
+      throw new Error('resolveChannels() has not been called or channel is not yet resolved');
+    }
+    return this._resolvedChannelId;
+  }
+
+  /** Returns the resolved ChannelRepoMap for multi-repo mode. Valid after resolveChannels() in multi-repo mode. */
+  getChannelRepoMap(): ChannelRepoMap {
+    if (this._resolvedChannelRepoMap === null) {
+      throw new Error('resolveChannels() has not been called or this adapter is not in multi-repo mode');
+    }
+    return this._resolvedChannelRepoMap;
+  }
+
   async start(): Promise<void> {
     // Resolve bot user ID
     const authResult = await this.app.client.auth.test();
@@ -47,40 +141,31 @@ export class SlackAdapter implements HumanInterfaceAdapter {
     }
     this.botUserId = authResult.user_id;
 
-    // Resolve channel name → channel ID
-    const listResult = await this.app.client.conversations.list({
-      types: 'public_channel',
-      limit: 1000,
-    });
-    // Warn if results were truncated — the target channel may be in a subsequent page
-    if ((listResult as { response_metadata?: { next_cursor?: string } }).response_metadata?.next_cursor) {
-      this.logger.warn(
-        { event: 'slack.error', error: 'conversations.list result truncated — channel may not be found if workspace has >1000 channels' },
-        'Channel list truncated; consider paginating if channel is not found',
-      );
-    }
-    const channel = listResult.channels?.find(
-      (c: { name?: string }) => c.name === this.config.channelName,
-    );
-    if (!channel || !('id' in channel) || typeof channel.id !== 'string') {
-      this.logger.error(
-        { event: 'slack.error', error: `channel not found: ${this.config.channelName}` },
-        'Slack channel not found — adapter cannot start',
-      );
-      throw new Error(`Slack channel not found: ${this.config.channelName}`);
-    }
-    this.channelId = channel.id;
-    this.logger.info(
-      { event: 'slack.startup.channel_resolved', channel_name: this.config.channelName, channel_id: this.channelId },
-      'Channel resolved',
+    // Resolve channel name(s) → channel ID(s) (idempotent)
+    await this.resolveChannels();
+
+    // Build set of allowed channel IDs for filtering
+    const allowedChannelIds = new Set<string>(
+      'channelName' in this.config
+        ? [this._resolvedChannelId!]
+        : [...this._resolvedChannelRepoMap!.keys()],
     );
 
     // Register message handler (must happen before app.start())
     this.app.message(async ({ message }) => {
       // Skip non-regular messages (bot_message, message_changed, etc.)
       if ('subtype' in message && (message as { subtype?: string }).subtype !== undefined) return;
-      // Filter to target channel
-      if (!('channel' in message) || (message as { channel?: string }).channel !== this.channelId) return;
+      // Filter to target channel(s)
+      const msgChannel = ('channel' in message) ? (message as { channel?: string }).channel : undefined;
+      if (!msgChannel || !allowedChannelIds.has(msgChannel)) {
+        this.logger.debug(
+          { event: 'slack.event.channel_filtered', channel_id: msgChannel },
+          'Message filtered — not in allowed channels',
+        );
+        return;
+      }
+
+      const channelId = msgChannel;
 
       const msg = message as {
         text?: string;
@@ -100,7 +185,7 @@ export class SlackAdapter implements HumanInterfaceAdapter {
 
       if (result.intent === 'ignore') {
         this.logger.debug(
-          { event: 'slack.message.ignored', author: msg.user, channel_id: this.channelId },
+          { event: 'slack.message.ignored', author: msg.user, channel_id: channelId },
           'Message ignored',
         );
         return;
@@ -111,7 +196,7 @@ export class SlackAdapter implements HumanInterfaceAdapter {
           command: result.command,
           args: result.args,
           source: 'slack',
-          channel_id: this.channelId!,
+          channel_id: channelId,
           thread_ts: msg.thread_ts ?? msg.ts,
           author: msg.user,
           received_at: new Date().toISOString(),
@@ -120,7 +205,7 @@ export class SlackAdapter implements HumanInterfaceAdapter {
           },
         };
         this.logger.info(
-          { event: 'slack.command.received', author: msg.user, channel_id: this.channelId, command: result.command, thread_ts: msg.thread_ts ?? msg.ts },
+          { event: 'slack.command.received', author: msg.user, channel_id: channelId, command: result.command, thread_ts: msg.thread_ts ?? msg.ts },
           'Command received',
         );
         this.emit({ type: 'command', payload: commandEvent });
@@ -128,7 +213,7 @@ export class SlackAdapter implements HumanInterfaceAdapter {
       }
 
       this.logger.info(
-        { event: 'slack.message.classified', author: msg.user, channel_id: this.channelId, intent: result.intent, thread_ts: msg.ts },
+        { event: 'slack.message.classified', author: msg.user, channel_id: channelId, intent: result.intent, thread_ts: msg.ts },
         'Message classified',
       );
 
@@ -140,12 +225,12 @@ export class SlackAdapter implements HumanInterfaceAdapter {
           author: msg.user,
           received_at: new Date().toISOString(),
           thread_ts: msg.ts,
-          channel_id: this.channelId!,
+          channel_id: channelId,
         };
 
         // Post acknowledgement and register thread before emitting
         this.registry.register(msg.ts, request.id);
-        await this.postMessage(this.channelId!, msg.ts, "Got it — I'll work on a spec and post it here.");
+        await this.postMessage(channelId, msg.ts, "Got it — I'll work on a spec and post it here.");
         this.emit({ type: 'new_request', payload: request });
 
       } else if (result.intent === 'thread_message') {
@@ -155,10 +240,10 @@ export class SlackAdapter implements HumanInterfaceAdapter {
           author: msg.user,
           received_at: new Date().toISOString(),
           thread_ts: msg.thread_ts!,
-          channel_id: this.channelId!,
+          channel_id: channelId,
         };
 
-        await this.postMessage(this.channelId!, msg.thread_ts!, "Thanks — I'll incorporate that feedback.");
+        await this.postMessage(channelId, msg.thread_ts!, "Thanks — I'll incorporate that feedback.");
         this.emit({ type: 'thread_message', payload: message });
       }
     });
@@ -171,7 +256,13 @@ export class SlackAdapter implements HumanInterfaceAdapter {
         item: { type: string; channel?: string; ts: string };
       };
       if (reaction.item.type !== 'message') return;
-      if (reaction.item.channel !== this.channelId) return;
+      if (!reaction.item.channel || !allowedChannelIds.has(reaction.item.channel)) {
+        this.logger.debug(
+          { event: 'slack.event.channel_filtered', channel_id: reaction.item.channel },
+          'Reaction filtered — not in allowed channels',
+        );
+        return;
+      }
 
       const commandName = EMOJI_COMMAND_TABLE[reaction.reaction];
       if (!commandName) {
@@ -220,7 +311,7 @@ export class SlackAdapter implements HumanInterfaceAdapter {
     // Start Bolt (opens Socket Mode WebSocket)
     await this.app.start();
     this.logger.info(
-      { event: 'slack.connected', channel_id: this.channelId, channel_name: this.config.channelName },
+      { event: 'slack.connected', channel_count: allowedChannelIds.size },
       'Connected to Slack',
     );
   }

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -3,7 +3,8 @@ import { resolve } from 'node:path';
 
 export interface ParsedArgs {
   command: 'run' | 'init';
-  repoPath: string;
+  repoPath: string;      // first path (backward compat)
+  repoPaths: string[];   // all paths; length >= 1 when --repo is provided
   help: boolean;
 }
 
@@ -13,7 +14,7 @@ export function parseArgs(args: string[]): ParsedArgs {
     const remaining = args.slice(1);
 
     if (remaining.includes('--help') || remaining.includes('-h')) {
-      return { command: 'init', repoPath: '', help: true };
+      return { command: 'init', repoPath: '', repoPaths: [], help: true };
     }
 
     const repoIndex = remaining.indexOf('--repo');
@@ -22,12 +23,12 @@ export function parseArgs(args: string[]): ParsedArgs {
         ? remaining[repoIndex + 1]
         : '';
 
-    return { command: 'init', repoPath, help: false };
+    return { command: 'init', repoPath, repoPaths: repoPath ? [repoPath] : [], help: false };
   }
 
   // --help / -h (run command)
   if (args.includes('--help') || args.includes('-h')) {
-    return { command: 'run', repoPath: '', help: true };
+    return { command: 'run', repoPath: '', repoPaths: [], help: true };
   }
 
   // run command — --repo is required and validated
@@ -36,27 +37,40 @@ export function parseArgs(args: string[]): ParsedArgs {
     throw new Error('Missing required argument: --repo <path>');
   }
 
-  const rawPath = args[repoIndex + 1];
-  const repoPath = resolve(rawPath);
-
-  if (!existsSync(repoPath)) {
-    throw new Error(`--repo path does not exist: ${repoPath}`);
+  // Collect all paths after --repo (until next flag or end)
+  const rawPaths: string[] = [];
+  let i = repoIndex + 1;
+  while (i < args.length && !args[i].startsWith('-')) {
+    rawPaths.push(args[i]);
+    i++;
   }
 
-  if (!statSync(repoPath).isDirectory()) {
-    throw new Error(`--repo path is not a directory: ${repoPath}`);
+  if (rawPaths.length === 0) {
+    throw new Error('Missing required argument: --repo <path>');
   }
 
-  return { command: 'run', repoPath, help: false };
+  const repoPaths = rawPaths.map(p => {
+    const resolved = resolve(p);
+    if (!existsSync(resolved)) {
+      throw new Error(`--repo path does not exist: ${resolved}`);
+    }
+    if (!statSync(resolved).isDirectory()) {
+      throw new Error(`--repo path is not a directory: ${resolved}`);
+    }
+    return resolved;
+  });
+
+  return { command: 'run', repoPath: repoPaths[0], repoPaths, help: false };
 }
 
 export function printUsage(): void {
   console.log(`Usage:
-  autocatalyst --repo <path>           Start the service for a repository
-  autocatalyst init [--repo <path>]    Initialize and validate configuration
+  autocatalyst --repo <path>                    Start the service for a single repository
+  autocatalyst --repo <path1> <path2> ...       Start the service for multiple repositories
+  autocatalyst init [--repo <path>]             Initialize and validate configuration
 
 Options:
-  --repo <path>   Path to the target repository
-  --help          Show this help message
+  --repo <path> [<path2>...]   Path(s) to target repository/repositories
+  --help                       Show this help message
 `);
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -151,10 +151,16 @@ export function redactConfig(
   return redactObject(config);
 }
 
-export function loadConfig(
-  filePath: string,
+export function loadConfigFromPath(
+  repoPath: string,
   env: Record<string, string | undefined>,
 ): LoadedConfig {
+  const filePath = join(resolve(repoPath), 'WORKFLOW.md');
+
+  if (!existsSync(filePath)) {
+    throw new Error('WORKFLOW.md not found at ' + filePath);
+  }
+
   const content = readFileSync(filePath, 'utf-8');
   const { config, promptTemplate } = parseWorkflow(content);
   const { resolved } = resolveEnvVars(config as Record<string, unknown>, env);
@@ -165,6 +171,15 @@ export function loadConfig(
     promptTemplate,
     filePath,
   };
+}
+
+export function loadConfig(
+  filePath: string,
+  env: Record<string, string | undefined>,
+): LoadedConfig {
+  // Derive repoPath from filePath by stripping the filename
+  const repoPath = filePath.replace(/\/WORKFLOW\.md$/, '') || '.';
+  return loadConfigFromPath(repoPath, env);
 }
 
 export function bootstrapWorkflow(repoPath: string): boolean {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -22,6 +22,7 @@ import type { IssueFiler, FilingResult } from '../adapters/agent/issue-filer.js'
 import { RunStore, FileRunStore } from './run-store.js';
 import type { ThreadRegistry } from '../adapters/slack/thread-registry.js';
 import type { CommandRegistry, CommandEvent } from '../types/commands.js';
+import type { ChannelRepoMap } from '../types/config.js';
 
 function extractH1(content: string): string | undefined {
   const match = content.match(/^#\s+(.+)$/m);
@@ -63,7 +64,7 @@ interface OrchestratorDeps {
   threadRegistry?: ThreadRegistry;
   postError: (channel_id: string, thread_ts: string, text: string) => Promise<void>;
   postMessage: (channel_id: string, thread_ts: string, text: string) => Promise<void>;
-  repo_url: string;
+  channelRepoMap: ChannelRepoMap;
   commandRegistry?: CommandRegistry;
 }
 
@@ -270,6 +271,11 @@ export class OrchestratorImpl implements Orchestrator {
   private async _handleRequest(event: InboundEvent): Promise<void> {
     if (event.type === 'new_request') {
       const request = event.payload;
+      // Secondary defense-in-depth check: discard if channel not in map
+      if (!this.deps.channelRepoMap.has(request.channel_id)) {
+        this.logger.warn({ event: 'run.channel_unmapped', channel_id: request.channel_id }, 'No repo configured for channel; discarding new_request');
+        return;
+      }
       const run = this.createRun(request);
 
       // Classify intent for new request
@@ -460,7 +466,8 @@ export class OrchestratorImpl implements Orchestrator {
         'Triage approved',
       );
 
-      const issue_url = `${this.deps.repo_url}/issues/${issue_number}`;
+      const repoEntry = this.deps.channelRepoMap.get(run.channel_id)!;
+      const issue_url = `${repoEntry.repo_url}/issues/${issue_number}`;
 
       // Step 4: Update Notion page properties (best-effort — non-blocking)
       await Promise.allSettled([
@@ -863,7 +870,8 @@ export class OrchestratorImpl implements Orchestrator {
     let workspace_path: string;
     let branch: string;
     try {
-      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, this.deps.repo_url));
+      const repoEntry = this.deps.channelRepoMap.get(request.channel_id)!;
+      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, repoEntry.repo_url, repoEntry.workspace_root));
       run.workspace_path = workspace_path;
       run.branch = branch;
     } catch (err) {
@@ -921,7 +929,8 @@ export class OrchestratorImpl implements Orchestrator {
     let workspace_path: string;
     let branch: string;
     try {
-      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, this.deps.repo_url));
+      const repoEntry = this.deps.channelRepoMap.get(request.channel_id)!;
+      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, repoEntry.repo_url, repoEntry.workspace_root));
       run.workspace_path = workspace_path;
       run.branch = branch;
     } catch (err) {
@@ -987,7 +996,8 @@ export class OrchestratorImpl implements Orchestrator {
     let workspace_path: string;
     let branch: string;
     try {
-      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, this.deps.repo_url));
+      const repoEntry = this.deps.channelRepoMap.get(request.channel_id)!;
+      ({ workspace_path, branch } = await this.deps.workspaceManager.create(request.id, repoEntry.repo_url, repoEntry.workspace_root));
       run.workspace_path = workspace_path;
       run.branch = branch;
     } catch (err) {

--- a/src/core/workspace-manager.ts
+++ b/src/core/workspace-manager.ts
@@ -11,7 +11,7 @@ const defaultExec = promisify(_exec);
 type ExecFn = (cmd: string, opts?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }>;
 
 export interface WorkspaceManager {
-  create(request_id: string, repo_url: string): Promise<{ workspace_path: string; branch: string }>;
+  create(request_id: string, repo_url: string, workspace_root: string): Promise<{ workspace_path: string; branch: string }>;
   destroy(workspace_path: string): Promise<void>;
 }
 
@@ -21,21 +21,20 @@ interface WorkspaceManagerOptions {
 }
 
 export class WorkspaceManagerImpl implements WorkspaceManager {
-  private readonly workspaceRoot: string;
   private readonly execFn: ExecFn;
   private readonly logger: pino.Logger;
 
-  constructor(workspaceRoot: string, options?: WorkspaceManagerOptions) {
-    this.workspaceRoot = workspaceRoot.replace(/^~/, homedir());
+  constructor(options?: WorkspaceManagerOptions) {
     this.execFn = options?.execFn ?? defaultExec;
     this.logger = createLogger('workspace-manager', { destination: options?.logDestination });
   }
 
-  async create(request_id: string, repo_url: string): Promise<{ workspace_path: string; branch: string }> {
+  async create(request_id: string, repo_url: string, workspace_root: string): Promise<{ workspace_path: string; branch: string }> {
     if (request_id.includes('/') || request_id.includes('..')) {
       throw new Error(`Invalid request_id: "${request_id}"`);
     }
-    const workspace_path = join(this.workspaceRoot, request_id);
+    const expandedRoot = workspace_root.replace(/^~/, homedir());
+    const workspace_path = join(expandedRoot, request_id);
     // request_id is a UUID; strip non-alphanumeric chars for a valid branch name segment
     const slug = request_id.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
     const branch = `spec/${slug}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { parseArgs, printUsage } from './core/cli.js';
-import { loadConfig, redactConfig, resolveEnvVars, resolveAwsProfile, repoNameFromUrl } from './core/config.js';
+import { loadConfig, loadConfigFromPath, redactConfig, resolveEnvVars, resolveAwsProfile, repoNameFromUrl } from './core/config.js';
+import type { ChannelRepoMap } from './types/config.js';
 import { runInit, configExists } from './core/init.js';
 import { ConfigWatcher } from './core/config-watcher.js';
 import { Service } from './core/service.js';
@@ -55,10 +56,15 @@ try {
     process.exit(0);
   }
 
-  // run command — repoPath is validated by parseArgs
-  const repoPath = args.repoPath;
+  // run command — repoPath(s) validated by parseArgs
+  const repoPaths = args.repoPaths;
+  const repoPath = repoPaths[0];
+  const isMultiRepo = repoPaths.length > 1;
 
-  logger.info({ event: 'service.starting' }, 'Starting Autocatalyst');
+  logger.info(
+    { event: 'service.starting', mode: isMultiRepo ? 'multi-repo' : 'single-repo', ...(isMultiRepo ? { channel_count: repoPaths.length } : {}) },
+    'Starting Autocatalyst',
+  );
 
   // Init always runs before service startup
   await runInit(repoPath);
@@ -177,13 +183,64 @@ try {
   // Build question answerer — always uses Agent SDK with repo path as cwd (no Bedrock variant needed)
   const questionAnswerer = new AgentSDKQuestionAnswerer(repoPath);
 
+  // Multi-repo: load config for each additional repo path and build PreRepoEntry list
+  type PreEntryLocal = { channel_name: string; repo_url: string; workspace_root: string };
+  const preRepoEntries: PreEntryLocal[] = [];
+
+  if (isMultiRepo) {
+    for (const rp of repoPaths) {
+      await runInit(rp);
+      if (!configExists(rp)) {
+        logger.error({ event: 'service.init_incomplete', repo_path: rp }, `Config is not set up for ${rp}. Run autocatalyst init --repo ${rp}`);
+        process.exit(1);
+      }
+      const rpLoaded = loadConfigFromPath(rp, process.env as Record<string, string>);
+      const { resolved: rpResolved, missing: rpMissing } = resolveEnvVars(rpLoaded.config as Record<string, unknown>, process.env as Record<string, string>);
+      if (rpMissing.length > 0) {
+        logger.warn({ event: 'config.env_missing', repo_path: rp, missing: rpMissing }, `Missing env vars for ${rp}: ${rpMissing.join(', ')}`);
+        process.exit(1);
+      }
+      const rpFinalConfig = rpResolved as import('./types/config.js').WorkflowConfig;
+
+      let rpRepoUrl: string;
+      try {
+        rpRepoUrl = execSync('git remote get-url origin', { cwd: rp }).toString().trim();
+        if (!rpRepoUrl) throw new Error('git remote get-url origin returned empty string');
+      } catch (err) {
+        logger.error({ event: 'config.parse_error', repo_path: rp, error: String(err) }, `Could not resolve git origin URL for ${rp}`);
+        process.exit(1);
+      }
+
+      const rpChannelName = rpFinalConfig.slack?.channel_name;
+      if (!rpChannelName) {
+        logger.error({ event: 'config.parse_error', repo_path: rp }, `slack.channel_name is required in ${rp}/WORKFLOW.md`);
+        process.exit(1);
+      }
+
+      const rpWorkspaceRoot = rpFinalConfig.workspace?.root ?? '~/.autocatalyst/workspaces';
+      preRepoEntries.push({ channel_name: rpChannelName, repo_url: rpRepoUrl!, workspace_root: rpWorkspaceRoot });
+    }
+  }
+
   // Build adapter, components, orchestrator
   const threadRegistry = new ThreadRegistry();
-  const adapter = new SlackAdapter(boltApp, {
-    channelName,
-  }, {
-    registry: threadRegistry,
-  });
+  const adapter = new SlackAdapter(
+    boltApp,
+    isMultiRepo ? { repoEntries: preRepoEntries } : { channelName: channelName! },
+    { registry: threadRegistry },
+  );
+
+  // Resolve channels before building orchestrator (idempotent — start() will be a no-op)
+  await adapter.resolveChannels();
+
+  // Build ChannelRepoMap
+  const channelRepoMap: ChannelRepoMap = isMultiRepo
+    ? adapter.getChannelRepoMap()
+    : (() => {
+        const channelId = adapter.getChannelId();
+        const map: ChannelRepoMap = new Map([[channelId, { channel_id: channelId, repo_url, workspace_root: workspaceRoot }]]);
+        return map;
+      })();
 
   const workspaceManager = new WorkspaceManagerImpl();
   const runStore = new FileRunStore(workspaceRoot);
@@ -233,12 +290,6 @@ try {
   }
 
   const commandRegistry = new CommandRegistryImpl();
-
-  // TODO: build ChannelRepoMap properly in Task 11 - placeholder for compilation
-  const channelRepoMap: import('./types/config.js').ChannelRepoMap = new Map([[
-    'PLACEHOLDER',
-    { channel_id: 'PLACEHOLDER', repo_url, workspace_root: workspaceRoot },
-  ]]);
 
   const orchestrator = new OrchestratorImpl({
     adapter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,12 @@ try {
 
   const commandRegistry = new CommandRegistryImpl();
 
+  // TODO: build ChannelRepoMap properly in Task 11 - placeholder for compilation
+  const channelRepoMap: import('./types/config.js').ChannelRepoMap = new Map([[
+    'PLACEHOLDER',
+    { channel_id: 'PLACEHOLDER', repo_url, workspace_root: workspaceRoot },
+  ]]);
+
   const orchestrator = new OrchestratorImpl({
     adapter,
     workspaceManager,
@@ -257,7 +263,7 @@ try {
     postMessage: async (channel_id, thread_ts, text) => {
       await boltApp.client.chat.postMessage({ channel: channel_id, thread_ts, text });
     },
-    repo_url,
+    channelRepoMap,
   });
 
   // Register command handlers

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ try {
     registry: threadRegistry,
   });
 
-  const workspaceManager = new WorkspaceManagerImpl(workspaceRoot);
+  const workspaceManager = new WorkspaceManagerImpl();
   const runStore = new FileRunStore(workspaceRoot);
   const specGenerator = new AgentSDKSpecGenerator();
   const implementer = new AgentSDKImplementer();

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -24,3 +24,20 @@ export interface LoadedConfig {
   promptTemplate: string;
   filePath: string;
 }
+
+/** A single repository entry resolved at startup for multi-repo routing. Internal use only. */
+export interface RepoEntry {
+  channel_id: string;      // resolved from WorkflowConfig.slack.channel_name at startup
+  repo_url: string;        // from git remote get-url origin in the repo directory
+  workspace_root: string;  // from WorkflowConfig or default (~/.autocatalyst/workspaces/)
+}
+
+/** Maps Slack channel_id → RepoEntry. Keyed by resolved channel_id. */
+export type ChannelRepoMap = Map<string, RepoEntry>;
+
+/** A pre-resolved entry used to configure multi-repo mode in SlackAdapter before channel IDs are known. */
+export interface PreRepoEntry {
+  channel_name: string;
+  repo_url: string;
+  workspace_root: string;
+}

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { App } from '@slack/bolt';
 import { SlackAdapter } from '../../../src/adapters/slack/slack-adapter.js';
 import type { Request, ThreadMessage } from '../../../src/types/events.js';
+import type { PreRepoEntry } from '../../../src/types/config.js';
 
 // Captures one event from the AsyncIterable then stops
 async function takeOne<T>(iterable: AsyncIterable<T>): Promise<T> {
@@ -10,6 +11,16 @@ async function takeOne<T>(iterable: AsyncIterable<T>): Promise<T> {
 }
 
 const nullDest = { write: () => {} };
+
+function makeLogCapture() {
+  const records: Record<string, unknown>[] = [];
+  const destination = {
+    write(msg: string) {
+      try { records.push(JSON.parse(msg) as Record<string, unknown>); } catch { /* ignore */ }
+    },
+  };
+  return { records, destination: destination as unknown as import('pino').DestinationStream };
+}
 
 function makeMockApp(opts: {
   botUserId?: string;
@@ -55,6 +66,150 @@ function makeMockApp(opts: {
   };
   return app;
 }
+
+describe('SlackAdapter — multi-channel startup', () => {
+  it('resolves two channels and logs slack.startup.channels_resolved', async () => {
+    const { records, destination } = makeLogCapture();
+    const mock = makeMockApp({ channels: [{ name: 'ch-a', id: 'CA1' }, { name: 'ch-b', id: 'CB1' }] });
+    const repoEntries: PreRepoEntry[] = [
+      { channel_name: 'ch-a', repo_url: 'https://github.com/org/repo-a.git', workspace_root: '/roots/a' },
+      { channel_name: 'ch-b', repo_url: 'https://github.com/org/repo-b.git', workspace_root: '/roots/b' },
+    ];
+    const adapter = new SlackAdapter(mock as unknown as App, { repoEntries }, { logDestination: destination });
+
+    await adapter.resolveChannels();
+    await adapter.start();
+    await adapter.stop();
+
+    const resolvedLog = records.find(r => r['event'] === 'slack.startup.channels_resolved');
+    expect(resolvedLog).toBeDefined();
+    const channels = resolvedLog!['channels'] as Array<{ channel_id: string }>;
+    expect(channels).toHaveLength(2);
+    expect(channels.map(c => c.channel_id)).toContain('CA1');
+    expect(channels.map(c => c.channel_id)).toContain('CB1');
+  });
+
+  it('throws and logs slack.startup.channel_resolution_failed when a channel is not found', async () => {
+    const { records, destination } = makeLogCapture();
+    const mock = makeMockApp({ channels: [{ name: 'ch-a', id: 'CA1' }] });
+    const repoEntries: PreRepoEntry[] = [
+      { channel_name: 'ch-a', repo_url: 'https://github.com/org/repo-a.git', workspace_root: '/roots/a' },
+      { channel_name: 'missing-channel', repo_url: 'https://github.com/org/repo-b.git', workspace_root: '/roots/b' },
+    ];
+    const adapter = new SlackAdapter(mock as unknown as App, { repoEntries }, { logDestination: destination });
+
+    await expect(adapter.resolveChannels()).rejects.toThrow(/missing-channel/);
+
+    const failLog = records.find(r => r['event'] === 'slack.startup.channel_resolution_failed');
+    expect(failLog).toBeDefined();
+    expect(failLog!['channel_name']).toBe('missing-channel');
+  });
+
+  it('resolveChannels() is idempotent — conversations.list called once even if called twice', async () => {
+    const mock = makeMockApp({ channels: [{ name: 'ch-a', id: 'CA1' }, { name: 'ch-b', id: 'CB1' }] });
+    const repoEntries: PreRepoEntry[] = [
+      { channel_name: 'ch-a', repo_url: 'url-a', workspace_root: '/roots/a' },
+      { channel_name: 'ch-b', repo_url: 'url-b', workspace_root: '/roots/b' },
+    ];
+    const adapter = new SlackAdapter(mock as unknown as App, { repoEntries }, { logDestination: nullDest });
+
+    await adapter.resolveChannels();
+    await adapter.resolveChannels(); // second call is a no-op
+
+    expect(mock.client.conversations.list).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SlackAdapter — multi-channel event filtering', () => {
+  const BOT_ID = 'UBOT001';
+
+  it('message in unconfigured channel logs slack.event.channel_filtered at debug and emits no event', async () => {
+    const { records, destination } = makeLogCapture();
+    const mock = makeMockApp({
+      botUserId: BOT_ID,
+      channels: [{ name: 'ch-a', id: 'CA1' }, { name: 'ch-b', id: 'CB1' }],
+    });
+    const repoEntries: PreRepoEntry[] = [
+      { channel_name: 'ch-a', repo_url: 'url-a', workspace_root: '/roots/a' },
+    ]; // only ch-a configured
+
+    const adapter = new SlackAdapter(mock as unknown as App, { repoEntries }, { logDestination: destination });
+    await adapter.resolveChannels();
+    await adapter.start();
+
+    // Send a message from ch-b (not configured)
+    await mock._triggerMessage({
+      text: `<@${BOT_ID}> idea from unconfigured channel`,
+      user: 'U123',
+      ts: '100.0',
+      channel: 'CB1', // CB1 is not in repoEntries
+    });
+
+    await adapter.stop();
+
+    const filterLog = records.find(r => r['event'] === 'slack.event.channel_filtered');
+    expect(filterLog).toBeDefined();
+    expect(filterLog!['channel_id']).toBe('CB1');
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ideas from two configured channels are dispatched with correct channel_id', async () => {
+    const mock = makeMockApp({
+      botUserId: BOT_ID,
+      channels: [{ name: 'ch-a', id: 'CA1' }, { name: 'ch-b', id: 'CB1' }],
+    });
+    const repoEntries: PreRepoEntry[] = [
+      { channel_name: 'ch-a', repo_url: 'url-a', workspace_root: '/roots/a' },
+      { channel_name: 'ch-b', repo_url: 'url-b', workspace_root: '/roots/b' },
+    ];
+
+    const adapter = new SlackAdapter(mock as unknown as App, { repoEntries }, { logDestination: nullDest });
+    await adapter.resolveChannels();
+    await adapter.start();
+
+    // Emit idea from ch-a
+    const eventA = takeOne(adapter.receive());
+    await mock._triggerMessage({ text: `<@${BOT_ID}> idea from A`, user: 'U1', ts: '1.0', channel: 'CA1' });
+    const a = await eventA;
+
+    // Emit idea from ch-b
+    const eventB = takeOne(adapter.receive());
+    await mock._triggerMessage({ text: `<@${BOT_ID}> idea from B`, user: 'U2', ts: '2.0', channel: 'CB1' });
+    const b = await eventB;
+
+    await adapter.stop();
+
+    expect(a.type).toBe('new_request');
+    expect((a.payload as Request).channel_id).toBe('CA1');
+
+    expect(b.type).toBe('new_request');
+    expect((b.payload as Request).channel_id).toBe('CB1');
+  });
+
+  it('reaction from unconfigured channel is silently dropped', async () => {
+    const mock = makeMockApp({
+      botUserId: BOT_ID,
+      channels: [{ name: 'ch-a', id: 'CA1' }],
+    });
+    const repoEntries: PreRepoEntry[] = [
+      { channel_name: 'ch-a', repo_url: 'url-a', workspace_root: '/roots/a' },
+    ];
+
+    const adapter = new SlackAdapter(mock as unknown as App, { repoEntries }, { logDestination: nullDest });
+    await adapter.resolveChannels();
+    await adapter.start();
+
+    // Trigger reaction from an unconfigured channel (CB1)
+    await mock._triggerReaction({
+      reaction: 'ac-run-status',
+      user: 'U1',
+      item: { type: 'message', channel: 'CB1', ts: '100.0' },
+    });
+
+    await adapter.stop();
+    expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+});
 
 describe('SlackAdapter — startup', () => {
   it('resolves channel name to ID and logs slack.startup.channel_resolved', async () => {

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -14,6 +14,7 @@ describe('parseArgs', () => {
     try {
       const result = parseArgs(['--repo', tempDir]);
       expect(result.repoPath).toBe(tempDir);
+      expect(result.repoPaths).toEqual([tempDir]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -97,6 +98,33 @@ describe('parseArgs subcommand routing', () => {
 
   it('still throws when no subcommand and no --repo', () => {
     expect(() => parseArgs([])).toThrow(/--repo/);
+  });
+});
+
+describe('parseArgs — multi-repo', () => {
+  it('parses --repo with two valid directories', () => {
+    const dir1 = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    const dir2 = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    try {
+      const result = parseArgs(['--repo', dir1, dir2]);
+      expect(result.repoPaths).toHaveLength(2);
+      expect(result.repoPaths[0]).toBe(dir1);
+      expect(result.repoPaths[1]).toBe(dir2);
+      expect(result.repoPath).toBe(dir1); // backward compat: first path
+    } finally {
+      rmSync(dir1, { recursive: true, force: true });
+      rmSync(dir2, { recursive: true, force: true });
+    }
+  });
+
+  it('single --repo path returns repoPaths with one element', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    try {
+      const result = parseArgs(['--repo', tempDir]);
+      expect(result.repoPaths).toEqual([tempDir]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { parseWorkflow, resolveEnvVars, validateConfig, redactConfig, resolveAwsProfile, repoNameFromUrl } from '../../src/core/config.js';
+import { tmpdir } from 'node:os';
+import { parseWorkflow, resolveEnvVars, validateConfig, redactConfig, resolveAwsProfile, repoNameFromUrl, loadConfigFromPath, loadConfig } from '../../src/core/config.js';
 import type { WorkflowConfig } from '../../src/types/config.js';
 
 const fixture = (name: string) =>
@@ -314,5 +315,51 @@ describe('repoNameFromUrl', () => {
   it('URL with only one path segment falls back gracefully', () => {
     const result = repoNameFromUrl('https://selfhosted/repo');
     expect(result).toMatch(/repo/);
+  });
+});
+
+describe('loadConfigFromPath', () => {
+  it('returns parsed LoadedConfig for a valid repo path', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'lcp-test-'));
+    try {
+      const content = readFileSync(join(import.meta.dirname, '../fixtures', 'valid-workflow.md'), 'utf-8');
+      writeFileSync(join(tempDir, 'WORKFLOW.md'), content, 'utf-8');
+      const result = loadConfigFromPath(tempDir, {});
+      expect(result.config.polling?.interval_ms).toBe(5000);
+      expect(result.filePath).toBe(join(tempDir, 'WORKFLOW.md'));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws with path in message when WORKFLOW.md is missing', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'lcp-test-'));
+    rmSync(tempDir, { recursive: true, force: true }); // ensure directory doesn't exist
+    expect(() => loadConfigFromPath(tempDir, {})).toThrow(tempDir);
+  });
+
+  it('throws with validation details when schema is invalid', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'lcp-test-'));
+    try {
+      writeFileSync(join(tempDir, 'WORKFLOW.md'), '---\npolling:\n  interval_ms: -1\n---\nprompt\n', 'utf-8');
+      expect(() => loadConfigFromPath(tempDir, {})).toThrow(/interval_ms/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loadConfig backward compatibility: same result as loadConfigFromPath', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'lcp-test-'));
+    try {
+      const content = readFileSync(join(import.meta.dirname, '../fixtures', 'valid-workflow.md'), 'utf-8');
+      writeFileSync(join(tempDir, 'WORKFLOW.md'), content, 'utf-8');
+      const filePath = join(tempDir, 'WORKFLOW.md');
+      const result1 = loadConfig(filePath, {});
+      const result2 = loadConfigFromPath(tempDir, {});
+      expect(result1.config).toEqual(result2.config);
+      expect(result1.promptTemplate).toBe(result2.promptTemplate);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -16,6 +16,7 @@ import type { ImplementationFeedbackPage } from '../../src/adapters/notion/imple
 import type { IssueManager } from '../../src/adapters/agent/issue-manager.js';
 import type { IssueFiler, FilingResult } from '../../src/adapters/agent/issue-filer.js';
 import type { CommandEvent, CommandRegistry } from '../../src/types/commands.js';
+import type { ChannelRepoMap, RepoEntry } from '../../src/types/config.js';
 
 const nullDest = { write: () => {} };
 
@@ -113,6 +114,36 @@ function makeWorkspaceManager(overrides: Partial<WorkspaceManager> = {}): Worksp
     destroy: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
+}
+
+/** A Map subclass that returns a default RepoEntry for any channel_id not explicitly set.
+ *  This allows existing tests to work without knowing the exact channel_id in advance. */
+class _UniversalChannelRepoMap extends Map<string, RepoEntry> {
+  private readonly _defaultEntry: RepoEntry;
+  constructor(defaultEntry: RepoEntry, explicitEntries: [string, RepoEntry][] = []) {
+    super([[defaultEntry.channel_id, defaultEntry], ...explicitEntries]);
+    this._defaultEntry = defaultEntry;
+  }
+  override has(_key: string): boolean { return true; }
+  override get(key: string): RepoEntry { return super.get(key) ?? this._defaultEntry; }
+}
+
+function makeChannelRepoMap(entries: Record<string, Partial<RepoEntry>> = {}): ChannelRepoMap {
+  const defaultEntry: RepoEntry = {
+    channel_id: 'C1',
+    repo_url: 'https://github.com/org/repo.git',
+    workspace_root: '~/.autocatalyst/workspaces',
+  };
+  const map = new _UniversalChannelRepoMap(defaultEntry);
+  for (const [channelId, partial] of Object.entries(entries)) {
+    map.set(channelId, {
+      channel_id: channelId,
+      repo_url: 'https://github.com/org/repo.git',
+      workspace_root: '~/.autocatalyst/workspaces',
+      ...partial,
+    });
+  }
+  return map;
 }
 
 function makeSpecGenerator(overrides: Partial<SpecGenerator> = {}): SpecGenerator {
@@ -287,7 +318,7 @@ describe('Orchestrator — new_request happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
     const request = makeRequest();
@@ -297,7 +328,7 @@ describe('Orchestrator — new_request happy path', () => {
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    expect(wm.create).toHaveBeenCalledWith('request-001', 'https://github.com/org/repo');
+    expect(wm.create).toHaveBeenCalledWith('request-001', 'https://github.com/org/repo.git', '~/.autocatalyst/workspaces');
     expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function));
     expect(cp.create).toHaveBeenCalledWith('C123', '100.0', '/ws/request-001/context-human/specs/feature-test.md');
   });
@@ -309,7 +340,7 @@ describe('Orchestrator — new_request happy path', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_request', payload: makeRequest() });
@@ -335,7 +366,7 @@ describe('Orchestrator — new_request failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
     adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
@@ -356,7 +387,7 @@ describe('Orchestrator — new_request failure paths', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
     adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
@@ -377,7 +408,7 @@ describe('Orchestrator — new_request failure paths', () => {
     const cp = makeSpecPublisher({ create: vi.fn().mockRejectedValue(new Error('canvas error')) });
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
     adapter._emit({ type: 'new_request', payload: makeRequest() });
     await new Promise(r => setTimeout(r, 50));
@@ -403,7 +434,7 @@ describe('Orchestrator — feedback happy path', () => {
     const ic = makeIntentClassifier('idea');
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
     // First seed the request to get a run in review
@@ -441,7 +472,7 @@ describe('Orchestrator — feedback guard conditions', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('feedback') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('feedback') }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'thread_message', payload: makeFeedback({ request_id: 'unknown-request' }) });
@@ -466,7 +497,7 @@ describe('Orchestrator — feedback guard conditions', () => {
     const ic = makeIntentClassifier('idea');
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_request', payload: makeRequest() });
@@ -493,7 +524,7 @@ describe('Orchestrator — feedback guard conditions', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_request', payload: makeRequest() });
@@ -520,7 +551,7 @@ describe('Orchestrator — feedback failure paths', () => {
     const ic = makeIntentClassifier('idea');
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_request', payload: makeRequest() });
@@ -546,7 +577,7 @@ describe('Orchestrator — feedback failure paths', () => {
     const ic = makeIntentClassifier('idea');
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_request', payload: makeRequest() });
@@ -583,7 +614,7 @@ describe('Orchestrator — concurrency', () => {
     const cp = makeSpecPublisher();
     const postError = vi.fn().mockResolvedValue(undefined);
 
-    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
+    const orch = new OrchestratorImpl({ adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('idea') }, { logDestination: nullDest });
     await orch.start();
 
     adapter._emit({ type: 'new_request', payload: makeRequest({ id: 'request-A', thread_ts: 'A.0' }) });
@@ -642,7 +673,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, postMessage, repo_url: 'https://github.com/org/repo', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: sp, feedbackSource: fs, postError, postMessage, channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -676,7 +707,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -702,7 +733,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -729,7 +760,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -765,7 +796,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -793,7 +824,7 @@ describe('Orchestrator — feedback completion notification', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), feedbackSource: fs, postError: vi.fn().mockResolvedValue(undefined), postMessage, channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -812,7 +843,7 @@ describe('Orchestrator — feedback completion notification', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -832,7 +863,7 @@ describe('Orchestrator — feedback completion notification', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage, repo_url: 'r', intentClassifier: ic } as never,
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage, channelRepoMap: makeChannelRepoMap(), intentClassifier: ic } as never,
       { logDestination: nullDest },
     );
     await orch.start();
@@ -851,7 +882,7 @@ describe('Orchestrator — intent classification routing', () => {
     const ic = makeIntentClassifier('idea');
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: makeSpecGenerator(), specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: makeSpecGenerator(), specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -871,7 +902,7 @@ describe('Orchestrator — intent classification routing', () => {
     const ic = makeIntentClassifier('idea');
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -886,7 +917,7 @@ describe('Orchestrator — intent classification routing', () => {
     const sg = makeSpecGenerator();
     const ic = makeIntentClassifier('approval');
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -907,7 +938,7 @@ describe('Orchestrator — intent classification routing', () => {
     const sg = makeSpecGenerator();
     const ic = makeIntentClassifier('feedback');
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -927,7 +958,7 @@ describe('Orchestrator — intent classification routing', () => {
     const sg = makeSpecGenerator();
     const ic = makeIntentClassifier('approval');
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -950,7 +981,7 @@ describe('Orchestrator — implementing stage guard', () => {
     const ic = makeIntentClassifier('feedback');
     const postMessage = vi.fn().mockResolvedValue(undefined);
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage, channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -976,7 +1007,7 @@ describe('Orchestrator — done stage guard', () => {
     const ic = makeIntentClassifier('feedback');
     const postError = vi.fn().mockResolvedValue(undefined);
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'r', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -1018,7 +1049,7 @@ function makeApprovalOrch(opts: {
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     } as never,
     { logDestination: nullDest },
   );
@@ -1260,7 +1291,7 @@ describe('Orchestrator — _runImplementation onProgress wiring', () => {
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: destination },
     );
@@ -1403,7 +1434,7 @@ function makeImplFeedbackOrch(opts: {
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     } as never,
     { logDestination: nullDest },
   );
@@ -1655,7 +1686,7 @@ function makeApprovalOrch2(opts: {
       prManager: opts.prManager ?? makePRManager(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     } as never,
     { logDestination: nullDest },
   );
@@ -1809,7 +1840,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
         prManager: makePRManager(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -1884,7 +1915,7 @@ function makeApprovalOrch3(opts: {
       prManager: opts.prManager ?? makePRManager(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     } as never,
     { logDestination: nullDest },
   );
@@ -1981,7 +2012,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         prManager: makePRManager(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -2014,7 +2045,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         prManager: makePRManager(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -2049,7 +2080,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         prManager,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -2092,7 +2123,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('feedback'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: mockRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2122,7 +2153,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: mockRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2155,7 +2186,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: ic,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: mockRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2191,7 +2222,7 @@ describe('Orchestrator — run persistence', () => {
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: mockRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2231,7 +2262,7 @@ describe('Orchestrator — run persistence', () => {
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: mockRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2272,7 +2303,7 @@ describe('Orchestrator — run persistence', () => {
         implFeedbackPage,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: mockRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2303,7 +2334,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       },
       { logDestination: nullDest },
     );
@@ -2361,7 +2392,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('feedback'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
         runStore: fileRunStore,
       } as never,
       { logDestination: nullDest },
@@ -2393,7 +2424,7 @@ describe('Orchestrator — question intent', () => {
         questionAnswerer: qa,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       },
       { logDestination: nullDest },
     );
@@ -2423,7 +2454,7 @@ describe('Orchestrator — question intent', () => {
         questionAnswerer: qa,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       },
       { logDestination: nullDest },
     );
@@ -2455,7 +2486,7 @@ describe('Orchestrator — question intent', () => {
         questionAnswerer: qa,
         postError,
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       },
       { logDestination: nullDest },
     );
@@ -2481,7 +2512,7 @@ describe('Orchestrator — question intent', () => {
         intentClassifier: makeIntentClassifier('question'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       },
       { logDestination: nullDest },
     );
@@ -2507,7 +2538,7 @@ describe('_classify — serial classification gate', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     });
     await orch.start();
 
@@ -2528,7 +2559,7 @@ describe('_classify — serial classification gate', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
 
@@ -2552,7 +2583,7 @@ describe('_classify — serial classification gate', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
 
@@ -2585,7 +2616,7 @@ describe('_classify — serial classification gate', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
 
@@ -2616,7 +2647,7 @@ describe('_classify — serial classification gate', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
 
@@ -2648,7 +2679,7 @@ describe('_classify — serial classification gate', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 10 });
 
     const run: Run = {
@@ -2689,7 +2720,7 @@ describe('_dispatchOrEnqueue and _launch', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2723,7 +2754,7 @@ describe('_dispatchOrEnqueue and _launch', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage,
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2767,7 +2798,7 @@ describe('_dispatchOrEnqueue and _launch', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 5 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2798,7 +2829,7 @@ describe('_dispatchOrEnqueue and _launch', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2838,7 +2869,7 @@ describe('_runLoop — classify-dispatch integration', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
 
@@ -2873,7 +2904,7 @@ describe('_runLoop — classify-dispatch integration', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2908,7 +2939,7 @@ describe('_runLoop — classify-dispatch integration', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2950,7 +2981,7 @@ describe('metrics instrumentation', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -2989,7 +3020,7 @@ describe('metrics instrumentation', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3030,7 +3061,7 @@ describe('metrics instrumentation', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3067,7 +3098,7 @@ describe('serial classification — additional coverage', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 10 });
 
     const origClassify = (orch as unknown as { _classify: (e: unknown) => Promise<string> })._classify.bind(orch);
@@ -3114,7 +3145,7 @@ describe('serial classification — additional coverage', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 5 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3151,7 +3182,7 @@ describe('concurrent dispatch — additional coverage', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
 
@@ -3210,7 +3241,7 @@ describe('concurrent dispatch — additional coverage', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3256,7 +3287,7 @@ describe('failure isolation', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3291,7 +3322,7 @@ describe('failure isolation', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3326,7 +3357,7 @@ describe('failure isolation', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3373,7 +3404,7 @@ describe('concurrency limit and queue', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3419,7 +3450,7 @@ describe('concurrency limit and queue', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3455,7 +3486,7 @@ describe('concurrency limit and queue', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 3 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3491,7 +3522,7 @@ describe('concurrency limit and queue', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 2 });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3525,7 +3556,7 @@ describe('stop drain — remaining cases', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3561,7 +3592,7 @@ describe('stop drain — remaining cases', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3593,7 +3624,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
     const e = makeEventFixture('thread_message', { request_id: 'no-such-run' });
@@ -3613,7 +3644,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
     const run: Run = {
@@ -3641,7 +3672,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     await orch.start();
     const run: Run = {
@@ -3670,7 +3701,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3693,7 +3724,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3723,7 +3754,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { maxConcurrentRuns: 1, logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3749,7 +3780,7 @@ describe('observability — log field correctness', () => {
       specPublisher: makeSpecPublisher(),
       postError: vi.fn(),
       postMessage: vi.fn(),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: destination });
     (orch as unknown as { _handleRequest: typeof handleReq })._handleRequest = handleReq;
     await orch.start();
@@ -3780,7 +3811,7 @@ describe('Orchestrator — _startSpecPipeline onProgress wiring', () => {
         intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -3816,7 +3847,7 @@ describe('Orchestrator — _startSpecPipeline onProgress wiring', () => {
         intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -3859,7 +3890,7 @@ describe('Orchestrator — _startSpecPipeline onProgress wiring', () => {
         intentClassifier: makeIntentClassifier('idea'),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: destination },
     );
@@ -3902,7 +3933,7 @@ describe('Orchestrator — _handleSpecFeedback onProgress wiring', () => {
         intentClassifier: ic,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -3939,7 +3970,7 @@ describe('Orchestrator — _handleSpecFeedback onProgress wiring', () => {
         intentClassifier: ic,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: nullDest },
     );
@@ -3984,7 +4015,7 @@ describe('Orchestrator — _handleSpecFeedback onProgress wiring', () => {
         intentClassifier: ic,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'r',
+        channelRepoMap: makeChannelRepoMap(),
       } as never,
       { logDestination: destination },
     );
@@ -4053,7 +4084,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         specPublisher: deps.cp,
         postError: vi.fn(),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementer: deps.impl,
@@ -4091,7 +4122,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         specPublisher: deps.cp,
         postError: vi.fn(),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementer: deps.impl,
@@ -4131,7 +4162,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         specPublisher: deps.cp,
         postError: vi.fn(),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementer: deps.impl,
@@ -4172,7 +4203,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         specPublisher: deps.cp,
         postError: vi.fn(),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementer: deps.impl,
@@ -4210,7 +4241,7 @@ describe('Orchestrator — spec lifecycle status updates', () => {
     const ic = makeIntentClassifier('idea');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4230,7 +4261,7 @@ describe('Orchestrator — spec lifecycle status updates', () => {
     const ic = makeIntentClassifier('idea');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4252,7 +4283,7 @@ describe('Orchestrator — spec lifecycle status updates', () => {
     (ic.classify as ReturnType<typeof vi.fn>).mockResolvedValueOnce('idea').mockResolvedValue('feedback');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4276,7 +4307,7 @@ describe('Orchestrator — spec lifecycle status updates', () => {
     const ic = makeIntentClassifier('idea');
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: ic },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn(), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: ic },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4297,7 +4328,7 @@ describe('Orchestrator — bug and chore routing', () => {
     const cp = makeSpecPublisher();
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('bug') },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('bug') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4318,7 +4349,7 @@ describe('Orchestrator — bug and chore routing', () => {
     const cp = makeSpecPublisher();
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('chore') },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: cp, postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('chore') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4337,7 +4368,7 @@ describe('Orchestrator — bug and chore routing', () => {
     const sg = makeSpecGenerator();
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('bug') },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('bug') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4354,7 +4385,7 @@ describe('Orchestrator — bug and chore routing', () => {
     const sg = makeSpecGenerator();
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('chore') },
+      { adapter: adapter as never, workspaceManager: makeWorkspaceManager(), specGenerator: sg, specPublisher: makeSpecPublisher(), postError: vi.fn().mockResolvedValue(undefined), postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('chore') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4374,7 +4405,7 @@ describe('Orchestrator — triage pipeline error paths', () => {
     const postError = vi.fn().mockResolvedValue(undefined);
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: makeSpecGenerator(), specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('bug') },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: makeSpecGenerator(), specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('bug') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4394,7 +4425,7 @@ describe('Orchestrator — triage pipeline error paths', () => {
     const postError = vi.fn().mockResolvedValue(undefined);
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('chore') },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: sg, specPublisher: makeSpecPublisher(), postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('chore') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4415,7 +4446,7 @@ describe('Orchestrator — triage pipeline error paths', () => {
     const postError = vi.fn().mockResolvedValue(undefined);
 
     const orch = new OrchestratorImpl(
-      { adapter: adapter as never, workspaceManager: wm, specGenerator: makeSpecGenerator(), specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), repo_url: 'https://github.com/org/repo', intentClassifier: makeIntentClassifier('bug') },
+      { adapter: adapter as never, workspaceManager: wm, specGenerator: makeSpecGenerator(), specPublisher: cp, postError, postMessage: vi.fn().mockResolvedValue(undefined), channelRepoMap: makeChannelRepoMap(), intentClassifier: makeIntentClassifier('bug') },
       { logDestination: nullDest },
     );
     await orch.start();
@@ -4456,7 +4487,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError,
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: nullDest },
@@ -4504,7 +4535,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: nullDest },
@@ -4556,7 +4587,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: nullDest },
@@ -4574,7 +4605,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
     }, { timeout: 2000 });
     await adapter.stop();
 
-    expect(setIssueLink).toHaveBeenCalledWith('CANVAS001', 'https://github.com/org/repo/issues/77');
+    expect(setIssueLink).toHaveBeenCalledWith('CANVAS001', 'https://github.com/org/repo.git/issues/77');
     expect(updateStatus).toHaveBeenCalledWith('CANVAS001', 'Approved');
   });
 
@@ -4612,7 +4643,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: dest as import('pino').DestinationStream },
@@ -4661,7 +4692,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError,
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: nullDest },
@@ -4707,7 +4738,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError,
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: nullDest },
@@ -4750,7 +4781,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: nullDest },
@@ -4804,7 +4835,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         issueManager: im,
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
-        repo_url: 'https://github.com/org/repo',
+        channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
       },
       { logDestination: dest as import('pino').DestinationStream },
@@ -4845,7 +4876,7 @@ describe('Orchestrator — file_issues routing', () => {
       issueFiler,
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage,
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -4877,7 +4908,7 @@ describe('Orchestrator — _startFilingPipeline error paths', () => {
       issueFiler,
       postError,
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -4907,7 +4938,7 @@ describe('Orchestrator — _startFilingPipeline error paths', () => {
       issueFiler,
       postError,
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -4941,7 +4972,7 @@ describe('Orchestrator — _startFilingPipeline error paths', () => {
       issueFiler,
       postError,
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -4981,7 +5012,7 @@ describe('Orchestrator — _startFilingPipeline success paths', () => {
       issueFiler,
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage,
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: logDest });
 
     await orch.start();
@@ -5037,7 +5068,7 @@ describe('Orchestrator — _startFilingPipeline success paths', () => {
       issueFiler,
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: logDest });
 
     await orch.start();
@@ -5072,7 +5103,7 @@ describe('Orchestrator — _startFilingPipeline success paths', () => {
       issueFiler,
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: logDest });
 
     await orch.start();
@@ -5102,7 +5133,7 @@ describe('Orchestrator — _startFilingPipeline success paths', () => {
       issueFiler,
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage,
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -5130,7 +5161,7 @@ describe('Orchestrator — _startFilingPipeline success paths', () => {
       issueFiler,
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage,
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -5157,7 +5188,7 @@ describe('Orchestrator — existing routing unaffected by file_issues', () => {
       intentClassifier: makeIntentClassifier('idea'),
       postError: vi.fn().mockResolvedValue(undefined),
       postMessage: vi.fn().mockResolvedValue(undefined),
-      repo_url: 'https://github.com/org/repo',
+      channelRepoMap: makeChannelRepoMap(),
     }, { logDestination: nullDest });
 
     await orch.start();
@@ -5190,7 +5221,7 @@ describe('OrchestratorImpl — command dispatch', () => {
         specPublisher: makeSpecPublisher(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/test/repo',
+        channelRepoMap: makeChannelRepoMap(),
         commandRegistry,
       },
       { logDestination: nullDest as unknown as import('pino').DestinationStream },
@@ -5236,7 +5267,7 @@ describe('OrchestratorImpl — command dispatch', () => {
         specPublisher: makeSpecPublisher(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/test/repo',
+        channelRepoMap: makeChannelRepoMap(),
         commandRegistry,
       },
       { logDestination: destination },
@@ -5268,7 +5299,7 @@ describe('OrchestratorImpl — command dispatch', () => {
         specPublisher: makeSpecPublisher(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/test/repo',
+        channelRepoMap: makeChannelRepoMap(),
         commandRegistry,
       },
       { logDestination: destination },
@@ -5306,7 +5337,7 @@ describe('OrchestratorImpl — command dispatch', () => {
         specPublisher: makeSpecPublisher(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
-        repo_url: 'https://github.com/test/repo',
+        channelRepoMap: makeChannelRepoMap(),
         commandRegistry,
       },
       { logDestination: destination },
@@ -5336,7 +5367,7 @@ describe('OrchestratorImpl — command dispatch', () => {
         specPublisher: makeSpecPublisher(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: failingPost,
-        repo_url: 'https://github.com/test/repo',
+        channelRepoMap: makeChannelRepoMap(),
         commandRegistry,
       },
       { logDestination: destination },
@@ -5359,5 +5390,155 @@ describe('OrchestratorImpl — command dispatch', () => {
     await orch.stop();
 
     expect(commandRegistry.dispatch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('OrchestratorImpl — multi-repo dispatch', () => {
+  it('new_request from mapped channel A uses channel A repo_url and workspace_root', async () => {
+    const { records, destination } = makeLogCapture();
+    const adapter = makeMockAdapter();
+    const workspaceManager = makeWorkspaceManager();
+    const channelRepoMap: ChannelRepoMap = new Map([
+      ['CA', { channel_id: 'CA', repo_url: 'https://github.com/org/repo-a.git', workspace_root: '/roots/a' }],
+      ['CB', { channel_id: 'CB', repo_url: 'https://github.com/org/repo-b.git', workspace_root: '/roots/b' }],
+    ]);
+
+    const orch = new OrchestratorImpl({
+      adapter: adapter as unknown as import('../../src/adapters/slack/slack-adapter.js').SlackAdapter,
+      workspaceManager,
+      specGenerator: makeSpecGenerator(),
+      specPublisher: makeSpecPublisher(),
+      channelRepoMap,
+      postError: vi.fn().mockResolvedValue(undefined),
+      postMessage: vi.fn().mockResolvedValue(undefined),
+    }, { logDestination: destination });
+
+    await orch.start();
+
+    const reqId = 'req-mr-1';
+    adapter._emit({
+      type: 'new_request',
+      payload: { id: reqId, source: 'slack' as const, content: 'idea', author: 'U1', received_at: new Date().toISOString(), thread_ts: '1.0', channel_id: 'CA' },
+    });
+
+    await vi.waitUntil(() => {
+      const run = [...orch.getRuns().values()].find(r => r.request_id === reqId);
+      return run?.stage === 'reviewing_spec';
+    }, { timeout: 3000 });
+
+    expect(workspaceManager.create).toHaveBeenCalledWith(reqId, 'https://github.com/org/repo-a.git', '/roots/a');
+    await orch.stop();
+  });
+
+  it('new_request from mapped channel B uses channel B repo_url and workspace_root', async () => {
+    const { records, destination } = makeLogCapture();
+    const adapter = makeMockAdapter();
+    const workspaceManager = makeWorkspaceManager();
+    const channelRepoMap: ChannelRepoMap = new Map([
+      ['CA', { channel_id: 'CA', repo_url: 'https://github.com/org/repo-a.git', workspace_root: '/roots/a' }],
+      ['CB', { channel_id: 'CB', repo_url: 'https://github.com/org/repo-b.git', workspace_root: '/roots/b' }],
+    ]);
+
+    const orch = new OrchestratorImpl({
+      adapter: adapter as unknown as import('../../src/adapters/slack/slack-adapter.js').SlackAdapter,
+      workspaceManager,
+      specGenerator: makeSpecGenerator(),
+      specPublisher: makeSpecPublisher(),
+      channelRepoMap,
+      postError: vi.fn().mockResolvedValue(undefined),
+      postMessage: vi.fn().mockResolvedValue(undefined),
+    }, { logDestination: destination });
+
+    await orch.start();
+
+    const reqId = 'req-mr-2';
+    adapter._emit({
+      type: 'new_request',
+      payload: { id: reqId, source: 'slack' as const, content: 'idea', author: 'U1', received_at: new Date().toISOString(), thread_ts: '2.0', channel_id: 'CB' },
+    });
+
+    await vi.waitUntil(() => {
+      const run = [...orch.getRuns().values()].find(r => r.request_id === reqId);
+      return run?.stage === 'reviewing_spec';
+    }, { timeout: 3000 });
+
+    expect(workspaceManager.create).toHaveBeenCalledWith(reqId, 'https://github.com/org/repo-b.git', '/roots/b');
+    await orch.stop();
+  });
+
+  it('new_request from unmapped channel: run.channel_unmapped warn logged, no run created', async () => {
+    const { records, destination } = makeLogCapture();
+    const adapter = makeMockAdapter();
+    const workspaceManager = makeWorkspaceManager();
+    const channelRepoMap: ChannelRepoMap = new Map([
+      ['CA', { channel_id: 'CA', repo_url: 'https://github.com/org/repo-a.git', workspace_root: '/roots/a' }],
+    ]);
+
+    const orch = new OrchestratorImpl({
+      adapter: adapter as unknown as import('../../src/adapters/slack/slack-adapter.js').SlackAdapter,
+      workspaceManager,
+      specGenerator: makeSpecGenerator(),
+      specPublisher: makeSpecPublisher(),
+      channelRepoMap,
+      postError: vi.fn().mockResolvedValue(undefined),
+      postMessage: vi.fn().mockResolvedValue(undefined),
+    }, { logDestination: destination });
+
+    await orch.start();
+
+    const reqId = 'req-mr-3';
+    adapter._emit({
+      type: 'new_request',
+      payload: { id: reqId, source: 'slack' as const, content: 'idea', author: 'U1', received_at: new Date().toISOString(), thread_ts: '3.0', channel_id: 'CUNMAPPED' },
+    });
+
+    await new Promise(r => setTimeout(r, 200));
+
+    expect(orch.getRuns().size).toBe(0);
+    expect(workspaceManager.create).not.toHaveBeenCalled();
+    const warnLog = records.find(r => r['event'] === 'run.channel_unmapped');
+    expect(warnLog).toBeDefined();
+    expect(warnLog!['channel_id']).toBe('CUNMAPPED');
+
+    await orch.stop();
+  });
+
+  it('single-entry ChannelRepoMap matches existing single-repo behavior', async () => {
+    const { records, destination } = makeLogCapture();
+    const adapter = makeMockAdapter();
+    const workspaceManager = makeWorkspaceManager();
+    const channelRepoMap: ChannelRepoMap = new Map([
+      ['C1', { channel_id: 'C1', repo_url: 'https://github.com/org/repo.git', workspace_root: '~/.autocatalyst/workspaces' }],
+    ]);
+
+    const orch = new OrchestratorImpl({
+      adapter: adapter as unknown as import('../../src/adapters/slack/slack-adapter.js').SlackAdapter,
+      workspaceManager,
+      specGenerator: makeSpecGenerator(),
+      specPublisher: makeSpecPublisher(),
+      channelRepoMap,
+      postError: vi.fn().mockResolvedValue(undefined),
+      postMessage: vi.fn().mockResolvedValue(undefined),
+    }, { logDestination: destination });
+
+    await orch.start();
+
+    const reqId = 'req-mr-4';
+    adapter._emit({
+      type: 'new_request',
+      payload: { id: reqId, source: 'slack' as const, content: 'idea', author: 'U1', received_at: new Date().toISOString(), thread_ts: '4.0', channel_id: 'C1' },
+    });
+
+    await vi.waitUntil(() => {
+      const run = [...orch.getRuns().values()].find(r => r.request_id === reqId);
+      return run?.stage === 'reviewing_spec';
+    }, { timeout: 3000 });
+
+    expect(workspaceManager.create).toHaveBeenCalledWith(
+      reqId,
+      'https://github.com/org/repo.git',
+      '~/.autocatalyst/workspaces',
+    );
+    await orch.stop();
   });
 });

--- a/tests/core/workspace-manager.test.ts
+++ b/tests/core/workspace-manager.test.ts
@@ -19,9 +19,9 @@ afterEach(() => {
 describe('WorkspaceManager.create', () => {
   it('runs git clone with --depth=1 and correct path', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
-    await wm.create('idea-abc', 'https://github.com/org/repo.git');
+    await wm.create('idea-abc', 'https://github.com/org/repo.git', tempRoot);
 
     expect(execFn).toHaveBeenCalledWith(
       expect.stringContaining('git clone --depth=1'),
@@ -35,9 +35,9 @@ describe('WorkspaceManager.create', () => {
 
   it('runs git checkout -b after clone with correct branch and cwd', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
-    await wm.create('idea-abc', 'https://github.com/org/repo.git');
+    await wm.create('idea-abc', 'https://github.com/org/repo.git', tempRoot);
 
     expect(execFn).toHaveBeenCalledTimes(2);
     const checkoutCall = execFn.mock.calls[1];
@@ -47,9 +47,9 @@ describe('WorkspaceManager.create', () => {
 
   it('returns workspace_path and branch', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
-    const result = await wm.create('idea-abc', 'https://github.com/org/repo.git');
+    const result = await wm.create('idea-abc', 'https://github.com/org/repo.git', tempRoot);
 
     expect(result.workspace_path).toBe(join(tempRoot, 'idea-abc'));
     expect(result.branch).toMatch(/^spec\//);
@@ -62,11 +62,11 @@ describe('WorkspaceManager.create', () => {
     // Pre-create the directory to simulate partial clone
     mkdirSync(join(tempRoot, 'idea-fail'), { recursive: true });
 
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
     const { existsSync } = await import('node:fs');
     expect(existsSync(join(tempRoot, 'idea-fail'))).toBe(true); // confirm dir exists before create
-    await expect(wm.create('idea-fail', 'https://github.com/org/repo.git')).rejects.toThrow('git clone failed');
+    await expect(wm.create('idea-fail', 'https://github.com/org/repo.git', tempRoot)).rejects.toThrow('git clone failed');
 
     // Verify cleanup occurred
     expect(existsSync(join(tempRoot, 'idea-fail'))).toBe(false);
@@ -79,46 +79,64 @@ describe('WorkspaceManager.create', () => {
     // Pre-create directory to simulate what clone would have done
     mkdirSync(join(tempRoot, 'idea-xyz'), { recursive: true });
 
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
     const { existsSync } = await import('node:fs');
     expect(existsSync(join(tempRoot, 'idea-xyz'))).toBe(true); // confirm dir exists before create
-    await expect(wm.create('idea-xyz', 'https://github.com/org/repo.git')).rejects.toThrow('git checkout -b failed');
+    await expect(wm.create('idea-xyz', 'https://github.com/org/repo.git', tempRoot)).rejects.toThrow('git checkout -b failed');
 
     expect(existsSync(join(tempRoot, 'idea-xyz'))).toBe(false);
   });
 
   it('two requests with different request_ids produce non-overlapping paths', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
-    const r1 = await wm.create('idea-111', 'https://github.com/org/repo.git');
-    const r2 = await wm.create('idea-222', 'https://github.com/org/repo.git');
+    const r1 = await wm.create('idea-111', 'https://github.com/org/repo.git', tempRoot);
+    const r2 = await wm.create('idea-222', 'https://github.com/org/repo.git', tempRoot);
 
     expect(r1.workspace_path).not.toBe(r2.workspace_path);
   });
 
   it('throws on invalid request_id containing path separator', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
-    await expect(wm.create('req/evil', 'https://github.com/org/repo.git')).rejects.toThrow(/Invalid request_id/);
+    await expect(wm.create('req/evil', 'https://github.com/org/repo.git', tempRoot)).rejects.toThrow(/Invalid request_id/);
     expect(execFn).not.toHaveBeenCalled();
   });
 
   it('throws on invalid request_id containing dot-dot traversal', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
-    await expect(wm.create('req..evil', 'https://github.com/org/repo.git')).rejects.toThrow(/Invalid request_id/);
+    await expect(wm.create('req..evil', 'https://github.com/org/repo.git', tempRoot)).rejects.toThrow(/Invalid request_id/);
     expect(execFn).not.toHaveBeenCalled();
+  });
+
+  it('two calls with different workspace_root values produce non-overlapping paths', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
+
+    const root1 = mkdtempSync(join(tmpdir(), 'wm-root1-'));
+    const root2 = mkdtempSync(join(tmpdir(), 'wm-root2-'));
+    try {
+      const r1 = await wm.create('idea-same', 'https://github.com/org/repo.git', root1);
+      const r2 = await wm.create('idea-same', 'https://github.com/org/repo.git', root2);
+      expect(r1.workspace_path).not.toBe(r2.workspace_path);
+      expect(r1.workspace_path).toContain(root1);
+      expect(r2.workspace_path).toContain(root2);
+    } finally {
+      rmSync(root1, { recursive: true, force: true });
+      rmSync(root2, { recursive: true, force: true });
+    }
   });
 });
 
 describe('WorkspaceManager.destroy', () => {
   it('removes the workspace directory recursively', async () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const wm = new WorkspaceManagerImpl(tempRoot, { execFn, logDestination: nullDest });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
 
     // Create a real directory to destroy
     const wsPath = join(tempRoot, 'to-destroy');

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Integration tests for src/index.ts startup modes.
+ *
+ * Testing top-level module execution requires vi.doMock() (non-hoisted) +
+ * vi.resetModules() + dynamic import to re-execute the startup logic per test.
+ *
+ * The strategy: mock createLogger so we capture log records, then mock enough
+ * of the dependency graph to reach the service.starting log line without
+ * process.exit(). Downstream failures are caught via .catch(() => {}).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Helper: creates a temp dir with a valid WORKFLOW.md
+function makeTempRepo(channelName = 'my-channel', workspaceRoot = '/tmp/ws') {
+  const dir = mkdtempSync(join(tmpdir(), 'index-test-'));
+  const content = `---\nslack:\n  bot_token: xoxb-test\n  app_token: xapp-test\n  channel_name: ${channelName}\nworkspace:\n  root: ${workspaceRoot}\n---\nPrompt template\n`;
+  writeFileSync(join(dir, 'WORKFLOW.md'), content, 'utf-8');
+  return dir;
+}
+
+function makeMinimalConfig(channelName: string) {
+  return {
+    config: {
+      slack: { bot_token: 'xoxb-test', app_token: 'xapp-test', channel_name: channelName },
+      workspace: { root: '/tmp/ws' },
+    },
+    promptTemplate: 'Prompt',
+    filePath: '/tmp/WORKFLOW.md',
+  };
+}
+
+describe('src/index.ts — startup modes', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    vi.resetModules();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    originalArgv = process.argv;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+  });
+
+  it('single --repo: service.starting logged with mode: "single-repo"', async () => {
+    const dir = makeTempRepo('my-channel');
+    const logRecords: Record<string, unknown>[] = [];
+
+    try {
+      const fakeLogger = {
+        info: vi.fn().mockImplementation((obj: Record<string, unknown>) => { logRecords.push(obj); }),
+        warn: vi.fn().mockImplementation((obj: Record<string, unknown>) => { logRecords.push(obj); }),
+        error: vi.fn().mockImplementation((obj: Record<string, unknown>) => { logRecords.push(obj); }),
+        debug: vi.fn(),
+      };
+
+      vi.doMock('../src/core/logger.js', () => ({
+        createLogger: vi.fn().mockReturnValue(fakeLogger),
+      }));
+
+      vi.doMock('node:child_process', () => ({
+        execSync: vi.fn().mockReturnValue('https://github.com/org/repo.git\n'),
+      }));
+
+      vi.doMock('../src/core/init.js', () => ({
+        runInit: vi.fn().mockResolvedValue(undefined),
+        configExists: vi.fn().mockReturnValue(true),
+      }));
+
+      vi.doMock('../src/core/config.js', () => ({
+        loadConfig: vi.fn().mockReturnValue(makeMinimalConfig('my-channel')),
+        loadConfigFromPath: vi.fn().mockReturnValue(makeMinimalConfig('my-channel')),
+        resolveEnvVars: vi.fn().mockReturnValue({ resolved: makeMinimalConfig('my-channel').config, missing: [] }),
+        redactConfig: vi.fn().mockReturnValue({}),
+        resolveAwsProfile: vi.fn().mockReturnValue(undefined),
+        repoNameFromUrl: vi.fn().mockReturnValue('org/repo'),
+      }));
+
+      const fakeAdapter = {
+        resolveChannels: vi.fn().mockResolvedValue(undefined),
+        getChannelId: vi.fn().mockReturnValue('C123'),
+        getChannelRepoMap: vi.fn().mockReturnValue(new Map()),
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        receive: async function* () {},
+        isConnected: vi.fn().mockReturnValue(true),
+      };
+
+      vi.doMock('../src/adapters/slack/slack-adapter.js', () => ({
+        SlackAdapter: vi.fn().mockImplementation(() => fakeAdapter),
+      }));
+
+      vi.doMock('@slack/bolt', () => ({
+        App: vi.fn().mockImplementation(() => ({ client: {}, start: vi.fn(), stop: vi.fn() })),
+      }));
+
+      vi.doMock('../src/core/workspace-manager.js', () => ({
+        WorkspaceManagerImpl: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/core/run-store.js', () => ({
+        FileRunStore: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/slack/thread-registry.js', () => ({
+        ThreadRegistry: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      const fakeOrchestrator = {
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        getRuns: vi.fn().mockReturnValue(new Map()),
+        getActiveRunCount: vi.fn().mockReturnValue(0),
+        cancelRun: vi.fn(),
+        getRunLogs: vi.fn(),
+      };
+
+      vi.doMock('../src/core/orchestrator.js', () => ({
+        OrchestratorImpl: vi.fn().mockImplementation(() => fakeOrchestrator),
+      }));
+
+      vi.doMock('../src/core/command-registry.js', () => ({
+        CommandRegistryImpl: vi.fn().mockImplementation(() => ({ register: vi.fn(), get: vi.fn(), list: vi.fn() })),
+      }));
+
+      vi.doMock('../src/core/commands/run-commands.js', () => ({
+        makeRunStatusHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeRunListHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeRunCancelHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeRunLogsHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/core/commands/meta-commands.js', () => ({
+        makeHealthHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeHelpHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/core/commands/classify-intent-command.js', () => ({
+        makeClassifyIntentHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/adapters/agent/spec-generator.js', () => ({
+        AgentSDKSpecGenerator: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/slack/canvas-publisher.js', () => ({
+        SlackCanvasPublisher: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/core/service.js', () => ({
+        Service: vi.fn().mockImplementation(() => ({
+          start: vi.fn(),
+          stop: vi.fn().mockResolvedValue(undefined),
+          stopped: new Promise(() => {}), // never resolves — keeps service "running"
+          updateConfig: vi.fn(),
+        })),
+      }));
+
+      vi.doMock('../src/core/config-watcher.js', () => ({
+        ConfigWatcher: vi.fn().mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() })),
+      }));
+
+      vi.doMock('../src/core/signals.js', () => ({
+        registerSignalHandlers: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('@anthropic-ai/bedrock-sdk', () => ({
+        default: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('@aws-sdk/credential-providers', () => ({
+        fromNodeProviderChain: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/adapters/agent/intent-classifier.js', () => ({
+        AnthropicIntentClassifier: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/question-answerer.js', () => ({
+        AgentSDKQuestionAnswerer: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/implementer.js', () => ({
+        AgentSDKImplementer: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/pr-manager.js', () => ({
+        GHPRManager: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/issue-manager.js', () => ({
+        GHIssueManager: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/issue-filer.js', () => ({
+        AgentSDKIssueFiler: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/notion-client.js', () => ({
+        NotionClientImpl: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/notion-publisher.js', () => ({
+        NotionPublisher: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/notion-feedback-source.js', () => ({
+        NotionFeedbackSource: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/spec-committer.js', () => ({
+        NotionSpecCommitter: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/implementation-feedback-page.js', () => ({
+        NotionImplementationFeedbackPage: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      process.argv = ['node', 'index.js', '--repo', dir];
+
+      await import('../src/index.js').catch(() => {});
+
+      const startingLog = logRecords.find(r => r['event'] === 'service.starting');
+      expect(startingLog).toBeDefined();
+      expect(startingLog!['mode']).toBe('single-repo');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('multi --repo: loadConfigFromPath called once per repo path', async () => {
+    const dir1 = makeTempRepo('ch-a');
+    const dir2 = makeTempRepo('ch-b');
+
+    try {
+      const fakeLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      vi.doMock('../src/core/logger.js', () => ({
+        createLogger: vi.fn().mockReturnValue(fakeLogger),
+      }));
+
+      vi.doMock('node:child_process', () => ({
+        execSync: vi.fn().mockReturnValue('https://github.com/org/repo.git\n'),
+      }));
+
+      vi.doMock('../src/core/init.js', () => ({
+        runInit: vi.fn().mockResolvedValue(undefined),
+        configExists: vi.fn().mockReturnValue(true),
+      }));
+
+      let callCount = 0;
+      const loadConfigFromPathSpy = vi.fn().mockImplementation(() => {
+        callCount++;
+        const channelName = callCount === 1 ? 'ch-a' : 'ch-b';
+        return makeMinimalConfig(channelName);
+      });
+
+      vi.doMock('../src/core/config.js', () => ({
+        loadConfig: vi.fn().mockReturnValue(makeMinimalConfig('ch-a')),
+        loadConfigFromPath: loadConfigFromPathSpy,
+        resolveEnvVars: vi.fn().mockReturnValue({ resolved: makeMinimalConfig('ch-a').config, missing: [] }),
+        redactConfig: vi.fn().mockReturnValue({}),
+        resolveAwsProfile: vi.fn().mockReturnValue(undefined),
+        repoNameFromUrl: vi.fn().mockReturnValue('org/repo'),
+      }));
+
+      const fakeAdapter = {
+        resolveChannels: vi.fn().mockResolvedValue(undefined),
+        getChannelId: vi.fn().mockReturnValue('C1'),
+        getChannelRepoMap: vi.fn().mockReturnValue(new Map([
+          ['CA', { channel_id: 'CA', repo_url: 'url-a', workspace_root: '/tmp/ws' }],
+          ['CB', { channel_id: 'CB', repo_url: 'url-b', workspace_root: '/tmp/ws' }],
+        ])),
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        receive: async function* () {},
+        isConnected: vi.fn().mockReturnValue(true),
+      };
+
+      vi.doMock('../src/adapters/slack/slack-adapter.js', () => ({
+        SlackAdapter: vi.fn().mockImplementation(() => fakeAdapter),
+      }));
+
+      vi.doMock('@slack/bolt', () => ({
+        App: vi.fn().mockImplementation(() => ({ client: {}, start: vi.fn(), stop: vi.fn() })),
+      }));
+
+      vi.doMock('../src/core/workspace-manager.js', () => ({
+        WorkspaceManagerImpl: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/core/run-store.js', () => ({
+        FileRunStore: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/slack/thread-registry.js', () => ({
+        ThreadRegistry: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/core/orchestrator.js', () => ({
+        OrchestratorImpl: vi.fn().mockImplementation(() => ({
+          start: vi.fn().mockResolvedValue(undefined),
+          stop: vi.fn().mockResolvedValue(undefined),
+          getRuns: vi.fn().mockReturnValue(new Map()),
+          getActiveRunCount: vi.fn().mockReturnValue(0),
+          cancelRun: vi.fn(),
+          getRunLogs: vi.fn(),
+        })),
+      }));
+
+      vi.doMock('../src/core/command-registry.js', () => ({
+        CommandRegistryImpl: vi.fn().mockImplementation(() => ({ register: vi.fn(), get: vi.fn(), list: vi.fn() })),
+      }));
+
+      vi.doMock('../src/core/commands/run-commands.js', () => ({
+        makeRunStatusHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeRunListHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeRunCancelHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeRunLogsHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/core/commands/meta-commands.js', () => ({
+        makeHealthHandler: vi.fn().mockReturnValue(vi.fn()),
+        makeHelpHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/core/commands/classify-intent-command.js', () => ({
+        makeClassifyIntentHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/adapters/agent/spec-generator.js', () => ({
+        AgentSDKSpecGenerator: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/slack/canvas-publisher.js', () => ({
+        SlackCanvasPublisher: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/core/service.js', () => ({
+        Service: vi.fn().mockImplementation(() => ({
+          start: vi.fn(),
+          stop: vi.fn().mockResolvedValue(undefined),
+          stopped: new Promise(() => {}),
+          updateConfig: vi.fn(),
+        })),
+      }));
+
+      vi.doMock('../src/core/config-watcher.js', () => ({
+        ConfigWatcher: vi.fn().mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() })),
+      }));
+
+      vi.doMock('../src/core/signals.js', () => ({
+        registerSignalHandlers: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('@anthropic-ai/bedrock-sdk', () => ({
+        default: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('@aws-sdk/credential-providers', () => ({
+        fromNodeProviderChain: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/adapters/agent/intent-classifier.js', () => ({
+        AnthropicIntentClassifier: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/question-answerer.js', () => ({
+        AgentSDKQuestionAnswerer: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/implementer.js', () => ({
+        AgentSDKImplementer: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/pr-manager.js', () => ({
+        GHPRManager: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/issue-manager.js', () => ({
+        GHIssueManager: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/agent/issue-filer.js', () => ({
+        AgentSDKIssueFiler: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/notion-client.js', () => ({
+        NotionClientImpl: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/notion-publisher.js', () => ({
+        NotionPublisher: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/notion-feedback-source.js', () => ({
+        NotionFeedbackSource: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/spec-committer.js', () => ({
+        NotionSpecCommitter: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      vi.doMock('../src/adapters/notion/implementation-feedback-page.js', () => ({
+        NotionImplementationFeedbackPage: vi.fn().mockImplementation(() => ({})),
+      }));
+
+      process.argv = ['node', 'index.js', '--repo', dir1, dir2];
+
+      await import('../src/index.js').catch(() => {});
+
+      expect(loadConfigFromPathSpy).toHaveBeenCalledTimes(2);
+      expect(loadConfigFromPathSpy).toHaveBeenCalledWith(dir1, expect.any(Object));
+      expect(loadConfigFromPathSpy).toHaveBeenCalledWith(dir2, expect.any(Object));
+    } finally {
+      rmSync(dir1, { recursive: true, force: true });
+      rmSync(dir2, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Multi-repo message routing: extended --repo to accept multiple space-separated paths; each repo's WORKFLOW.md supplies its own Slack channel binding; SlackAdapter resolves all channel IDs at startup and filters events per channel; OrchestratorImpl replaced single repo_url with a ChannelRepoMap for per-channel dispatch; WorkspaceManager.create() takes an explicit workspace_root; loadConfigFromPath() added so any directory's WORKFLOW.md can be loaded; single-repo deployments are unchanged.

## Testing

Branch: spec/d618104f-4525-4d72-944c-3a6eed2e0e3f
Setup: npm install && npm run build
Test: npm test

Manual smoke test:
1. Start with two repos: autocatalyst start --repo /path/to/repo-a /path/to/repo-b
   Confirm startup log lists both channels (service.starting mode=multi-repo, channel_count=2)
2. Post a message in repo-a's Slack channel — verify a spec is created in repo-a's workspace only
3. Post a message in repo-b's Slack channel — verify it routes to repo-b's workspace with no interference
4. Post a message in an unconfigured channel — verify nothing is posted back and no run is created
5. Start with a single repo (no --repo flag) — verify behavior is identical to pre-feature baseline

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/d618104f-4525-4d72-944c-3a6eed2e0e3f/context-human/specs/enhancement-multi-repo-message-routing.md`
Closes #33