### PR TITLE
fix: fix windows shell path handling in workspace and config operations

### DIFF
--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import type pino from 'pino';
 import type { Meter } from '@opentelemetry/api';
@@ -193,7 +193,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
 
 function resolveRepoUrl(repoPath: string, logger: RuntimeLogger): string {
   try {
-    const repoUrl = execSync('git remote get-url origin', { cwd: repoPath }).toString().trim();
+    const repoUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: repoPath }).toString().trim();
     if (!repoUrl) throw new Error('git remote get-url origin returned empty string');
     return repoUrl;
   } catch (err) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,6 @@
 import { parse as parseYaml } from 'yaml';
 import { existsSync, writeFileSync, readFileSync } from 'node:fs';
-import { join, basename, resolve } from 'node:path';
+import { join, basename, dirname, resolve } from 'node:path';
 import type { WorkflowConfig, LoadedConfig, AiConfig, CredentialConfig, EndpointConfig, ProfileConfig, RoutingConfig } from '../types/config.js';
 import { generateDefaultConfig } from '../config/defaults.js';
 
@@ -283,8 +283,8 @@ export function loadConfig(
   filePath: string,
   env: Record<string, string | undefined>,
 ): LoadedConfig {
-  const repoPath = filePath.replace(/\/autocatalyst\.yaml$/, '') || '.';
-  return loadConfigFromPath(repoPath, env);
+  const repoPath = basename(filePath) === 'autocatalyst.yaml' ? dirname(filePath) : filePath;
+  return loadConfigFromPath(repoPath || '.', env);
 }
 
 export function bootstrapConfig(repoPath: string): boolean {

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, basename, resolve } from 'node:path';
 import * as readline from 'node:readline';
 import { stringify } from 'yaml';
 import { parseAutocatalystConfig } from './config.js';
@@ -219,7 +219,7 @@ function setByPath(obj: Record<string, unknown>, path: string, value: unknown): 
 }
 
 function createSkeleton(repoPath: string): void {
-  const name = repoPath.split('/').filter(Boolean).pop() ?? 'project';
+  const name = basename(resolve(repoPath)) || 'project';
   const content = `workspace:
   root: ''
 channels:

--- a/src/core/workspace-manager.ts
+++ b/src/core/workspace-manager.ts
@@ -1,14 +1,19 @@
-import { promisify } from 'node:util';
-import { exec as _exec } from 'node:child_process';
+import { execFile as _execFile } from 'node:child_process';
 import { rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type pino from 'pino';
 import { createLogger } from './logger.js';
 
-const defaultExec = promisify(_exec);
+function defaultExec(cmd: string, args: string[], opts?: { cwd?: string }): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    _execFile(cmd, args, opts ?? {}, (err, stdout, stderr) => {
+      if (err) { reject(err); } else { resolve({ stdout, stderr }); }
+    });
+  });
+}
 
-type ExecFn = (cmd: string, opts?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }>;
+type ExecFn = (cmd: string, args: string[], opts?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }>;
 
 export interface WorkspaceManager {
   create(request_id: string, repo_url: string, workspace_root: string): Promise<{ workspace_path: string; branch: string }>;
@@ -41,7 +46,7 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
 
     // Clone
     try {
-      await this.execFn(`git clone --depth=1 "${repo_url}" "${workspace_path}"`);
+      await this.execFn('git', ['clone', '--depth=1', repo_url, workspace_path]);
     } catch (err) {
       // Clean up partially-created directory if present
       try { rmSync(workspace_path, { recursive: true, force: true }); } catch { /* ignore */ }
@@ -50,7 +55,7 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
 
     // Create branch
     try {
-      await this.execFn(`git checkout -b "${branch}"`, { cwd: workspace_path });
+      await this.execFn('git', ['checkout', '-b', branch], { cwd: workspace_path });
     } catch (err) {
       // Clean up cloned directory if present
       try { rmSync(workspace_path, { recursive: true, force: true }); } catch { /* ignore */ }

--- a/tests/core/bootstrap.test.ts
+++ b/tests/core/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, chmodSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import { tmpdir } from 'node:os';
 import { rmSync } from 'node:fs';
 import { bootstrapConfig } from '../../src/core/config.js';
@@ -31,14 +31,14 @@ describe('bootstrapWorkflow', () => {
   it('derives repo name from directory path', () => {
     bootstrapConfig(tempDir);
     const content = readFileSync(join(tempDir, 'autocatalyst.yaml'), 'utf-8');
-    const dirName = tempDir.split('/').pop()!;
+    const dirName = basename(tempDir);
     expect(content).toContain(dirName);
   });
 
   it('derives repo name from path with trailing slash', () => {
     bootstrapConfig(tempDir + '/');
     const content = readFileSync(join(tempDir, 'autocatalyst.yaml'), 'utf-8');
-    const dirName = tempDir.split('/').pop()!;
+    const dirName = basename(tempDir);
     expect(content).toContain(dirName);
   });
 

--- a/tests/core/hot-reload.test.ts
+++ b/tests/core/hot-reload.test.ts
@@ -55,4 +55,22 @@ describe('loadConfig', () => {
     );
     expect(() => loadConfig(join(tempDir, 'autocatalyst.yaml'), {})).toThrow(/interval_ms/);
   });
+
+  it('handles a Windows-style file path using dirname rather than POSIX regex', () => {
+    // Simulate the path that node:path.win32 would produce on Windows.
+    // On POSIX the path separators won't actually be backslashes, but we can
+    // test the cross-platform logic by constructing a path where basename() is
+    // 'autocatalyst.yaml' and dirname() returns the real temp dir.
+    // That is exactly what join(tempDir, 'autocatalyst.yaml') already gives us
+    // on every platform — we rely on the implementation using dirname() rather
+    // than a regex that only strips the POSIX '/autocatalyst.yaml' suffix.
+    writeFileSync(
+      join(tempDir, 'autocatalyst.yaml'),
+      `polling:\n  interval_ms: 3000\n${MINIMAL_AI_CONFIG}`,
+    );
+    // Pass the full file path; loadConfig must correctly resolve the repo dir.
+    const result = loadConfig(join(tempDir, 'autocatalyst.yaml'), {});
+    expect(result.config.polling?.interval_ms).toBe(3000);
+    expect(result.filePath).toContain('autocatalyst.yaml');
+  });
 });

--- a/tests/core/runtime-composition.test.ts
+++ b/tests/core/runtime-composition.test.ts
@@ -4,6 +4,7 @@ import type { LoadedConfig } from '../../src/types/config.js';
 vi.mock('node:child_process', async (importOriginal) => ({
   ...(await importOriginal<typeof import('node:child_process')>()),
   execSync: vi.fn().mockReturnValue('https://example.test/org/repo.git\n'),
+  execFileSync: vi.fn().mockReturnValue('https://example.test/org/repo.git\n'),
 }));
 
 vi.mock('@slack/bolt', () => ({

--- a/tests/core/workspace-manager.test.ts
+++ b/tests/core/workspace-manager.test.ts
@@ -23,14 +23,25 @@ describe('WorkspaceManager.create', () => {
 
     await wm.create('idea-abc', 'https://github.com/org/repo.git', tempRoot);
 
-    expect(execFn).toHaveBeenCalledWith(
-      expect.stringContaining('git clone --depth=1'),
-    );
-    expect(execFn).toHaveBeenCalledWith(
-      expect.stringContaining('https://github.com/org/repo.git'),
-    );
-    const cloneCall = execFn.mock.calls[0][0] as string;
-    expect(cloneCall).toContain(join(tempRoot, 'idea-abc'));
+    const cloneCall = execFn.mock.calls[0];
+    expect(cloneCall[0]).toBe('git');
+    expect(cloneCall[1]).toContain('clone');
+    expect(cloneCall[1]).toContain('--depth=1');
+    expect(cloneCall[1]).toContain('https://github.com/org/repo.git');
+    expect(cloneCall[1]).toContain(join(tempRoot, 'idea-abc'));
+  });
+
+  it('passes workspace_path as a single argument (not embedded in a shell string)', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
+
+    await wm.create('idea-abc', 'https://github.com/org/repo.git', tempRoot);
+
+    const cloneArgs: string[] = execFn.mock.calls[0][1];
+    // The workspace path must appear as its own element, never concatenated with quotes or other text
+    const workspacePath = join(tempRoot, 'idea-abc');
+    expect(cloneArgs).toContain(workspacePath);
+    expect(cloneArgs.some(a => a.includes('"') && a.includes(workspacePath))).toBe(false);
   });
 
   it('runs git checkout -b after clone with correct branch and cwd', async () => {
@@ -41,8 +52,9 @@ describe('WorkspaceManager.create', () => {
 
     expect(execFn).toHaveBeenCalledTimes(2);
     const checkoutCall = execFn.mock.calls[1];
-    expect(checkoutCall[0]).toMatch(/^git checkout -b "?spec\//);
-    expect(checkoutCall[1]).toEqual({ cwd: join(tempRoot, 'idea-abc') });
+    expect(checkoutCall[0]).toBe('git');
+    expect(checkoutCall[1]).toEqual(['checkout', '-b', expect.stringMatching(/^spec\//)]);
+    expect(checkoutCall[2]).toEqual({ cwd: join(tempRoot, 'idea-abc') });
   });
 
   it('returns workspace_path and branch', async () => {
@@ -130,6 +142,24 @@ describe('WorkspaceManager.create', () => {
       rmSync(root1, { recursive: true, force: true });
       rmSync(root2, { recursive: true, force: true });
     }
+  });
+
+  it('preserves a Windows-style workspace root as a single argument without shell quoting', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+    const wm = new WorkspaceManagerImpl({ execFn, logDestination: nullDest });
+
+    // Simulate a Windows-style path by passing it as workspace_root.
+    // The ~ expansion won't apply because the path doesn't start with ~.
+    // We call create directly so we can inspect the args without running real git.
+    const windowsRoot = 'C:\\Users\\mark\\.autocatalyst\\workspaces';
+    await wm.create('idea-win', 'https://github.com/org/repo.git', windowsRoot);
+
+    const cloneArgs: string[] = execFn.mock.calls[0][1];
+    // workspace_path should be the last arg and must be a plain string (no embedded quotes)
+    const workspacePath = cloneArgs[cloneArgs.length - 1];
+    expect(workspacePath).toContain('idea-win');
+    expect(workspacePath).not.toMatch(/^".*"$/); // not wrapped in double-quotes
+    expect(cloneArgs.some(a => a.startsWith('"') || a.endsWith('"'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixed Windows shell path handling across workspace creation, config loading, and subprocess calls.

## Testing

npm install && npx vitest run

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/0203364d-19d8-4f93-bc72-7f0a65d16451/.autocatalyst/triage/triage-bug-windows-shell-path-handling.md`
Closes #102