### PR TITLE
fix: remove double-nested filter in resolveFilenameToPageId

### DIFF
--- a/src/adapters/notion/notion-publisher.ts
+++ b/src/adapters/notion/notion-publisher.ts
@@ -175,7 +175,7 @@ export class NotionPublisher implements ArtifactPublisher, ArtifactContentSource
 
   private async resolveFilenameToPageId(filename: string): Promise<string | undefined> {
     const result = await this.client.dataSources.query(this.specs_database_id, {
-      filter: { property: 'Filename', rich_text: { equals: filename } },
+      property: 'Filename', rich_text: { equals: filename },
     });
     if (result.results.length === 0) {
       this.logger.warn(

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -369,7 +369,7 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via createArtifa
     );
     await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
     expect(client.dataSources.query).toHaveBeenCalledWith('db-specs-id', {
-      filter: { property: 'Filename', rich_text: { equals: 'feature-old-spec.md' } },
+      property: 'Filename', rich_text: { equals: 'feature-old-spec.md' },
     });
     const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(createCall.properties['Superseded by / Supersedes'].relation).toEqual([{ id: 'old-spec-page-id' }]);


### PR DESCRIPTION
## Summary

- `resolveFilenameToPageId` was passing `{ filter: { property, rich_text } }` as the `filter` argument to `dataSources.query`
- `NotionClientImpl.dataSources.query` then spread that into `{ filter: filter }`, producing a double-nested body the Notion API rejects
- Fix passes the raw filter object directly, removing the extra wrapper

This bug predates the `dataSources` migration but became a hard failure after `notionhq/client@5` tightened filter validation on the `dataSources` endpoint (introduced in #83).

Closes #106

## Test plan

- [x] Updated the existing `resolveFilenameToPageId` test assertion to expect the corrected (non-double-nested) filter shape
- [x] All 832 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)