### PR TITLE
fix: migrate Notion API to 2026-03-11 with data source ID resolution

### DIFF
--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -24,6 +24,7 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
   private readonly client: NotionClient;
   private readonly testing_guides_database_id: string;
   private readonly logger: pino.Logger;
+  private testingGuidesDataSourceIdPromise: Promise<string> | undefined;
 
   constructor(
     client: NotionClient,
@@ -35,9 +36,19 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
     this.logger = createLogger('implementation-feedback-page', { destination: options?.logDestination });
   }
 
+  private getTestingGuidesDataSourceId(): Promise<string> {
+    if (!this.testingGuidesDataSourceIdPromise) {
+      this.testingGuidesDataSourceIdPromise = this.client.databases
+        .retrieve(this.testing_guides_database_id)
+        .then(db => db.data_sources[0].id);
+    }
+    return this.testingGuidesDataSourceIdPromise;
+  }
+
   async create(input: ImplementationReviewInput): Promise<PublishedImplementationReview> {
+    const dataSourceId = await this.getTestingGuidesDataSourceId();
     const response = await this.client.pages.create({
-      parent: { type: 'database_id', database_id: this.testing_guides_database_id } as never,
+      parent: { type: 'data_source_id', data_source_id: dataSourceId } as never,
       properties: {
         Title: {
           title: [{ text: { content: `Testing guide: ${input.title}` } }],

--- a/src/adapters/notion/notion-client.ts
+++ b/src/adapters/notion/notion-client.ts
@@ -33,6 +33,9 @@ export interface NotionClient {
   users: {
     me(): Promise<{ id: string }>;
   };
+  databases: {
+    retrieve(database_id: string): Promise<{ data_sources: Array<{ id: string; name: string }> }>;
+  };
   dataSources: {
     query(
       data_source_id: string,
@@ -45,7 +48,7 @@ export class NotionClientImpl implements NotionClient {
   private readonly client: Client;
 
   constructor({ integration_token }: { integration_token: string }) {
-    this.client = new Client({ auth: integration_token });
+    this.client = new Client({ auth: integration_token, notionVersion: '2026-03-11' });
   }
 
   readonly pages = {
@@ -54,22 +57,20 @@ export class NotionClientImpl implements NotionClient {
 
     getMarkdown: async (page_id: string): Promise<string> => {
       const response = await (this.client as unknown as {
-        request: (args: { path: string; method: string; headers?: Record<string, string> }) => Promise<unknown>;
+        request: (args: { path: string; method: string }) => Promise<unknown>;
       }).request({
         path: `pages/${page_id}/markdown`,
         method: 'GET',
-        headers: { 'Notion-Version': '2026-03-11' },
       });
       return (response as { markdown: string }).markdown;
     },
 
     updateMarkdown: async (page_id: string, operation: MarkdownOperation): Promise<void> => {
       await (this.client as unknown as {
-        request: (args: { path: string; method: string; body: unknown; headers?: Record<string, string> }) => Promise<unknown>;
+        request: (args: { path: string; method: string; body: unknown }) => Promise<unknown>;
       }).request({
         path: `pages/${page_id}/markdown`,
         method: 'PATCH',
-        headers: { 'Notion-Version': '2026-03-11' },
         body: operation,
       });
     },
@@ -102,6 +103,13 @@ export class NotionClientImpl implements NotionClient {
         method: 'GET',
       });
       return { id: (response as { id: string }).id };
+    },
+  };
+
+  readonly databases = {
+    retrieve: async (database_id: string): Promise<{ data_sources: Array<{ id: string; name: string }> }> => {
+      const response = await this.client.databases.retrieve({ database_id });
+      return { data_sources: (response as unknown as { data_sources: Array<{ id: string; name: string }> }).data_sources };
     },
   };
 

--- a/src/adapters/notion/notion-publisher.ts
+++ b/src/adapters/notion/notion-publisher.ts
@@ -26,6 +26,7 @@ export class NotionPublisher implements ArtifactPublisher, ArtifactContentSource
   private readonly specs_database_id: string;
   private readonly options?: NotionPublisherOptions;
   private readonly logger: pino.Logger;
+  private specsDataSourceIdPromise: Promise<string> | undefined;
 
   constructor(
     client: NotionClient,
@@ -36,6 +37,15 @@ export class NotionPublisher implements ArtifactPublisher, ArtifactContentSource
     this.specs_database_id = specs_database_id;
     this.options = options;
     this.logger = createLogger('notion-publisher', { destination: this.options?.logDestination });
+  }
+
+  private getSpecsDataSourceId(): Promise<string> {
+    if (!this.specsDataSourceIdPromise) {
+      this.specsDataSourceIdPromise = this.client.databases
+        .retrieve(this.specs_database_id)
+        .then(db => db.data_sources[0].id);
+    }
+    return this.specsDataSourceIdPromise;
   }
 
   async createArtifact(_conversation: ConversationRef, artifact: Artifact): Promise<ArtifactPublication> {
@@ -78,8 +88,9 @@ export class NotionPublisher implements ArtifactPublisher, ArtifactContentSource
       properties['Superseded by / Supersedes'] = { relation: [{ id: supersedingPageId }] };
     }
 
+    const dataSourceId = await this.getSpecsDataSourceId();
     const page = await this.client.pages.create({
-      parent: { database_id: this.specs_database_id } as unknown as Parameters<NotionClient['pages']['create']>[0]['parent'],
+      parent: { type: 'data_source_id', data_source_id: dataSourceId } as unknown as Parameters<NotionClient['pages']['create']>[0]['parent'],
       properties: properties as unknown as Parameters<NotionClient['pages']['create']>[0]['properties'],
     });
 
@@ -174,7 +185,8 @@ export class NotionPublisher implements ArtifactPublisher, ArtifactContentSource
   }
 
   private async resolveFilenameToPageId(filename: string): Promise<string | undefined> {
-    const result = await this.client.dataSources.query(this.specs_database_id, {
+    const dataSourceId = await this.getSpecsDataSourceId();
+    const result = await this.client.dataSources.query(dataSourceId, {
       property: 'Filename', rich_text: { equals: filename },
     });
     if (result.results.length === 0) {

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -32,7 +32,7 @@ function makeNotionClient(overrides: Partial<{
       me: vi.fn().mockResolvedValue({ id: 'bot-id' }),
     },
     databases: {
-      query: vi.fn().mockResolvedValue({ results: [] }),
+      retrieve: vi.fn().mockResolvedValue({ data_sources: [{ id: 'ds-testing-guides-id', name: 'Testing Guides' }] }),
     },
   } as unknown as NotionClient;
 }
@@ -87,7 +87,7 @@ function makeBlocksChildrenListFn(
 }
 
 describe('NotionImplementationFeedbackPage — create', () => {
-  it('creates a page in the testing_guides_database_id (not under a parent page)', async () => {
+  it('creates a page with data_source_id parent (not database_id or page_id)', async () => {
     const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
     const client = makeNotionClient({ pagesCreate });
     const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
@@ -95,10 +95,9 @@ describe('NotionImplementationFeedbackPage — create', () => {
     await page.create(makeReviewInput({ summary: 'the summary', testing_instructions: 'run npm test' }));
 
     const createCall = pagesCreate.mock.calls[0][0];
-    expect(createCall.parent).toEqual(
-      expect.objectContaining({ database_id: 'db-testing-guides-id' }),
-    );
+    expect(createCall.parent).toEqual({ type: 'data_source_id', data_source_id: 'ds-testing-guides-id' });
     expect(createCall.parent.page_id).toBeUndefined();
+    expect(createCall.parent.database_id).toBeUndefined();
   });
 
   it('returns the page_id', async () => {

--- a/tests/adapters/notion/notion-client.test.ts
+++ b/tests/adapters/notion/notion-client.test.ts
@@ -4,8 +4,10 @@ import { NotionClientImpl } from '../../../src/adapters/notion/notion-client.js'
 
 // Mock the Notion SDK Client so we can inspect what NotionClientImpl passes to it
 const mockSdkQuery = vi.fn();
+const mockSdkDbRetrieve = vi.fn();
 vi.mock('@notionhq/client', () => ({
   Client: vi.fn(() => ({
+    databases: { retrieve: mockSdkDbRetrieve },
     dataSources: { query: mockSdkQuery },
   })),
 }));
@@ -22,6 +24,7 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
+      databases: { retrieve: async () => ({ data_sources: [] }) },
       dataSources: { query: async () => ({ results: [] }) },
     };
     expect(typeof client.users.me).toBe('function');
@@ -38,6 +41,7 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
+      databases: { retrieve: async () => ({ data_sources: [] }) },
       dataSources: { query: async () => ({ results: [] }) },
     };
     expect(typeof client.pages.updateProperties).toBe('function');
@@ -55,6 +59,7 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
+      databases: { retrieve: async () => ({ data_sources: [] }) },
       dataSources: { query: mockQuery },
     };
     expect(typeof client.dataSources.query).toBe('function');
@@ -72,9 +77,26 @@ describe('NotionClient interface', () => {
       blocks: { children: { list: async () => ({}) as never } },
       comments: { list: async () => ({}) as never, create: async () => ({}) as never },
       users: { me: async () => ({ id: 'test' }) },
+      databases: { retrieve: async () => ({ data_sources: [] }) },
       dataSources: { query: mockQuery },
     };
     await expect(client.dataSources.query('db-id')).resolves.toEqual({ results: [] });
+  });
+});
+
+describe('NotionClientImpl.databases.retrieve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls SDK databases.retrieve with database_id and returns data_sources', async () => {
+    mockSdkDbRetrieve.mockResolvedValue({ data_sources: [{ id: 'ds-xyz', name: 'My DB' }] });
+    const impl = new NotionClientImpl({ integration_token: 'test-token' });
+
+    const result = await impl.databases.retrieve('db-abc');
+
+    expect(mockSdkDbRetrieve).toHaveBeenCalledWith({ database_id: 'db-abc' });
+    expect(result).toEqual({ data_sources: [{ id: 'ds-xyz', name: 'My DB' }] });
   });
 });
 

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -63,6 +63,9 @@ function makeMockNotionClient(pageId = 'page-abc123'): NotionClient {
       create: vi.fn().mockResolvedValue({}),
     },
     users: { me: vi.fn() },
+    databases: {
+      retrieve: vi.fn().mockResolvedValue({ data_sources: [{ id: 'ds-specs-id', name: 'Specs' }] }),
+    },
     dataSources: {
       query: vi.fn().mockResolvedValue({ results: [] }),
     },
@@ -78,7 +81,7 @@ describe('NotionPublisher.createArtifact', () => {
     await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
 
     expect(client.pages.create).toHaveBeenCalledWith(
-      expect.objectContaining({ parent: expect.objectContaining({ database_id: 'db-specs-id' }) }),
+      expect.objectContaining({ parent: expect.objectContaining({ data_source_id: 'ds-specs-id' }) }),
     );
     // No children in pages.create — content set via markdown API
     const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
@@ -368,7 +371,7 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via createArtifa
       'feature-new-spec.md',
     );
     await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
-    expect(client.dataSources.query).toHaveBeenCalledWith('db-specs-id', {
+    expect(client.dataSources.query).toHaveBeenCalledWith('ds-specs-id', {
       property: 'Filename', rich_text: { equals: 'feature-old-spec.md' },
     });
     const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
@@ -411,14 +414,15 @@ describe('NotionPublisher — resolveFilenameToPageId behavior (via createArtifa
 });
 
 describe('NotionPublisher.createArtifact — database entry with typed properties', () => {
-  it('calls pages.create with database_id parent (not page_id)', async () => {
+  it('calls pages.create with data_source_id parent (not database_id or page_id)', async () => {
     const client = makeMockNotionClient();
     const publisher = new NotionPublisher(client, 'db-specs-id', { logDestination: nullDest });
     const specPath = makeSpecFile('---\nspecced_by: alice\nlast_updated: 2026-04-16\n---\n# Spec', 'feature-setup-wizard.md');
     await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
     const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(createCall.parent).toEqual(expect.objectContaining({ database_id: 'db-specs-id' }));
+    expect(createCall.parent).toEqual({ type: 'data_source_id', data_source_id: 'ds-specs-id' });
     expect(createCall.parent.page_id).toBeUndefined();
+    expect(createCall.parent.database_id).toBeUndefined();
   });
 
   it('sets all required typed properties', async () => {


### PR DESCRIPTION
## Summary

- Adds lazy `databases.retrieve` discovery step to resolve `database_id` → `data_source_id` on first use in both `NotionPublisher` and `NotionImplementationFeedbackPage`
- Passes resolved `data_source_id` to `dataSources.query` and as the `pages.create` parent (fixing the active crash)
- Bumps SDK client to `notionVersion: '2026-03-11'` globally; removes redundant per-call `Notion-Version` headers

## Test plan

- [ ] All 833 existing tests pass (`npm test`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] `dataSources.query` now receives a `data_source_id` (not a `database_id`) — verified by updated test assertions
- [ ] `pages.create` parent is now `{ type: 'data_source_id', data_source_id: '...' }` in both publishers

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)