### PR TITLE
fix: prevent agents from force-adding gitignored .autocatalyst files

### DIFF
--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -771,8 +771,11 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
 
   lines.push('/superpowers:subagent-driven-development');
   lines.push('');
-  lines.push('Step 3 - Commit all remaining changes');
-  lines.push('Run `git status` and commit anything uncommitted before proceeding.');
+  lines.push('Step 3 - Commit all remaining source changes');
+  lines.push('Run `git status`. Stage and commit only source files that belong in the repository.');
+  lines.push('Never use `git add --force` or `git add -f`.');
+  lines.push('Never stage files under `.autocatalyst/` — that directory is gitignored and contains');
+  lines.push('internal pipeline state, not repository artifacts.');
   lines.push('');
   lines.push(`Step 4 - Write the result to: ${result_file_path}`);
   lines.push('Create the directory if it does not exist. The JSON must have this structure:');

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -1,3 +1,4 @@
+import { rm } from 'node:fs/promises';
 import type pino from 'pino';
 import type { IssueFiler } from '../types/issue-filing.js';
 import type { IssueManager, PRManager } from '../types/issue-tracker.js';
@@ -139,6 +140,7 @@ async function approveArtifact(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
+    deleteFile: (path) => rm(path, { force: true }),
   });
   return handler.handle(run, feedback);
 }

--- a/src/core/handlers/artifact-approval-handler.ts
+++ b/src/core/handlers/artifact-approval-handler.ts
@@ -23,6 +23,7 @@ export interface ArtifactApprovalDeps {
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'error'>;
+  deleteFile?: (path: string) => Promise<void>;
 }
 
 export type ArtifactApprovalResult =
@@ -113,6 +114,16 @@ export class ArtifactApprovalHandler {
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return false;
+    }
+
+    // Remove the triage file from disk now that its content lives in the issue tracker.
+    if (this.deps.deleteFile) {
+      await this.deps.deleteFile(refs.local_path).catch(err =>
+        this.deps.logger.error(
+          { event: 'triage.delete_failed', run_id: run.id, path: refs.local_path, error: String(err) },
+          'Failed to delete triage artifact from disk; continuing',
+        ),
+      );
     }
 
     this.markArtifactApproved(run, issue_number);

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -195,6 +195,31 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('implementation prompt forbids force-adding and staging .autocatalyst files', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-prompt-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'Done', testing_instructions: 'Run tests' }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await service.implement('/tmp/spec.md', workspace);
+
+      expect(calls[0].prompt).not.toMatch(/commit anything uncommitted/i);
+      expect(calls[0].prompt).toMatch(/never use `git add --force`|never.*git add.*--force/i);
+      expect(calls[0].prompt).toMatch(/never stage.*\.autocatalyst|do not stage.*\.autocatalyst/i);
+      expect(calls[0].prompt).toContain('.autocatalyst/');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('uses issue triage agent output before creating issues through IssueManager', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'ac-issue-'));
     try {

--- a/tests/core/handlers/artifact-approval-handler.test.ts
+++ b/tests/core/handlers/artifact-approval-handler.test.ts
@@ -288,4 +288,37 @@ describe('ArtifactApprovalHandler', () => {
       expect.any(String),
     );
   });
+
+  it('deletes the triage artifact from disk after syncing it to an issue', async () => {
+    const deleteFile = vi.fn().mockResolvedValue(undefined);
+    const { handler, deps } = makeHandler({
+      artifactContentSource: {
+        getContent: vi.fn().mockResolvedValue('---\nstatus: triaged\n---\n# Bug: login broken\n\nDetails here.'),
+      },
+      deleteFile,
+    } as Partial<ConstructorParameters<typeof ArtifactApprovalHandler>[0]>);
+    const run = makeRun({
+      intent: 'bug',
+      artifact: {
+        kind: 'bug_triage',
+        local_path: '/ws/request-001/.autocatalyst/triage/triage-bug-login.md',
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
+        status: 'waiting_on_feedback',
+      },
+    });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deleteFile).toHaveBeenCalledWith('/ws/request-001/.autocatalyst/triage/triage-bug-login.md');
+  });
+
+  it('does not delete artifacts for kinds that are committed rather than synced', async () => {
+    const deleteFile = vi.fn().mockResolvedValue(undefined);
+    const { handler } = makeHandler({ deleteFile } as Partial<ConstructorParameters<typeof ArtifactApprovalHandler>[0]>);
+    const run = makeRun(); // intent: 'idea', kind: 'feature_spec' — uses commit_on_approval
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deleteFile).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixed two root causes of agents committing gitignored .autocatalyst/ files into PRs. (1) Tightened the implementation prompt's Step 3 instruction to explicitly forbid `git add --force` / `git add -f` and name `.autocatalyst/` as off-limits — replacing the vague 'commit anything uncommitted' that triggered force-add fallback. (2) Added triage artifact cleanup to ArtifactApprovalHandler: after successfully syncing a bug/chore triage document to the issue tracker, the local file is deleted from disk via an injected `deleteFile` dep, removing it from the workspace before the implementation agent starts. Wired with `rm(path, { force: true })` at the composition root. All 778 tests pass.

## Testing

Branch: spec/07eca801-e68a-4faa-9d74-8d044515b00d
Setup: npm install && npm run build
Test: npx vitest run --passWithNoTests

Key tests to inspect:
- tests/core/ai/agent-services.test.ts — 'implementation prompt forbids force-adding and staging .autocatalyst files'
- tests/core/handlers/artifact-approval-handler.test.ts — 'deletes the triage artifact from disk after syncing it to an issue' and 'does not delete artifacts for kinds that are committed rather than synced'

Manual verification:
1. Submit a bug report and approve the triage — confirm the .autocatalyst/triage/ file is deleted before implementation starts.
2. Inspect the prompt delivered to the implementation agent — confirm it contains the prohibition text and no 'commit anything uncommitted' language.

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/07eca801-e68a-4faa-9d74-8d044515b00d/.autocatalyst/triage/triage-bug-agent-commits-gitignored-files.md`
Closes #82