### PR TITLE
fix: pass base_url and api-key header to Anthropic client for Grove endpoints

### DIFF
--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -266,10 +266,17 @@ export function buildDirectModelRunner(
 
   if (credential.type === 'api_key') {
     logger.info(
-      { event: 'service.config', provider: 'anthropic', auth: 'api_key' },
+      { event: 'service.config', provider: 'anthropic', auth: 'api_key', base_url: endpoint.base_url ?? 'default' },
       'Using Anthropic direct API with API key',
     );
+    const clientOptions: ConstructorParameters<typeof Anthropic>[0] = { apiKey: credential.resolvedValue! };
+    if (endpoint.base_url) {
+      clientOptions.baseURL = endpoint.base_url;
+      clientOptions.defaultHeaders = { 'api-key': credential.resolvedValue! };
+    }
+    const client = new Anthropic(clientOptions);
     return new AnthropicDirectModelRunner(credential.resolvedValue!, {
+      createFn: params => client.messages.create(params) as Promise<{ content: Array<{ type: string; text?: string }> }>,
       defaultModel: directProfile.model,
     });
   }


### PR DESCRIPTION
## Summary

When an `anthropic_direct` profile uses an endpoint with a `base_url` (e.g. Grove/Azure APIM), the Anthropic SDK was constructed without the custom URL or the `api-key` header Grove requires. This caused 401 `invalid x-api-key` errors on all intent classification calls.

## Changes

- Construct the Anthropic client with `baseURL` and `defaultHeaders: { 'api-key': ... }` when `endpoint.base_url` is set
- Falls back to default Anthropic endpoint behaviour when no `base_url` is configured

## Test

Restart the service with a Grove-backed `autocatalyst.yaml` and verify intent classification no longer returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)