### PR TITLE
feat: add OpenAI Agent SDK runner

### DIFF
--- a/context-human/specs/feature-openai-agent-sdk-runner.md
+++ b/context-human/specs/feature-openai-agent-sdk-runner.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-10
 last_updated: 2026-05-11
-status: implementing
+status: complete
 issue: 112
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/context-human/specs/feature-openai-agent-sdk-runner.md
+++ b/context-human/specs/feature-openai-agent-sdk-runner.md
@@ -1,0 +1,615 @@
+---
+created: 2026-05-10
+last_updated: 2026-05-11
+status: implementing
+issue: 112
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+# OpenAI Agent SDK Runner
+
+## What
+
+The OpenAI Agent SDK Runner adds a new agent runner class to Autocatalyst's adapter layer — one that drives the OpenAI Agents SDK (`@openai/agents`) instead of the Claude Agent SDK. When a profile in `autocatalyst.yaml` specifies `runner: ``openai_agent_sdk`, this runner handles all agent tasks: it accepts an `AgentRunRequest`, selects and materializes only the runtime skills required for the current route, drives the OpenAI Agents SDK loop, and streams the resulting events as `AgentRunEvent`.
+The runner works with any service that speaks the OpenAI Agents API: OpenAI's hosted API, Azure OpenAI deployments, or any self-hosted compatible endpoint. For Azure APIM and Grove deployments that require the `api-key` request header in place of `Authorization: Bearer`, the runner applies the same header override as `OpenAIDirectModelRunner`.
+## Why
+
+Issue #105 defines `openai_agent_sdk` as a valid `RunnerKind` in `src/types/config.ts`, and the config types already include it. Issue #89 introduced the `runtime-skills/` catalog so skills can be resolved without a local Claude installation. But `composeBuiltInWorkflowRuntime` in `runtime-composition.ts` unconditionally constructs `ClaudeAgentSdkAgentRunner` regardless of which runner the resolved profile declares. Any operator who configures an `openai_agent_sdk` profile today gets Claude's agent behavior regardless, and there is no path to run agent tasks through an OpenAI-protocol endpoint.
+This matters for teams that:
+- Route all AI traffic through Grove (Azure APIM), which exposes an OpenAI-compatible API
+- Prefer GPT-family models for agent tasks such as spec writing and implementation
+- Operate under policies that prohibit direct Anthropic API calls
+- Want to evaluate OpenAI models for autonomous coding work alongside existing Claude deployments
+Closing this gap makes `openai_agent_sdk` a fully functional runner kind, completing the multi-vendor agent routing capability that the config schema has promised since #105.
+## Personas
+
+- **Enzo: Engineer** — configures and maintains Autocatalyst; wants to route spec writing and implementation tasks to a GPT-family model through Grove without changing the rest of the workflow loop or breaking existing Anthropic routes.
+## Narratives
+
+### Routing spec creation through Grove
+
+Enzo's organization routes all external AI traffic through Grove, an internal Azure APIM gateway that exposes an OpenAI-compatible API. He wants Autocatalyst to generate specs using a GPT-family model. He opens `autocatalyst.yaml`, adds a `grove-key` credential with his Grove API key, adds a `grove` endpoint with `base_url: https://grove.internal/openai`, and creates a `spec-gpt4o` profile with `runner: openai_agent_sdk` and `model: gpt-4o`. He updates `routing.artifact.create` to `spec-gpt4o`. Autocatalyst restarts, validates the config, logs `"Using OpenAI Agents SDK"`, and begins routing spec creation through Grove. The spec is generated using the `mm:planning` skill loaded from the `runtime-skills/` catalog. Nothing else in the loop changes.
+### Running implementation on OpenAI direct
+
+Enzo wants to evaluate GPT-4o for implementation tasks alongside the existing Claude setup. He adds an `openai-key` credential, an `openai` endpoint with no `base_url`, and an `impl-gpt4o` profile with `runner: openai_agent_sdk`, `model: gpt-4o`, and `reasoning_effort: high`. He updates `routing.implementation.run` to `impl-gpt4o`. Autocatalyst builds `OpenAIAgentSdkAgentRunner` for this profile and runs implementation requests through it, loading `superpowers:writing-plans` and `superpowers:subagent-driven-development` from the catalog. Claude handles all other routes unchanged.
+## User stories
+
+**Routing agent tasks through Grove**
+- Enzo can configure an `openai_agent_sdk` profile in `autocatalyst.yaml` with a Grove endpoint and start the service without errors
+- Enzo can route `artifact.create` to an `openai_agent_sdk` profile and receive a correctly structured spec
+- Enzo sees `"Using OpenAI Agents SDK"` logged at startup when an `openai_agent_sdk` profile is configured
+- Enzo sees a clear, actionable startup error when the API key credential for an `openai_agent_sdk` profile is missing or unresolved
+**Routing implementation through OpenAI direct**
+- Enzo can route `implementation.run` to an `openai_agent_sdk` profile and have `superpowers:writing-plans` and `superpowers:subagent-driven-development` loaded from the catalog automatically
+- Enzo can set `base_url` on an `openai_agent_sdk` endpoint and have the `api-key` header applied automatically, with no extra config
+**Skill handling**
+- Routes with no required skills (`question.answer`, `intent.classify`, `pr.title_generate`, `artifact.revise`) run without skill setup
+- A missing catalog entry or missing skill file produces a clear error at run time before the SDK loop starts, not a silent failure mid-run
+## Goals
+
+- `OpenAIAgentSdkAgentRunner.run()` accepts `AgentRunRequest`, materializes only the runtime skills required for the route, drives the OpenAI Agents SDK loop, and streams well-formed `AgentRunEvent`
+- `buildAgentRunner` in `runtime-composition.ts` dispatches on the runner kind declared by the resolved profile: returns `OpenAIAgentSdkAgentRunner` when the profile's runner is `openai_agent_sdk`, returns `ClaudeAgentSdkAgentRunner` when the profile's runner is `claude_agent_sdk`, and throws a clear startup error for any other runner kind — there is no default
+- Route-to-skill mapping is applied at run time based on route and intent: `artifact.create/idea` → `mm:planning`; `artifact.create/bug|chore` and `issue.triage` → `mm:issue-triage`; `implementation.run` → `superpowers:writing-plans` + `superpowers:subagent-driven-development`; all others → no skills
+- `SandboxAgent` (currently in beta in `@openai/agents`) is the preferred skill-passing mechanism: `OpenAIRuntimeSkillMaterializer` must use `SandboxAgent`'s native `capabilities` API to pass skills as first-class objects rather than injecting raw `SKILL.md` text into system instructions; this enables proper sandboxed execution and tool exposure as designed by the `@openai/agents` SDK
+- The runner emits OTLP telemetry on every run: `autocatalyst.agent.turns` (counter), `autocatalyst.agent.runs` (counter with `outcome` attribute), and `autocatalyst.adapter.latency` (histogram), using `component: 'openai-agent-sdk'` to match the metric naming conventions of `ClaudeAgentSdkAgentRunner`
+- Grove/Azure APIM compatibility: when the resolved endpoint has a `base_url`, the `api-key` header is set on all requests
+- Missing catalog entries or files produce a clear error before the SDK loop starts
+- `tsc --noEmit` passes after all changes
+## Non-goals
+
+- A composite agent runner that dispatches per-request across both Claude and OpenAI runner kinds (a valid future enhancement, not in scope here)
+- Streaming responses for direct model tasks (handled by `OpenAIDirectModelRunner`)
+- The direct OpenAI runner (`openai_direct`, covered by #111)
+- Hot-swapping runner configuration without a restart
+- IAM or workload identity credential types (only `api_key` is supported for `openai_agent_sdk`)
+- OpenAI fine-tuned models or assistants API
+## Design spec
+
+*(Not applicable — no UI elements)*
+## Tech spec
+
+### 1. Introduction and overview
+
+**Dependencies**
+- Issue #105 — complete; `RunnerKind` in `src/types/config.ts` already includes `openai_agent_sdk`
+- Issue #111 — complete; `OpenAIDirectModelRunner` establishes the Grove/api-key header pattern; reuse its construction logic
+- Issue #89 — complete; `runtime-skills/` catalog, `resolveRuntimeSkillRefs`, and `materializeClaudeRuntimeSkillPlugins` are available and tested
+- `src/types/ai.ts` — `AgentRunner`, `AgentRunRequest`, `AgentRunEvent`, `AgentSkillRef`
+- `src/types/config.ts` — `ProfileConfig.runner: RunnerKind`, `EndpointConfig.base_url`, `CredentialConfig`
+- `src/adapters/runtime-composition.ts` — `composeBuiltInWorkflowRuntime` is the wiring point
+- `@openai/agents` npm package — not yet a dependency; must be added
+- `openai` npm package — already a dependency (`^6.37.0`); reuse for client construction
+**Technical goals**
+- `OpenAIAgentSdkAgentRunner` implements `AgentRunner` with an injectable `runFn` for testing (same pattern as `ClaudeAgentSdkAgentRunner.queryFn`)
+- Route-based skill resolution is a pure function: given a route and optional intent, return the list of `AgentSkillRef` values required — no I/O, fully testable
+- `buildAgentRunner` mirrors `buildDirectModelRunner` in structure: inspects the resolved profile's runner kind and dispatches accordingly — `openai_agent_sdk` → `OpenAIAgentSdkAgentRunner`, `claude_agent_sdk` → `ClaudeAgentSdkAgentRunner`, any other kind → startup error
+- Grove/Azure APIM support reuses the same `api-key` defaultHeaders pattern from `OpenAIDirectModelRunner`; no new config fields
+**Non-goals (technical)**
+- No new config schema fields
+- No database, state, or storage changes
+- No changes to `AgentRoutingPolicy`, `AgentRunnerArtifactAuthoringAgent`, or other agent service classes — they accept `AgentRunner` by interface
+**Glossary**
+- **`@openai/agents`** — the OpenAI TypeScript SDK for building agentic AI applications
+- **`SandboxAgent`** — beta feature in `@openai/agents` providing isolated Unix-like execution environments with filesystems, shell access, and a native `capabilities` API for passing skills as first-class objects
+- **skill materialization** — the process of reading runtime skill content from the catalog and converting it into a form the runner can use (via `SandboxAgent` capabilities or instruction-injection)
+- **`openai_agent_sdk`** — the runner kind for agent (multi-turn, tool-using) calls via the OpenAI Agents SDK
+- **Grove** — Azure APIM gateway for AI traffic; uses `api-key` header instead of `Authorization: Bearer`
+- **`runFn`** — injected function wrapping the SDK agent loop; used in tests to avoid real HTTP calls
+### 2. System design and architecture
+
+**High-level architecture**
+```mermaid
+graph TD
+  RC[runtime-composition.ts\nbuildAgentRunner] -->|openai_agent_sdk profile| OA[OpenAIAgentSdkAgentRunner]
+  RC -->|claude_agent_sdk profile| CA[ClaudeAgentSdkAgentRunner]
+  RC -->|unknown runner kind| ERR[startup error]
+  OA -->|implements| AR[AgentRunner interface]
+  CA -->|implements| AR
+  AR --> AAA[AgentRunnerArtifactAuthoringAgent]
+  AR --> AIA[AgentRunnerImplementationAgent]
+  AR --> AITA[AgentRunnerIssueTriageAgent]
+  AR --> AQAA[AgentRunnerQuestionAnsweringAgent]
+  OA --> SM[OpenAIRuntimeSkillMaterializer]
+  SM --> CAT[runtime-skills/ catalog]
+  OA --> SDK[@openai/agents SDK]
+  SDK --> API[OpenAI / Grove / Azure APIM]
+```
+**Component breakdown**
+
+Component
+Status
+Change
+
+`src/adapters/openai/agent-sdk-agent-runner.ts`
+New
+`OpenAIAgentSdkAgentRunner` class
+
+`src/adapters/openai/openai-runtime-skill-materializer.ts`
+New
+Converts `AgentSkillRef[]` to OpenAI Agents SDK skill form
+
+`src/adapters/runtime-composition.ts`
+Modified
+`buildAgentRunner` function; dispatch in `composeBuiltInWorkflowRuntime`
+
+`tests/adapters/openai/agent-sdk-agent-runner.test.ts`
+New
+Unit tests for `OpenAIAgentSdkAgentRunner`
+
+`tests/adapters/openai/openai-runtime-skill-materializer.test.ts`
+New
+Unit tests for the materializer
+
+`package.json`
+Modified
+Add `@openai/agents` dependency
+
+**Sequence diagram — spec creation via openai_agent_sdk**
+```mermaid
+sequenceDiagram
+  participant AAA as AgentRunnerArtifactAuthoringAgent
+  participant RP as DefaultAgentRoutingPolicy
+  participant OA as OpenAIAgentSdkAgentRunner
+  participant SM as OpenAIRuntimeSkillMaterializer
+  participant CAT as runtime-skills/
+  participant SDK as @openai/agents
+  participant API as OpenAI / Grove
+
+  AAA->>RP: resolve({ task: 'artifact.create', intent: 'idea' })
+  RP-->>AAA: profile (runner: openai_agent_sdk, model: gpt-4o)
+  AAA->>OA: run({ route, profile, working_directory, prompt })
+  OA->>OA: skillRefsForRoute(route) → ['mm:planning']
+  OA->>SM: materialize(['mm:planning'])
+  SM->>CAT: resolveRuntimeSkillRefs(['mm:planning'])
+  CAT-->>SM: resolved skill content (SKILL.md + dependencies)
+  SM-->>OA: materialized skill (SandboxAgent capability object)
+  OA->>SDK: run(agent with materialized skills, prompt)
+  SDK->>API: agent loop requests
+  API-->>SDK: events
+  SDK-->>OA: RunResultStreaming events
+  OA-->>AAA: yield AgentRunEvent (normalized)
+```
+### 3. Detailed design
+
+#### `skillRefsForRoute` — route-to-skill mapping
+
+This is a pure function that returns the skill refs required for a given route. It lives in `src/adapters/openai/agent-sdk-agent-runner.ts`.
+```typescript
+export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
+  if (route.task === 'implementation.run') {
+    return ['superpowers:writing-plans', 'superpowers:subagent-driven-development'];
+  }
+  if (route.task === 'issue.triage') {
+    return ['mm:issue-triage'];
+  }
+  if (route.task === 'artifact.create') {
+    if (route.intent === 'idea') return ['mm:planning'];
+    if (route.intent === 'bug' || route.intent === 'chore') return ['mm:issue-triage'];
+  }
+  return [];
+}
+```
+Routes that return no skills: `question.answer`, `intent.classify`, `pr.title_generate`, `artifact.revise`, and any `artifact.create` without a recognized intent.
+#### `OpenAIRuntimeSkillMaterializer`
+
+File: `src/adapters/openai/openai-runtime-skill-materializer.ts`
+Skills are sourced exclusively from the `runtime-skills/` catalog introduced by issue #89. The runner does not rely on Claude plugin directories, user-local Claude settings, or prompt-only skill references.
+The materializer must use `SandboxAgent`'s native `capabilities` API (beta in `@openai/agents/sandbox`) to pass skills as first-class objects. `SandboxAgent` accepts a `capabilities` array including `skills({ from: ... })` entries that map to individual `Skill` objects with `name`, `description`, and `content` (the `SKILL.md` file). This is the correct mechanism — injecting raw `SKILL.md` text into system instructions is the fallback only when `SandboxAgent` is not available for a given execution path.
+The implementer must consult the installed `@openai/agents` TypeScript types for the exact `Skill` and `skills()` signatures, as the API is in beta and details may change. The interface below is illustrative; return type and call sites should reflect the actual SDK types.
+Key behaviors:
+- Returns an empty capabilities array for an empty refs array — no I/O in the no-skills case
+- `resolveRuntimeSkillRefs` already validates that every ref is declared in the manifest and that every `SKILL.md` exists; it throws a clear error if not
+- Skill content is passed in dependency-resolved order (dependencies before dependents, as guaranteed by the catalog traversal in `resolveSkill`)
+- Only skills declared as required for the current route are loaded
+Illustrative interface (adjust types to match installed SDK):
+```typescript
+import { skills as sdkSkills, type Skill } from '@openai/agents/sandbox';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveRuntimeSkillRefs } from '../../core/runtime-skills/catalog.js';
+import type { AgentSkillRef } from '../../types/ai.js';
+
+export interface OpenAIRuntimeSkillMaterializerOptions {
+  rootDir?: string;
+}
+
+export async function materializeOpenAIRuntimeSkills(
+  refs: AgentSkillRef[],
+  options?: OpenAIRuntimeSkillMaterializerOptions,
+) {
+  if (refs.length === 0) return [];
+
+  const resolved = resolveRuntimeSkillRefs(refs, { rootDir: options?.rootDir });
+  const skillObjects: Skill[] = [];
+
+  for (const provider of resolved.providers) {
+    for (const skill of provider.skills) {
+      const skillMdPath = join(skill.sourcePath, 'SKILL.md');
+      const content = readFileSync(skillMdPath, 'utf-8');
+      skillObjects.push({
+        name: skill.ref,
+        description: `Runtime skill: ${skill.ref}`,
+        content,
+      });
+    }
+  }
+
+  return [sdkSkills({ skills: skillObjects })];
+}
+```
+#### `OpenAIAgentSdkAgentRunner`
+
+File: `src/adapters/openai/agent-sdk-agent-runner.ts`
+```typescript
+import { Agent, SandboxAgent, run as _run } from '@openai/agents';
+import OpenAI from 'openai';
+import { performance } from 'node:perf_hooks';
+import { metrics } from '@opentelemetry/api';
+import type { Counter, Histogram, Meter } from '@opentelemetry/api';
+import type { AgentRunEvent, AgentRunRequest, AgentRunner, AgentSkillRef } from '../../types/ai.js';
+import { materializeOpenAIRuntimeSkills } from './openai-runtime-skill-materializer.js';
+import { skillRefsForRoute } from './agent-sdk-agent-runner.js';
+
+type RunFn = typeof _run;
+
+export interface OpenAIAgentSdkAgentRunnerOptions {
+  runFn?: RunFn;
+  materializeSkills?: (refs: AgentSkillRef[]) => Promise;
+  meter?: Meter;
+}
+
+export class OpenAIAgentSdkAgentRunner implements AgentRunner {
+  private readonly runFn: RunFn;
+  private readonly materializeSkills: (refs: AgentSkillRef[]) => Promise;
+  private readonly _agentTurns: Counter;
+  private readonly _adapterLatency: Histogram;
+  private readonly _agentRunOutcome: Counter;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl: string | undefined,
+    private readonly defaultModel: string | undefined,
+    options?: OpenAIAgentSdkAgentRunnerOptions,
+  ) {
+    this.runFn = options?.runFn ?? _run;
+    this.materializeSkills =
+      options?.materializeSkills ?? materializeOpenAIRuntimeSkills;
+    const meter = options?.meter ?? metrics.getMeter('autocatalyst');
+    this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
+      unit: '{turn}',
+      description: 'Agent turns yielded',
+    });
+    this._adapterLatency = meter.createHistogram('autocatalyst.adapter.latency', {
+      unit: 'ms',
+      description: 'Latency of adapter operations',
+    });
+    this._agentRunOutcome = meter.createCounter('autocatalyst.agent.runs', {
+      unit: '{run}',
+      description: 'Agent runs completed, by outcome',
+    });
+  }
+
+  async *run(request: AgentRunRequest): AsyncIterable {
+    const model = request.profile?.model ?? this.defaultModel ?? 'gpt-4o';
+    const refs = skillRefsForRoute(request.route);
+    const skillCapabilities = await this.materializeSkills(refs);
+
+    const clientOptions: ConstructorParameters[0] = { apiKey: this.apiKey };
+    if (this.baseUrl) {
+      clientOptions.baseURL = this.baseUrl;
+      clientOptions.defaultHeaders = { 'api-key': this.apiKey };
+    }
+
+    const baseInstructions = [
+      'You are an AI agent for software development automation.',
+      'Work in the provided working directory.',
+      request.working_directory ? `Working directory: ${request.working_directory}` : '',
+    ].filter(Boolean).join('\n');
+
+    // SandboxAgent is preferred when skills are required; Agent is used for skill-free routes.
+    // Implementer must verify the SandboxAgent constructor signature against installed SDK types.
+    const agent = skillCapabilities.length > 0
+      ? new SandboxAgent({
+          name: 'autocatalyst-agent',
+          model,
+          instructions: baseInstructions,
+          capabilities: skillCapabilities,
+        })
+      : new Agent({
+          name: 'autocatalyst-agent',
+          model,
+          instructions: baseInstructions,
+        });
+
+    const startMs = performance.now();
+    let outcome: 'success' | 'error' = 'success';
+
+    try {
+      const stream = await this.runFn(agent, request.prompt);
+      for await (const event of stream) {
+        const normalized = normalizeOpenAIEvent(event);
+        if (normalized) {
+          if (normalized.type === 'assistant') {
+            this._agentTurns.add(1, { component: 'openai-agent-sdk', model });
+          }
+          yield normalized;
+        }
+      }
+    } catch (err) {
+      outcome = 'error';
+      throw err;
+    } finally {
+      this._agentRunOutcome.add(1, { component: 'openai-agent-sdk', model, outcome });
+      this._adapterLatency.record(performance.now() - startMs, {
+        adapter: 'agent-sdk',
+        operation: 'run',
+        model,
+      });
+    }
+  }
+}
+
+function normalizeOpenAIEvent(event: unknown): AgentRunEvent | null {
+  // Map @openai/agents streaming events to AgentRunEvent.
+  // Events with a text content payload map to type: 'assistant'.
+  // Other event types (tool calls, handoffs, etc.) map to their event type with raw payload.
+  if (!event || typeof event !== 'object') return null;
+  const e = event as Record;
+  if (e.type === 'message_output_item' || e.type === 'agent_updated_stream_event') {
+    const content = extractTextContent(e);
+    if (content !== null) {
+      return { type: 'assistant', content: [{ type: 'text', text: content }] };
+    }
+  }
+  if (typeof e.type === 'string') {
+    return { type: e.type, ...e };
+  }
+  return null;
+}
+
+function extractTextContent(event: Record): string | null {
+  // Walk common OpenAI Agents SDK event shapes to find text output
+  const item = event.item as Record | undefined;
+  if (!item) return null;
+  if (item.type === 'message' && Array.isArray(item.content)) {
+    const textBlock = (item.content as Record[]).find(b => b.type === 'output_text');
+    if (textBlock && typeof textBlock.text === 'string') return textBlock.text;
+  }
+  return null;
+}
+```
+**Important notes on the event mapping:**
+The `@openai/agents` SDK event shapes must be verified against the actual SDK version installed. The `normalizeOpenAIEvent` and `extractTextContent` implementations above are illustrative; the implementer must consult the SDK's TypeScript types for the correct event shape. The invariant that must hold: any event containing text output from the model must yield `{ type: 'assistant', content: [{ type: 'text', text: '...' }] }`.
+#### `buildAgentRunner` in `runtime-composition.ts`
+
+`buildAgentRunner` dispatches on the runner kind declared by the resolved profile. It does not default to any runner — if the profile's runner kind is unrecognized, it throws a startup error. This ensures misconfigured environments fail fast rather than silently running the wrong runner.
+`composeBuiltInWorkflowRuntime` replaces:
+```typescript
+const agentRunner = new ClaudeAgentSdkAgentRunner({ meter: options.meter });
+```
+with:
+```typescript
+const agentRunner = buildAgentRunner(resolvedAi, logger, options.meter);
+```
+`buildAgentRunner` implementation:
+```typescript
+export function buildAgentRunner(
+  resolvedAi: ResolvedAiConfig,
+  logger: RuntimeLogger,
+  meter?: Meter,
+): AgentRunner {
+  const claudeProfile = resolvedAi.profiles.find(p => p.runner === 'claude_agent_sdk');
+  if (claudeProfile) {
+    return new ClaudeAgentSdkAgentRunner({ meter });
+  }
+
+  const openAiAgentProfile = resolvedAi.profiles.find(p => p.runner === 'openai_agent_sdk');
+  if (openAiAgentProfile) {
+    const endpoint = resolvedAi.endpoints.find(e => e.name === openAiAgentProfile.endpoint)!;
+    const credential = resolvedAi.credentials.find(c => c.name === endpoint.credential)!;
+
+    if (credential.type !== 'api_key') {
+      throw new Error(
+        `Credential type '${credential.type}' is not supported for openai_agent_sdk runner`,
+      );
+    }
+
+    logger.info(
+      {
+        event: 'service.config',
+        provider: 'openai',
+        runner: 'openai_agent_sdk',
+        model: openAiAgentProfile.model ?? 'default',
+        base_url: endpoint.base_url ?? 'default',
+      },
+      'Using OpenAI Agents SDK',
+    );
+
+    return new OpenAIAgentSdkAgentRunner(
+      credential.resolvedValue!,
+      endpoint.base_url,
+      openAiAgentProfile.model,
+      { meter },
+    );
+  }
+
+  const runnerKinds = resolvedAi.profiles.map(p => p.runner).join(', ') || 'none';
+  throw new Error(
+    `No recognized agent runner configured. Expected a profile with runner: claude_agent_sdk or openai_agent_sdk. Found: ${runnerKinds}`,
+  );
+}
+```
+Profile lookup: `claude_agent_sdk` is checked first to preserve current behavior when the config has only Claude profiles. `openai_agent_sdk` is checked next. Any other runner kind — or a config with no agent runner profiles — throws a clear startup error. Mixed configs (some routes on Claude, some on OpenAI) are a non-goal for this feature.
+**No data model or API contract changes** — this feature adds no new HTTP endpoints, database tables, or schema migrations.
+### 4. Security, privacy, and compliance
+
+- API keys are injected via environment variables and resolved by `resolveAiConfig` before `buildAgentRunner` runs; the runner never reads env directly
+- The `api-key` header value is identical to the API key credential — no new credential surface is introduced
+- API keys are never logged; the `service.config` log event records only `provider`, `runner`, `model`, and `base_url`
+- No user-generated content is stored by the runner; the agent loop is fire-and-forget
+- Runtime skill content ([SKILL.md](http://SKILL.md) files) is read from the local `runtime-skills/` directory and passed to the agent as `SandboxAgent` capability objects; it is never sent to external logging or storage
+### 5. Observability
+
+The runner emits the same three OTLP metrics as `ClaudeAgentSdkAgentRunner`, with `component: 'openai-agent-sdk'` as the differentiating attribute:
+
+Metric
+Type
+Attributes
+
+`autocatalyst.agent.turns`
+Counter
+`component`, `model`
+
+`autocatalyst.agent.runs`
+Counter
+`component`, `model`, `outcome`
+
+`autocatalyst.adapter.latency`
+Histogram (ms)
+`adapter: 'agent-sdk'`, `operation: 'run'`, `model`
+
+One `service.config` log event is emitted at startup: `{ event: 'service.config', provider: 'openai', runner: 'openai_agent_sdk', model, base_url }` at `INFO` level.
+### 6. Testing plan
+
+**Unit tests — ****`skillRefsForRoute`** (`tests/adapters/openai/agent-sdk-agent-runner.test.ts`)
+- Returns `['mm:planning']` for `{ task: 'artifact.create', intent: 'idea' }`
+- Returns `['mm:issue-triage']` for `{ task: 'artifact.create', intent: 'bug' }`
+- Returns `['mm:issue-triage']` for `{ task: 'artifact.create', intent: 'chore' }`
+- Returns `['mm:issue-triage']` for `{ task: 'issue.triage' }`
+- Returns `['superpowers:writing-plans', 'superpowers:subagent-driven-development']` for `{ task: 'implementation.run' }`
+- Returns `[]` for `{ task: 'question.answer' }`, `{ task: 'artifact.revise' }`, `{ task: 'intent.classify' }`, `{ task: 'pr.title_generate' }`
+- Returns `[]` for `{ task: 'artifact.create' }` with no intent
+**Unit tests — ****`OpenAIAgentSdkAgentRunner`** (`tests/adapters/openai/agent-sdk-agent-runner.test.ts`)
+- `run()` calls `materializeSkills` with the skill refs for the route
+- `run()` calls `runFn` with a `SandboxAgent` (when skills are present) or `Agent` (when no skills) with the resolved model and instructions
+- `run()` yields `{ type: 'assistant', content: [...] }` events for model text output
+- `run()` sets `api-key` header when `baseUrl` is provided (verify via spy on agent model config)
+- `run()` uses `request.profile?.model` as model when set, falling back to `defaultModel`, then `'gpt-4o'`
+- Metrics: `autocatalyst.agent.turns` increments once per assistant event; `autocatalyst.agent.runs` records `outcome: 'success'` on clean exit and `outcome: 'error'` when `runFn` throws; `autocatalyst.adapter.latency` records a positive value
+All tests use mock `runFn` and mock `materializeSkills` — no real HTTP calls or file I/O.
+**Unit tests — ****`materializeOpenAIRuntimeSkills`** (`tests/adapters/openai/openai-runtime-skill-materializer.test.ts`)
+- Returns `[]` for an empty refs array
+- Returns a non-empty capabilities array containing the `SKILL.md` content for a resolved skill ref
+- Propagates errors from `resolveRuntimeSkillRefs` for unknown refs
+**Unit tests — ****`buildAgentRunner`** (extend `tests/adapters/runtime-composition.test.ts` or add new file)
+- Returns `ClaudeAgentSdkAgentRunner` when the resolved profile's runner is `claude_agent_sdk`
+- Returns `OpenAIAgentSdkAgentRunner` when the resolved profile's runner is `openai_agent_sdk`
+- Throws a clear startup error when no recognized runner kind is configured
+- Throws when the `openai_agent_sdk` profile uses a non-`api_key` credential
+- Logs `service.config` with correct provider, runner, model, and base_url
+### 7. Alternatives considered
+
+**Reusing ****`materializeClaudeRuntimeSkillPlugins`**** instead of a new materializer**
+The Claude materializer copies plugin directories to a temp location and returns `AgentPluginConfig[]` with local paths. The Claude Agent SDK loads these as plugins with their own tools and instructions. The OpenAI Agents SDK has no equivalent plugin-loading mechanism — it does not accept local plugin directories. A new materializer that reads [SKILL.md](http://SKILL.md) content and passes it via `SandboxAgent` capabilities is the correct abstraction. Rejected for reuse.
+**A composite runner that dispatches per-request across Claude and OpenAI**
+If the routing config maps some routes to `claude_agent_sdk` profiles and others to `openai_agent_sdk` profiles, a single runner cannot serve both. A `RoutingAwareAgentRunner` (similar to `RoutingAwareDirectModelRunner`) would hold one runner per kind and dispatch on `request.profile?.runner`. This is a valid future enhancement; for this feature, the simpler approach of picking one runner kind at startup is sufficient and matches the current usage pattern where all agent routes use the same model family. Mixed configs are a non-goal.
+**Using the ****`openai`**** npm package directly instead of ****`@openai/agents`**
+The `openai` SDK (`^6.37.0`) includes Responses API and Assistants API but does not provide a managed agent loop with tool execution and event streaming at the level the `@openai/agents` SDK does. Building an agent loop from scratch on the raw `openai` SDK would duplicate work the Agents SDK is designed to handle. Rejected in favor of `@openai/agents`.
+**Instruction-injection instead of ****`SandboxAgent`**** capabilities for skill passing**
+Concatenating `SKILL.md` content into system instructions works but bypasses the `@openai/agents` SDK's designed skill-passing mechanism. `SandboxAgent`'s `capabilities` API passes skills as first-class objects with name, description, and content — enabling proper tool exposure and sandboxed execution. The beta status means API details may change, but using the SDK-native path is correct and the implementer should pin to a tested version. Rejected in favor of `SandboxAgent` capabilities.
+### 8. Risks
+
+Risk
+Likelihood
+Mitigation
+
+`@openai/agents` TypeScript event shapes differ from the spec's assumptions
+Medium
+Implementer must consult the installed SDK's types; `normalizeOpenAIEvent` is explicitly marked as requiring verification against actual SDK types
+
+`SandboxAgent` beta API changes before this feature ships
+Medium
+Pin `@openai/agents` to a specific tested version; review release notes before upgrading. The skill-passing invariant (skills as first-class capability objects) is unlikely to change even if method signatures do
+
+Grove endpoint rejects requests despite correct `api-key` header
+Medium (runtime)
+Cannot be caught at startup; surfaced as a runtime error on first agent run. Document the Grove config pattern in the operator guide
+
+Mixed configs (some routes on Claude, some on OpenAI) silently route everything to one runner
+Low for current users
+Documented as a non-goal; `buildAgentRunner` uses the first matching runner kind found. Operators relying on mixed configs should wait for the composite runner feature
+
+`@openai/agents` version incompatibility with `openai ^6.37.0`
+Low
+Both packages are from OpenAI; check peer dependency requirements before pinning versions
+
+## Task list
+
+- [ ] **Story: Add the OpenAI Agents SDK package**
+	- [ ] **Task: Add ****`@openai/agents`**** package dependency**
+		- **Description**: Run `npm install @openai/agents` to add the package as a production dependency. Verify the installed version is compatible with the currently installed `openai ^6.37.0` (check peer dependency requirements). Confirm `tsc --noEmit` still passes after install.
+		- **Acceptance criteria**:
+			- [ ] `@openai/agents` appears in `package.json` `dependencies`
+			- [ ] `npm install` completes without errors or peer dependency conflicts
+			- [ ] `tsc --noEmit` passes after install
+		- **Dependencies**: None
+- [ ] **Story: Implement ****`skillRefsForRoute`**** and ****`OpenAIAgentSdkAgentRunner`**
+	- [ ] **Task: Implement ****`skillRefsForRoute`**
+		- **Description**: Create `src/adapters/openai/agent-sdk-agent-runner.ts`. Implement and export `skillRefsForRoute(route: AgentRoute): AgentSkillRef[]` as a pure function using the route-to-skill mapping table in the tech spec. No I/O, no imports from external packages.
+		- **Acceptance criteria**:
+			- [ ] Returns `['mm:planning']` for `artifact.create / intent: idea`
+			- [ ] Returns `['mm:issue-triage']` for `artifact.create / intent: bug` and `artifact.create / intent: chore`
+			- [ ] Returns `['mm:issue-triage']` for `issue.triage`
+			- [ ] Returns `['superpowers:writing-plans', 'superpowers:subagent-driven-development']` for `implementation.run`
+			- [ ] Returns `[]` for `question.answer`, `artifact.revise`, `intent.classify`, `pr.title_generate`, and `artifact.create` with no recognized intent
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Add `@openai/agents` package dependency
+	- [ ] **Task: Implement ****`materializeOpenAIRuntimeSkills`**
+		- **Description**: Create `src/adapters/openai/openai-runtime-skill-materializer.ts`. Use `SandboxAgent`'s native `capabilities` API from `@openai/agents/sandbox` — consult the installed TypeScript types for the exact `Skill` and `skills()` signatures. Call `resolveRuntimeSkillRefs`, read the `SKILL.md` for each resolved skill, construct a `Skill` object per entry, and return `[sdkSkills({ skills: [...] })]`. Return `[]` for an empty refs array. Let `resolveRuntimeSkillRefs` throw for missing catalog entries or files — do not catch.
+		- **Acceptance criteria**:
+			- [ ] Returns `[]` for an empty refs array (no file I/O)
+			- [ ] Returns a non-empty capabilities array containing each skill's content for valid refs
+			- [ ] Propagates errors from `resolveRuntimeSkillRefs` without wrapping
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Implement `skillRefsForRoute`
+	- [ ] **Task: Write unit tests for ****`skillRefsForRoute`**
+		- **Description**: Create `tests/adapters/openai/agent-sdk-agent-runner.test.ts`. Add a `describe('skillRefsForRoute')` block covering every route kind listed in the acceptance criteria above.
+		- **Acceptance criteria**:
+			- [ ] One test per route kind documented in the tech spec
+			- [ ] `vitest run` passes with no failures
+		- **Dependencies**: Task: Implement `skillRefsForRoute`
+	- [ ] **Task: Write unit tests for ****`materializeOpenAIRuntimeSkills`**
+		- **Description**: Create `tests/adapters/openai/openai-runtime-skill-materializer.test.ts`. Use a `rootDir` pointing to the actual `runtime-skills/` directory (integration-style) or stub `resolveRuntimeSkillRefs` (unit-style). Cover: empty refs returns `[]`, valid ref returns capabilities array containing expected skill content, invalid ref propagates error.
+		- **Acceptance criteria**:
+			- [ ] Test: empty refs → returns `[]`
+			- [ ] Test: valid skill ref → returned capabilities array contains the skill's `SKILL.md` content
+			- [ ] Test: unknown skill ref → error propagated
+			- [ ] `vitest run` passes with no failures
+		- **Dependencies**: Task: Implement `materializeOpenAIRuntimeSkills`
+	- [ ] **Task: Implement ****`OpenAIAgentSdkAgentRunner`**
+		- **Description**: In `src/adapters/openai/agent-sdk-agent-runner.ts`, implement `OpenAIAgentSdkAgentRunner` implementing `AgentRunner`. Constructor accepts `apiKey`, optional `baseUrl`, optional `defaultModel`, and `OpenAIAgentSdkAgentRunnerOptions` (injectable `runFn`, `materializeSkills`, `meter`). The `run()` method: (1) resolves skill refs via `skillRefsForRoute`; (2) calls `materializeSkills` to get `SandboxAgent` capability objects; (3) constructs an OpenAI client with `api-key` header override when `baseUrl` is set; (4) builds a `SandboxAgent` (with capabilities) when skills are present, or a plain `Agent` when no skills; (5) calls `runFn(agent, prompt)` and iterates the stream; (6) normalizes each event via `normalizeOpenAIEvent` and yields non-null results; (7) records telemetry counters and histogram. Implement `normalizeOpenAIEvent` — consult the installed `@openai/agents` TypeScript types for the correct event shapes and adjust from the illustrative design above.
+		- **Acceptance criteria**:
+			- [ ] `run()` calls `materializeSkills` with the correct refs for the route
+			- [ ] `run()` uses `SandboxAgent` with capabilities when skills are present, plain `Agent` otherwise
+			- [ ] `run()` yields `{ type: 'assistant', content }` for model text output events
+			- [ ] When `baseUrl` is set, the OpenAI client is constructed with `api-key` header
+			- [ ] Telemetry: turns counter increments on assistant events; runs counter records success/error; latency histogram records elapsed time
+			- [ ] `tsc --noEmit` passes
+		- **Dependencies**: Task: Implement `materializeOpenAIRuntimeSkills`; Task: Add `@openai/agents` package dependency
+	- [ ] **Task: Write unit tests for ****`OpenAIAgentSdkAgentRunner`**
+		- **Description**: Extend `tests/adapters/openai/agent-sdk-agent-runner.test.ts` with a `describe('OpenAIAgentSdkAgentRunner')` block. Use injectable `runFn` and `materializeSkills` to avoid real HTTP calls and file I/O. Cover all acceptance criteria from the testing plan in the tech spec.
+		- **Acceptance criteria**:
+			- [ ] Test: `run()` calls `materializeSkills` with skill refs matching the route
+			- [ ] Test: `run()` uses `SandboxAgent` when `materializeSkills` returns non-empty capabilities
+			- [ ] Test: `run()` yields `{ type: 'assistant', content }` for text output events
+			- [ ] Test: `api-key` header is set when `baseUrl` is provided
+			- [ ] Test: model resolves from `profile.model` → `defaultModel` → `'gpt-4o'`
+			- [ ] Test: turns counter increments once per assistant event
+			- [ ] Test: runs counter records `outcome: 'success'` on clean exit
+			- [ ] Test: runs counter records `outcome: 'error'` when `runFn` throws
+			- [ ] Test: latency histogram records a value
+			- [ ] `vitest run` passes with no failures
+		- **Dependencies**: Task: Implement `OpenAIAgentSdkAgentRunner`
+- [ ] **Story: Wire ****`openai_agent_sdk`**** into ****`runtime-composition.ts`**
+	- [ ] **Task: Implement ****`buildAgentRunner`**** and update ****`composeBuiltInWorkflowRuntime`**
+		- **Description**: In `src/adapters/runtime-composition.ts`: (1) Add `buildAgentRunner(resolvedAi, logger, meter?)` function that checks for a `claude_agent_sdk` profile first (returns `ClaudeAgentSdkAgentRunner`), then checks for an `openai_agent_sdk` profile (validates `api_key` credential, logs the `service.config` event, returns `OpenAIAgentSdkAgentRunner`), and throws a clear error if neither is found. (2) Replace the hardcoded `new ClaudeAgentSdkAgentRunner({ meter })` with `buildAgentRunner(resolvedAi, logger, options.meter)`. Import `OpenAIAgentSdkAgentRunner` from `./openai/agent-sdk-agent-runner.js`. Add `AgentRunner` to the imports from `../types/ai.js`.
+		- **Acceptance criteria**:
+			- [ ] `buildAgentRunner` returns `ClaudeAgentSdkAgentRunner` when the profile runner is `claude_agent_sdk`
+			- [ ] `buildAgentRunner` returns `OpenAIAgentSdkAgentRunner` when the profile runner is `openai_agent_sdk`
+			- [ ] Throws a clear startup error when no recognized runner kind is configured
+			- [ ] Throws a clear startup error when the `openai_agent_sdk` profile uses a non-`api_key` credential
+			- [ ] Logs `{ event: 'service.config', provider: 'openai', runner: 'openai_agent_sdk', model, base_url }` at INFO
+			- [ ] `tsc --noEmit` passes
+			- [ ] `vitest run` passes — no regressions in existing tests
+		- **Dependencies**: Task: Implement `OpenAIAgentSdkAgentRunner`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@anthropic-ai/sdk": "^0.88.0",
         "@aws-sdk/credential-providers": "^3.1029.0",
         "@notionhq/client": "^5.17.0",
+        "@openai/agents": "^0.11.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
         "@opentelemetry/exporter-logs-otlp-proto": "^0.217.0",
@@ -2948,6 +2949,72 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@openai/agents": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.11.1.tgz",
+      "integrity": "sha512-fk0WRLcwvuSSc+2zbfdXRZza14qbknOvEBudePncFHg6sR/QbIZxUy1TUpkc4ldqb5+h9Y6OABzA61roXSHjaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.11.1",
+        "@openai/agents-openai": "0.11.1",
+        "@openai/agents-realtime": "0.11.1",
+        "debug": "^4.4.0",
+        "openai": "^6.35.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.11.1.tgz",
+      "integrity": "sha512-R193y0WU7BJTlv68G3+09YZuMVXxVjVDNwcJZwkMCdt1cG2I6N4pcGPkRfMBUCcrbcqDoERK7CtpI1w6EdtvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.35.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.11.1.tgz",
+      "integrity": "sha512-QYf6eW1kbJtrUnvw8xHnEJIrYSKRuAFy6RJvS/7PZdIj1Repm6MfDPjMUYyIyS1JK0oH3m08q5N4aPjq4zjXFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.11.1",
+        "debug": "^4.4.0",
+        "openai": "^6.35.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.11.1.tgz",
+      "integrity": "sha512-mGZD92MJhp1TnmMTlud2THABelVQdIb/X+eAZis/vxiEltD9oJMjBelw9trRnnUjeqiJhRqej8arTh2wWvJQ+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.11.1",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@anthropic-ai/sdk": "^0.88.0",
     "@aws-sdk/credential-providers": "^3.1029.0",
     "@notionhq/client": "^5.17.0",
+    "@openai/agents": "^0.11.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
     "@opentelemetry/exporter-logs-otlp-proto": "^0.217.0",

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -1,0 +1,15 @@
+import type { AgentRoute, AgentSkillRef } from '../../types/ai.js';
+
+export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
+  if (route.task === 'implementation.run') {
+    return ['superpowers:writing-plans', 'superpowers:subagent-driven-development'];
+  }
+  if (route.task === 'issue.triage') {
+    return ['mm:issue-triage'];
+  }
+  if (route.task === 'artifact.create') {
+    if (route.intent === 'idea') return ['mm:planning'];
+    if (route.intent === 'bug' || route.intent === 'chore') return ['mm:issue-triage'];
+  }
+  return [];
+}

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -1,18 +1,37 @@
-import { Agent, run as _run, OpenAIResponsesModel } from '@openai/agents';
-import { SandboxAgent, type Capability } from '@openai/agents/sandbox';
+import { run as _run, OpenAIResponsesModel, type Agent } from '@openai/agents';
+import { SandboxAgent, type Capability, filesystem, shell, compaction } from '@openai/agents/sandbox';
+import { UnixLocalSandboxClient, type UnixLocalSandboxSessionState } from '@openai/agents/sandbox/local';
+import { Manifest } from '@openai/agents/sandbox';
 import OpenAI from 'openai';
+import type pino from 'pino';
+import type { LoggerProvider } from '@opentelemetry/api-logs';
 import { performance } from 'node:perf_hooks';
 import { metrics } from '@opentelemetry/api';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';
 import type { AgentRunEvent, AgentRunRequest, AgentRunner, AgentRoute, AgentSkillRef } from '../../types/ai.js';
+import { createLogger } from '../../core/logger.js';
 import { materializeOpenAIRuntimeSkills } from './openai-runtime-skill-materializer.js';
 
-type RunFn = (agent: unknown, prompt: string) => AsyncIterable<unknown>;
+const DEFAULT_OPENAI_AGENT_MAX_TURNS = 50;
+
+interface RunFnOptions {
+  maxTurns: number;
+}
+
+type RunFn = (
+  agent: unknown,
+  prompt: string,
+  workingDirectory: string,
+  options: RunFnOptions,
+) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>;
 
 export interface OpenAIAgentSdkAgentRunnerOptions {
   runFn?: RunFn;
   materializeSkills?: (refs: AgentSkillRef[]) => Promise<unknown[]>;
   meter?: Meter;
+  logDestination?: pino.DestinationStream;
+  loggerProvider?: LoggerProvider;
+  maxTurns?: number;
 }
 
 export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
@@ -35,6 +54,8 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
   private readonly _agentTurns: Counter;
   private readonly _adapterLatency: Histogram;
   private readonly _agentRunOutcome: Counter;
+  private readonly logger: pino.Logger;
+  private readonly maxTurns: number;
 
   constructor(
     private readonly apiKey: string,
@@ -44,6 +65,11 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
   ) {
     this.runFn = options?.runFn ?? defaultRunFn;
     this.materializeSkillsFn = options?.materializeSkills ?? materializeOpenAIRuntimeSkills;
+    this.logger = createLogger('openai-agent-sdk', {
+      destination: options?.logDestination,
+      loggerProvider: options?.loggerProvider,
+    });
+    this.maxTurns = options?.maxTurns ?? DEFAULT_OPENAI_AGENT_MAX_TURNS;
     const meter = options?.meter ?? metrics.getMeter('autocatalyst');
     this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
       unit: '{turn}',
@@ -63,6 +89,12 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
     const model = request.profile?.model ?? this.defaultModel ?? 'gpt-4o';
     const refs = skillRefsForRoute(request.route);
     const skillCapabilities = await this.materializeSkillsFn(refs);
+    const capabilities: Capability[] = [
+      filesystem(),
+      shell(),
+      compaction(),
+      ...(skillCapabilities as Capability[]),
+    ];
 
     // For Grove/Azure APIM: create a configured OpenAI client with api-key header and wrap it
     // in OpenAIResponsesModel so the custom base URL is applied to every agent HTTP request.
@@ -86,25 +118,41 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
       request.working_directory ? `Working directory: ${request.working_directory}` : '',
     ].filter(Boolean).join('\n');
 
-    const agent = skillCapabilities.length > 0
-      ? new SandboxAgent({
-          name: 'autocatalyst-agent',
-          model: agentModel,
-          instructions: baseInstructions,
-          capabilities: skillCapabilities as Capability[],
-        })
-      : new Agent({
-          name: 'autocatalyst-agent',
-          model: agentModel,
-          instructions: baseInstructions,
-        });
+    const agent = new SandboxAgent({
+      name: 'autocatalyst-agent',
+      model: agentModel,
+      instructions: baseInstructions,
+      capabilities,
+    });
 
     const startMs = performance.now();
     let outcome: 'success' | 'error' = 'success';
 
+    this.logger.info(
+      {
+        event: 'agent.run_started',
+        model,
+        ...routeLogAttributes(request.route),
+        working_directory: request.working_directory,
+        skill_refs: refs,
+        capability_types: capabilities.map(c => c.type),
+        max_turns: this.maxTurns,
+      },
+      'OpenAI Agents SDK run started',
+    );
+
     try {
-      const stream = this.runFn(agent, request.prompt);
+      const stream = await Promise.resolve(this.runFn(agent, request.prompt, request.working_directory, { maxTurns: this.maxTurns }));
       for await (const event of stream) {
+        this.logger.debug(
+          {
+            event: 'agent.sdk_item',
+            model,
+            ...routeLogAttributes(request.route),
+            ...openAIEventDiagnostic(event),
+          },
+          'OpenAI Agents SDK item',
+        );
         const normalized = normalizeOpenAIEvent(event);
         if (normalized) {
           if (normalized.type === 'assistant') {
@@ -115,6 +163,16 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
       }
     } catch (err) {
       outcome = 'error';
+      this.logger.error(
+        {
+          event: 'agent.run_failed',
+          model,
+          ...routeLogAttributes(request.route),
+          error: String(err),
+          generated_item_count: generatedItemsFromError(err).length,
+        },
+        'OpenAI Agents SDK run failed',
+      );
       throw err;
     } finally {
       this._agentRunOutcome.add(1, { component: 'openai-agent-sdk', model, outcome });
@@ -123,13 +181,79 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
         operation: 'run',
         model,
       });
+      this.logger.info(
+        {
+          event: 'agent.run_completed',
+          model,
+          ...routeLogAttributes(request.route),
+          outcome,
+          latency_ms: Math.round(performance.now() - startMs),
+        },
+        'OpenAI Agents SDK run completed',
+      );
     }
   }
 }
 
-function defaultRunFn(agent: unknown, prompt: string): AsyncIterable<unknown> {
-  // run() with stream: true returns Promise<StreamedRunResult> which is AsyncIterable<RunStreamEvent>
-  return _run(agent as Agent, prompt, { stream: true }) as unknown as AsyncIterable<unknown>;
+async function* defaultRunFn(
+  agent: unknown,
+  prompt: string,
+  workingDirectory: string,
+  options: RunFnOptions,
+): AsyncIterable<unknown> {
+  const client = new UnixLocalSandboxClient();
+  const state: UnixLocalSandboxSessionState = {
+    manifest: new Manifest(),
+    workspaceRootPath: workingDirectory,
+    workspaceRootOwned: false,
+    environment: {},
+  };
+  const session = await client.resume(state);
+  const sandbox = { client, session };
+  try {
+    const result = await _run(agent as Agent, prompt, { sandbox, maxTurns: options.maxTurns });
+    yield* openAIEventsFromRunItems(runItemsFromResult(result));
+  } catch (err) {
+    yield* openAIEventsFromRunItems(generatedItemsFromError(err));
+    throw err;
+  }
+}
+
+function* openAIEventsFromRunItems(items: unknown[]): Iterable<unknown> {
+  for (const item of items) {
+    const name = openAIEventNameForRunItem(item);
+    yield { type: 'run_item_stream_event', name: name ?? 'unknown_item', item };
+  }
+}
+
+function runItemsFromResult(result: unknown): unknown[] {
+  if (!result || typeof result !== 'object') return [];
+  const newItems = (result as { newItems?: unknown }).newItems;
+  return Array.isArray(newItems) ? newItems : [];
+}
+
+function generatedItemsFromError(err: unknown): unknown[] {
+  if (!err || typeof err !== 'object') return [];
+  const state = (err as { state?: unknown }).state;
+  if (!state || typeof state !== 'object') return [];
+  const generatedItems = (state as { _generatedItems?: unknown })._generatedItems;
+  return Array.isArray(generatedItems) ? generatedItems : [];
+}
+
+function openAIEventNameForRunItem(item: unknown): string | undefined {
+  if (!item || typeof item !== 'object') return undefined;
+  switch ((item as { type?: string }).type) {
+    case 'message_output_item': return 'message_output_created';
+    case 'handoff_call_item': return 'handoff_requested';
+    case 'handoff_output_item': return 'handoff_occurred';
+    case 'tool_search_call_item': return 'tool_search_called';
+    case 'tool_search_output_item': return 'tool_search_output_created';
+    case 'tool_call_item': return 'tool_called';
+    case 'tool_call_output_item': return 'tool_output';
+    case 'reasoning_item': return 'reasoning_item_created';
+    case 'tool_approval_item': return 'tool_approval_requested';
+    default: return undefined;
+  }
 }
 
 function normalizeOpenAIEvent(event: unknown): AgentRunEvent | null {
@@ -149,6 +273,178 @@ function normalizeOpenAIEvent(event: unknown): AgentRunEvent | null {
     return { type: e['type'], ...e } as AgentRunEvent;
   }
   return null;
+}
+
+function routeLogAttributes(route: AgentRoute): Record<string, string> {
+  return {
+    route_task: route.task,
+    ...(route.stage ? { route_stage: route.stage } : {}),
+    ...(route.intent ? { route_intent: route.intent } : {}),
+    ...(route.artifact_kind ? { artifact_kind: route.artifact_kind } : {}),
+  };
+}
+
+function openAIEventDiagnostic(event: unknown): Record<string, unknown> {
+  if (!event || typeof event !== 'object') {
+    return { sdk_event_type: typeof event };
+  }
+  const e = event as Record<string, unknown>;
+  const item = e['item'];
+  const itemRecord = item && typeof item === 'object' ? item as Record<string, unknown> : undefined;
+  const rawItem = itemRecord?.['rawItem'];
+  const rawRecord = rawItem && typeof rawItem === 'object' ? rawItem as Record<string, unknown> : undefined;
+
+  return withoutUndefined({
+    sdk_event_type: typeof e['type'] === 'string' ? e['type'] : undefined,
+    sdk_event_name: typeof e['name'] === 'string' ? e['name'] : undefined,
+    item_type: typeof itemRecord?.['type'] === 'string' ? itemRecord['type'] : undefined,
+    raw_item_type: rawItemType(rawRecord),
+    ...toolDiagnostic(rawRecord, itemRecord),
+  });
+}
+
+function rawItemType(rawItem: Record<string, unknown> | undefined): string | undefined {
+  if (!rawItem) return undefined;
+  if (typeof rawItem['type'] === 'string') return rawItem['type'];
+  if (typeof rawItem['role'] === 'string') return rawItem['role'];
+  return undefined;
+}
+
+function toolDiagnostic(
+  rawItem: Record<string, unknown> | undefined,
+  item: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!rawItem) return {};
+  const type = rawItemType(rawItem);
+  const callId = stringValue(rawItem['callId']) ?? stringValue(rawItem['call_id']);
+  const status = stringValue(rawItem['status']);
+
+  switch (type) {
+    case 'function_call':
+      return {
+        tool_name: stringValue(rawItem['name']),
+        call_id: callId,
+        tool_status: status,
+      };
+    case 'function_call_result':
+      return {
+        tool_name: stringValue(rawItem['name']),
+        call_id: callId,
+        tool_status: status,
+        output_type: outputType(rawItem['output']),
+      };
+    case 'hosted_tool_call':
+      return {
+        tool_name: stringValue(rawItem['name']),
+        call_id: callId,
+        tool_status: status,
+      };
+    case 'shell_call':
+      return {
+        tool_name: 'shell',
+        call_id: callId,
+        tool_status: status,
+        command_count: shellCommandCount(rawItem['action']),
+      };
+    case 'shell_call_output':
+      return {
+        tool_name: 'shell',
+        call_id: callId,
+        output_count: shellOutput(rawItem['output']).length,
+        exit_codes: shellOutput(rawItem['output'])
+          .map(output => shellExitCode(output))
+          .filter((code): code is number => typeof code === 'number'),
+      };
+    case 'apply_patch_call':
+      return {
+        tool_name: 'apply_patch',
+        call_id: callId,
+        tool_status: status,
+        patch_operation: patchOperation(rawItem['operation']),
+      };
+    case 'apply_patch_call_output':
+      return {
+        tool_name: 'apply_patch',
+        call_id: callId,
+        tool_status: status,
+        output_length: typeof rawItem['output'] === 'string' ? rawItem['output'].length : undefined,
+      };
+    case 'computer_call':
+      return {
+        tool_name: 'computer',
+        call_id: callId,
+        tool_status: status,
+        action_type: computerActionType(rawItem['action']),
+      };
+    case 'computer_call_result':
+      return {
+        tool_name: 'computer',
+        call_id: callId,
+      };
+    case 'tool_search_call':
+      return {
+        tool_name: 'tool_search',
+        call_id: callId,
+        tool_status: status,
+      };
+    case 'tool_search_output':
+      return {
+        tool_name: 'tool_search',
+        call_id: callId,
+        tool_status: status,
+        output_count: Array.isArray(rawItem['tools']) ? rawItem['tools'].length : undefined,
+      };
+    default:
+      return {
+        call_id: callId,
+        tool_status: status,
+        output_type: outputType(item?.['output']),
+      };
+  }
+}
+
+function shellCommandCount(action: unknown): number | undefined {
+  if (!action || typeof action !== 'object') return undefined;
+  const commands = (action as { commands?: unknown }).commands;
+  return Array.isArray(commands) ? commands.length : undefined;
+}
+
+function shellOutput(output: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(output)
+    ? output.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+    : [];
+}
+
+function shellExitCode(output: Record<string, unknown>): number | undefined {
+  const outcome = output['outcome'];
+  if (!outcome || typeof outcome !== 'object') return undefined;
+  const exitCode = (outcome as { exitCode?: unknown }).exitCode;
+  return typeof exitCode === 'number' ? exitCode : undefined;
+}
+
+function patchOperation(operation: unknown): string | undefined {
+  if (!operation || typeof operation !== 'object') return undefined;
+  return stringValue((operation as { type?: unknown }).type);
+}
+
+function computerActionType(action: unknown): string | undefined {
+  if (!action || typeof action !== 'object') return undefined;
+  return stringValue((action as { type?: unknown }).type);
+}
+
+function outputType(output: unknown): string | undefined {
+  if (typeof output === 'string') return 'string';
+  if (Array.isArray(output)) return 'array';
+  if (!output || typeof output !== 'object') return undefined;
+  return stringValue((output as { type?: unknown }).type) ?? 'object';
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function withoutUndefined(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined));
 }
 
 function extractTextFromMessageOutputItem(item: unknown): string | null {

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -1,4 +1,19 @@
-import type { AgentRoute, AgentSkillRef } from '../../types/ai.js';
+import { Agent, run as _run } from '@openai/agents';
+import { SandboxAgent, type Capability } from '@openai/agents/sandbox';
+import OpenAI from 'openai';
+import { performance } from 'node:perf_hooks';
+import { metrics } from '@opentelemetry/api';
+import type { Counter, Histogram, Meter } from '@opentelemetry/api';
+import type { AgentRunEvent, AgentRunRequest, AgentRunner, AgentRoute, AgentSkillRef } from '../../types/ai.js';
+import { materializeOpenAIRuntimeSkills } from './openai-runtime-skill-materializer.js';
+
+type RunFn = (agent: unknown, prompt: string) => AsyncIterable<unknown>;
+
+export interface OpenAIAgentSdkAgentRunnerOptions {
+  runFn?: RunFn;
+  materializeSkills?: (refs: AgentSkillRef[]) => Promise<unknown[]>;
+  meter?: Meter;
+}
 
 export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
   if (route.task === 'implementation.run') {
@@ -12,4 +27,128 @@ export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
     if (route.intent === 'bug' || route.intent === 'chore') return ['mm:issue-triage'];
   }
   return [];
+}
+
+export class OpenAIAgentSdkAgentRunner implements AgentRunner {
+  private readonly runFn: RunFn;
+  private readonly materializeSkillsFn: (refs: AgentSkillRef[]) => Promise<unknown[]>;
+  private readonly _agentTurns: Counter;
+  private readonly _adapterLatency: Histogram;
+  private readonly _agentRunOutcome: Counter;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl: string | undefined,
+    private readonly defaultModel: string | undefined,
+    options?: OpenAIAgentSdkAgentRunnerOptions,
+  ) {
+    this.runFn = options?.runFn ?? defaultRunFn;
+    this.materializeSkillsFn = options?.materializeSkills ?? materializeOpenAIRuntimeSkills;
+    const meter = options?.meter ?? metrics.getMeter('autocatalyst');
+    this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
+      unit: '{turn}',
+      description: 'Agent turns yielded',
+    });
+    this._adapterLatency = meter.createHistogram('autocatalyst.adapter.latency', {
+      unit: 'ms',
+      description: 'Latency of adapter operations',
+    });
+    this._agentRunOutcome = meter.createCounter('autocatalyst.agent.runs', {
+      unit: '{run}',
+      description: 'Agent runs completed, by outcome',
+    });
+  }
+
+  async *run(request: AgentRunRequest): AsyncIterable<AgentRunEvent> {
+    const model = request.profile?.model ?? this.defaultModel ?? 'gpt-4o';
+    const refs = skillRefsForRoute(request.route);
+    const skillCapabilities = await this.materializeSkillsFn(refs);
+
+    const clientOptions: ConstructorParameters<typeof OpenAI>[0] = { apiKey: this.apiKey };
+    if (this.baseUrl) {
+      clientOptions.baseURL = this.baseUrl;
+      clientOptions.defaultHeaders = { 'api-key': this.apiKey };
+    }
+
+    const baseInstructions = [
+      'You are an AI agent for software development automation.',
+      'Work in the provided working directory.',
+      request.working_directory ? `Working directory: ${request.working_directory}` : '',
+    ].filter(Boolean).join('\n');
+
+    const agent = skillCapabilities.length > 0
+      ? new SandboxAgent({
+          name: 'autocatalyst-agent',
+          model,
+          instructions: baseInstructions,
+          capabilities: skillCapabilities as Capability[],
+        })
+      : new Agent({
+          name: 'autocatalyst-agent',
+          model,
+          instructions: baseInstructions,
+        });
+
+    const startMs = performance.now();
+    let outcome: 'success' | 'error' = 'success';
+
+    try {
+      const stream = this.runFn(agent, request.prompt);
+      for await (const event of stream) {
+        const normalized = normalizeOpenAIEvent(event);
+        if (normalized) {
+          if (normalized.type === 'assistant') {
+            this._agentTurns.add(1, { component: 'openai-agent-sdk', model });
+          }
+          yield normalized;
+        }
+      }
+    } catch (err) {
+      outcome = 'error';
+      throw err;
+    } finally {
+      this._agentRunOutcome.add(1, { component: 'openai-agent-sdk', model, outcome });
+      this._adapterLatency.record(performance.now() - startMs, {
+        adapter: 'agent-sdk',
+        operation: 'run',
+        model,
+      });
+    }
+  }
+}
+
+function defaultRunFn(agent: unknown, prompt: string): AsyncIterable<unknown> {
+  // run() with stream: true returns Promise<StreamedRunResult> which is AsyncIterable<RunStreamEvent>
+  return _run(agent as Agent, prompt, { stream: true }) as unknown as AsyncIterable<unknown>;
+}
+
+function normalizeOpenAIEvent(event: unknown): AgentRunEvent | null {
+  if (!event || typeof event !== 'object') return null;
+  const e = event as Record<string, unknown>;
+
+  // RunItemStreamEvent with name 'message_output_created' carries model text output.
+  // item.type === 'message_output_item', item.rawItem.content has { type: 'output_text', text }
+  if (e['type'] === 'run_item_stream_event' && e['name'] === 'message_output_created') {
+    const text = extractTextFromMessageOutputItem(e['item']);
+    if (text !== null) {
+      return { type: 'assistant', content: [{ type: 'text', text }] };
+    }
+  }
+
+  if (typeof e['type'] === 'string') {
+    return { type: e['type'], ...e } as AgentRunEvent;
+  }
+  return null;
+}
+
+function extractTextFromMessageOutputItem(item: unknown): string | null {
+  if (!item || typeof item !== 'object') return null;
+  const i = item as Record<string, unknown>;
+  const rawItem = i['rawItem'] as Record<string, unknown> | undefined;
+  if (!rawItem) return null;
+  const content = rawItem['content'];
+  if (!Array.isArray(content)) return null;
+  const textBlock = (content as Record<string, unknown>[]).find(b => b['type'] === 'output_text');
+  if (textBlock && typeof textBlock['text'] === 'string') return textBlock['text'];
+  return null;
 }

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -1,4 +1,4 @@
-import { Agent, run as _run } from '@openai/agents';
+import { Agent, run as _run, OpenAIResponsesModel } from '@openai/agents';
 import { SandboxAgent, type Capability } from '@openai/agents/sandbox';
 import OpenAI from 'openai';
 import { performance } from 'node:perf_hooks';
@@ -64,10 +64,20 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
     const refs = skillRefsForRoute(request.route);
     const skillCapabilities = await this.materializeSkillsFn(refs);
 
-    const clientOptions: ConstructorParameters<typeof OpenAI>[0] = { apiKey: this.apiKey };
+    // For Grove/Azure APIM: create a configured OpenAI client with api-key header and wrap it
+    // in OpenAIResponsesModel so the custom base URL is applied to every agent HTTP request.
+    // For standard OpenAI endpoints: pass the model string and let the SDK use its default client.
+    let agentModel: string | OpenAIResponsesModel;
     if (this.baseUrl) {
-      clientOptions.baseURL = this.baseUrl;
-      clientOptions.defaultHeaders = { 'api-key': this.apiKey };
+      const client = new OpenAI({
+        apiKey: this.apiKey,
+        baseURL: this.baseUrl,
+        defaultHeaders: { 'api-key': this.apiKey },
+      });
+      // Cast required: resolution-mode difference between our OpenAI import and @openai/agents-openai's import
+      agentModel = new OpenAIResponsesModel(client as never, model);
+    } else {
+      agentModel = model;
     }
 
     const baseInstructions = [
@@ -79,13 +89,13 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
     const agent = skillCapabilities.length > 0
       ? new SandboxAgent({
           name: 'autocatalyst-agent',
-          model,
+          model: agentModel,
           instructions: baseInstructions,
           capabilities: skillCapabilities as Capability[],
         })
       : new Agent({
           name: 'autocatalyst-agent',
-          model,
+          model: agentModel,
           instructions: baseInstructions,
         });
 

--- a/src/adapters/openai/openai-runtime-skill-materializer.ts
+++ b/src/adapters/openai/openai-runtime-skill-materializer.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { skills as sdkSkills } from '@openai/agents/sandbox';
+import { resolveRuntimeSkillRefs } from '../../core/runtime-skills/catalog.js';
+import type { AgentSkillRef } from '../../types/ai.js';
+
+export interface OpenAIRuntimeSkillMaterializerOptions {
+  rootDir?: string;
+}
+
+export async function materializeOpenAIRuntimeSkills(
+  refs: AgentSkillRef[],
+  options?: OpenAIRuntimeSkillMaterializerOptions,
+): Promise<unknown[]> {
+  if (refs.length === 0) return [];
+
+  const resolved = resolveRuntimeSkillRefs(refs, { rootDir: options?.rootDir });
+
+  const skillObjects: Array<{ name: string; description: string; content: string }> = [];
+
+  for (const provider of resolved.providers) {
+    for (const skill of provider.skills) {
+      const skillMdPath = join(skill.sourcePath, 'SKILL.md');
+      const content = readFileSync(skillMdPath, 'utf-8');
+      skillObjects.push({
+        name: skill.ref,
+        description: `Runtime skill: ${skill.ref}`,
+        content,
+      });
+    }
+  }
+
+  return [sdkSkills({ skills: skillObjects })];
+}

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -43,7 +43,7 @@ import {
 } from '../core/ai/agent-services.js';
 import { AnthropicDirectModelRunner, type AnthropicCreateFn } from './anthropic/direct-model-runner.js';
 import { OpenAIDirectModelRunner } from './openai/direct-model-runner.js';
-import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner, AgentRunner } from '../types/ai.js';
+import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner, AgentRunner, AgentRunRequest, AgentRunEvent } from '../types/ai.js';
 import { ClaudeAgentSdkAgentRunner } from './anthropic/claude-agent-sdk-agent-runner.js';
 import { OpenAIAgentSdkAgentRunner } from './openai/agent-sdk-agent-runner.js';
 
@@ -230,18 +230,25 @@ export function buildAgentRunner(
   meter?: Meter,
 ): AgentRunner {
   const claudeProfile = resolvedAi.profiles.find(p => p.runner === 'claude_agent_sdk');
-  if (claudeProfile) {
-    return new ClaudeAgentSdkAgentRunner({ meter });
+  const openAiAgentProfile = resolvedAi.profiles.find(p => p.runner === 'openai_agent_sdk');
+
+  if (!claudeProfile && !openAiAgentProfile) {
+    const runnerKinds = resolvedAi.profiles.map(p => p.runner).join(', ') || 'none';
+    throw new Error(
+      `No recognized agent runner configured. Expected a profile with runner: claude_agent_sdk or openai_agent_sdk. Found: ${runnerKinds}`,
+    );
   }
 
-  const openAiAgentProfile = resolvedAi.profiles.find(p => p.runner === 'openai_agents');
+  const claudeRunner = claudeProfile ? new ClaudeAgentSdkAgentRunner({ meter }) : null;
+
+  let openAiRunner: AgentRunner | null = null;
   if (openAiAgentProfile) {
     const endpoint = resolvedAi.endpoints.find(e => e.name === openAiAgentProfile.endpoint)!;
     const credential = resolvedAi.credentials.find(c => c.name === endpoint.credential)!;
 
     if (credential.type !== 'api_key') {
       throw new Error(
-        `Credential type '${credential.type}' is not supported for openai_agents runner`,
+        `Credential type '${credential.type}' is not supported for openai_agent_sdk runner`,
       );
     }
 
@@ -249,14 +256,14 @@ export function buildAgentRunner(
       {
         event: 'service.config',
         provider: 'openai',
-        runner: 'openai_agents',
+        runner: 'openai_agent_sdk',
         model: openAiAgentProfile.model ?? 'default',
         base_url: endpoint.base_url ?? 'default',
       },
       'Using OpenAI Agents SDK',
     );
 
-    return new OpenAIAgentSdkAgentRunner(
+    openAiRunner = new OpenAIAgentSdkAgentRunner(
       credential.resolvedValue!,
       endpoint.base_url,
       openAiAgentProfile.model,
@@ -264,10 +271,13 @@ export function buildAgentRunner(
     );
   }
 
-  const runnerKinds = resolvedAi.profiles.map(p => p.runner).join(', ') || 'none';
-  throw new Error(
-    `No recognized agent runner configured. Expected a profile with runner: claude_agent_sdk or openai_agents. Found: ${runnerKinds}`,
-  );
+  // Only one runner kind present — return directly (no routing overhead)
+  if (claudeRunner && !openAiRunner) return claudeRunner;
+  if (openAiRunner && !claudeRunner) return openAiRunner;
+
+  // Both runner kinds present — wrap in a routing-aware runner that dispatches
+  // on request.profile?.provider at call time.
+  return new RoutingAwareAgentRunner(claudeRunner!, openAiRunner!);
 }
 
 /**
@@ -285,6 +295,25 @@ export class RoutingAwareDirectModelRunner implements DirectModelRunner {
     const profileId = request.profile?.id;
     const runner = (profileId !== undefined && this.runners.get(profileId)) || this.fallback;
     return runner.run(request);
+  }
+}
+
+/**
+ * Dispatches `run()` calls to the agent runner registered for the resolved profile's provider.
+ * Used when the routing table maps different tasks to profiles with different agent runner kinds
+ * (e.g. artifact.create → claude_agent_sdk, implementation.run → openai_agent_sdk).
+ */
+export class RoutingAwareAgentRunner implements AgentRunner {
+  constructor(
+    private readonly claudeRunner: AgentRunner,
+    private readonly openAiRunner: AgentRunner,
+  ) {}
+
+  run(request: AgentRunRequest): AsyncIterable<AgentRunEvent> {
+    if (request.profile?.provider === 'openai_agent_sdk') {
+      return this.openAiRunner.run(request);
+    }
+    return this.claudeRunner.run(request);
   }
 }
 

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -43,8 +43,9 @@ import {
 } from '../core/ai/agent-services.js';
 import { AnthropicDirectModelRunner, type AnthropicCreateFn } from './anthropic/direct-model-runner.js';
 import { OpenAIDirectModelRunner } from './openai/direct-model-runner.js';
-import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner } from '../types/ai.js';
+import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner, AgentRunner } from '../types/ai.js';
 import { ClaudeAgentSdkAgentRunner } from './anthropic/claude-agent-sdk-agent-runner.js';
+import { OpenAIAgentSdkAgentRunner } from './openai/agent-sdk-agent-runner.js';
 
 export type RuntimeLogger = Pick<pino.Logger, 'debug' | 'error' | 'info' | 'warn'>;
 
@@ -116,7 +117,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
 
   const aiRoutingPolicy = buildAgentRoutingPolicy(resolvedAi);
   const directModelRunner = buildDirectModelRunner(resolvedAi, logger, options.loggerProvider);
-  const agentRunner = new ClaudeAgentSdkAgentRunner({ meter: options.meter });
+  const agentRunner = buildAgentRunner(resolvedAi, logger, options.meter);
   const intentClassifier = new ModelIntentClassifier(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const prTitleGenerator = new ModelPRTitleGenerator(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const questionAnswerer = new AgentRunnerQuestionAnsweringAgent(agentRunner, aiRoutingPolicy, repoPath);
@@ -221,6 +222,52 @@ function recordConfig(config: Record<string, unknown> | undefined, key: string):
 
 export function buildAgentRoutingPolicy(resolvedAi: ResolvedAiConfig): DefaultAgentRoutingPolicy {
   return new DefaultAgentRoutingPolicy(resolvedAi);
+}
+
+export function buildAgentRunner(
+  resolvedAi: ResolvedAiConfig,
+  logger: RuntimeLogger,
+  meter?: Meter,
+): AgentRunner {
+  const claudeProfile = resolvedAi.profiles.find(p => p.runner === 'claude_agent_sdk');
+  if (claudeProfile) {
+    return new ClaudeAgentSdkAgentRunner({ meter });
+  }
+
+  const openAiAgentProfile = resolvedAi.profiles.find(p => p.runner === 'openai_agents');
+  if (openAiAgentProfile) {
+    const endpoint = resolvedAi.endpoints.find(e => e.name === openAiAgentProfile.endpoint)!;
+    const credential = resolvedAi.credentials.find(c => c.name === endpoint.credential)!;
+
+    if (credential.type !== 'api_key') {
+      throw new Error(
+        `Credential type '${credential.type}' is not supported for openai_agents runner`,
+      );
+    }
+
+    logger.info(
+      {
+        event: 'service.config',
+        provider: 'openai',
+        runner: 'openai_agents',
+        model: openAiAgentProfile.model ?? 'default',
+        base_url: endpoint.base_url ?? 'default',
+      },
+      'Using OpenAI Agents SDK',
+    );
+
+    return new OpenAIAgentSdkAgentRunner(
+      credential.resolvedValue!,
+      endpoint.base_url,
+      openAiAgentProfile.model,
+      { meter },
+    );
+  }
+
+  const runnerKinds = resolvedAi.profiles.map(p => p.runner).join(', ') || 'none';
+  throw new Error(
+    `No recognized agent runner configured. Expected a profile with runner: claude_agent_sdk or openai_agents. Found: ${runnerKinds}`,
+  );
 }
 
 /**

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -628,7 +628,7 @@ function buildArtifactCreatePrompt(
       ``,
       request.content,
       ``,
-      `Invoke the \`mm:issue-triage\` skill to perform a thorough investigation of this bug.`,
+      `Use the \`mm:issue-triage\` skill to perform a thorough investigation of this bug.`,
       `Examine relevant source files, recent commits, and related issue-tracker records to understand the`,
       `root cause before forming conclusions. The investigation must be thorough - do not`,
       `skip the codebase inspection step.`,
@@ -651,7 +651,7 @@ function buildArtifactCreatePrompt(
       ``,
       request.content,
       ``,
-      `Invoke the \`mm:issue-triage\` skill to investigate the current state of the relevant`,
+      `Use the \`mm:issue-triage\` skill to investigate the current state of the relevant`,
       `code and understand why this work is needed now. Use thorough investigation.`,
       ``,
       `When the chore plan is complete:`,
@@ -667,9 +667,7 @@ function buildArtifactCreatePrompt(
   }
 
   return [
-    `Use the /mm:planning skill to create a complete product spec for the following request.`,
-    ``,
-    `/mm:planning`,
+    `Use the \`mm:planning\` skill to create a complete product spec for the following request.`,
     ``,
     `Request:`,
     `<<<`,
@@ -760,7 +758,7 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
 
   if (!additionalContext) {
     lines.push('Step 1 - Create an implementation plan');
-    lines.push('/superpowers:writing-plans');
+    lines.push('Use the `superpowers:writing-plans` skill.');
     lines.push('');
     lines.push('Use the artifact as the authoritative baseline, especially its task list.');
     lines.push('');
@@ -769,7 +767,7 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
     lines.push('Step 2 - Execute the plan in subagent mode');
   }
 
-  lines.push('/superpowers:subagent-driven-development');
+  lines.push('Use the `superpowers:subagent-driven-development` skill.');
   lines.push('');
   lines.push('Step 3 - Commit all remaining source changes');
   lines.push('Run `git status`. Stage and commit only source files that belong in the repository.');
@@ -816,7 +814,7 @@ export function buildIssueTriagePrompt(request: Request, resultPath: string): st
   return [
     `You are enriching a list of items to be filed in the issue tracker.`,
     ``,
-    `Invoke the \`mm:issue-triage\` skill in feedback intake mode to:`,
+    `Use the \`mm:issue-triage\` skill in feedback intake mode to:`,
     `1. Identify each distinct issue in the list below`,
     `2. Investigate each item against the codebase (thorough mode)`,
     `3. For each item:`,

--- a/src/core/ai/routing-policy.ts
+++ b/src/core/ai/routing-policy.ts
@@ -44,6 +44,6 @@ function runnerToProvider(runner: RunnerKind): string {
     case 'anthropic_direct': return 'anthropic';
     case 'openai_direct': return 'openai';
     case 'claude_agent_sdk': return 'claude_agent_sdk';
-    case 'openai_agents': return 'openai_agents';
+    case 'openai_agent_sdk': return 'openai_agent_sdk';
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,7 +6,7 @@ import type { AgentPluginConfig } from './ai.js';
 
 export type CredentialType = 'api_key' | 'iam' | 'workload_identity' | 'bearer_token';
 export type EndpointProtocol = 'anthropic' | 'openai';
-export type RunnerKind = 'anthropic_direct' | 'openai_direct' | 'claude_agent_sdk' | 'openai_agents';
+export type RunnerKind = 'anthropic_direct' | 'openai_direct' | 'claude_agent_sdk' | 'openai_agent_sdk';
 
 export interface CredentialConfig {
   name: string;

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { skillRefsForRoute } from '../../../src/adapters/openai/agent-sdk-agent-runner.js';
+
+describe('skillRefsForRoute', () => {
+  test('artifact.create / intent:idea → mm:planning', () => {
+    expect(skillRefsForRoute({ task: 'artifact.create', intent: 'idea' }))
+      .toEqual(['mm:planning']);
+  });
+
+  test('artifact.create / intent:bug → mm:issue-triage', () => {
+    expect(skillRefsForRoute({ task: 'artifact.create', intent: 'bug' }))
+      .toEqual(['mm:issue-triage']);
+  });
+
+  test('artifact.create / intent:chore → mm:issue-triage', () => {
+    expect(skillRefsForRoute({ task: 'artifact.create', intent: 'chore' }))
+      .toEqual(['mm:issue-triage']);
+  });
+
+  test('issue.triage → mm:issue-triage', () => {
+    expect(skillRefsForRoute({ task: 'issue.triage' }))
+      .toEqual(['mm:issue-triage']);
+  });
+
+  test('implementation.run → writing-plans + subagent-driven-development', () => {
+    expect(skillRefsForRoute({ task: 'implementation.run' }))
+      .toEqual(['superpowers:writing-plans', 'superpowers:subagent-driven-development']);
+  });
+
+  test('question.answer → no skills', () => {
+    expect(skillRefsForRoute({ task: 'question.answer' })).toEqual([]);
+  });
+
+  test('artifact.revise → no skills', () => {
+    expect(skillRefsForRoute({ task: 'artifact.revise' })).toEqual([]);
+  });
+
+  test('intent.classify → no skills', () => {
+    expect(skillRefsForRoute({ task: 'intent.classify' })).toEqual([]);
+  });
+
+  test('pr.title_generate → no skills', () => {
+    expect(skillRefsForRoute({ task: 'pr.title_generate' })).toEqual([]);
+  });
+
+  test('artifact.create with no intent → no skills', () => {
+    expect(skillRefsForRoute({ task: 'artifact.create' })).toEqual([]);
+  });
+});

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -1,7 +1,25 @@
-import { describe, expect, test, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { run as sdkRun } from '@openai/agents';
 import { skillRefsForRoute, OpenAIAgentSdkAgentRunner } from '../../../src/adapters/openai/agent-sdk-agent-runner.js';
 import type { AgentRunEvent } from '../../../src/types/ai.js';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';
+
+const nullDest = { write: () => {} } as import('pino').DestinationStream;
+
+vi.mock('@openai/agents', async importOriginal => {
+  const actual = await importOriginal<typeof import('@openai/agents')>();
+  return {
+    ...actual,
+    run: vi.fn(),
+  };
+});
+
+vi.mock('@openai/agents/sandbox/local', () => ({
+  UnixLocalSandboxClient: class {
+    resume = vi.fn().mockResolvedValue({});
+  },
+}));
 
 describe('skillRefsForRoute', () => {
   test('artifact.create / intent:idea → mm:planning', () => {
@@ -91,11 +109,25 @@ function makeMockMeter() {
   return { meter, counterAdds, histogramRecords };
 }
 
+function makeLogCapture(): { dest: import('pino').DestinationStream; getLogs: () => Record<string, unknown>[] } {
+  const stream = new PassThrough();
+  const logs: Record<string, unknown>[] = [];
+  stream.on('data', (chunk: Buffer) => {
+    for (const line of chunk.toString().split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        try { logs.push(JSON.parse(trimmed)); } catch { /* skip non-JSON */ }
+      }
+    }
+  });
+  return { dest: stream as unknown as import('pino').DestinationStream, getLogs: () => logs };
+}
+
 // The @openai/agents SDK run() function yields RunStreamEvent objects.
 // For text output: type === "run_item_stream_event", name === "message_output_created",
 // item.rawItem.content has entries with type === "output_text" and text field.
 // The RunFn in OpenAIAgentSdkAgentRunner is typed as:
-//   (agent: unknown, prompt: string) => AsyncIterable<unknown>
+//   (agent: unknown, prompt: string, workingDirectory: string, options: { maxTurns: number }) => AsyncIterable<unknown>
 // So our mock just needs to yield events in the right shape.
 function makeRunFnYieldingText(text: string) {
   return vi.fn().mockImplementation(async function* () {
@@ -114,6 +146,10 @@ function makeRunFnYieldingText(text: string) {
 }
 
 describe('OpenAIAgentSdkAgentRunner', () => {
+  beforeEach(() => {
+    vi.mocked(sdkRun).mockReset();
+  });
+
   test('run() calls materializeSkills with skill refs matching the route', async () => {
     const materializeSkills = vi.fn().mockResolvedValue([]);
     const runFn = vi.fn().mockImplementation(async function* () {});
@@ -121,6 +157,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
     const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
       runFn,
       materializeSkills,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -141,6 +178,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
     const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
       runFn,
       materializeSkills,
+      logDestination: nullDest,
     });
 
     const events = await collect(runner.run({
@@ -155,6 +193,163 @@ describe('OpenAIAgentSdkAgentRunner', () => {
     });
   });
 
+  test('default run function converts non-streaming result.newItems into assistant events', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    vi.mocked(sdkRun).mockResolvedValue({
+      newItems: [
+        {
+          type: 'message_output_item',
+          rawItem: {
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'non-streaming result' }],
+          },
+        },
+      ],
+      output: [],
+    } as never);
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      materializeSkills,
+      logDestination: nullDest,
+    });
+
+    const events = await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'What changed?',
+    }));
+
+    expect(events).toContainEqual({
+      type: 'assistant',
+      content: [{ type: 'text', text: 'non-streaming result' }],
+    });
+  });
+
+  test('default run function passes a larger turn budget to the OpenAI SDK', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    vi.mocked(sdkRun).mockResolvedValue({
+      newItems: [],
+      output: [],
+    } as never);
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      materializeSkills,
+      logDestination: nullDest,
+    });
+
+    await collect(runner.run({
+      route: { task: 'artifact.create', intent: 'bug' },
+      working_directory: '/tmp/ws',
+      prompt: 'triage issue',
+    }));
+
+    expect(vi.mocked(sdkRun).mock.calls[0][2]).toMatchObject({
+      maxTurns: 50,
+    });
+  });
+
+  test('run() logs each SDK tool call and tool response with sanitized metadata', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const { dest, getLogs } = makeLogCapture();
+    const runFn = vi.fn().mockImplementation(async function* () {
+      yield {
+        type: 'run_item_stream_event',
+        name: 'tool_called',
+        item: {
+          type: 'tool_call_item',
+          rawItem: {
+            type: 'shell_call',
+            callId: 'call-shell-1',
+            status: 'completed',
+            action: { commands: ['cat secret.txt'] },
+          },
+        },
+      };
+      yield {
+        type: 'run_item_stream_event',
+        name: 'tool_output',
+        item: {
+          type: 'tool_call_output_item',
+          rawItem: {
+            type: 'shell_call_output',
+            callId: 'call-shell-1',
+            output: [
+              {
+                stdout: 'sensitive output',
+                stderr: '',
+                outcome: { type: 'exit', exitCode: 0 },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      logDestination: dest,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'inspect files',
+    }));
+
+    const toolCallLog = getLogs().find(log => log['event'] === 'agent.sdk_item' && log['sdk_event_name'] === 'tool_called');
+    expect(toolCallLog).toMatchObject({
+      component: 'openai-agent-sdk',
+      model: 'gpt-4o',
+      route_task: 'question.answer',
+      sdk_event_type: 'run_item_stream_event',
+      sdk_event_name: 'tool_called',
+      item_type: 'tool_call_item',
+      raw_item_type: 'shell_call',
+      tool_name: 'shell',
+      call_id: 'call-shell-1',
+      tool_status: 'completed',
+      command_count: 1,
+    });
+    expect(toolCallLog).not.toHaveProperty('commands');
+
+    const toolOutputLog = getLogs().find(log => log['event'] === 'agent.sdk_item' && log['sdk_event_name'] === 'tool_output');
+    expect(toolOutputLog).toMatchObject({
+      sdk_event_name: 'tool_output',
+      item_type: 'tool_call_output_item',
+      raw_item_type: 'shell_call_output',
+      tool_name: 'shell',
+      call_id: 'call-shell-1',
+      output_count: 1,
+      exit_codes: [0],
+    });
+    expect(toolOutputLog).not.toHaveProperty('stdout');
+    expect(toolOutputLog).not.toHaveProperty('stderr');
+  });
+
+  test('run() creates a sandbox agent with filesystem and shell capabilities even when the route has no skills', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    let capturedAgent: unknown;
+    const runFn = vi.fn().mockImplementation(async function* (agent: unknown) {
+      capturedAgent = agent;
+    });
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      logDestination: nullDest,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'answer from repo',
+    }));
+
+    const capabilities = (capturedAgent as { capabilities?: Array<{ type?: string }> }).capabilities;
+    expect(capabilities?.map(c => c.type)).toEqual(expect.arrayContaining(['filesystem', 'shell', 'compaction']));
+  });
+
   test('run() uses profile.model over defaultModel', async () => {
     const materializeSkills = vi.fn().mockResolvedValue([]);
     const runFn = vi.fn().mockImplementation(async function* () {});
@@ -164,6 +359,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -186,6 +382,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -207,6 +404,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -239,6 +437,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -260,6 +459,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -284,6 +484,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await expect(collect(runner.run({
@@ -306,6 +507,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       runFn,
       materializeSkills,
       meter,
+      logDestination: nullDest,
     });
 
     await collect(runner.run({
@@ -330,7 +532,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       'grove-key-123',
       'https://grove.internal/openai',
       'gpt-4o',
-      { runFn, materializeSkills },
+      { runFn, materializeSkills, logDestination: nullDest },
     );
 
     await collect(runner.run({

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from 'vitest';
-import { skillRefsForRoute } from '../../../src/adapters/openai/agent-sdk-agent-runner.js';
+import { describe, expect, test, vi } from 'vitest';
+import { skillRefsForRoute, OpenAIAgentSdkAgentRunner } from '../../../src/adapters/openai/agent-sdk-agent-runner.js';
+import type { AgentRunEvent } from '../../../src/types/ai.js';
+import type { Counter, Histogram, Meter } from '@opentelemetry/api';
 
 describe('skillRefsForRoute', () => {
   test('artifact.create / intent:idea → mm:planning', () => {
@@ -45,5 +47,299 @@ describe('skillRefsForRoute', () => {
 
   test('artifact.create with no intent → no skills', () => {
     expect(skillRefsForRoute({ task: 'artifact.create' })).toEqual([]);
+  });
+});
+
+async function collect(events: AsyncIterable<AgentRunEvent>): Promise<AgentRunEvent[]> {
+  const collected: AgentRunEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}
+
+function makeMockMeter() {
+  const counterAdds: { name: string; value: number; attrs: Record<string, string> }[] = [];
+  const histogramRecords: { name: string; value: number; attrs: Record<string, string> }[] = [];
+
+  function makeCounter(name: string): Counter {
+    return {
+      add(value: number, attrs?: Record<string, string>) {
+        counterAdds.push({ name, value, attrs: attrs ?? {} });
+      },
+    } as unknown as Counter;
+  }
+
+  function makeHistogram(name: string): Histogram {
+    return {
+      record(value: number, attrs?: Record<string, string>) {
+        histogramRecords.push({ name, value, attrs: attrs ?? {} });
+      },
+    } as unknown as Histogram;
+  }
+
+  const meter: Meter = {
+    createCounter: (name: string) => makeCounter(name),
+    createHistogram: (name: string) => makeHistogram(name),
+    createObservableCounter: vi.fn(),
+    createObservableGauge: vi.fn(),
+    createObservableUpDownCounter: vi.fn(),
+    createUpDownCounter: vi.fn(),
+    createGauge: vi.fn(),
+    addBatchObservableCallback: vi.fn(),
+    removeBatchObservableCallback: vi.fn(),
+  } as unknown as Meter;
+
+  return { meter, counterAdds, histogramRecords };
+}
+
+// The @openai/agents SDK run() function yields RunStreamEvent objects.
+// For text output: type === "run_item_stream_event", name === "message_output_created",
+// item.rawItem.content has entries with type === "output_text" and text field.
+// The RunFn in OpenAIAgentSdkAgentRunner is typed as:
+//   (agent: unknown, prompt: string) => AsyncIterable<unknown>
+// So our mock just needs to yield events in the right shape.
+function makeRunFnYieldingText(text: string) {
+  return vi.fn().mockImplementation(async function* () {
+    yield {
+      type: 'run_item_stream_event',
+      name: 'message_output_created',
+      item: {
+        type: 'message_output_item',
+        rawItem: {
+          role: 'assistant',
+          content: [{ type: 'output_text', text }],
+        },
+      },
+    };
+  });
+}
+
+describe('OpenAIAgentSdkAgentRunner', () => {
+  test('run() calls materializeSkills with skill refs matching the route', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+    });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/ws',
+      prompt: 'implement feature X',
+    }));
+
+    expect(materializeSkills).toHaveBeenCalledWith(
+      ['superpowers:writing-plans', 'superpowers:subagent-driven-development'],
+    );
+  });
+
+  test('run() yields { type: assistant, content } for text output events', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = makeRunFnYieldingText('hello from GPT');
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+    });
+
+    const events = await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'What is 1+1?',
+    }));
+
+    expect(events).toContainEqual({
+      type: 'assistant',
+      content: [{ type: 'text', text: 'hello from GPT' }],
+    });
+  });
+
+  test('run() uses profile.model over defaultModel', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+    const { meter, histogramRecords } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o-mini', {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+      profile: { id: 'prof', provider: 'openai', model: 'gpt-4-turbo' },
+    }));
+
+    const latencyRecord = histogramRecords.find(r => r.name === 'autocatalyst.adapter.latency');
+    expect(latencyRecord?.attrs.model).toBe('gpt-4-turbo');
+  });
+
+  test('run() uses defaultModel when profile.model is absent', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+    const { meter, histogramRecords } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o-mini', {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    const latencyRecord = histogramRecords.find(r => r.name === 'autocatalyst.adapter.latency');
+    expect(latencyRecord?.attrs.model).toBe('gpt-4o-mini');
+  });
+
+  test('run() falls back to gpt-4o when no model is provided anywhere', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+    const { meter, histogramRecords } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, undefined, {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    const latencyRecord = histogramRecords.find(r => r.name === 'autocatalyst.adapter.latency');
+    expect(latencyRecord?.attrs.model).toBe('gpt-4o');
+  });
+
+  test('turns counter increments once per assistant event', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {
+      yield {
+        type: 'run_item_stream_event',
+        name: 'message_output_created',
+        item: { type: 'message_output_item', rawItem: { role: 'assistant', content: [{ type: 'output_text', text: 'turn 1' }] } },
+      };
+      yield {
+        type: 'run_item_stream_event',
+        name: 'message_output_created',
+        item: { type: 'message_output_item', rawItem: { role: 'assistant', content: [{ type: 'output_text', text: 'turn 2' }] } },
+      };
+    });
+    const { meter, counterAdds } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    const turnAdds = counterAdds.filter(c => c.name === 'autocatalyst.agent.turns');
+    expect(turnAdds).toHaveLength(2);
+  });
+
+  test('runs counter records outcome:success on clean exit', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+    const { meter, counterAdds } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    const outcomeAdds = counterAdds.filter(c => c.name === 'autocatalyst.agent.runs');
+    expect(outcomeAdds).toHaveLength(1);
+    expect(outcomeAdds[0].attrs.outcome).toBe('success');
+  });
+
+  test('runs counter records outcome:error when runFn throws', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {
+      throw new Error('API error');
+    });
+    const { meter, counterAdds } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await expect(collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }))).rejects.toThrow('API error');
+
+    const outcomeAdds = counterAdds.filter(c => c.name === 'autocatalyst.agent.runs');
+    expect(outcomeAdds).toHaveLength(1);
+    expect(outcomeAdds[0].attrs.outcome).toBe('error');
+  });
+
+  test('latency histogram records a value on clean exit', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+    const { meter, histogramRecords } = makeMockMeter();
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      meter,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    const latencyRecords = histogramRecords.filter(r => r.name === 'autocatalyst.adapter.latency');
+    expect(latencyRecords).toHaveLength(1);
+    expect(latencyRecords[0].value).toBeGreaterThanOrEqual(0);
+  });
+
+  test('api-key header is set when baseUrl is provided (runFn called with defined agent)', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    let capturedAgent: unknown;
+    const runFn = vi.fn().mockImplementation(async function* (agent: unknown) {
+      capturedAgent = agent;
+    });
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    expect(runFn).toHaveBeenCalled();
+    expect(capturedAgent).toBeDefined();
   });
 });

--- a/tests/adapters/openai/openai-runtime-skill-materializer.test.ts
+++ b/tests/adapters/openai/openai-runtime-skill-materializer.test.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { materializeOpenAIRuntimeSkills } from '../../../src/adapters/openai/openai-runtime-skill-materializer.js';
+
+function makeRuntimeSkillsRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-openai-skills-'));
+  writeFileSync(
+    join(root, 'manifest.yaml'),
+    [
+      'providers:',
+      '  mm:',
+      '    source: vendor/mm',
+      '    plugin_manifest: .claude-plugin/plugin.json',
+      '    skills:',
+      '      planning:',
+      '        path: skills/planning',
+      '  superpowers:',
+      '    source: vendor/superpowers',
+      '    plugin_manifest: .claude-plugin/plugin.json',
+      '    skills:',
+      '      writing-plans:',
+      '        path: skills/writing-plans',
+      '      subagent-driven-development:',
+      '        path: skills/subagent-driven-development',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  mkdirSync(join(root, 'vendor', 'mm', '.claude-plugin'), { recursive: true });
+  writeFileSync(join(root, 'vendor', 'mm', '.claude-plugin', 'plugin.json'), '{"name":"mm"}', 'utf-8');
+  mkdirSync(join(root, 'vendor', 'mm', 'skills', 'planning'), { recursive: true });
+  writeFileSync(
+    join(root, 'vendor', 'mm', 'skills', 'planning', 'SKILL.md'),
+    '# Planning skill content',
+    'utf-8',
+  );
+
+  mkdirSync(join(root, 'vendor', 'superpowers', '.claude-plugin'), { recursive: true });
+  writeFileSync(join(root, 'vendor', 'superpowers', '.claude-plugin', 'plugin.json'), '{"name":"superpowers"}', 'utf-8');
+  for (const skill of ['writing-plans', 'subagent-driven-development']) {
+    mkdirSync(join(root, 'vendor', 'superpowers', 'skills', skill), { recursive: true });
+    writeFileSync(
+      join(root, 'vendor', 'superpowers', 'skills', skill, 'SKILL.md'),
+      `# ${skill} skill content`,
+      'utf-8',
+    );
+  }
+
+  return root;
+}
+
+describe('materializeOpenAIRuntimeSkills', () => {
+  test('returns [] for empty refs array (no file I/O)', async () => {
+    await expect(materializeOpenAIRuntimeSkills([])).resolves.toEqual([]);
+  });
+
+  test('returns non-empty capabilities array for a valid skill ref', async () => {
+    const root = makeRuntimeSkillsRoot();
+    const result = await materializeOpenAIRuntimeSkills(['mm:planning'], { rootDir: root });
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test('returned capabilities contain the SKILL.md content for the resolved skill', async () => {
+    const root = makeRuntimeSkillsRoot();
+    const result = await materializeOpenAIRuntimeSkills(['mm:planning'], { rootDir: root });
+    const capabilityJson = JSON.stringify(result);
+    expect(capabilityJson).toContain('Planning skill content');
+  });
+
+  test('propagates errors from resolveRuntimeSkillRefs for unknown refs', async () => {
+    const root = makeRuntimeSkillsRoot();
+    await expect(
+      materializeOpenAIRuntimeSkills(['mm:nonexistent'], { rootDir: root }),
+    ).rejects.toThrow(/not declared in runtime-skills\/manifest\.yaml/);
+  });
+});

--- a/tests/adapters/runtime-composition.test.ts
+++ b/tests/adapters/runtime-composition.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, test } from 'vitest';
 import { resolveAiConfig } from '../../src/core/config.js';
 import type { WorkflowConfig, AiConfig } from '../../src/types/config.js';
-import { buildDirectModelRunner, RoutingAwareDirectModelRunner } from '../../src/adapters/runtime-composition.js';
+import { buildDirectModelRunner, buildAgentRunner, RoutingAwareDirectModelRunner } from '../../src/adapters/runtime-composition.js';
 import { OpenAIDirectModelRunner } from '../../src/adapters/openai/direct-model-runner.js';
 import { AnthropicDirectModelRunner } from '../../src/adapters/anthropic/direct-model-runner.js';
+import { OpenAIAgentSdkAgentRunner } from '../../src/adapters/openai/agent-sdk-agent-runner.js';
+import { ClaudeAgentSdkAgentRunner } from '../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
 import type { ResolvedAiConfig } from '../../src/core/config.js';
 import type { RuntimeLogger } from '../../src/adapters/runtime-composition.js';
 import type { DirectModelRunner, DirectModelRunRequest } from '../../src/types/ai.js';
@@ -187,5 +189,65 @@ describe('RoutingAwareDirectModelRunner dispatch', () => {
     };
     const result = await wrapper.run(req);
     expect(result.text).toBe('fallback');
+  });
+});
+
+function makeAgentResolvedAi(runner: 'claude_agent_sdk' | 'openai_agents', credentialType: string = 'api_key'): ResolvedAiConfig {
+  return {
+    credentials: [{ name: 'cred', type: credentialType, resolvedValue: 'sk-test' }],
+    endpoints: [{ name: 'ep', protocol: 'openai', credential: 'cred' }],
+    profiles: [{ name: 'p', endpoint: 'ep', runner, model: 'gpt-4o' }],
+    routing: { 'implementation.run': 'p' },
+  } as unknown as ResolvedAiConfig;
+}
+
+describe('buildAgentRunner dispatch', () => {
+  test('returns ClaudeAgentSdkAgentRunner when profile runner is claude_agent_sdk', () => {
+    const runner = buildAgentRunner(makeAgentResolvedAi('claude_agent_sdk'), noopLogger);
+    expect(runner).toBeInstanceOf(ClaudeAgentSdkAgentRunner);
+  });
+
+  test('returns OpenAIAgentSdkAgentRunner when profile runner is openai_agents', () => {
+    const runner = buildAgentRunner(makeAgentResolvedAi('openai_agents'), noopLogger);
+    expect(runner).toBeInstanceOf(OpenAIAgentSdkAgentRunner);
+  });
+
+  test('throws a clear startup error when no recognized runner kind is configured', () => {
+    const resolvedAi: ResolvedAiConfig = {
+      credentials: [{ name: 'cred', type: 'api_key', resolvedValue: 'sk' }],
+      endpoints: [{ name: 'ep', protocol: 'openai', credential: 'cred' }],
+      profiles: [{ name: 'p', endpoint: 'ep', runner: 'openai_direct', model: 'gpt-4o' }],
+      routing: {},
+    } as unknown as ResolvedAiConfig;
+
+    expect(() => buildAgentRunner(resolvedAi, noopLogger)).toThrow(
+      /No recognized agent runner configured/,
+    );
+  });
+
+  test('throws a clear startup error when openai_agents profile uses non-api_key credential', () => {
+    expect(() =>
+      buildAgentRunner(makeAgentResolvedAi('openai_agents', 'bearer_token'), noopLogger),
+    ).toThrow(/not supported for openai_agents runner/);
+  });
+
+  test('logs service.config event with correct fields when openai_agents profile is used', () => {
+    const loggedInfoCalls: unknown[] = [];
+    const capturingLogger: RuntimeLogger = {
+      debug: () => {},
+      error: () => {},
+      warn: () => {},
+      info: (obj: unknown) => { loggedInfoCalls.push(obj); },
+    };
+
+    buildAgentRunner(makeAgentResolvedAi('openai_agents'), capturingLogger);
+
+    const serviceConfigEvent = loggedInfoCalls.find(
+      (c): c is Record<string, unknown> =>
+        typeof c === 'object' && c !== null && (c as Record<string, unknown>)['event'] === 'service.config',
+    );
+    expect(serviceConfigEvent).toBeDefined();
+    expect(serviceConfigEvent?.['provider']).toBe('openai');
+    expect(serviceConfigEvent?.['runner']).toBe('openai_agents');
   });
 });

--- a/tests/adapters/runtime-composition.test.ts
+++ b/tests/adapters/runtime-composition.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, test } from 'vitest';
 import { resolveAiConfig } from '../../src/core/config.js';
 import type { WorkflowConfig, AiConfig } from '../../src/types/config.js';
-import { buildDirectModelRunner, buildAgentRunner, RoutingAwareDirectModelRunner } from '../../src/adapters/runtime-composition.js';
+import { buildDirectModelRunner, buildAgentRunner, RoutingAwareDirectModelRunner, RoutingAwareAgentRunner } from '../../src/adapters/runtime-composition.js';
 import { OpenAIDirectModelRunner } from '../../src/adapters/openai/direct-model-runner.js';
 import { AnthropicDirectModelRunner } from '../../src/adapters/anthropic/direct-model-runner.js';
 import { OpenAIAgentSdkAgentRunner } from '../../src/adapters/openai/agent-sdk-agent-runner.js';
 import { ClaudeAgentSdkAgentRunner } from '../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
 import type { ResolvedAiConfig } from '../../src/core/config.js';
 import type { RuntimeLogger } from '../../src/adapters/runtime-composition.js';
-import type { DirectModelRunner, DirectModelRunRequest } from '../../src/types/ai.js';
+import type { DirectModelRunner, DirectModelRunRequest, AgentRunner, AgentRunRequest } from '../../src/types/ai.js';
 
 function makeWorkflowConfig(ai: Partial<AiConfig>): WorkflowConfig {
   return { ai } as unknown as WorkflowConfig;
@@ -192,12 +192,24 @@ describe('RoutingAwareDirectModelRunner dispatch', () => {
   });
 });
 
-function makeAgentResolvedAi(runner: 'claude_agent_sdk' | 'openai_agents', credentialType: string = 'api_key'): ResolvedAiConfig {
+function makeAgentResolvedAi(runner: 'claude_agent_sdk' | 'openai_agent_sdk', credentialType: string = 'api_key'): ResolvedAiConfig {
   return {
     credentials: [{ name: 'cred', type: credentialType, resolvedValue: 'sk-test' }],
     endpoints: [{ name: 'ep', protocol: 'openai', credential: 'cred' }],
     profiles: [{ name: 'p', endpoint: 'ep', runner, model: 'gpt-4o' }],
     routing: { 'implementation.run': 'p' },
+  } as unknown as ResolvedAiConfig;
+}
+
+function makeMixedAgentResolvedAi(): ResolvedAiConfig {
+  return {
+    credentials: [{ name: 'cred', type: 'api_key', resolvedValue: 'sk-test' }],
+    endpoints: [{ name: 'ep', protocol: 'openai', credential: 'cred' }],
+    profiles: [
+      { name: 'claude-p', endpoint: 'ep', runner: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+      { name: 'openai-p', endpoint: 'ep', runner: 'openai_agent_sdk', model: 'gpt-4o' },
+    ],
+    routing: { 'artifact.create': 'claude-p', 'implementation.run': 'openai-p' },
   } as unknown as ResolvedAiConfig;
 }
 
@@ -207,8 +219,8 @@ describe('buildAgentRunner dispatch', () => {
     expect(runner).toBeInstanceOf(ClaudeAgentSdkAgentRunner);
   });
 
-  test('returns OpenAIAgentSdkAgentRunner when profile runner is openai_agents', () => {
-    const runner = buildAgentRunner(makeAgentResolvedAi('openai_agents'), noopLogger);
+  test('returns OpenAIAgentSdkAgentRunner when profile runner is openai_agent_sdk', () => {
+    const runner = buildAgentRunner(makeAgentResolvedAi('openai_agent_sdk'), noopLogger);
     expect(runner).toBeInstanceOf(OpenAIAgentSdkAgentRunner);
   });
 
@@ -225,13 +237,13 @@ describe('buildAgentRunner dispatch', () => {
     );
   });
 
-  test('throws a clear startup error when openai_agents profile uses non-api_key credential', () => {
+  test('throws a clear startup error when openai_agent_sdk profile uses non-api_key credential', () => {
     expect(() =>
-      buildAgentRunner(makeAgentResolvedAi('openai_agents', 'bearer_token'), noopLogger),
-    ).toThrow(/not supported for openai_agents runner/);
+      buildAgentRunner(makeAgentResolvedAi('openai_agent_sdk', 'bearer_token'), noopLogger),
+    ).toThrow(/not supported for openai_agent_sdk runner/);
   });
 
-  test('logs service.config event with correct fields when openai_agents profile is used', () => {
+  test('logs service.config event with correct fields when openai_agent_sdk profile is used', () => {
     const loggedInfoCalls: unknown[] = [];
     const capturingLogger: RuntimeLogger = {
       debug: () => {},
@@ -240,7 +252,7 @@ describe('buildAgentRunner dispatch', () => {
       info: (obj: unknown) => { loggedInfoCalls.push(obj); },
     };
 
-    buildAgentRunner(makeAgentResolvedAi('openai_agents'), capturingLogger);
+    buildAgentRunner(makeAgentResolvedAi('openai_agent_sdk'), capturingLogger);
 
     const serviceConfigEvent = loggedInfoCalls.find(
       (c): c is Record<string, unknown> =>
@@ -248,6 +260,75 @@ describe('buildAgentRunner dispatch', () => {
     );
     expect(serviceConfigEvent).toBeDefined();
     expect(serviceConfigEvent?.['provider']).toBe('openai');
-    expect(serviceConfigEvent?.['runner']).toBe('openai_agents');
+    expect(serviceConfigEvent?.['runner']).toBe('openai_agent_sdk');
+  });
+
+  test('returns RoutingAwareAgentRunner when both claude_agent_sdk and openai_agent_sdk profiles exist', () => {
+    const runner = buildAgentRunner(makeMixedAgentResolvedAi(), noopLogger);
+    expect(runner).toBeInstanceOf(RoutingAwareAgentRunner);
+  });
+});
+
+describe('RoutingAwareAgentRunner dispatch', () => {
+  function makeAgentRunnerMock(): AgentRunner {
+    return {
+      run: vi.fn().mockImplementation(async function* () {
+        yield { type: 'assistant', content: [{ type: 'text', text: 'ok' }] };
+      }),
+    };
+  }
+
+  it('dispatches to openAiRunner when request.profile.provider is openai_agent_sdk', async () => {
+    const claudeRunner = makeAgentRunnerMock();
+    const openAiRunner = makeAgentRunnerMock();
+    const wrapper = new RoutingAwareAgentRunner(claudeRunner, openAiRunner);
+
+    const req: AgentRunRequest = {
+      route: { task: 'implementation.run' },
+      profile: { id: 'openai-p', provider: 'openai_agent_sdk', model: 'gpt-4o' },
+      working_directory: '/tmp',
+      prompt: 'do it',
+    };
+    const events = [];
+    for await (const event of wrapper.run(req)) {
+      events.push(event);
+    }
+    expect(openAiRunner.run).toHaveBeenCalledWith(req);
+    expect(claudeRunner.run).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+  });
+
+  it('dispatches to claudeRunner when request.profile.provider is claude_agent_sdk', async () => {
+    const claudeRunner = makeAgentRunnerMock();
+    const openAiRunner = makeAgentRunnerMock();
+    const wrapper = new RoutingAwareAgentRunner(claudeRunner, openAiRunner);
+
+    const req: AgentRunRequest = {
+      route: { task: 'artifact.create' },
+      profile: { id: 'claude-p', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+      working_directory: '/tmp',
+      prompt: 'write a spec',
+    };
+    const events = [];
+    for await (const event of wrapper.run(req)) {
+      events.push(event);
+    }
+    expect(claudeRunner.run).toHaveBeenCalledWith(req);
+    expect(openAiRunner.run).not.toHaveBeenCalled();
+  });
+
+  it('falls back to claudeRunner when no profile is present', async () => {
+    const claudeRunner = makeAgentRunnerMock();
+    const openAiRunner = makeAgentRunnerMock();
+    const wrapper = new RoutingAwareAgentRunner(claudeRunner, openAiRunner);
+
+    const req: AgentRunRequest = {
+      route: { task: 'question.answer' },
+      working_directory: '/tmp',
+      prompt: 'what is this?',
+    };
+    for await (const _ of wrapper.run(req)) { /* drain */ }
+    expect(claudeRunner.run).toHaveBeenCalledWith(req);
+    expect(openAiRunner.run).not.toHaveBeenCalled();
   });
 });

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -110,6 +110,29 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('artifact creation prompt uses provider-neutral skill wording', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-artifact-prompt-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+
+      await service.create(makeRequest(), workspace);
+
+      expect(calls[0].prompt).toContain('Use the `mm:planning` skill');
+      expect(calls[0].prompt).not.toContain('/mm:planning');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('answers questions in the provided repo directory without creating a cloned workspace', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'ac-question-'));
     try {
@@ -204,6 +227,30 @@ describe('AgentRunner-backed core AI services', () => {
       });
       expect(calls[0].route).toEqual({ task: 'implementation.run' });
       expect(calls[0].working_directory).toBe(workspace);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation prompt names skills without slash commands', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-provider-neutral-prompt-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'Done', testing_instructions: 'Run tests' }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await service.implement('/tmp/spec.md', workspace);
+
+      expect(calls[0].prompt).toContain('superpowers:writing-plans');
+      expect(calls[0].prompt).toContain('superpowers:subagent-driven-development');
+      expect(calls[0].prompt).not.toContain('/superpowers:');
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }

--- a/tests/core/runtime-composition.test.ts
+++ b/tests/core/runtime-composition.test.ts
@@ -89,6 +89,7 @@ const BASE_AI_CONFIG = {
   ],
   profiles: [
     { name: 'default', endpoint: 'anthropic-direct', model: 'claude-sonnet-4-5', runner: 'anthropic_direct' as const },
+    { name: 'agent', endpoint: 'anthropic-direct', model: 'claude-sonnet-4-5', runner: 'claude_agent_sdk' as const },
   ],
   routing: { default_profile: 'default' },
 };
@@ -102,6 +103,7 @@ const BEDROCK_AI_CONFIG = {
   ],
   profiles: [
     { name: 'default', endpoint: 'bedrock-direct', model: 'claude-sonnet-4-5', runner: 'anthropic_direct' as const },
+    { name: 'agent', endpoint: 'bedrock-direct', model: 'claude-sonnet-4-5', runner: 'claude_agent_sdk' as const },
   ],
   routing: { default_profile: 'default' },
 };


### PR DESCRIPTION
Implements `OpenAIAgentSdkAgentRunner` — a new agent runner that drives the OpenAI Agents SDK (`@openai/agents`) using `SandboxAgent`, enabling agent tasks to be routed through OpenAI-compatible endpoints (e.g. Grove/Azure APIM).

## Changes

- Add `OpenAIAgentSdkAgentRunner` with `SandboxAgent`, telemetry, skill routing, logging, and configurable max turns
- Add `materializeOpenAIRuntimeSkills` — reads runtime skill catalog and passes skills as `SandboxAgent` capabilities via `sdkSkills()`
- Add `skillRefsForRoute` — maps agent route to required skill refs
- Add `RoutingAwareAgentRunner` for mixed `claude_agent_sdk` + `openai_agent_sdk` configs
- Fix `RunnerKind`: rename `openai_agents` → `openai_agent_sdk` throughout to match spec
- Wire `buildAgentRunner` into `composeBuiltInWorkflowRuntime`
- Use `OpenAIResponsesModel` to properly apply `api-key` header for Grove/Azure APIM endpoints
- Wire `UnixLocalSandboxClient` to run agent in existing workspace directory
- Add filesystem/shell/compaction default capabilities alongside skill capabilities

## Testing

\`\`\`
npm install && npx tsc --noEmit
npx vitest run
\`\`\`

Closes #112