### PR TITLE
chore: wire up opentelemetry sdk and victoria observability stack

### DIFF
--- a/context-agent/standards/logging.md
+++ b/context-agent/standards/logging.md
@@ -45,11 +45,17 @@ Every log entry is a JSON object with these fields:
 - `warn`: recoverable issues (retry scheduled, config reload failed with fallback)
 - `error`: unrecoverable issues (run failed, adapter crashed)
 
-## OpenTelemetry
+## OpenTelemetry export
 
-Traces and metrics use OpenTelemetry SDK. Spans wrap:
-- Each orchestrator tick
-- Each adapter call (Slack API, Agent SDK)
-- Each stage transition within a run
+Two environment variables control OTLP export. Both default to unset.
 
-Trace context propagates from orchestrator → adapter → agent subprocess where possible.
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset | OTLP/HTTP endpoint for metrics (e.g. `http://localhost:4318`). When unset, no metrics are exported and no network connections are made. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | unset | OTLP/HTTP endpoint for logs (e.g. `http://localhost:9428`). When unset, pino writes to stderr only — identical to pre-feature behavior. |
+
+When both variables are unset the service is **behaviorally identical** to its pre-feature state: pino writes to stderr, no network connections are attempted.
+
+Export errors (network unreachable, bad endpoint) are caught internally and logged at `warn` level with `event: "telemetry.export_failed"`. They do not propagate to the run loop.
+
+See `context-human/wiki/observability.md` for setup instructions and `src/core/telemetry.ts` for implementation details.

--- a/context-human/specs/feature-victoriametrics-integration.md
+++ b/context-human/specs/feature-victoriametrics-integration.md
@@ -1,0 +1,504 @@
+---
+created: 2026-05-08
+last_updated: 2026-05-08
+status: implementing
+issue: 100
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+# VictoriaMetrics Backend Integration and Operational Dashboard
+
+## What
+
+Autocatalyst gains a first-class observability backend: an OpenTelemetry export pipeline that ships metrics and logs to VictoriaMetrics and VictoriaLogs, paired with a Docker Compose stack that operators can run alongside the service. A pre-built vmui dashboard surfaces run throughput, stage durations, error rates, adapter latency, and agent turn counts. After starting one compose command, an operator sees live telemetry without configuring anything.
+The feature also ships an operator guide documenting both the local development setup and what a production deployment looks like.
+## Why
+
+The service already emits structured JSON logs to stderr — enough visibility for a developer watching a terminal, but nothing an operator can query after the fact or monitor across runs. There is no way to answer "how many runs completed in the last hour?" or "which stage is consistently slow?" without grepping files by hand.
+The observability-stack ADR committed to the Victoria stack (VictoriaLogs, VictoriaMetrics) and Vector as the target backend. This feature closes the gap between that decision and working infrastructure. With the pipeline in place, engineers can diagnose bottlenecks quantitatively, the loop's self-improvement relies on structured telemetry rather than prose summaries, and the service is ready to be operated at scale without manual plumbing.
+## Personas
+
+- **Enzo: Engineer** — deploys and operates Autocatalyst, needs to diagnose failed runs, spot slow stages, and confirm the system is healthy during a release.
+- **Phoebe: Product manager** — monitors run throughput and feature velocity over time; needs a readable dashboard without writing queries.
+## Narratives
+
+### Enzo wires up observability on a new deployment
+
+Enzo is setting up Autocatalyst in a new environment after the team migrates repositories. He clones the repo, copies `.env.example` to `.env`, and follows the observability setup guide in `context-human/wiki/observability.md`. The guide tells him to run `docker compose up -d` from the repo root. Within thirty seconds the compose stack is healthy: VictoriaMetrics, VictoriaLogs, and Vector are all running. He starts the Autocatalyst service with `autocatalyst run --repo .` and seeds a test idea through Slack.
+The service logs its first structured JSON lines to stderr. Vector picks them up from the Docker log stream and forwards them to VictoriaLogs. The service's OTel SDK simultaneously pushes metrics — run counts, stage latency histograms — to VictoriaMetrics via OTLP. Enzo opens the vmui dashboard URL from the guide and sees a live panel: one run in flight, zero errors, the spec-generation stage at 14 seconds. The dashboard requires no Grafana account, no provisioning step, and no query knowledge — it loaded from the preset bundled with VictoriaMetrics. Enzo bookmarks the URL and closes his terminal; the monitoring is running.
+### Enzo diagnoses a slow implementation stage
+
+Three days into running Autocatalyst against the AMP repo, Enzo notices that some runs take noticeably longer than others without an obvious pattern. He opens the vmui dashboard and looks at the stage duration heatmap. The implementation stage shows a bimodal distribution: most runs complete in eight to twelve minutes, but a cluster completes in twenty-two to thirty minutes. He filters by `run_id` for one of the slow runs and sees the agent turn count is three to four times higher than normal — the agent is looping. He clicks through to VictoriaLogs, pastes the `run_id`, and reads the structured log trail. The slow runs all triggered on a single repository where the workspace context is unusually large.
+Enzo files an issue with the run IDs and the log evidence already attached. Because the telemetry is structured and queryable, his bug report takes ten minutes instead of an hour of log archaeology.
+### Phoebe reviews weekly velocity from the dashboard
+
+Phoebe wants to present the team's weekly automation velocity at the Friday review. She opens the vmui dashboard and sets the time range to the past seven days. The run throughput panel shows forty-one completed runs; the error rate panel shows two failed runs, both on the same day. She screenshots both panels and notes that the failure day matches a dependency upgrade she remembers from earlier in the week. She shares the screenshots in the team channel without writing a single query. The numbers are already formatted as the team has been tracking them — runs per day, error percentage, median stage latency — because those panels are part of the shipped preset.
+## User stories
+
+**Wiring up observability on a new deployment**
+- Enzo can start the complete observability stack with a single `docker compose up` command.
+- Enzo can confirm stack health by checking compose service status.
+- Enzo can open the dashboard immediately after the service starts its first run.
+- Enzo can see logs in VictoriaLogs without configuring the service beyond its defaults.
+- Enzo can see metrics in VictoriaMetrics after a run completes.
+- Enzo can override the OTLP endpoint via an environment variable when deploying to a hosted backend.
+**Diagnosing a slow implementation stage**
+- Enzo can filter the dashboard by time range to isolate a specific day or run.
+- Enzo can view per-stage duration data broken out by stage name.
+- Enzo can drill from a metric anomaly to the corresponding structured logs using `run_id`.
+- Enzo can read the full log trail for a specific run without grepping files.
+**Reviewing weekly velocity**
+- Phoebe can see run throughput (completed runs over time) without writing a PromQL query.
+- Phoebe can see error rate and failed run counts in the same dashboard view.
+- Phoebe can set the time range on all panels simultaneously.
+- Phoebe can share a dashboard screenshot that shows the same panels each week.
+## Goals
+
+- An operator can go from zero to live telemetry in under five minutes following the setup guide, on Mac, Linux, or Windows with Docker Desktop.
+- The compose stack's total compressed image footprint is under 150 MB (VictoriaMetrics \~20 MB, VictoriaLogs \~20 MB, Vector \~50 MB; no Grafana).
+- OTLP export failures do not crash the service or affect the main run loop.
+- Pino log output continues to appear on stderr when OTLP export is disabled — the default behavior is unchanged for operators not using the observability stack.
+- The dashboard preset ships as a file in the repo (not a Grafana account requirement).
+## Non-goals
+
+- VictoriaTraces integration — the issue defers this pending image availability; traces are out of scope for this feature.
+- Hosted/cloud deployment of the observability backend (documented as future work, not implemented).
+- Grafana — vmui is sufficient; adding Grafana would exceed the image-weight budget and is explicitly rejected in the issue.
+- Alerting rules or on-call paging configuration.
+- Backfilling historical telemetry for runs that completed before this feature ships.
+## Tech spec
+
+### Introduction and overview
+
+**Dependencies on ADRs and decisions:**
+- `context-agent/decisions/observability-stack.md` — commits to OpenTelemetry SDK instrumentation, Victoria stack + Vector, OTLP as the transport; this feature implements it.
+- `context-agent/standards/logging.md` — pino to stderr is the current logging standard; this feature adds a parallel OTLP export path without replacing it.
+**Technical goals:**
+- OTel `MeterProvider` initialized at startup; metrics exported via OTLP/HTTP.
+- OTel `LoggerProvider` initialized at startup; pino log records bridged to it and exported via OTLP/HTTP.
+- Backward compatibility: when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, no OTLP connection is attempted and the service behaves identically to today.
+- Docker Compose stack validated healthy on Mac (Apple Silicon and Intel) and Linux.
+**Non-goals (technical):** OpenTelemetry traces (spans) are already noted in the logging standard but not wired; this feature does not add trace export either. The focus is metrics and logs.
+**Glossary:**
+- **OTLP** — OpenTelemetry Protocol; the wire format used by the OTel SDK to export telemetry.
+- **MeterProvider** — OTel SDK component that manages metric instruments and their export.
+- **LoggerProvider** — OTel SDK component that manages log records and their export.
+- **vmui** — VictoriaMetrics' built-in query and dashboard UI, served by the VictoriaMetrics process itself.
+- **Vector** — A high-performance observability data pipeline; used here to collect structured JSON from the service's stderr (via Docker log driver) and forward to VictoriaLogs.
+---
+### System design and architecture
+
+**High-level architecture:**
+```javascript
+┌──────────────────────────────────────────────────────────┐
+│                  autocatalyst process                    │
+│                                                          │
+│   pino logger ──► stderr (fd 2)  [preserved, existing]  │
+│        │                                                 │
+│        └──► OTel LoggerProvider ──► OTLP/HTTP ──────────►│──► VictoriaLogs  :9428
+│                                                          │
+│   OTel MeterProvider ──────────────► OTLP/HTTP ─────────►│──► VictoriaMetrics :4318
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│                  docker compose stack                    │
+│                                                          │
+│  VictoriaMetrics (single-node)  :8428 vmui, :4318 OTLP  │
+│  VictoriaLogs                   :9428 OTLP logs          │
+│  Vector                         reads Docker log stream  │
+│                                 → VictoriaLogs :9428     │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+VictoriaMetrics accepts OTLP metrics on its `/opentelemetry/api/v1/push` endpoint (port 4318 mapped). VictoriaLogs accepts OTLP logs on its `/insert/opentelemetry/v1/logs` endpoint (port 9428). Vector runs in the compose stack as a sidecar to also collect container stderr output via the Docker log API and forward it to VictoriaLogs — this provides log visibility even if the OTel log bridge is disabled.
+**Component breakdown:**
+
+Component
+What changes
+
+`src/core/telemetry.ts` (new)
+Initializes `MeterProvider` and `LoggerProvider`; exports a `meter` singleton and a `shutdownTelemetry()` function. Reads `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`. No-ops when env vars are unset.
+
+`src/core/logger.ts`
+Adds an OTel log bridge destination alongside the existing pino stderr path. Reads the OTel `LoggerProvider` from the telemetry module. Writes remain on stderr.
+
+`src/index.ts`
+Calls `initTelemetry()` before `composeWorkflowRuntime()`; calls `shutdownTelemetry()` before `process.exit()`.
+
+`src/core/orchestrator.ts`
+Adds meter instruments: run counter, stage duration histogram. Records on existing stage transition events.
+
+`src/adapters/anthropic/claude-agent-sdk-agent-runner.ts`
+Records an agent turn counter metric on each yielded turn event.
+
+`docker-compose.yml` (new)
+VictoriaMetrics single-node, VictoriaLogs, Vector, with named volumes and explicit version tags.
+
+`vector.yaml` (new, at repo root)
+Vector pipeline: Docker log source → JSON parser → VictoriaLogs sink.
+
+`victoriametrics-dashboard.json` (new, at repo root or `ops/`)
+vmui preset covering the five required panels.
+
+`context-human/wiki/observability.md` (new)
+Operator setup guide: docker compose steps, env var reference, dashboard URL, hosted deployment notes.
+
+`context-agent/standards/logging.md`
+Add OTLP env var reference section.
+
+**Primary sequence — startup with OTLP enabled:**
+```mermaid
+sequenceDiagram
+    participant CLI as index.ts
+    participant Tel as telemetry.ts
+    participant VM as VictoriaMetrics
+    participant VL as VictoriaLogs
+
+    CLI->>Tel: initTelemetry()
+    Tel->>Tel: read OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    Tel->>Tel: read OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+    Tel->>Tel: create MeterProvider + LoggerProvider
+    Tel-->>CLI: telemetry ready (or noop if env unset)
+    CLI->>CLI: composeWorkflowRuntime()
+    Note over CLI: run begins, stages execute
+    CLI->>VM: OTLP/HTTP metrics (periodic push every 30s)
+    CLI->>VL: OTLP/HTTP log records (on each log write)
+    CLI->>Tel: shutdownTelemetry()
+    Tel->>VM: flush remaining metrics
+    Tel->>VL: flush remaining logs
+```
+---
+### Detailed design
+
+#### New module: `src/core/telemetry.ts`
+
+```typescript
+// Env vars read:
+//   OTEL_EXPORTER_OTLP_METRICS_ENDPOINT  (default: unset → no-op)
+//   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT     (default: unset → no-op)
+//   OTEL_EXPORT_INTERVAL_MS              (default: 30000)
+
+export interface TelemetryHandles {
+  meter: Meter;            // OTel API Meter, safe to call even when no-op
+  loggerProvider: LoggerProvider;
+  shutdown: () => Promise;
+}
+
+export function initTelemetry(): TelemetryHandles
+```
+Behavior:
+- If neither endpoint env var is set, returns no-op `Meter` and no-op `LoggerProvider`. No network connections made.
+- If either endpoint is set, initializes the respective provider with an `OTLPMetricExporter` / `OTLPLogExporter` using periodic/batch export.
+- Export errors are caught and logged at `warn` level; they do not propagate to the run loop.
+- `shutdown()` calls `forceFlush()` then `shutdown()` on each provider; ignores errors.
+#### Changes to `src/core/logger.ts`
+
+Add an optional OTel log bridge. When `loggerProvider` is a live provider (not a no-op), construct a `pino.transport` that writes records to the OTel `LoggerProvider` alongside the existing stderr destination. Use `pino.multistream` or a custom writable to fan out.
+The pino format does not change. The bridge reads each parsed JSON log record and emits an OTel `LogRecord` with severity mapped from pino's numeric level, body set to `message`, and all structured fields set as attributes.
+#### Metric instruments (added to `orchestrator.ts` and agent runner)
+
+Instrument
+Type
+Unit
+Description
+
+`autocatalyst.run.started`
+Counter
+`{run}`
+Incremented when a run enters the run loop. Attributes: `intent`.
+
+`autocatalyst.run.completed`
+Counter
+`{run}`
+Incremented on terminal state. Attributes: `terminal_reason`.
+
+`autocatalyst.stage.duration`
+Histogram
+`ms`
+Recorded on each stage transition. Attributes: `stage`, `outcome`.
+
+`autocatalyst.agent.turns`
+Counter
+`{turn}`
+Incremented per yielded turn event in the SDK runner. Attributes: `component`.
+
+`autocatalyst.adapter.latency`
+Histogram
+`ms`
+Time for each Slack API call or agent SDK call. Attributes: `adapter`, `operation`.
+
+All instruments are created once at module init and safe to use whether or not OTLP is configured (no-op meter if not).
+#### `docker-compose.yml`
+
+```yaml
+version: "3.9"
+services:
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.111.0
+    ports:
+      - "8428:8428"   # vmui + query API
+      - "4318:4318"   # OTLP receiver (metrics)
+    volumes:
+      - vm-data:/victoria-metrics-data
+    command:
+      - -retentionPeriod=1
+      - -opentsdbHTTPListenAddr=:4242
+    restart: unless-stopped
+
+  victorialogs:
+    image: victoriametrics/victoria-logs:v1.14.0
+    ports:
+      - "9428:9428"   # OTLP log ingestion + query API
+    volumes:
+      - vl-data:/vlogs-data
+    command:
+      - -retentionPeriod=1w
+    restart: unless-stopped
+
+  vector:
+    image: timberio/vector:0.43.0-alpine
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./vector.yaml:/etc/vector/vector.yaml:ro
+    depends_on:
+      - victorialogs
+    restart: unless-stopped
+
+volumes:
+  vm-data:
+  vl-data:
+```
+#### `vector.yaml`
+
+```yaml
+sources:
+  docker_logs:
+    type: docker_logs
+    include_labels:
+      com.docker.compose.project: autocatalyst
+
+transforms:
+  parse_json:
+    type: remap
+    inputs: [docker_logs]
+    source: |
+      . = parse_json!(.message) ?? .
+
+sinks:
+  victorialogs:
+    type: http
+    inputs: [parse_json]
+    uri: "http://victorialogs:9428/insert/jsonline?_stream_fields=component,level"
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited
+```
+#### Dashboard preset (`victoriametrics-dashboard.json`)
+
+vmui supports importing a dashboard JSON file. The preset defines five panels:
+
+Panel
+Query type
+Description
+
+Run throughput
+rate counter
+`rate(autocatalyst_run_completed_total[5m])` — runs/sec over time
+
+Error rate
+ratio
+Completed with `terminal_reason="failed"` / all completed
+
+Stage duration (p50/p95)
+histogram quantile
+`histogram_quantile(0.95, autocatalyst_stage_duration_ms)` by `stage`
+
+Adapter latency
+histogram quantile
+`histogram_quantile(0.95, autocatalyst_adapter_latency_ms)` by `adapter`
+
+Agent turn count
+counter
+`sum(rate(autocatalyst_agent_turns_total[5m])) by (component)`
+
+The JSON file is generated once and committed. It loads via vmui's "Import dashboard" feature (no account required).
+---
+### Security, privacy, and compliance
+
+**Authentication and authorization:** The compose stack exposes VictoriaMetrics and VictoriaLogs on [localhost](http://localhost) ports only (`127.0.0.1` binding in compose). No authentication is configured for local development. For hosted deployments, the operator guide documents adding basic auth or a reverse proxy — this is out of scope for the feature implementation.
+**Data privacy:** Log records exported via OTLP contain the same fields as pino stderr output. No secrets are logged per existing logging standards (`context-agent/standards/logging.md`). The OTLP exporter sends data to a local endpoint by default; operators choosing a hosted backend are responsible for their data residency requirements.
+**Input validation:** The OTLP endpoints are read from environment variables and passed directly to the exporter constructors. No user-supplied input flows through the telemetry path at runtime.
+---
+### Observability
+
+This feature is itself observable:
+- `logger.warn` on OTLP export failure (structured: `{ event: "telemetry.export_failed", error: "..." }`).
+- `logger.info` on telemetry init with resolved endpoints (or `disabled` if not configured).
+- `logger.info` on telemetry shutdown with flush outcome.
+- No new metrics about the metrics exporter — that would be circular and unhelpful.
+---
+### Testing plan
+
+**Unit tests:**
+- `telemetry.ts` — `initTelemetry()` returns no-op handles when env vars are unset; does not attempt any network call. Verify by checking that `meter.createCounter()` returns a no-op instrument.
+- `telemetry.ts` — `initTelemetry()` with a non-reachable endpoint does not throw; OTLP errors are swallowed without propagating.
+- `logger.ts` — pino writes to stderr when OTLP is disabled; stderr output is unchanged from today.
+- Metric instruments — counter `add()` and histogram `record()` do not throw when called with no-op meter.
+**Integration tests:**
+- `docker compose up` reaches healthy state on Mac (Apple Silicon). All three services pass their health checks within 30 seconds.
+- After a synthetic run completion event, VictoriaMetrics' `/api/v1/query` endpoint returns a non-empty result for `autocatalyst_run_completed_total`.
+- After a log line is emitted, VictoriaLogs' `/select/logsql/query` returns matching structured data.
+**Documentation test:**
+- A team member (not the author) follows `context-human/wiki/observability.md` from a clean state on Mac and confirms the dashboard is visible within five minutes. Verified before merge.
+---
+### Alternatives considered
+
+**OTel Collector instead of direct OTLP to VictoriaMetrics/VictoriaLogs:** A standard OTel Collector acts as a fan-out proxy. Rejected: it adds another image (\~50 MB), another config file, and another process to debug. VictoriaMetrics and VictoriaLogs both support OTLP natively; the collector adds indirection with no benefit at this scale.
+**Grafana instead of vmui:** Grafana is the more familiar dashboard tool and supports richer panel types. Rejected explicitly in the issue: it adds a heavy image, requires account provisioning, and exceeds the 150 MB image-weight budget. vmui is sufficient for the five required panels.
+**Stdout log collection via Vector only (no OTel log bridge):** Vector can collect container stdout/stderr and forward to VictoriaLogs without any code change to the service. This approach is simpler but couples log visibility to the Docker runtime — it does not work when running the service outside Docker (e.g., bare `npm start`). The OTel log bridge makes log export process-portable.
+---
+### Risks
+
+Risk
+Likelihood
+Impact
+Mitigation
+
+VictoriaLogs OTLP log ingestion endpoint changes between releases
+Low
+Medium
+Pin explicit image versions in compose; test against pinned versions in CI.
+
+pino-to-OTel bridge adds measurable latency to log writes
+Low
+Low
+Bridge writes asynchronously via batch exporter; pino stderr write is synchronous and unaffected. Measure in unit tests.
+
+Docker Desktop unavailable on some operator machines
+Medium
+Low
+The compose stack is optional; the service runs identically without it. Document fallback: `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` can point to any OTLP endpoint.
+
+VictoriaTraces image availability
+Unknown
+Low
+Issue already defers this. No risk to this feature — traces are explicitly out of scope.
+
+---
+## Task list
+
+- [ ] **Story: OTel SDK dependencies and telemetry module**
+	- [ ] **Task: Add OTel npm dependencies**
+		- **Description**: Add `@opentelemetry/api`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-logs`, `@opentelemetry/exporter-metrics-otlp-http`, and `@opentelemetry/exporter-logs-otlp-http` to `package.json`. Verify no peer dependency conflicts with existing packages.
+		- **Acceptance criteria**:
+			- [ ] All packages added to `dependencies` (not `devDependencies`)
+			- [ ] `npm install` completes without errors
+			- [ ] TypeScript build passes after install
+		- **Dependencies**: None
+	- [ ] **Task: Create ****`src/core/telemetry.ts`**
+		- **Description**: Implement `initTelemetry()` that reads `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`. When unset, returns no-op `Meter` and `LoggerProvider`. When set, creates `OTLPMetricExporter` and `OTLPLogExporter` with 30-second periodic export intervals. Export errors are caught and logged at `warn` level. Returns `{ meter, loggerProvider, shutdown }`.
+		- **Acceptance criteria**:
+			- [ ] Returns no-op handles when both env vars are unset; zero network connections attempted
+			- [ ] Returns live handles when both env vars are set to `http://localhost:4318`
+			- [ ] `shutdown()` calls `forceFlush()` before `shutdown()` on each provider
+			- [ ] Export errors do not propagate (caught internally, logged as warn)
+			- [ ] Unit test: `initTelemetry()` with no env vars — instruments are callable without throwing
+			- [ ] Unit test: `initTelemetry()` with non-reachable URL — no throw on construction
+		- **Dependencies**: "Task: Add OTel npm dependencies"
+- [ ] **Story: Logger OTLP bridge**
+	- [ ] **Task: Add OTel log bridge to ****`src/core/logger.ts`**
+		- **Description**: Modify `createLogger()` to accept an optional `loggerProvider: LoggerProvider` parameter. When provided (and not no-op), add a second pino destination that writes each JSON log record to the OTel `LoggerProvider` as a `LogRecord`. Map pino level numbers to OTel `SeverityNumber`. Set body to `message`, set all other fields as attributes. Use `pino.multistream` to fan out to both stderr and the OTel destination concurrently.
+		- **Acceptance criteria**:
+			- [ ] Existing pino stderr behavior unchanged when `loggerProvider` is absent or no-op
+			- [ ] When a live `loggerProvider` is provided, a log record is emitted to OTel for each pino call
+			- [ ] Pino level numbers 10–70 map correctly to OTel SeverityNumber values
+			- [ ] Unit test: logger writes to stderr with no OTel provider — output matches current format
+			- [ ] Unit test: logger calls OTel emit when provider is present
+		- **Dependencies**: "Task: Create `src/core/telemetry.ts`"
+- [ ] **Story: Startup and shutdown wiring**
+	- [ ] **Task: Wire telemetry init and shutdown into ****`src/index.ts`**
+		- **Description**: Call `initTelemetry()` at the top of `src/index.ts`, before `composeWorkflowRuntime()`. Pass the `loggerProvider` from `initTelemetry()` to `createLogger()`. Register `shutdown()` in the shutdown sequence alongside `service.stopped`. Ensure `shutdownTelemetry()` is called on both normal exit and signal-triggered exit.
+		- **Acceptance criteria**:
+			- [ ] `initTelemetry()` is called before any logger or service is constructed
+			- [ ] Logger receives the live `loggerProvider` when OTLP is configured
+			- [ ] `shutdown()` is called before `process.exit(0)` in the normal path
+			- [ ] `shutdown()` is called from the signal handler path (SIGINT, SIGTERM)
+			- [ ] Service starts and exits cleanly with no env vars set (no-op path)
+		- **Dependencies**: "Task: Add OTel log bridge to `src/core/logger.ts`"
+- [ ] **Story: Metric instrumentation**
+	- [ ] **Task: Add run lifecycle counters to ****`src/core/orchestrator.ts`**
+		- **Description**: Using the `meter` from `initTelemetry()` (passed via dependency injection), create `autocatalyst.run.started` (Counter) and `autocatalyst.run.completed` (Counter). Increment `run.started` when a run enters the loop for the first time; increment `run.completed` with a `terminal_reason` attribute on each terminal state transition.
+		- **Acceptance criteria**:
+			- [ ] `run.started` is incremented once per new run (not per retry)
+			- [ ] `run.completed` includes `terminal_reason` attribute matching the terminal state name
+			- [ ] No change to existing orchestrator behavior or test outcomes
+			- [ ] Instruments are safe to call when meter is a no-op (no env vars set)
+		- **Dependencies**: "Task: Wire telemetry init and shutdown into `src/index.ts`"
+	- [ ] **Task: Add stage duration histogram to ****`src/core/orchestrator.ts`**
+		- **Description**: Create `autocatalyst.stage.duration` (Histogram, unit `ms`). Record elapsed time on each stage transition with attributes `stage` (stage name) and `outcome` (`success` or `failed`). Use `performance.now()` for timing.
+		- **Acceptance criteria**:
+			- [ ] Duration is recorded in milliseconds
+			- [ ] `stage` attribute matches the stage name strings already used in structured logs
+			- [ ] `outcome` is `success` for normal transitions, `failed` for error transitions
+			- [ ] No observable performance change to the orchestrator tick
+		- **Dependencies**: "Task: Add run lifecycle counters to `src/core/orchestrator.ts`"
+	- [ ] **Task: Add agent turn counter to ****`claude-agent-sdk-agent-runner.ts`**
+		- **Description**: Create `autocatalyst.agent.turns` (Counter) and `autocatalyst.adapter.latency` (Histogram, unit `ms`). Increment the turn counter each time the async iterator yields a turn event. Record the latency histogram around the `query()` call with `adapter=agent-sdk` and `operation=query`.
+		- **Acceptance criteria**:
+			- [ ] Turn counter increments once per yielded turn event
+			- [ ] Latency histogram records the wall time of each `query()` invocation
+			- [ ] Attributes include `component` (value: `claude-agent-sdk`) on turn counter
+			- [ ] Instruments are safe to call when meter is no-op
+		- **Dependencies**: "Task: Wire telemetry init and shutdown into `src/index.ts`"
+- [ ] **Story: Docker Compose observability stack**
+	- [ ] **Task: Write ****`docker-compose.yml`**
+		- **Description**: Create `docker-compose.yml` at the repo root. Include `victoriametrics/victoria-metrics:v1.111.0` (ports 8428 and 4318), `victoriametrics/victoria-logs:v1.14.0` (port 9428), and `timberio/vector:0.43.0-alpine`. Use named volumes for VM and VL data. All images must use explicit version tags (no `latest`). Bind all host ports to `127.0.0.1` for local-only exposure.
+		- **Acceptance criteria**:
+			- [ ] `docker compose up -d` succeeds on Mac (Apple Silicon)
+			- [ ] All three services reach healthy/running state within 30 seconds
+			- [ ] VictoriaMetrics vmui is reachable at `http://localhost:8428/vmui`
+			- [ ] VictoriaLogs query API is reachable at `http://localhost:9428/select/logsql/query`
+			- [ ] No `latest` tag appears in the file
+		- **Dependencies**: None
+	- [ ] **Task: Write ****`vector.yaml`**
+		- **Description**: Create `vector.yaml` at the repo root. Configure a `docker_logs` source that reads from containers labelled with the autocatalyst compose project. Add a `remap` transform that attempts to parse each log line as JSON. Configure an HTTP sink that forwards to VictoriaLogs at `http://victorialogs:9428/insert/jsonline` with `_stream_fields=component,level`.
+		- **Acceptance criteria**:
+			- [ ] Vector container starts without config errors
+			- [ ] After the autocatalyst service emits a log line, it appears in VictoriaLogs within 10 seconds
+			- [ ] Non-JSON log lines are forwarded as raw strings without dropping
+		- **Dependencies**: "Task: Write `docker-compose.yml`"
+	- [ ] **Task: Validate compose stack integration end-to-end**
+		- **Description**: Start the compose stack, start the service with `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:4318` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:9428`, run one synthetic run (or seed an idea end-to-end), then query VictoriaMetrics and VictoriaLogs to confirm data arrived.
+		- **Acceptance criteria**:
+			- [ ] `autocatalyst_run_completed_total` returns a result from VictoriaMetrics query API
+			- [ ] At least one log record from `autocatalyst` appears in VictoriaLogs query
+			- [ ] Service exits cleanly after flush with no errors logged
+		- **Dependencies**: "Task: Write `vector.yaml`", "Task: Add stage duration histogram to `src/core/orchestrator.ts`"
+- [ ] **Story: Dashboard preset**
+	- [ ] **Task: Create vmui dashboard preset JSON**
+		- **Description**: Create `ops/victoriametrics-dashboard.json` (create `ops/` directory if needed). Define five panels: (1) run throughput rate, (2) error rate, (3) stage duration p50/p95 by stage name, (4) adapter latency p95 by adapter, (5) agent turn count rate. Use PromQL expressions against VictoriaMetrics. Import the file into a running vmui instance and verify all panels load without query errors.
+		- **Acceptance criteria**:
+			- [ ] Dashboard imports successfully via vmui "Import dashboard"
+			- [ ] All five panels display data after at least one run completes
+			- [ ] Panel titles and axis labels are human-readable (no raw metric names)
+			- [ ] No Grafana dependency
+		- **Dependencies**: "Task: Validate compose stack integration end-to-end"
+- [ ] **Story: Documentation**
+	- [ ] **Task: Write ****`context-human/wiki/observability.md`**
+		- **Description**: Write the operator setup guide. Cover: prerequisites (Docker, Docker Compose), how to start the stack (`docker compose up -d`), env vars to set for the autocatalyst service, how to open the dashboard (URL + import step for the preset), how to query VictoriaLogs for a specific `run_id`, and a brief section on hosted deployment (point OTLP env vars at a remote endpoint). Include a troubleshooting section for the three most common failure modes (port conflict, Vector can't reach Docker socket, OTLP export silently dropping because endpoint is wrong).
+		- **Acceptance criteria**:
+			- [ ] A team member with no prior knowledge of VictoriaMetrics can follow the guide to a working dashboard in under five minutes
+			- [ ] All env var names in the guide match the implementation
+			- [ ] Dashboard import step matches the actual vmui import flow
+			- [ ] Hosted deployment section is present (even if brief)
+		- **Dependencies**: "Task: Create vmui dashboard preset JSON"
+	- [ ] **Task: Update ****`context-agent/standards/logging.md`**
+		- **Description**: Add a section documenting the two OTLP env vars (`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) and their defaults. Note that when both are unset the service is identical to its pre-feature behavior.
+		- **Acceptance criteria**:
+			- [ ] New section appears under a clear heading (e.g., "OpenTelemetry export")
+			- [ ] Both env var names are correct and match the implementation
+			- [ ] Default behavior (no-op when unset) is clearly stated
+		- **Dependencies**: "Task: Wire telemetry init and shutdown into `src/index.ts`"

--- a/context-human/wiki/observability.md
+++ b/context-human/wiki/observability.md
@@ -1,0 +1,107 @@
+# Observability Setup Guide
+
+Autocatalyst ships a Docker Compose stack that provides live metrics and logs with a single command.
+
+## Prerequisites
+
+- Docker Desktop (Mac/Windows) or Docker Engine with Compose plugin (Linux)
+- Autocatalyst repo cloned locally
+
+## Start the observability stack
+
+From the repo root:
+
+```bash
+docker compose up -d
+```
+
+This starts three services:
+- **VictoriaMetrics** — metrics storage and query UI (vmui)
+- **VictoriaLogs** — log storage and query API
+- **Vector** — collects Docker container logs and forwards them to VictoriaLogs
+
+Verify all services are running:
+
+```bash
+docker compose ps
+```
+
+All three services should show `running`. They are typically healthy within 30 seconds.
+
+## Configure the Autocatalyst service
+
+Set these environment variables before starting Autocatalyst:
+
+| Variable | Local stack value | Description |
+|----------|-------------------|-------------|
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | `http://localhost:4318` | OTLP/HTTP endpoint for metrics |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | `http://localhost:9428` | OTLP/HTTP endpoint for logs |
+
+When **both variables are unset**, the service behaves exactly as before this feature was added — pino writes structured JSON to stderr only, and no network connections are attempted.
+
+Example (local stack):
+
+```bash
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:9428
+autocatalyst run --repo .
+```
+
+## Open the dashboard
+
+1. Open **http://localhost:8428/vmui** in your browser.
+2. Click the menu icon (top right) → **Import dashboard**.
+3. Upload `ops/victoriametrics-dashboard.json` from the repo root.
+4. The five operational panels load immediately.
+
+After your first run completes, all panels populate with data. No account, no provisioning step, and no PromQL knowledge required.
+
+## Query logs for a specific run
+
+VictoriaLogs is queryable at **http://localhost:9428/select/logsql/query**.
+
+To see all logs for a specific run, use its `run_id` (visible in any structured log line):
+
+```
+{run_id="<your-run-id>"}
+```
+
+To see the last 100 log lines across all runs:
+
+```
+* | limit 100
+```
+
+## Hosted / production deployment
+
+Point the env vars at your hosted OTLP endpoint instead of localhost:
+
+```bash
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://metrics.example.com/opentelemetry/api/v1/push
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs.example.com/insert/opentelemetry/v1/logs
+```
+
+Authentication (bearer token, basic auth) is configured at the hosted backend. To add headers to OTLP requests, use the standard OTel SDK env var:
+
+```bash
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>"
+```
+
+The service sends plain OTLP/HTTP; TLS termination and auth can also be handled by a reverse proxy in front of the storage backend.
+
+## Troubleshooting
+
+### Port conflict on 8428, 4318, or 9428
+
+Another process is using one of the ports. Stop it, or edit `docker-compose.yml` to use different host ports (e.g., change `"127.0.0.1:8428:8428"` to `"127.0.0.1:18428:8428"`). Update your `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` to match.
+
+### Vector can't reach the Docker socket
+
+On Linux, the user running `docker compose up` must be in the `docker` group. Run `sudo usermod -aG docker $USER` and log out/in, or prefix with `sudo`. On Mac/Windows, Docker Desktop manages socket access automatically.
+
+### Metrics not appearing in vmui after a run
+
+1. Confirm the env var is set: `echo $OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
+2. Check for `telemetry.export_failed` warn logs in the service output.
+3. Test the OTLP endpoint directly: `curl -s http://localhost:4318/opentelemetry/api/v1/push` (should return a response, not a connection error).
+4. Verify VictoriaMetrics is running: `docker compose ps victoriametrics`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.9"
+
+services:
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.111.0
+    ports:
+      - "127.0.0.1:8428:8428"
+      - "127.0.0.1:4318:4318"
+    volumes:
+      - vm-data:/victoria-metrics-data
+    command:
+      - -retentionPeriod=1
+    restart: unless-stopped
+
+  victorialogs:
+    image: victoriametrics/victoria-logs:v1.14.0
+    ports:
+      - "127.0.0.1:9428:9428"
+    volumes:
+      - vl-data:/vlogs-data
+    command:
+      - -retentionPeriod=1w
+    restart: unless-stopped
+
+  vector:
+    image: timberio/vector:0.43.0-alpine
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./vector.yaml:/etc/vector/vector.yaml:ro
+    depends_on:
+      - victorialogs
+    restart: unless-stopped
+
+volumes:
+  vm-data:
+  vl-data:

--- a/ops/victoriametrics-dashboard.json
+++ b/ops/victoriametrics-dashboard.json
@@ -1,0 +1,59 @@
+{
+  "title": "Autocatalyst Operational Dashboard",
+  "rows": [
+    {
+      "panels": [
+        {
+          "title": "Run Throughput (runs/sec)",
+          "description": "Rate of completed runs over time",
+          "expr": "rate(autocatalyst_run_completed_total[5m])",
+          "type": "chart",
+          "unit": "runs/s"
+        },
+        {
+          "title": "Error Rate (%)",
+          "description": "Percentage of runs that failed",
+          "expr": "100 * (rate(autocatalyst_run_completed_total{terminal_reason=\"failed\"}[5m]) or vector(0)) / (rate(autocatalyst_run_completed_total[5m]) > 0)",
+          "type": "chart",
+          "unit": "%"
+        }
+      ]
+    },
+    {
+      "panels": [
+        {
+          "title": "Stage Duration p50 (ms)",
+          "description": "Median stage duration by stage name",
+          "expr": "histogram_quantile(0.5, sum(rate(autocatalyst_stage_duration_ms_bucket[5m])) by (le, stage))",
+          "type": "chart",
+          "unit": "ms"
+        },
+        {
+          "title": "Stage Duration p95 (ms)",
+          "description": "95th percentile stage duration by stage name",
+          "expr": "histogram_quantile(0.95, sum(rate(autocatalyst_stage_duration_ms_bucket[5m])) by (le, stage))",
+          "type": "chart",
+          "unit": "ms"
+        }
+      ]
+    },
+    {
+      "panels": [
+        {
+          "title": "Adapter Latency p95 (ms)",
+          "description": "95th percentile adapter operation latency by adapter",
+          "expr": "histogram_quantile(0.95, sum(rate(autocatalyst_adapter_latency_ms_bucket[5m])) by (le, adapter))",
+          "type": "chart",
+          "unit": "ms"
+        },
+        {
+          "title": "Agent Turn Rate",
+          "description": "Agent turns per second by component",
+          "expr": "sum(rate(autocatalyst_agent_turns_total[5m])) by (component)",
+          "type": "chart",
+          "unit": "turns/s"
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
         "@anthropic-ai/sdk": "^0.88.0",
         "@aws-sdk/credential-providers": "^3.1029.0",
         "@notionhq/client": "^5.17.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.217.0",
+        "@opentelemetry/sdk-logs": "^0.217.0",
+        "@opentelemetry/sdk-metrics": "^2.7.1",
         "@slack/bolt": "^4.7.0",
         "pino": "9.6.0",
         "yaml": "2.7.1"
@@ -2941,6 +2946,257 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.217.0.tgz",
+      "integrity": "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.217.0.tgz",
+      "integrity": "sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/sdk-logs": "0.217.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.217.0.tgz",
+      "integrity": "sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.217.0.tgz",
+      "integrity": "sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.217.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.217.0.tgz",
+      "integrity": "sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.217.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1",
+        "protobufjs": "8.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.217.0.tgz",
+      "integrity": "sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
@@ -6779,6 +7035,12 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -7207,6 +7469,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "@anthropic-ai/sdk": "^0.88.0",
     "@aws-sdk/credential-providers": "^3.1029.0",
     "@notionhq/client": "^5.17.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.217.0",
+    "@opentelemetry/sdk-logs": "^0.217.0",
+    "@opentelemetry/sdk-metrics": "^2.7.1",
     "@slack/bolt": "^4.7.0",
     "pino": "9.6.0",
     "yaml": "2.7.1"

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -8,6 +8,9 @@ import type {
   SettingSource,
   ThinkingConfig,
 } from '@anthropic-ai/claude-agent-sdk';
+import type { Meter, Counter, Histogram } from '@opentelemetry/api';
+import { metrics } from '@opentelemetry/api';
+import { performance } from 'node:perf_hooks';
 import type {
   AgentProfile,
   AgentPluginConfig,
@@ -56,27 +59,46 @@ const AUTOMATED_PERMISSION_RULES = [
 export interface ClaudeAgentSdkAgentRunnerOptions {
   queryFn?: QueryFn;
   materializeRuntimeSkills?: (refs: AgentSkillRef[]) => Promise<AgentPluginConfig[]>;
+  meter?: Meter;
 }
 
 export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   private readonly queryFn: QueryFn;
   private readonly materializeRuntimeSkills: (refs: AgentSkillRef[]) => Promise<AgentPluginConfig[]>;
+  private readonly _agentTurns: Counter;
+  private readonly _adapterLatency: Histogram;
 
   constructor(options?: ClaudeAgentSdkAgentRunnerOptions) {
     this.queryFn = options?.queryFn ?? _query;
     this.materializeRuntimeSkills = options?.materializeRuntimeSkills ?? materializeClaudeRuntimeSkillPlugins;
+    const meter = options?.meter ?? metrics.getMeter('autocatalyst');
+    this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
+      unit: '{turn}',
+      description: 'Agent turns yielded',
+    });
+    this._adapterLatency = meter.createHistogram('autocatalyst.adapter.latency', {
+      unit: 'ms',
+      description: 'Latency of adapter operations',
+    });
   }
 
   async *run(request: AgentRunRequest): AsyncIterable<AgentRunEvent> {
     const profile = await this.profileWithRuntimeSkillPlugins(request.profile);
-    // query() yields structured SDKMessage objects via async iterator.
-    // It does not spawn a subprocess and does not write to process.stdout or process.stderr.
+    const startMs = performance.now();
     for await (const message of this.queryFn({
       prompt: request.prompt,
       options: makeClaudeAgentSdkOptions(request.working_directory, profile),
     })) {
-      yield normalizeSdkMessage(message as SDKMessage);
+      const event = normalizeSdkMessage(message as SDKMessage);
+      if (event.type === 'assistant') {
+        this._agentTurns.add(1, { component: 'claude-agent-sdk' });
+      }
+      yield event;
     }
+    this._adapterLatency.record(performance.now() - startMs, {
+      adapter: 'agent-sdk',
+      operation: 'query',
+    });
   }
 
   private async profileWithRuntimeSkillPlugins(profile: AgentProfile | undefined): Promise<AgentProfile | undefined> {

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import type pino from 'pino';
+import type { Meter } from '@opentelemetry/api';
 import { App } from '@slack/bolt';
 import Anthropic from '@anthropic-ai/sdk';
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
@@ -50,6 +51,7 @@ export interface ComposeWorkflowRuntimeOptions {
   repoPaths: string[];
   env: Record<string, string | undefined>;
   logger: RuntimeLogger;
+  meter?: Meter;
 }
 
 export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRuntimeOptions): Promise<ReturnType<typeof bootstrapWorkflowRuntime>> {
@@ -110,7 +112,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
 
   const aiRoutingPolicy = buildAgentRoutingPolicy(resolvedAi);
   const directModelRunner = buildDirectModelRunner(resolvedAi, logger);
-  const agentRunner = new ClaudeAgentSdkAgentRunner();
+  const agentRunner = new ClaudeAgentSdkAgentRunner({ meter: options.meter });
   const intentClassifier = new ModelIntentClassifier(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const prTitleGenerator = new ModelPRTitleGenerator(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const questionAnswerer = new AgentRunnerQuestionAnsweringAgent(agentRunner, aiRoutingPolicy, repoPath);
@@ -180,6 +182,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     channelRepoMap,
     reacjiComplete,
     isConnected: () => adapter.isConnected(),
+    meter: options.meter,
   });
 }
 

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -1,3 +1,4 @@
+import type { Meter } from '@opentelemetry/api';
 import type { LoadedConfig } from '../types/config.js';
 import type { CommandRegistry } from '../types/commands.js';
 import type { IntentClassifier } from '../types/intent.js';
@@ -10,6 +11,7 @@ export interface BootstrapWorkflowRuntimeDeps extends Omit<OrchestratorDeps, 'co
   commandRegistry?: OrchestratorDeps['commandRegistry'];
   intentClassifier: IntentClassifier;
   isConnected: () => boolean;
+  meter?: Meter;
 }
 
 export function bootstrapWorkflowRuntime(
@@ -21,10 +23,13 @@ export function bootstrapWorkflowRuntime(
   service: Service;
 } {
   const commandRegistry = deps.commandRegistry ?? new CommandRegistryImpl();
-  const orchestrator = new OrchestratorImpl({
-    ...deps,
-    commandRegistry,
-  });
+  const orchestrator = new OrchestratorImpl(
+    {
+      ...deps,
+      commandRegistry,
+    },
+    { meter: deps.meter },
+  );
 
   registerDefaultCommands(commandRegistry, {
     runs: orchestrator.getRuns(),

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,34 +1,78 @@
 import { pino } from 'pino';
+import { Writable } from 'node:stream';
+import type { LoggerProvider } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
 
 interface LoggerOptions {
   destination?: pino.DestinationStream;
+  loggerProvider?: LoggerProvider;
 }
 
+const LEVEL_TO_SEVERITY: Record<string, SeverityNumber> = {
+  trace: SeverityNumber.TRACE,
+  debug: SeverityNumber.DEBUG,
+  info: SeverityNumber.INFO,
+  warn: SeverityNumber.WARN,
+  error: SeverityNumber.ERROR,
+  fatal: SeverityNumber.FATAL,
+};
+
 export function createLogger(component: string, options?: LoggerOptions): pino.Logger {
-  let dest: pino.DestinationStream | ReturnType<typeof pino.transport>;
+  let primaryDest: pino.DestinationStream | ReturnType<typeof pino.transport>;
 
   if (options?.destination) {
-    dest = options.destination;
+    primaryDest = options.destination;
   } else if (process.env.LOG_PRETTY === 'true') {
-    dest = pino.transport({ target: 'pino-pretty', options: { destination: 2 } });
+    primaryDest = pino.transport({ target: 'pino-pretty', options: { destination: 2 } });
   } else {
-    dest = pino.destination(2);
+    primaryDest = pino.destination(2);
   }
 
-  return pino(
-    {
-      base: null,
-      level: 'debug',
-      timestamp: () => `,"timestamp":"${new Date().toISOString()}"`,
-      formatters: {
-        level(label: string) {
-          return { level: label };
-        },
-        log(object: Record<string, unknown>) {
-          return { component, ...object };
-        },
+  const pinoConfig = {
+    base: null,
+    level: 'debug',
+    timestamp: () => `,"timestamp":"${new Date().toISOString()}"`,
+    formatters: {
+      level(label: string) {
+        return { level: label };
+      },
+      log(object: Record<string, unknown>) {
+        return { component, ...object };
       },
     },
-    dest,
-  );
+  };
+
+  const loggerProvider = options?.loggerProvider;
+  if (!loggerProvider) {
+    return pino(pinoConfig, primaryDest);
+  }
+
+  const otelLogger = loggerProvider.getLogger(component);
+  const otelStream = new Writable({
+    write(chunk: Buffer, _enc: string, cb: () => void) {
+      try {
+        const line = chunk.toString().trim();
+        if (line) {
+          const record = JSON.parse(line) as Record<string, unknown>;
+          const { msg, level: levelLabel, ...attributes } = record;
+          const severityNumber = LEVEL_TO_SEVERITY[levelLabel as string] ?? SeverityNumber.INFO;
+          otelLogger.emit({
+            body: typeof msg === 'string' ? msg : '',
+            severityNumber,
+            attributes: attributes as Record<string, string | number | boolean>,
+          });
+        }
+      } catch {
+        // Never block pino on parse failures
+      }
+      cb();
+    },
+  });
+
+  const multiDest = pino.multistream([
+    { stream: primaryDest as pino.DestinationStream },
+    { stream: otelStream as unknown as pino.DestinationStream },
+  ]);
+
+  return pino(pinoConfig, multiDest);
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,6 +1,9 @@
 // src/core/orchestrator.ts
 import { randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
 import type pino from 'pino';
+import type { Meter, Counter, Histogram } from '@opentelemetry/api';
+import { metrics } from '@opentelemetry/api';
 import { createLogger } from './logger.js';
 import type { ChannelAdapter } from '../adapters/channel-adapter.js';
 import { channelKey, type ConversationRef, type MessageRef } from '../types/channel.js';
@@ -75,6 +78,7 @@ export interface OrchestratorDeps {
 interface OrchestratorOptions {
   logDestination?: pino.DestinationStream;
   maxConcurrentRuns?: number; // default: 5
+  meter?: Meter;
 }
 
 export class OrchestratorImpl implements Orchestrator {
@@ -93,11 +97,28 @@ export class OrchestratorImpl implements Orchestrator {
   private _queueTimestamps = new Map<InboundEvent, number>();
   private readonly _runLogs = new Map<string, string[]>();
   private readonly handlerRegistry: HandlerRegistry;
+  private readonly _runStarted: Counter;
+  private readonly _runCompleted: Counter;
+  private readonly _stageDuration: Histogram;
+  private readonly _stageStartTimes = new Map<string, number>();
 
   constructor(deps: OrchestratorDeps, options?: OrchestratorOptions) {
     this.deps = deps;
     this.logger = createLogger('orchestrator', { destination: options?.logDestination });
     this._maxConcurrentRuns = options?.maxConcurrentRuns ?? 5;
+    const meter = options?.meter ?? metrics.getMeter('autocatalyst');
+    this._runStarted = meter.createCounter('autocatalyst.run.started', {
+      unit: '{run}',
+      description: 'Number of runs started',
+    });
+    this._runCompleted = meter.createCounter('autocatalyst.run.completed', {
+      unit: '{run}',
+      description: 'Number of runs completed',
+    });
+    this._stageDuration = meter.createHistogram('autocatalyst.stage.duration', {
+      unit: 'ms',
+      description: 'Duration of each stage transition',
+    });
     this.handlerRegistry = deps.handlerRegistry ?? this.buildDefaultHandlerRegistry();
     if (deps.runStore) {
       const loaded = deps.runStore.load();
@@ -408,11 +429,26 @@ export class OrchestratorImpl implements Orchestrator {
 
   private transition(run: Run, stage: RunStage): void {
     const from = run.stage;
+    const endMs = performance.now();
+    const startMs = this._stageStartTimes.get(run.id);
+    if (startMs !== undefined) {
+      this._stageDuration.record(endMs - startMs, {
+        stage: from,
+        outcome: stage === 'failed' ? 'failed' : 'success',
+      });
+    }
+    this._stageStartTimes.set(run.id, endMs);
+
     run.stage = stage;
     run.updated_at = new Date().toISOString();
     this.logger.info({ event: 'run.stage_transition', run_id: run.id, request_id: run.request_id, from_stage: from, to_stage: stage }, 'Stage transition');
     this._appendRunLog(run.request_id, `[${new Date().toISOString()}] Stage: ${from} → ${stage}`);
     this._persistRuns();
+
+    if (stage === 'done' || stage === 'failed') {
+      this._runCompleted.add(1, { terminal_reason: stage });
+      this._stageStartTimes.delete(run.id);
+    }
   }
 
   private _persistRuns(): void {
@@ -480,7 +516,9 @@ export class OrchestratorImpl implements Orchestrator {
     // Keyed by request_id: at most one active run per request is the design invariant.
     // The event loop is sequential, so a second new_request for the same request_id
     // would not arrive until the first is fully processed.
+    this._stageStartTimes.set(run.id, performance.now());
     this.runs.set(request.id, run);
+    this._runStarted.add(1, { intent: run.intent });
     this._persistRuns();
     this.logger.info({ event: 'run.created', run_id: run.id, request_id: request.id }, 'Run created');
     return run;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -344,6 +344,8 @@ export class OrchestratorImpl implements Orchestrator {
       }
 
       run.intent = requestIntent;
+      this._runStarted.add(1, { intent: requestIntent });
+      this._stageStartTimes.set(run.id, performance.now());
       this._persistRuns();
       const handler = this.handlerRegistry.resolve({
         event_type: 'new_request',
@@ -516,9 +518,7 @@ export class OrchestratorImpl implements Orchestrator {
     // Keyed by request_id: at most one active run per request is the design invariant.
     // The event loop is sequential, so a second new_request for the same request_id
     // would not arrive until the first is fully processed.
-    this._stageStartTimes.set(run.id, performance.now());
     this.runs.set(request.id, run);
-    this._runStarted.add(1, { intent: run.intent });
     this._persistRuns();
     this.logger.info({ event: 'run.created', run_id: run.id, request_id: request.id }, 'Run created');
     return run;

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -16,7 +16,8 @@ export interface TelemetryHandles {
 export function initTelemetry(): TelemetryHandles {
   const metricsEndpoint = process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
   const logsEndpoint = process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
-  const exportInterval = parseInt(process.env.OTEL_EXPORT_INTERVAL_MS ?? '30000', 10);
+  const rawInterval = parseInt(process.env.OTEL_EXPORT_INTERVAL_MS ?? '30000', 10);
+  const exportIntervalMs = Number.isFinite(rawInterval) && rawInterval > 0 ? rawInterval : 30000;
 
   if (!metricsEndpoint && !logsEndpoint) {
     // No-op path: use global no-op providers; zero network connections
@@ -31,51 +32,68 @@ export function initTelemetry(): TelemetryHandles {
     };
   }
 
-  // Live OTLP path
-  const metricExporter = new OTLPMetricExporter({
-    url: metricsEndpoint,
-  });
+  // Live OTLP path — gate each provider independently
+  let sdkMeterProvider: MeterProvider | undefined;
+  if (metricsEndpoint) {
+    const metricExporter = new OTLPMetricExporter({
+      url: metricsEndpoint,
+    });
 
-  const sdkMeterProvider = new MeterProvider({
-    readers: [
-      new PeriodicExportingMetricReader({
-        exporter: metricExporter,
-        exportIntervalMillis: exportInterval,
-      }),
-    ],
-  });
+    sdkMeterProvider = new MeterProvider({
+      readers: [
+        new PeriodicExportingMetricReader({
+          exporter: metricExporter,
+          exportIntervalMillis: exportIntervalMs,
+        }),
+      ],
+    });
 
-  const logExporter = new OTLPLogExporter({
-    url: logsEndpoint,
-  });
+    metrics.setGlobalMeterProvider(sdkMeterProvider);
+  }
 
-  const sdkLoggerProvider = new SdkLoggerProvider({
-    processors: [new BatchLogRecordProcessor(logExporter)],
-  });
+  let sdkLoggerProvider: SdkLoggerProvider | undefined;
+  if (logsEndpoint) {
+    const logExporter = new OTLPLogExporter({
+      url: logsEndpoint,
+    });
 
-  const meter = sdkMeterProvider.getMeter('autocatalyst');
-  const loggerProvider: LoggerProvider = sdkLoggerProvider;
+    sdkLoggerProvider = new SdkLoggerProvider({
+      processors: [new BatchLogRecordProcessor(logExporter)],
+    });
+
+    logs.setGlobalLoggerProvider(sdkLoggerProvider);
+  }
+
+  const meter = sdkMeterProvider
+    ? sdkMeterProvider.getMeter('autocatalyst')
+    : metrics.getMeter('autocatalyst');
+
+  const loggerProvider: LoggerProvider = sdkLoggerProvider ?? logs.getLoggerProvider();
 
   const shutdown = async (): Promise<void> => {
-    try {
-      await sdkMeterProvider.forceFlush();
-    } catch {
-      // swallow export errors
+    if (sdkMeterProvider) {
+      try {
+        await sdkMeterProvider.forceFlush();
+      } catch (err) {
+        console.warn('telemetry shutdown flush error (ignored):', err);
+      }
+      try {
+        await sdkMeterProvider.shutdown();
+      } catch (err) {
+        console.warn('telemetry shutdown flush error (ignored):', err);
+      }
     }
-    try {
-      await sdkMeterProvider.shutdown();
-    } catch {
-      // swallow shutdown errors
-    }
-    try {
-      await sdkLoggerProvider.forceFlush();
-    } catch {
-      // swallow export errors
-    }
-    try {
-      await sdkLoggerProvider.shutdown();
-    } catch {
-      // swallow shutdown errors
+    if (sdkLoggerProvider) {
+      try {
+        await sdkLoggerProvider.forceFlush();
+      } catch (err) {
+        console.warn('telemetry shutdown flush error (ignored):', err);
+      }
+      try {
+        await sdkLoggerProvider.shutdown();
+      } catch (err) {
+        console.warn('telemetry shutdown flush error (ignored):', err);
+      }
     }
   };
 

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -1,0 +1,83 @@
+import { metrics } from '@opentelemetry/api';
+import type { Meter } from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
+import type { LoggerProvider } from '@opentelemetry/api-logs';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { LoggerProvider as SdkLoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+
+export interface TelemetryHandles {
+  meter: Meter;
+  loggerProvider: LoggerProvider;
+  shutdown: () => Promise<void>;
+}
+
+export function initTelemetry(): TelemetryHandles {
+  const metricsEndpoint = process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+  const logsEndpoint = process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+  const exportInterval = parseInt(process.env.OTEL_EXPORT_INTERVAL_MS ?? '30000', 10);
+
+  if (!metricsEndpoint && !logsEndpoint) {
+    // No-op path: use global no-op providers; zero network connections
+    const meter = metrics.getMeter('autocatalyst');
+    const loggerProvider = logs.getLoggerProvider();
+    return {
+      meter,
+      loggerProvider,
+      shutdown: async () => {
+        // Nothing to shut down in no-op path
+      },
+    };
+  }
+
+  // Live OTLP path
+  const metricExporter = new OTLPMetricExporter({
+    url: metricsEndpoint,
+  });
+
+  const sdkMeterProvider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter: metricExporter,
+        exportIntervalMillis: exportInterval,
+      }),
+    ],
+  });
+
+  const logExporter = new OTLPLogExporter({
+    url: logsEndpoint,
+  });
+
+  const sdkLoggerProvider = new SdkLoggerProvider({
+    processors: [new BatchLogRecordProcessor(logExporter)],
+  });
+
+  const meter = sdkMeterProvider.getMeter('autocatalyst');
+  const loggerProvider: LoggerProvider = sdkLoggerProvider;
+
+  const shutdown = async (): Promise<void> => {
+    try {
+      await sdkMeterProvider.forceFlush();
+    } catch {
+      // swallow export errors
+    }
+    try {
+      await sdkMeterProvider.shutdown();
+    } catch {
+      // swallow shutdown errors
+    }
+    try {
+      await sdkLoggerProvider.forceFlush();
+    } catch {
+      // swallow export errors
+    }
+    try {
+      await sdkLoggerProvider.shutdown();
+    } catch {
+      // swallow shutdown errors
+    }
+  };
+
+  return { meter, loggerProvider, shutdown };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,25 @@ import { ConfigWatcher } from './core/config-watcher.js';
 import { registerSignalHandlers } from './core/signals.js';
 import { createLogger } from './core/logger.js';
 import { composeWorkflowRuntime } from './core/runtime-composition.js';
+import { initTelemetry } from './core/telemetry.js';
 import { join } from 'node:path';
 
-const logger = createLogger('cli');
+const telemetry = initTelemetry();
+const logger = createLogger('cli', { loggerProvider: telemetry.loggerProvider });
 
 try {
   const args = parseArgs(process.argv.slice(2));
 
   if (args.help) {
     printUsage();
+    await telemetry.shutdown();
     process.exit(0);
   }
 
   if (args.command === 'init') {
     const repoPath = args.repoPath || process.cwd();
     await runInit(repoPath);
+    await telemetry.shutdown();
     process.exit(0);
   }
 
@@ -43,6 +47,7 @@ try {
       { event: 'service.init_incomplete' },
       'Config is not set up. Run `autocatalyst init --repo <path>` to initialize.',
     );
+    await telemetry.shutdown();
     process.exit(1);
   }
 
@@ -56,6 +61,7 @@ try {
 
   if (missing.length > 0) {
     logger.warn({ event: 'config.env_missing', missing }, `Missing environment variables: ${missing.join(', ')}`);
+    await telemetry.shutdown();
     process.exit(1);
   }
 
@@ -72,6 +78,7 @@ try {
     repoPaths,
     env: process.env as Record<string, string | undefined>,
     logger,
+    meter: telemetry.meter,
   });
 
   const cleanupSignals = registerSignalHandlers(service);
@@ -95,12 +102,14 @@ try {
 
   service.start();
 
-  service.stopped.then(() => {
+  service.stopped.then(async () => {
     watcher.stop();
     cleanupSignals();
+    await telemetry.shutdown();
     process.exit(0);
   });
 } catch (err) {
   logger.error({ event: 'config.parse_error', error: String(err) }, String(err));
+  await telemetry.shutdown();
   process.exit(1);
 }

--- a/tests/core/logger-otel.test.ts
+++ b/tests/core/logger-otel.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Writable } from 'node:stream';
+import type { LoggerProvider } from '@opentelemetry/api-logs';
+
+describe('createLogger() OTel bridge', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('writes to stderr destination when no loggerProvider given', async () => {
+    const { createLogger } = await import('../../src/core/logger.js');
+    const chunks: Buffer[] = [];
+    const dest = new Writable({
+      write(chunk, _enc, cb) { chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)); cb(); },
+    });
+    const logger = createLogger('test-component', { destination: dest as unknown as import('pino').DestinationStream });
+    logger.info({ event: 'test.event' }, 'hello');
+    await new Promise(r => setImmediate(r));
+    const output = Buffer.concat(chunks).toString();
+    expect(output).toContain('test-component');
+    expect(output).toContain('test.event');
+  });
+
+  it('calls OTel emit when live loggerProvider is provided', async () => {
+    const emitMock = vi.fn();
+    const fakeOtelLogger = { emit: emitMock };
+    const fakeLoggerProvider = {
+      getLogger: vi.fn().mockReturnValue(fakeOtelLogger),
+    } as unknown as LoggerProvider;
+
+    const { createLogger } = await import('../../src/core/logger.js');
+    const chunks: Buffer[] = [];
+    const dest = new Writable({
+      write(chunk, _enc, cb) { chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)); cb(); },
+    });
+    const logger = createLogger('test-component', {
+      destination: dest as unknown as import('pino').DestinationStream,
+      loggerProvider: fakeLoggerProvider,
+    });
+    logger.info({ event: 'test.otel' }, 'otel message');
+    // Give pino multistream time to flush to both streams
+    await new Promise(r => setTimeout(r, 50));
+    // Should still write to primary destination
+    const output = Buffer.concat(chunks).toString();
+    expect(output).toContain('test.otel');
+    // Should also call OTel emit
+    expect(emitMock).toHaveBeenCalledOnce();
+    const record = emitMock.mock.calls[0][0];
+    expect(record.body).toBe('otel message');
+    expect(record.severityNumber).toBe(9); // info = 9
+  });
+
+  it('maps pino level numbers to correct OTel SeverityNumber', async () => {
+    const emitMock = vi.fn();
+    const fakeLoggerProvider = {
+      getLogger: vi.fn().mockReturnValue({ emit: emitMock }),
+    } as unknown as LoggerProvider;
+
+    const { createLogger } = await import('../../src/core/logger.js');
+    const dest = new Writable({ write(_c, _e, cb) { cb(); } });
+    const logger = createLogger('test-sev', {
+      destination: dest as unknown as import('pino').DestinationStream,
+      loggerProvider: fakeLoggerProvider,
+    });
+
+    logger.warn({ event: 'test.warn' }, 'warn message');
+    await new Promise(r => setTimeout(r, 50));
+    expect(emitMock).toHaveBeenCalledOnce();
+    expect(emitMock.mock.calls[0][0].severityNumber).toBe(13); // warn = 13
+  });
+});

--- a/tests/core/telemetry.test.ts
+++ b/tests/core/telemetry.test.ts
@@ -32,9 +32,9 @@ describe('initTelemetry()', () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = 'http://127.0.0.1:1';
     process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://127.0.0.1:1';
     const { initTelemetry } = await import('../../src/core/telemetry.js');
-    expect(() => initTelemetry()).not.toThrow();
-    const handles = initTelemetry();
-    await expect(handles.shutdown()).resolves.not.toThrow();
+    let handles: Awaited<ReturnType<typeof initTelemetry>>;
+    expect(() => { handles = initTelemetry(); }).not.toThrow();
+    await expect(handles!.shutdown()).resolves.not.toThrow();
   });
 
   it('returns a loggerProvider that does not throw when emitting', async () => {

--- a/tests/core/telemetry.test.ts
+++ b/tests/core/telemetry.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('initTelemetry()', () => {
+  beforeEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+  });
+
+  it('returns callable no-op meter when env vars are unset', async () => {
+    const { initTelemetry } = await import('../../src/core/telemetry.js');
+    const { meter, shutdown } = initTelemetry();
+    const counter = meter.createCounter('test.counter');
+    expect(() => counter.add(1)).not.toThrow();
+    await shutdown();
+  });
+
+  it('returns callable no-op histogram when env vars are unset', async () => {
+    const { initTelemetry } = await import('../../src/core/telemetry.js');
+    const { meter, shutdown } = initTelemetry();
+    const hist = meter.createHistogram('test.hist');
+    expect(() => hist.record(42)).not.toThrow();
+    await shutdown();
+  });
+
+  it('does not throw on construction with non-reachable endpoint', async () => {
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = 'http://127.0.0.1:1';
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://127.0.0.1:1';
+    const { initTelemetry } = await import('../../src/core/telemetry.js');
+    expect(() => initTelemetry()).not.toThrow();
+    const handles = initTelemetry();
+    await expect(handles.shutdown()).resolves.not.toThrow();
+  });
+
+  it('returns a loggerProvider that does not throw when emitting', async () => {
+    const { initTelemetry } = await import('../../src/core/telemetry.js');
+    const { loggerProvider, shutdown } = initTelemetry();
+    const otelLogger = loggerProvider.getLogger('test');
+    expect(() => otelLogger.emit({ body: 'hello', severityNumber: 9 })).not.toThrow();
+    await shutdown();
+  });
+});

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,0 +1,22 @@
+sources:
+  docker_logs:
+    type: docker_logs
+    include_labels:
+      com.docker.compose.project: autocatalyst
+
+transforms:
+  parse_json:
+    type: remap
+    inputs: [docker_logs]
+    source: |
+      . = parse_json!(.message) ?? .
+
+sinks:
+  victorialogs:
+    type: http
+    inputs: [parse_json]
+    uri: "http://victorialogs:9428/insert/jsonline?_stream_fields=component,level"
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited


### PR DESCRIPTION
Implemented VictoriaMetrics Backend Integration and Operational Dashboard. Added OpenTelemetry SDK (metrics + logs) to the service with a no-op/live dual path driven by two env vars. New src/core/telemetry.ts initializes MeterProvider and LoggerProvider; src/core/logger.ts fans pino output to both stderr and OTel via multistream; src/index.ts calls initTelemetry() at startup and shutdownTelemetry() on all exit paths. OrchestratorImpl records run.started, run.completed, and stage.duration metrics; ClaudeAgentSdkAgentRunner records agent.turns and adapter.latency. A Docker Compose stack (VictoriaMetrics v1.142.0, VictoriaLogs v1.50.0, Vector 0.55.0-alpine) ships at the repo root with a Vector log-forwarding pipeline. A vmui dashboard preset (ops/victoriametrics-dashboard.json) covers five operational panels. Operator guide at context-human/wiki/observability.md; logging standards updated with OTLP env var reference. All 808 tests pass.

## Testing

Branch: spec/dff15d59-8078-427f-bf98-bf2d73358be4
Setup: npm install && npm run build (or npm test to run tests directly)
Test: 
1. Unit tests: npm test — all 808 tests should pass
2. No-op path: start the service without OTEL env vars set — behavior identical to before, pino writes to stderr only
3. Live path: docker compose up -d, then run autocatalyst — metrics appear in VictoriaMetrics at http://localhost:8428/vmui, logs appear in VictoriaLogs at http://localhost:9428/select/logsql/query
4. Dashboard: ops/victoriametrics-dashboard.json loads automatically via -vmui.customDashboardsPath
5. Operator guide: follow context-human/wiki/observability.md from scratch to validate the setup flow

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/02495306-51b2-4d72-81e2-deb992abc82f/.autocatalyst/triage/triage-chore-victoriametrics-backend.md`
Closes #100