### PR TITLE
fix: source PR titles from a DirectModelRunner call instead of the impl summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@types/node": "22.14.1",
         "tsx": "4.19.3",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.3",
         "vitest": "3.1.1"
       },
       "engines": {
@@ -7665,9 +7665,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/node": "22.14.1",
     "tsx": "4.19.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.3",
     "vitest": "3.1.1"
   }
 }

--- a/src/adapters/github/pr-manager.ts
+++ b/src/adapters/github/pr-manager.ts
@@ -77,12 +77,15 @@ export class GHPRManager implements PRManager {
     options?: PRManagerOptions,
   ): Promise<string> {
     const specContent = readFileSync(spec_path, 'utf-8');
-    const specTitle = extractSpecTitle(specContent);
-    const prTitle = derivePrTitle(options?.run_intent, specTitle);
+    const rawTitle = options?.title ?? extractSpecTitle(specContent);
+    const prTitle = derivePrTitle(options?.run_intent, rawTitle);
 
+    const issueFromOptions = options?.issue_number ?? null;
     const issueRaw = extractFrontmatterField(specContent, 'issue');
-    const issueNumber = issueRaw !== null ? parseInt(issueRaw, 10) : null;
-    const issueForBody = issueNumber !== null && !isNaN(issueNumber) ? issueNumber : null;
+    const issueFromFrontmatter = issueRaw !== null ? parseInt(issueRaw, 10) : null;
+    const issueForBody = issueFromOptions !== null
+      ? issueFromOptions
+      : (issueFromFrontmatter !== null && !isNaN(issueFromFrontmatter) ? issueFromFrontmatter : null);
 
     const prBody = buildPrBody(spec_path, issueForBody, options);
 
@@ -115,7 +118,7 @@ export class GHPRManager implements PRManager {
     }
 
     this.logger.info(
-      { event: 'pr.created', pr_url: prUrl, branch, spec_title: specTitle },
+      { event: 'pr.created', pr_url: prUrl, branch, spec_title: rawTitle },
       'PR created',
     );
     return prUrl;

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -30,6 +30,7 @@ import { createBuiltInExtensionRegistry } from './built-in-extensions.js';
 import type { BuiltInExtensionKind, BuiltInExtensionRegistry } from '../core/extensions/built-ins.js';
 import { DefaultAgentRoutingPolicy } from '../core/ai/routing-policy.js';
 import { ModelIntentClassifier } from '../core/ai/model-intent-classifier.js';
+import { ModelPRTitleGenerator } from '../core/ai/pr-title-generator.js';
 import {
   AgentRunnerArtifactAuthoringAgent,
   AgentRunnerImplementationAgent,
@@ -108,6 +109,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
   const directModelRunner = buildDirectModelRunner(env, logger, resolvedAwsProfile);
   const agentRunner = new ClaudeAgentSdkAgentRunner();
   const intentClassifier = new ModelIntentClassifier(directModelRunner, { routingPolicy: aiRoutingPolicy });
+  const prTitleGenerator = new ModelPRTitleGenerator(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const questionAnswerer = new AgentRunnerQuestionAnsweringAgent(agentRunner, aiRoutingPolicy, repoPath);
   const preRepoEntries = isMultiRepo
     ? await resolvePreRepoEntries(repoPaths, env, logger)
@@ -168,6 +170,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     implementer,
     implFeedbackPage: artifactDeps.implFeedbackPage,
     prManager,
+    prTitleGenerator,
     issueManager,
     issueFiler,
     runStore,

--- a/src/core/ai/pr-title-generator.ts
+++ b/src/core/ai/pr-title-generator.ts
@@ -46,8 +46,41 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
       max_tokens: this.options.max_tokens ?? 60,
       messages: [{ role: 'user', content: prompt }],
     });
-    return response.text.trim() || null;
+    const title = postProcess(response.text);
+    if (title === null) {
+      this.logger.warn(
+        { event: 'pr_title.invalid_output', raw: response.text },
+        'Title post-processing rejected model output',
+      );
+      return null;
+    }
+    this.logger.info(
+      { event: 'pr_title.generated', intent: input.intent, spec_path: input.spec_path, length: title.length },
+      'Generated PR title',
+    );
+    return title;
   }
+}
+
+const MAX_TITLE_LEN = 100;
+
+function postProcess(raw: string): string | null {
+  let title = raw.trim();
+  if (!title) return null;
+  const firstNewline = title.indexOf('\n');
+  if (firstNewline !== -1) title = title.slice(0, firstNewline).trim();
+  if (
+    (title.startsWith('"') && title.endsWith('"')) ||
+    (title.startsWith("'") && title.endsWith("'")) ||
+    (title.startsWith('`') && title.endsWith('`'))
+  ) {
+    title = title.slice(1, -1).trim();
+  }
+  if (title.endsWith('.')) title = title.slice(0, -1).trim();
+  if (!title) return null;
+  if (title.length > MAX_TITLE_LEN) return null;
+  if (title.includes('\n')) return null;
+  return title;
 }
 
 const IMPL_HEADINGS = [

--- a/src/core/ai/pr-title-generator.ts
+++ b/src/core/ai/pr-title-generator.ts
@@ -1,0 +1,75 @@
+import { readFile } from 'node:fs/promises';
+import type pino from 'pino';
+import { createLogger } from '../logger.js';
+import type {
+  AgentRoutingPolicy,
+  DirectModelRunner,
+} from '../../types/ai.js';
+import type { RequestIntent } from '../../types/runs.js';
+
+export interface PRTitleInput {
+  intent: RequestIntent;
+  spec_path: string;
+  impl_summary: string | undefined;
+}
+
+export interface PRTitleGenerator {
+  generate(input: PRTitleInput): Promise<string | null>;
+}
+
+export interface ModelPRTitleGeneratorOptions {
+  routingPolicy?: AgentRoutingPolicy;
+  model?: string;
+  max_tokens?: number;
+  logDestination?: pino.DestinationStream;
+}
+
+export class ModelPRTitleGenerator implements PRTitleGenerator {
+  private readonly logger: pino.Logger;
+
+  constructor(
+    private readonly runner: DirectModelRunner,
+    private readonly options: ModelPRTitleGeneratorOptions = {},
+  ) {
+    this.logger = createLogger('pr-title-generator', { destination: options.logDestination });
+  }
+
+  async generate(input: PRTitleInput): Promise<string | null> {
+    const content = await readFile(input.spec_path, 'utf8');
+    const prompt = buildPrompt(input.intent, content, input.impl_summary);
+    const route = { task: 'pr.title_generate' as const, intent: input.intent };
+    const response = await this.runner.run({
+      route,
+      profile: this.options.routingPolicy?.resolve(route),
+      model: this.options.model,
+      max_tokens: this.options.max_tokens ?? 60,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    return response.text.trim() || null;
+  }
+}
+
+function buildPrompt(intent: RequestIntent, artifact: string, implSummary: string | undefined): string {
+  return [
+    'You are writing the title for a pull request.',
+    '',
+    `Intent: ${intent}`,
+    'Artifact:',
+    '<<<',
+    artifact,
+    '>>>',
+    '',
+    'Implementation summary:',
+    '<<<',
+    implSummary ?? '',
+    '>>>',
+    '',
+    'Rules:',
+    '- Output only the title, no prefix, no quotes, no trailing period.',
+    '- Max 72 characters. Lowercase except for proper nouns and code identifiers.',
+    '- Describe the change concretely (what was done / fixed / added), not the problem.',
+    '- Use imperative mood.',
+    '',
+    'Title:',
+  ].join('\n');
+}

--- a/src/core/ai/pr-title-generator.ts
+++ b/src/core/ai/pr-title-generator.ts
@@ -35,30 +35,56 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
   }
 
   async generate(input: PRTitleInput): Promise<string | null> {
-    const content = await readFile(input.spec_path, 'utf8');
-    const truncated = truncateArtifact(content);
-    const prompt = buildPrompt(input.intent, truncated, input.impl_summary);
-    const route = { task: 'pr.title_generate' as const, intent: input.intent };
-    const response = await this.runner.run({
-      route,
-      profile: this.options.routingPolicy?.resolve(route),
-      model: this.options.model,
-      max_tokens: this.options.max_tokens ?? 60,
-      messages: [{ role: 'user', content: prompt }],
-    });
-    const title = postProcess(response.text);
-    if (title === null) {
+    let content: string;
+    try {
+      content = await readFile(input.spec_path, 'utf8');
+    } catch (err) {
       this.logger.warn(
-        { event: 'pr_title.invalid_output', raw: response.text },
-        'Title post-processing rejected model output',
+        { event: 'pr_title.spec_read_failed', spec_path: input.spec_path, error: String(err) },
+        'Failed to read spec for PR title generation',
       );
       return null;
     }
-    this.logger.info(
-      { event: 'pr_title.generated', intent: input.intent, spec_path: input.spec_path, length: title.length },
-      'Generated PR title',
+
+    const truncated = truncateArtifact(content);
+    const prompt = buildPrompt(input.intent, truncated, input.impl_summary);
+    const route = { task: 'pr.title_generate' as const, intent: input.intent };
+
+    let attempt = 0;
+    let lastError: unknown;
+    while (attempt < 2) {
+      try {
+        const response = await this.runner.run({
+          route,
+          profile: this.options.routingPolicy?.resolve(route),
+          model: this.options.model,
+          max_tokens: this.options.max_tokens ?? 60,
+          messages: [{ role: 'user', content: prompt }],
+        });
+        const title = postProcess(response.text);
+        if (title === null) {
+          this.logger.warn(
+            { event: 'pr_title.invalid_output', raw: response.text },
+            'Title post-processing rejected model output',
+          );
+          return null;
+        }
+        this.logger.info(
+          { event: 'pr_title.generated', intent: input.intent, spec_path: input.spec_path, length: title.length },
+          'Generated PR title',
+        );
+        return title;
+      } catch (err) {
+        lastError = err;
+        attempt += 1;
+      }
+    }
+
+    this.logger.warn(
+      { event: 'pr_title.model_failed', spec_path: input.spec_path, error: String(lastError) },
+      'PR title generation failed after retry',
     );
-    return title;
+    return null;
   }
 }
 

--- a/src/core/ai/pr-title-generator.ts
+++ b/src/core/ai/pr-title-generator.ts
@@ -36,7 +36,8 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
 
   async generate(input: PRTitleInput): Promise<string | null> {
     const content = await readFile(input.spec_path, 'utf8');
-    const prompt = buildPrompt(input.intent, content, input.impl_summary);
+    const truncated = truncateArtifact(content);
+    const prompt = buildPrompt(input.intent, truncated, input.impl_summary);
     const route = { task: 'pr.title_generate' as const, intent: input.intent };
     const response = await this.runner.run({
       route,
@@ -47,6 +48,24 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
     });
     return response.text.trim() || null;
   }
+}
+
+const IMPL_HEADINGS = [
+  '## Design changes',
+  '## Technical changes',
+  '## Task list',
+  '## Implementation',
+];
+const MAX_ARTIFACT_CHARS = 3000;
+
+function truncateArtifact(content: string): string {
+  let earliest = -1;
+  for (const heading of IMPL_HEADINGS) {
+    const idx = content.indexOf(`\n${heading}`);
+    if (idx !== -1 && (earliest === -1 || idx < earliest)) earliest = idx;
+  }
+  if (earliest !== -1) return content.slice(0, earliest).trimEnd();
+  return content.length > MAX_ARTIFACT_CHARS ? content.slice(0, MAX_ARTIFACT_CHARS) : content;
 }
 
 function buildPrompt(intent: RequestIntent, artifact: string, implSummary: string | undefined): string {

--- a/src/core/ai/routing-policy.ts
+++ b/src/core/ai/routing-policy.ts
@@ -54,7 +54,9 @@ function defaultProfileForTask(
   task: AgentTaskKind,
   defaults: DefaultAgentRoutingPolicyOptions['defaults'],
 ): AgentProfile {
-  if (task === 'intent.classify') return defaults.direct;
+  if (task === 'intent.classify' || task === 'pr.title_generate') {
+    return defaults.direct;
+  }
   return defaults.agent;
 }
 

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -2,6 +2,7 @@ import { rm } from 'node:fs/promises';
 import type pino from 'pino';
 import type { IssueFiler } from '../types/issue-filing.js';
 import type { IssueManager, PRManager } from '../types/issue-tracker.js';
+import type { PRTitleGenerator } from './ai/pr-title-generator.js';
 import type { ArtifactAuthoringAgent, ImplementationAgent, QuestionAnsweringAgent } from '../types/ai.js';
 import type { Request, ThreadMessage } from '../types/events.js';
 import type { ConversationRef } from '../types/channel.js';
@@ -39,6 +40,7 @@ export interface DefaultHandlerRegistryDeps {
   implementer?: ImplementationAgent;
   implFeedbackPage?: ImplementationReviewPublisher;
   prManager?: PRManager;
+  prTitleGenerator?: PRTitleGenerator;
   issueManager?: IssueManager;
   issueFiler?: IssueFiler;
   channelRepoMap: ChannelRepoMap;
@@ -208,6 +210,7 @@ async function handleImplementationApproval(
     specCommitter: deps.specCommitter,
     artifactPublisher: deps.artifactPublisher,
     prManager: deps.prManager!,
+    prTitleGenerator: deps.prTitleGenerator!,
     implFeedbackPage: deps.implFeedbackPage,
     postMessage: deps.postMessage,
     transition: deps.transition,

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -1,5 +1,6 @@
 import type pino from 'pino';
 import type { PRManager, PRManagerOptions } from '../../types/issue-tracker.js';
+import type { PRTitleGenerator } from '../ai/pr-title-generator.js';
 import type { SpecCommitter } from '../spec-committer.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
@@ -12,6 +13,7 @@ export interface ImplementationApprovalDeps {
   specCommitter?: Pick<SpecCommitter, 'updateStatus'>;
   artifactPublisher: Pick<ArtifactPublisher, 'updateStatus'>;
   prManager: Pick<PRManager, 'createPR'>;
+  prTitleGenerator: PRTitleGenerator;
   implFeedbackPage?: Pick<ImplementationReviewPublisher, 'setPRLink' | 'updateStatus'>;
   postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
   transition: (run: Run, stage: RunStage) => void;
@@ -57,11 +59,17 @@ export class ImplementationApprovalHandler {
     }
     this.markArtifactComplete(run);
 
+    const generatedTitle = await this.deps.prTitleGenerator.generate({
+      intent: run.intent,
+      spec_path: localPath ?? '',
+      impl_summary: run.last_impl_result?.summary,
+    });
+
     const prOptions: PRManagerOptions = {
       impl_result: run.last_impl_result,
       run_intent: run.intent,
       ...(run.issue !== undefined ? { issue_number: run.issue } : {}),
-      ...(run.last_impl_result?.summary ? { title: run.last_impl_result.summary } : {}),
+      ...(generatedTitle !== null ? { title: generatedTitle } : {}),
     };
     let prUrl: string;
     try {

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -60,6 +60,8 @@ export class ImplementationApprovalHandler {
     const prOptions: PRManagerOptions = {
       impl_result: run.last_impl_result,
       run_intent: run.intent,
+      ...(run.issue !== undefined ? { issue_number: run.issue } : {}),
+      ...(run.last_impl_result?.summary ? { title: run.last_impl_result.summary } : {}),
     };
     let prUrl: string;
     try {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -15,6 +15,7 @@ import type { ArtifactLifecyclePolicy, ArtifactKind } from '../types/artifact.js
 import type { SpecCommitter } from './spec-committer.js';
 import type { ImplementationReviewPublisher } from '../types/impl-feedback-page.js';
 import type { PRManager, IssueManager } from '../types/issue-tracker.js';
+import type { PRTitleGenerator } from './ai/pr-title-generator.js';
 import type { IssueFiler } from '../types/issue-filing.js';
 import { RunStore, FileRunStore } from './run-store.js';
 import type { CommandRegistry, CommandEvent } from '../types/commands.js';
@@ -59,6 +60,7 @@ export interface OrchestratorDeps {
   implementer?: ImplementationAgent;
   implFeedbackPage?: ImplementationReviewPublisher;
   prManager?: PRManager;
+  prTitleGenerator?: PRTitleGenerator;
   issueManager?: IssueManager;
   issueFiler?: IssueFiler;
   runStore?: RunStore;
@@ -389,6 +391,7 @@ export class OrchestratorImpl implements Orchestrator {
       implementer: this.deps.implementer,
       implFeedbackPage: this.deps.implFeedbackPage,
       prManager: this.deps.prManager,
+      prTitleGenerator: this.deps.prTitleGenerator,
       issueManager: this.deps.issueManager,
       issueFiler: this.deps.issueFiler,
       channelRepoMap: this.deps.channelRepoMap,

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -9,7 +9,8 @@ export type AgentTaskKind =
   | 'artifact.revise'
   | 'implementation.run'
   | 'question.answer'
-  | 'issue.triage';
+  | 'issue.triage'
+  | 'pr.title_generate';
 
 export interface AgentRoute {
   task: AgentTaskKind;

--- a/src/types/issue-tracker.ts
+++ b/src/types/issue-tracker.ts
@@ -11,6 +11,8 @@ export interface PRManagerOptions {
     testing_instructions: string;
   };
   run_intent?: RequestIntent;
+  issue_number?: number;
+  title?: string;
 }
 
 export interface PRManager {

--- a/tests/adapters/github/pr-manager.test.ts
+++ b/tests/adapters/github/pr-manager.test.ts
@@ -39,6 +39,16 @@ const SPEC_NO_ISSUE = [
   'This is the spec.',
 ].join('\n');
 
+const TRIAGE_DOC_NO_H1 = [
+  '## Summary',
+  '',
+  'The widget blows up when you click it.',
+  '',
+  '## Steps to reproduce',
+  '',
+  '1. Click the widget',
+].join('\n');
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'pr-manager-'));
   mkdirSync(join(tmpDir, 'context-human', 'specs'), { recursive: true });
@@ -261,5 +271,60 @@ describe('GHPRManager — mergePR()', () => {
     await expect(manager.mergePR(tmpDir, 'https://github.com/org/repo/pull/1')).rejects.toThrow();
     const failed = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'pr.merge_failed');
     expect(failed).toBeDefined();
+  });
+});
+
+// ---- createPR: options.title and options.issue_number ----
+
+describe('GHPRManager — createPR() with options.title and options.issue_number', () => {
+  it('uses options.title instead of spec H1 when provided', async () => {
+    writeFileSync(specPath, TRIAGE_DOC_NO_H1, 'utf-8');
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+    await manager.createPR(tmpDir, 'branch', specPath, {
+      run_intent: 'bug',
+      title: 'Replace databases.query with dataSources.query',
+    });
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    expect(prArgs[prArgs.indexOf('--title') + 1]).toBe('fix: replace databases.query with datasources.query');
+  });
+
+  it('falls back to spec H1 when options.title is not provided', async () => {
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+    await manager.createPR(tmpDir, 'branch', specPath, { run_intent: 'idea' });
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    expect(prArgs[prArgs.indexOf('--title') + 1]).toBe('feat: my feature');
+  });
+
+  it('body contains "Closes #54" when options.issue_number is 54 and spec has no issue frontmatter', async () => {
+    writeFileSync(specPath, TRIAGE_DOC_NO_H1, 'utf-8');
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+    await manager.createPR(tmpDir, 'branch', specPath, { issue_number: 54 });
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    const body = prArgs[prArgs.indexOf('--body') + 1] as string;
+    expect(body).toContain('Closes #54');
+  });
+
+  it('options.issue_number takes precedence over spec frontmatter issue', async () => {
+    writeFileSync(specPath, SPEC_WITH_ISSUE, 'utf-8'); // frontmatter has issue: 42
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+    await manager.createPR(tmpDir, 'branch', specPath, { issue_number: 99 });
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    const body = prArgs[prArgs.indexOf('--body') + 1] as string;
+    expect(body).toContain('Closes #99');
+    expect(body).not.toContain('Closes #42');
+  });
+
+  it('body does NOT contain "Closes #" when no issue_number in options and spec has no issue frontmatter', async () => {
+    writeFileSync(specPath, TRIAGE_DOC_NO_H1, 'utf-8');
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+    await manager.createPR(tmpDir, 'branch', specPath);
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    const body = prArgs[prArgs.indexOf('--body') + 1] as string;
+    expect(body).not.toContain('Closes #');
   });
 });

--- a/tests/core/ai/pr-title-generator.test.ts
+++ b/tests/core/ai/pr-title-generator.test.ts
@@ -18,6 +18,13 @@ function fakeRunner(
   return { runner, requests };
 }
 
+function extractArtifactSection(prompt: string): string {
+  const marker = 'Artifact:\n<<<\n';
+  const start = prompt.indexOf(marker) + marker.length;
+  const end = prompt.indexOf('\n>>>', start);
+  return prompt.slice(start, end);
+}
+
 async function withSpec(content: string, run: (path: string) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), 'pr-title-'));
   const path = join(dir, 'spec.md');
@@ -45,5 +52,36 @@ describe('ModelPRTitleGenerator', () => {
     expect(requests[0].route).toEqual({ task: 'pr.title_generate', intent: 'bug' });
     expect(requests[0].messages[0].content).toContain('Bug: login crash');
     expect(requests[0].messages[0].content).toContain('switched to dataSources.query');
+  });
+
+  test('truncates the artifact at the first implementation-heavy heading', async () => {
+    const { runner, requests } = fakeRunner('title ok');
+    const gen = new ModelPRTitleGenerator(runner);
+    const body = [
+      '# Enhancement: @-reference files',
+      '',
+      '## What',
+      'allow @foo references',
+      '',
+      '## Design changes',
+      'INCLUDE-NOTHING-AFTER-THIS',
+    ].join('\n');
+    await withSpec(body, async (path) => {
+      await gen.generate({ intent: 'idea', spec_path: path, impl_summary: undefined });
+    });
+    const promptContent = requests[0].messages[0].content;
+    expect(promptContent).toContain('## What');
+    expect(promptContent).not.toContain('INCLUDE-NOTHING-AFTER-THIS');
+  });
+
+  test('falls back to a character cap when no implementation heading is present', async () => {
+    const { runner, requests } = fakeRunner('title ok');
+    const gen = new ModelPRTitleGenerator(runner);
+    const long = 'x'.repeat(5000);
+    await withSpec(long, async (path) => {
+      await gen.generate({ intent: 'bug', spec_path: path, impl_summary: undefined });
+    });
+    const artifactSection = extractArtifactSection(requests[0].messages[0].content);
+    expect(artifactSection.length).toBeLessThanOrEqual(3000);
   });
 });

--- a/tests/core/ai/pr-title-generator.test.ts
+++ b/tests/core/ai/pr-title-generator.test.ts
@@ -115,4 +115,44 @@ describe('ModelPRTitleGenerator', () => {
       });
     }
   });
+
+  test('returns null when the spec file cannot be read', async () => {
+    const { runner } = fakeRunner('unused');
+    const gen = new ModelPRTitleGenerator(runner);
+    const title = await gen.generate({ intent: 'bug', spec_path: '/nonexistent/spec.md', impl_summary: undefined });
+    expect(title).toBeNull();
+  });
+
+  test('retries once on runner failure then returns null', async () => {
+    let calls = 0;
+    const runner: DirectModelRunner = {
+      async run() {
+        calls += 1;
+        throw new Error('upstream down');
+      },
+    };
+    const gen = new ModelPRTitleGenerator(runner);
+    await withSpec('# x', async (path) => {
+      const title = await gen.generate({ intent: 'bug', spec_path: path, impl_summary: undefined });
+      expect(title).toBeNull();
+    });
+    expect(calls).toBe(2);
+  });
+
+  test('retries once on runner failure and returns success from the second call', async () => {
+    let calls = 0;
+    const runner: DirectModelRunner = {
+      async run() {
+        calls += 1;
+        if (calls === 1) throw new Error('transient');
+        return { text: 'recovered title' };
+      },
+    };
+    const gen = new ModelPRTitleGenerator(runner);
+    await withSpec('# x', async (path) => {
+      const title = await gen.generate({ intent: 'bug', spec_path: path, impl_summary: undefined });
+      expect(title).toBe('recovered title');
+    });
+    expect(calls).toBe(2);
+  });
 });

--- a/tests/core/ai/pr-title-generator.test.ts
+++ b/tests/core/ai/pr-title-generator.test.ts
@@ -84,4 +84,35 @@ describe('ModelPRTitleGenerator', () => {
     const artifactSection = extractArtifactSection(requests[0].messages[0].content);
     expect(artifactSection.length).toBeLessThanOrEqual(3000);
   });
+
+  test('strips surrounding quotes, backticks, and trailing period', async () => {
+    for (const raw of ['"fix the thing"', "'fix the thing'", '`fix the thing`', 'fix the thing.', '   fix the thing   ']) {
+      const { runner } = fakeRunner(raw);
+      const gen = new ModelPRTitleGenerator(runner);
+      await withSpec('# x', async (path) => {
+        const title = await gen.generate({ intent: 'bug', spec_path: path, impl_summary: undefined });
+        expect(title).toBe('fix the thing');
+      });
+    }
+  });
+
+  test('takes only the first line if model returns multiple lines', async () => {
+    const { runner } = fakeRunner('fix the thing\nextra commentary');
+    const gen = new ModelPRTitleGenerator(runner);
+    await withSpec('# x', async (path) => {
+      const title = await gen.generate({ intent: 'bug', spec_path: path, impl_summary: undefined });
+      expect(title).toBe('fix the thing');
+    });
+  });
+
+  test('rejects empty, whitespace-only, or over-length titles', async () => {
+    for (const raw of ['', '   ', 'x'.repeat(101)]) {
+      const { runner } = fakeRunner(raw);
+      const gen = new ModelPRTitleGenerator(runner);
+      await withSpec('# x', async (path) => {
+        const title = await gen.generate({ intent: 'bug', spec_path: path, impl_summary: undefined });
+        expect(title).toBeNull();
+      });
+    }
+  });
 });

--- a/tests/core/ai/pr-title-generator.test.ts
+++ b/tests/core/ai/pr-title-generator.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ModelPRTitleGenerator } from '../../../src/core/ai/pr-title-generator.js';
+import type { DirectModelRunner, DirectModelRunRequest } from '../../../src/types/ai.js';
+
+function fakeRunner(
+  textOrFn: string | ((req: DirectModelRunRequest) => string),
+): { runner: DirectModelRunner; requests: DirectModelRunRequest[] } {
+  const requests: DirectModelRunRequest[] = [];
+  const runner: DirectModelRunner = {
+    async run(request) {
+      requests.push(request);
+      return { text: typeof textOrFn === 'function' ? textOrFn(request) : textOrFn };
+    },
+  };
+  return { runner, requests };
+}
+
+async function withSpec(content: string, run: (path: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'pr-title-'));
+  const path = join(dir, 'spec.md');
+  await writeFile(path, content, 'utf8');
+  try {
+    await run(path);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('ModelPRTitleGenerator', () => {
+  test('returns the model-provided title verbatim on happy path', async () => {
+    const { runner, requests } = fakeRunner('replace databases.query with dataSources.query');
+    const gen = new ModelPRTitleGenerator(runner);
+    await withSpec('# Bug: login crash\n\nsome details', async (path) => {
+      const title = await gen.generate({
+        intent: 'bug',
+        spec_path: path,
+        impl_summary: 'switched to dataSources.query',
+      });
+      expect(title).toBe('replace databases.query with dataSources.query');
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].route).toEqual({ task: 'pr.title_generate', intent: 'bug' });
+    expect(requests[0].messages[0].content).toContain('Bug: login crash');
+    expect(requests[0].messages[0].content).toContain('switched to dataSources.query');
+  });
+});

--- a/tests/core/ai/routing-policy.test.ts
+++ b/tests/core/ai/routing-policy.test.ts
@@ -67,4 +67,12 @@ describe('DefaultAgentRoutingPolicy', () => {
     expect(policy.resolve({ task: 'intent.classify' })).toMatchObject({ id: 'direct', provider: 'anthropic' });
     expect(policy.resolve({ task: 'question.answer' })).toMatchObject({ id: 'agent', provider: 'claude_agent_sdk' });
   });
+
+  test('routes pr.title_generate to the direct defaults', () => {
+    const policy = new DefaultAgentRoutingPolicy({ defaults });
+    expect(policy.resolve({ task: 'pr.title_generate' })).toMatchObject({
+      id: 'direct',
+      provider: 'anthropic',
+    });
+  });
 });

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -61,6 +61,9 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
     prManager: {
       createPR: vi.fn().mockResolvedValue('https://example.test/org/repo/pull/42'),
     },
+    prTitleGenerator: {
+      generate: vi.fn().mockResolvedValue('generated title'),
+    },
     implFeedbackPage: {
       setPRLink: vi.fn().mockResolvedValue(undefined),
       updateStatus: vi.fn().mockResolvedValue(undefined),
@@ -132,7 +135,7 @@ describe('ImplementationApprovalHandler', () => {
       {
         impl_result: { summary: 'Implemented it.', testing_instructions: 'npm test' },
         run_intent: 'idea',
-        title: 'Implemented it.',
+        title: 'generated title',
       },
     );
     expect(run.artifact?.status).toBe('complete');
@@ -222,22 +225,36 @@ describe('ImplementationApprovalHandler', () => {
     );
   });
 
-  it('passes impl_result.summary as title to createPR', async () => {
-    const { handler, deps } = makeHandler();
-    const run = makeRun({
-      intent: 'bug',
-      issue: 54,
-      last_impl_result: { summary: 'Fixed the widget crash.', testing_instructions: 'npm test' },
+  it('uses the generator-produced title when non-null', async () => {
+    const { handler, deps } = makeHandler({
+      prTitleGenerator: { generate: vi.fn().mockResolvedValue('short descriptive title') },
     });
+    const run = makeRun({ intent: 'bug', issue: 54 });
 
     await handler.handle(run, makeFeedback());
 
+    expect(deps.prTitleGenerator.generate).toHaveBeenCalledWith({
+      intent: 'bug',
+      spec_path: '/ws/request-001/context-human/specs/feature-test.md',
+      impl_summary: 'Implemented it.',
+    });
     expect(deps.prManager.createPR).toHaveBeenCalledWith(
       '/ws/request-001',
       'spec/request-001',
       expect.any(String),
-      expect.objectContaining({ title: 'Fixed the widget crash.' }),
+      expect.objectContaining({ title: 'short descriptive title' }),
     );
+  });
+
+  it('omits title when the generator returns null', async () => {
+    const { handler, deps } = makeHandler({
+      prTitleGenerator: { generate: vi.fn().mockResolvedValue(null) },
+    });
+
+    await handler.handle(makeRun({ intent: 'bug' }), makeFeedback());
+
+    const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
+    expect(callArg['title']).toBeUndefined();
   });
 
   it('does not pass issue_number to createPR when run.issue is undefined', async () => {
@@ -248,15 +265,5 @@ describe('ImplementationApprovalHandler', () => {
 
     const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
     expect(callArg['issue_number']).toBeUndefined();
-  });
-
-  it('does not pass title to createPR when last_impl_result has no summary', async () => {
-    const { handler, deps } = makeHandler();
-    const run = makeRun({ last_impl_result: undefined });
-
-    await handler.handle(run, makeFeedback());
-
-    const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
-    expect(callArg['title']).toBeUndefined();
   });
 });

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -249,4 +249,14 @@ describe('ImplementationApprovalHandler', () => {
     const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
     expect(callArg['issue_number']).toBeUndefined();
   });
+
+  it('does not pass title to createPR when last_impl_result has no summary', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ last_impl_result: undefined });
+
+    await handler.handle(run, makeFeedback());
+
+    const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
+    expect(callArg['title']).toBeUndefined();
+  });
 });

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -132,6 +132,7 @@ describe('ImplementationApprovalHandler', () => {
       {
         impl_result: { summary: 'Implemented it.', testing_instructions: 'npm test' },
         run_intent: 'idea',
+        title: 'Implemented it.',
       },
     );
     expect(run.artifact?.status).toBe('complete');
@@ -205,5 +206,47 @@ describe('ImplementationApprovalHandler', () => {
       expect.objectContaining({ event: 'run.status_update_failed', run_id: 'run-001' }),
       'Failed to update impl feedback page on implementation approval',
     );
+  });
+
+  it('passes run.issue as issue_number to createPR when run.issue is set', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ intent: 'bug', issue: 54 });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.prManager.createPR).toHaveBeenCalledWith(
+      '/ws/request-001',
+      'spec/request-001',
+      expect.any(String),
+      expect.objectContaining({ issue_number: 54 }),
+    );
+  });
+
+  it('passes impl_result.summary as title to createPR', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({
+      intent: 'bug',
+      issue: 54,
+      last_impl_result: { summary: 'Fixed the widget crash.', testing_instructions: 'npm test' },
+    });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.prManager.createPR).toHaveBeenCalledWith(
+      '/ws/request-001',
+      'spec/request-001',
+      expect.any(String),
+      expect.objectContaining({ title: 'Fixed the widget crash.' }),
+    );
+  });
+
+  it('does not pass issue_number to createPR when run.issue is undefined', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ intent: 'idea', issue: undefined });
+
+    await handler.handle(run, makeFeedback());
+
+    const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
+    expect(callArg['issue_number']).toBeUndefined();
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -1913,11 +1913,19 @@ describe('Orchestrator — _handleImplementationFeedback failure paths', () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 import type { PRManager } from '../../src/types/issue-tracker.js';
+import type { PRTitleGenerator } from '../../src/core/ai/pr-title-generator.js';
 
 function makePRManager(overrides: Partial<PRManager> = {}): PRManager {
   return {
     createPR: vi.fn().mockResolvedValue('https://github.com/org/repo/pull/42'),
     mergePR: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makePRTitleGenerator(overrides: Partial<PRTitleGenerator> = {}): PRTitleGenerator {
+  return {
+    generate: vi.fn().mockResolvedValue('generated title'),
     ...overrides,
   };
 }
@@ -1940,6 +1948,7 @@ function makeApprovalOrch2(opts: {
       implementer: makeImplementationAgent(),
       implFeedbackPage: makeImplFeedbackPage(),
       prManager: opts.prManager ?? makePRManager(),
+      prTitleGenerator: makePRTitleGenerator(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
       channelRepoMap: makeChannelRepoMap(),
@@ -2179,6 +2188,7 @@ function makeApprovalOrch3(opts: {
       implementer: makeImplementationAgent(),
       implFeedbackPage: makeImplFeedbackPage(),
       prManager: opts.prManager ?? makePRManager(),
+      prTitleGenerator: makePRTitleGenerator(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
       channelRepoMap: makeChannelRepoMap(),
@@ -4386,6 +4396,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
+        prTitleGenerator: makePRTitleGenerator(),
       } as never,
       { logDestination: nullDest },
     );
@@ -4424,6 +4435,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
+        prTitleGenerator: makePRTitleGenerator(),
       } as never,
       { logDestination: nullDest },
     );
@@ -4505,6 +4517,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
+        prTitleGenerator: makePRTitleGenerator(),
       } as never,
       { logDestination: nullDest },
     );

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -2103,6 +2103,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
+        prTitleGenerator: makePRTitleGenerator(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage: vi.fn().mockResolvedValue(undefined),
         channelRepoMap: makeChannelRepoMap(),


### PR DESCRIPTION
## Summary

- Adds `ModelPRTitleGenerator` (mirrors `ModelIntentClassifier`) which calls `DirectModelRunner` with a trimmed artifact + impl summary to produce a concise PR title; result feeds `PRManagerOptions.title`, then existing `derivePrTitle` prefixes `fix:` / `chore:` / `feat:`.
- Replaces the current source in `ImplementationApprovalHandler` (`run.last_impl_result.summary`, a multi-paragraph blob that produced monstrous titles) with the generator's output; any generator failure returns `null` and falls back to existing `extractSpecTitle` behavior — the generator never throws.
- Issue #84 root-causes: both bug/chore (no H1 → `fix: spec`) and the post-branch regression (full summary as title) are resolved.
- Input to the prompt is truncated at `## Design changes` / `## Technical changes` / `## Task list` / `## Implementation` headings or a 3000-char cap, to keep the what/why content and drop the implementation-heavy tail.
- Post-processing normalizes quotes/backticks/trailing periods/multi-line output, and rejects titles > 100 chars.
- New `pr.title_generate` task kind is routed to `defaults.direct` (Haiku) alongside `intent.classify`.
- Verified against PR #95's real triage + impl summary using Bedrock Haiku; produced titles like `prevent agents from force-adding gitignored .autocatalyst files` (which was applied to PR #95).
- Closes #84.

## Test plan

- [x] `npm run build` — typecheck passes
- [x] `npx vitest run` — 797 tests pass (added 9 generator tests + 2 handler tests)
- [ ] Manual: submit a bug flow, approve triage + implementation, confirm the PR title is concise and prefixed correctly for `fix:`
- [ ] Manual: submit an idea flow, confirm the PR title reflects the spec's what/why (not implementation detail)
- [ ] Manual: simulate a Bedrock credential failure during title generation, confirm PR still opens with the spec H1 fallback title