### PR TITLE
feat: fix :ac-set-status: for runs in terminal state

### DIFF
--- a/context-human/specs/feature-debug-mode-slack.md
+++ b/context-human/specs/feature-debug-mode-slack.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-11
-last_updated: 2026-05-11
-status: implementing
+last_updated: 2026-05-12
+status: complete
 issue: 67
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/context-human/specs/feature-debug-mode-slack.md
+++ b/context-human/specs/feature-debug-mode-slack.md
@@ -1,0 +1,277 @@
+---
+created: 2026-05-11
+last_updated: 2026-05-11
+status: implementing
+issue: 67
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Ignored message reactions and :ac-set-status: for Slack
+
+## What
+
+Two always-on improvements to Slack operator visibility:
+1. Autocatalyst reacts with `:ac-message-ignored:` when it ignores a Slack message, making deliberate discards visible without log access. When a message is received in a known run thread but discarded because the run's current stage cannot accept input, Autocatalyst additionally responds with `:ac-message-discarded:`.
+2. Operators can update a stuck run's stage by posting the target stage name in a run thread and reacting to that message with `:ac-set-status:`. The command is thread-only; the thread context determines which run to update.
+Neither capability requires a config flag. Both are always active. If granular control is needed in the future, a `debug` config block can be introduced at that time.
+## Why
+
+Autocatalyst currently gives operators no signal when a Slack message is silently discarded. A message can be ignored because it lacks a bot mention, belongs to an unrelated thread, or arrives while a run is in a stage that cannot accept feedback. Without a visible signal, operators cannot distinguish an expected discard from a broken connection without leaving Slack to read process logs.
+Runs can also get stuck in a stale stage after an agent failure, process restart, or incorrect classification. Operators currently have no in-Slack way to correct this; they must access the filesystem or restart the service.
+Both problems are addressed by lightweight, always-available Slack interactions that require no configuration.
+## Personas
+
+- **Enzo: Engineer/operator** — monitors Autocatalyst runs, diagnoses routing failures, and corrects stale run state when needed.
+- **Phoebe: Product manager** — notices when a thread appears silent and can ask an operator to investigate without needing filesystem access herself.
+## Narratives
+
+### Finding a silently ignored or discarded message
+
+Enzo is testing a new Slack routing rule. He posts a message he expects Autocatalyst to ignore because it does not mention the bot. The bot reacts with `:ac-message-ignored:`. Enzo knows the message was seen and deliberately discarded rather than missed.
+He then replies in an unrelated Slack thread and mentions the bot. The bot again reacts with `:ac-message-ignored:` because the thread is not tied to a known run. Enzo can distinguish an expected discard from a broken connection without reading logs.
+Later, Enzo posts a feedback message in a run thread while the run is in the `implementing` stage, which does not accept operator input. The bot responds with `:ac-message-discarded:`, signaling that the message was received in a known run context but explicitly dropped because the stage does not accept input — distinct from being ignored outright.
+### Unsticking a stuck run
+
+A process restart leaves a run in `implementing`, but the PR review thread is ready. Enzo opens the Slack thread for the run, posts the message `reviewing_implementation`, and reacts to it with `:ac-set-status:`. Autocatalyst validates the stage name, updates the run in memory, persists it, and replies with the old and new stage.
+Because stage text is trimmed and lowercased before processing, Enzo could also post `"  Reviewing_Implementation  "` and get the same result — the normalized form `reviewing_implementation` is what is validated and applied.
+If Enzo mistypes the stage name, Autocatalyst replies with a list of valid stages and leaves the run unchanged.
+## User stories
+
+### Ignored-message reaction
+
+- When Autocatalyst classifies a Slack message as `ignore` because it lacks a bot mention or belongs to an unrelated thread, it adds `:ac-message-ignored:` to the message.
+- When a message arrives in a known run thread but is discarded because the run's current stage cannot accept input, Autocatalyst responds with `:ac-message-discarded:`.
+- Reaction and response failures are logged but do not emit inbound events or reply further in Slack.
+### Stage override via :ac-set-status:
+
+- Enzo can post a valid stage name in a run thread and react to that message with `:ac-set-status:` to update the run's stage.
+- The command works only in a thread associated with a known run. Using it in an unlinked thread returns a clear error.
+- Autocatalyst replies with the previous stage and the new stage on success.
+- An invalid stage name returns an error listing valid stage names; the run is not changed.
+- A successful override is persisted so the updated stage survives a process restart.
+- Malformed input (empty message text, whitespace only) returns a usage error.
+## Goals
+
+- React to ignored Slack messages with `:ac-message-ignored:` with no config flag.
+- Respond to blocked-stage thread messages with `:ac-message-discarded:` with no config flag.
+- Support `:ac-set-status:` as an emoji command that works only within a run thread.
+- Resolve the run from thread context; no run ID argument is required.
+- Read the target stage from the trimmed, lowercased text of the message the emoji is applied to.
+- Validate the target stage against the `RunStage` union before mutating state.
+- Persist a successful stage override through the existing run store.
+- Reply with a clear confirmation or a clear error for every `:ac-set-status:` invocation.
+## Non-goals
+
+- A `debug` config block or any per-flag gating of these behaviors.
+- Log retrieval via Slack text commands (already provided by `:ac-run-logs:`).
+- Run listing or run detail inspection via Slack text commands (already provided by `:ac-run-status:`).
+- Supporting `:ac-set-status:` outside a run thread (e.g., as a top-level mention command with an explicit run ID).
+- Editing run fields other than `stage`.
+- Creating, deleting, retrying, or canceling runs. Existing command-mode cancellation remains separate.
+- Role-based authorization beyond channel access.
+- Supporting these behaviors for non-Slack channel adapters in this iteration.
+- Guaranteeing that every ignored internal event receives a reaction. Only Slack message events with a valid message timestamp can be reacted to.
+## Design changes
+
+### Ignored-message reaction and discarded-message response
+
+When `classifyMessage()` returns `ignore` because a message lacks a bot mention or belongs to an unrelated thread, the Slack adapter calls `reactions.add` with `ac-message-ignored` on the message. No config check precedes this call. Reaction failures are logged and do not affect downstream processing.
+When a message arrives in a known run thread but is rejected because the run's current stage cannot accept input, the Slack adapter calls `reactions.add` with `ac-message-discarded` on the message. The same failure-handling policy applies.
+**Ignored reaction:**
+```plain text
+:ac-message-ignored:
+```
+**Discarded response:**
+```plain text
+:ac-message-discarded:
+```
+### :ac-set-status: emoji command
+
+`:ac-set-status:` follows the existing emoji command path. The command handler:
+1. Resolves the run from the thread's `ThreadRegistry` entry.
+2. Reads the stage name from the text of the message the emoji was applied to (trimmed, lowercased).
+	- Example: `"  Reviewing_Implementation  "` → `reviewing_implementation`
+	- Example: `"IMPLEMENTING"` → `implementing`
+3. Validates the stage name against `VALID_RUN_STAGES`.
+4. On success: updates `run.stage` and `run.updated_at`, calls `_persistRuns()`, and replies in thread.
+5. On failure: replies with the applicable error and leaves state unchanged.
+**Success reply:**
+```plain text
+Run 4f8c... stage updated: implementing → reviewing_implementation. Change persisted.
+```
+**Invalid stage reply:**
+```plain text
+Unknown stage "implemneting". Valid stages: intake, speccing, reviewing_spec, implementing, awaiting_impl_input, reviewing_implementation, pr_open, done, failed.
+```
+**Not in a run thread reply:**
+```plain text
+:ac-set-status: can only be used in a thread linked to an active run.
+```
+**Empty message text reply:**
+```plain text
+React to a message containing the target stage name. Valid stages: intake, speccing, reviewing_spec, implementing, awaiting_impl_input, reviewing_implementation, pr_open, done, failed.
+```
+## Technical changes
+
+### Affected files
+
+- `src/adapters/slack/slack-adapter.ts` — add `:ac-message-ignored:` reaction for every `ignore` classification; add `:ac-message-discarded:` response for blocked-stage thread messages; ensure `:ac-set-status:` dispatches through the existing emoji command path.
+- `src/adapters/slack/classifier.ts` — no change expected; emoji command classification already handles `:ac-*:` patterns.
+- `src/core/commands/registry-setup.ts` — register `ac-set-status` command handler unconditionally.
+- `src/core/commands/set-status-command.ts` *(new)* — implement stage override handler: resolve run from thread, read stage from message text, validate, persist, reply.
+- `src/core/orchestrator.ts` — add `overrideRunStage(runId, stage)` private helper used by the command handler.
+- `src/core/run-store.ts` — no schema change expected; verify stage override uses the existing `save()` path.
+- Tests in `tests/adapters/slack/`, `tests/core/commands/`, and `tests/core/orchestrator.test.ts`.
+## Tech spec
+
+### 1. Introduction and overview
+
+**Dependencies and assumptions**
+- Depends on `feature-command-mode.md` — emoji command dispatch and `ThreadRegistry` already exist.
+- Depends on `feature-slack-message-routing.md` — Slack adapter classification and thread-to-run mapping already exist.
+- Depends on `FileRunStore` — run persistence already writes all records to `.autocatalyst/runs.json`.
+- Slack API calls may fail. Reactions are best-effort. `:ac-set-status:` must return user-visible errors for all failure cases.
+**Technical goals**
+- `:ac-message-ignored:` reaction fires for every `ignore` classification (no bot mention, unrelated thread) with no config check.
+- `:ac-message-discarded:` response fires for blocked-stage thread messages with no config check.
+- `:ac-set-status:` dispatches via the existing emoji command path without any new classification logic.
+- `overrideRunStage()` validates the stage, mutates in-memory state, and persists before returning.
+- No new config types, resolvers, or runtime composition changes are required.
+**Glossary**
+- **Discard reaction** — a Slack emoji reaction added to a message classified as `ignore` (`:ac-message-ignored:`) or blocked by stage (`:ac-message-discarded:`).
+- **Stage override** — operator-forced update to `run.stage`, persisted through the existing run store.
+---
+### 2. Stage override design
+
+**Stage override flow**
+```mermaid
+sequenceDiagram
+    actor Enzo
+    participant Slack
+    participant Orchestrator
+    participant RunStore
+
+    Enzo->>Slack: Posts "reviewing_implementation" in thread
+    Enzo->>Slack: Reacts with :ac-set-status:
+    Slack->>Orchestrator: CommandEvent ac-set-status
+    Orchestrator->>Orchestrator: resolve run from ThreadRegistry
+    Orchestrator->>Orchestrator: read stage from message text (trim + lowercase)
+    Orchestrator->>Orchestrator: validate stage against VALID_RUN_STAGES
+    Orchestrator->>Orchestrator: update stage and updated_at
+    Orchestrator->>RunStore: save(runs)
+    Orchestrator-->>Slack: stage updated confirmation
+```
+#### Orchestrator helper
+
+```typescript
+private overrideRunStage(
+  runId: string,
+  stage: RunStage
+): 'updated' | 'not_found' | 'invalid_stage';
+```
+- `runId` is resolved from the thread's `ThreadRegistry` entry by the command handler before calling this method.
+- Validates `stage` against `VALID_RUN_STAGES` before touching state.
+- On success: updates `run.stage`, sets `run.updated_at = new Date().toISOString()`, calls `_persistRuns()`.
+- Returns one of three discriminated results; the command handler formats the Slack reply accordingly.
+#### Valid stages constant
+
+```typescript
+export const VALID_RUN_STAGES: RunStage[] = [
+  'intake',
+  'speccing',
+  'reviewing_spec',
+  'implementing',
+  'awaiting_impl_input',
+  'reviewing_implementation',
+  'pr_open',
+  'done',
+  'failed',
+];
+```
+#### :ac-set-status: handler
+
+```typescript
+// src/core/commands/set-status-command.ts
+
+export interface SetStatusCommandDeps {
+  findRunForThread: (threadTs: string, channelId: string) => Run | undefined;
+  overrideRunStage: (runId: string, stage: RunStage) => 'updated' | 'not_found' | 'invalid_stage';
+}
+
+export function createSetStatusHandler(deps: SetStatusCommandDeps): CommandHandler;
+```
+The handler reads the stage from `event.messageText` (the text of the message the emoji was reacted to), trims and lowercases it, then:
+1. Rejects empty or whitespace-only text with a usage error and valid stage list.
+2. Resolves the run via `findRunForThread(event.threadTs, event.channelId)`.
+3. Returns a not-in-thread error if no run is found.
+4. Calls `overrideRunStage(run.id, stage)` and replies based on the result.
+---
+### 3. Testing plan
+
+**Ignored-message reaction**
+- Ignored root messages (no bot mention) call `reactions.add` with `ac-message-ignored`.
+- Ignored unrelated thread replies call `reactions.add` with `ac-message-ignored`.
+- Blocked-stage thread messages call `reactions.add` with `ac-message-discarded`.
+- No config flag is consulted before any `reactions.add` call.
+- Reaction failures are logged and do not emit inbound events.
+**:ac-set-status: handler**
+- Valid stage in a known thread: updates stage, persists, replies with old and new stage.
+- Stage text with mixed case and surrounding whitespace (`"  Reviewing_Implementation  "`) is normalized and accepted.
+- Invalid stage: replies with valid stage list, leaves run unchanged, does not call `_persistRuns()`.
+- Unknown thread (no linked run): replies with not-in-thread error.
+- Empty or whitespace-only message text: replies with usage error and valid stage list.
+- Successful override persists through the run store.
+**Regression**
+- Existing `:ac-run-logs:`, `:ac-run-status:`, `:ac-run-cancel:`, `health`, and `help` command tests still pass.
+- Existing Slack routing tests for ignored messages, new requests, and thread messages still pass.
+## Task decomposition
+
+### Story 1: Ignored and discarded Slack messages receive visibility reactions
+
+**Description:** React to every ignored or discarded Slack message so operators can distinguish deliberate routing decisions from silent failures, and can tell apart stage-blocked messages from fully unrouted ones.
+**Tasks:**
+1. Add `:ac-message-ignored:` reaction and `:ac-message-discarded:` response in the Slack adapter.
+	- Acceptance criteria:
+		- Every `ignore` classification (no mention, unrelated thread) triggers `reactions.add` with `ac-message-ignored`.
+		- Every blocked-stage thread message triggers `reactions.add` with `ac-message-discarded`.
+		- No config flag is consulted.
+		- Reaction failure is logged; no inbound event is emitted.
+	- Dependencies: none.
+2. Add adapter tests.
+	- Acceptance criteria:
+		- Tests assert `reactions.add` is called with `ac-message-ignored` for ignored root and unrelated thread messages.
+		- Tests assert `reactions.add` is called with `ac-message-discarded` for blocked-stage thread messages.
+		- Tests assert no inbound event is emitted on reaction failure.
+	- Dependencies: task 1.
+### Story 2: :ac-set-status: emoji command updates run stage in a thread
+
+**Description:** Implement the emoji command that lets operators correct a stuck run's stage directly from the Slack thread.
+**Tasks:**
+1. Add `VALID_RUN_STAGES` constant.
+	- Acceptance criteria:
+		- Constant covers every `RunStage` value.
+		- Invalid strings are rejected by comparison.
+	- Dependencies: none.
+2. Add `overrideRunStage()` orchestrator helper.
+	- Acceptance criteria:
+		- Validates stage against `VALID_RUN_STAGES`.
+		- Updates `stage` and `updated_at` on success.
+		- Calls `_persistRuns()` on success.
+		- Does not mutate state on invalid stage or missing run.
+	- Dependencies: task 1.
+3. Implement `set-status-command.ts` handler.
+	- Acceptance criteria:
+		- Reads stage from message text (trimmed, lowercased).
+		- Resolves run from thread context.
+		- Delegates to `overrideRunStage()`.
+		- Replies with appropriate success or error message for all outcomes (valid, invalid stage, unknown thread, empty text).
+	- Dependencies: task 2.
+4. Register handler and add tests.
+	- Acceptance criteria:
+		- Handler is registered unconditionally in `registry-setup.ts`.
+		- Tests cover valid override, invalid stage, unknown thread, and empty message text.
+		- Tests cover mixed-case and whitespace-padded input being normalized correctly.
+		- Successful override persists through run store mock.
+		- Regression: existing emoji command tests pass.
+	- Dependencies: task 3.

--- a/src/adapters/slack/classifier.ts
+++ b/src/adapters/slack/classifier.ts
@@ -21,6 +21,7 @@ export const EMOJI_COMMAND_TABLE: Record<string, string> = {
   'ac-health': 'health',
   'ac-help': 'help',
   'ac-classify-intent': 'classify-intent',
+  'ac-set-status': 'run.set-status',
 };
 
 export function classifyMessage(

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -196,6 +196,7 @@ export class SlackAdapter implements ChannelAdapter {
           { event: 'slack.message.ignored', author: msg.user, channel_id: channelId },
           'Message ignored',
         );
+        await this.reactToMessage(channelId, msg.ts, 'ac-message-ignored');
         return;
       }
 

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -296,6 +296,7 @@ export class SlackAdapter implements ChannelAdapter {
       }
 
       let reactedThreadTs: string = reaction.item.ts;
+      let reactedMessageText: string | undefined;
       try {
         const historyResult = await this.app.client.conversations.history({
           channel: reaction.item.channel!,
@@ -307,6 +308,7 @@ export class SlackAdapter implements ChannelAdapter {
         if (reactedMessage?.thread_ts) {
           reactedThreadTs = reactedMessage.thread_ts as string;
         }
+        reactedMessageText = typeof reactedMessage?.text === 'string' ? reactedMessage.text : undefined;
       } catch (err) {
         this.logger.warn(
           { event: 'slack.error', error: String(err) },
@@ -327,6 +329,7 @@ export class SlackAdapter implements ChannelAdapter {
         },
         author: reaction.user,
         received_at: new Date().toISOString(),
+        messageText: reactedMessageText,
         inferred_context: {
           request_id: this.registry.resolve(reactedThreadTs),
         },

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -305,10 +305,48 @@ export class SlackAdapter implements ChannelAdapter {
           inclusive: true,
         });
         const reactedMessage = historyResult.messages?.[0];
-        if (reactedMessage?.thread_ts) {
-          reactedThreadTs = reactedMessage.thread_ts as string;
+
+        if (reactedMessage?.ts === reaction.item.ts) {
+          // Exact match: the reacted message is a top-level channel message.
+          if (reactedMessage.thread_ts) {
+            reactedThreadTs = reactedMessage.thread_ts as string;
+          }
+          reactedMessageText = typeof reactedMessage.text === 'string' ? reactedMessage.text : undefined;
+        } else {
+          // conversations.history only returns top-level messages. The reacted message
+          // is a thread reply — search each registered thread for the exact reply.
+          const reactionTs = parseFloat(reaction.item.ts);
+          const candidates = this.registry.rootTimestamps()
+            .filter(rootTs => parseFloat(rootTs) < reactionTs)
+            .sort((a, b) => parseFloat(b) - parseFloat(a)); // most recent first
+
+          for (const rootTs of candidates) {
+            try {
+              const repliesResult = await this.app.client.conversations.replies({
+                channel: reaction.item.channel!,
+                ts: rootTs,
+                latest: reaction.item.ts,
+                limit: 1,
+                inclusive: true,
+              });
+              const replyMsg = (repliesResult.messages ?? []).find(
+                (m: { ts?: string }) => m.ts === reaction.item.ts,
+              );
+              if (replyMsg) {
+                reactedThreadTs = rootTs;
+                reactedMessageText = typeof (replyMsg as { text?: string }).text === 'string'
+                  ? (replyMsg as { text?: string }).text
+                  : undefined;
+                break;
+              }
+            } catch (replyErr) {
+              this.logger.debug(
+                { event: 'slack.error', error: String(replyErr) },
+                'Failed to fetch replies for thread root during reaction lookup',
+              );
+            }
+          }
         }
-        reactedMessageText = typeof reactedMessage?.text === 'string' ? reactedMessage.text : undefined;
       } catch (err) {
         this.logger.warn(
           { event: 'slack.error', error: String(err) },

--- a/src/adapters/slack/thread-registry.ts
+++ b/src/adapters/slack/thread-registry.ts
@@ -8,4 +8,12 @@ export class ThreadRegistry {
   resolve(thread_ts: string): string | undefined {
     return this.map.get(thread_ts);
   }
+
+  /**
+   * Returns all registered root timestamps. Used by the Slack adapter to search
+   * for thread replies when conversations.history cannot locate the exact message.
+   */
+  rootTimestamps(): string[] {
+    return [...this.map.keys()];
+  }
 }

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -38,6 +38,7 @@ export function bootstrapWorkflowRuntime(
     isConnected: deps.isConnected,
     getActiveRunCount: () => orchestrator.getActiveRunCount(),
     intentClassifier: deps.intentClassifier,
+    overrideRunStage: (requestId, stage) => orchestrator.overrideRunStage(requestId, stage),
   });
 
   const service = new Service(config, { orchestrator });

--- a/src/core/commands/registry-setup.ts
+++ b/src/core/commands/registry-setup.ts
@@ -1,5 +1,5 @@
 import type { CommandRegistry } from '../../types/commands.js';
-import type { Run } from '../../types/runs.js';
+import type { Run, RunStage } from '../../types/runs.js';
 import type { IntentClassifier } from '../../types/intent.js';
 import { makeClassifyIntentHandler } from './classify-intent-command.js';
 import { makeHealthHandler, makeHelpHandler } from './meta-commands.js';
@@ -9,6 +9,7 @@ import {
   makeRunLogsHandler,
   makeRunStatusHandler,
 } from './run-commands.js';
+import { createSetStatusHandler } from './set-status-command.js';
 
 export interface DefaultCommandDeps {
   runs: Map<string, Run>;
@@ -17,6 +18,7 @@ export interface DefaultCommandDeps {
   isConnected: () => boolean;
   getActiveRunCount: () => number;
   intentClassifier: IntentClassifier;
+  overrideRunStage: (requestId: string, stage: RunStage) => 'updated' | 'not_found' | 'invalid_stage';
 }
 
 export function registerDefaultCommands(registry: CommandRegistry, deps: DefaultCommandDeps): void {
@@ -54,5 +56,13 @@ export function registerDefaultCommands(registry: CommandRegistry, deps: Default
     'classify-intent',
     makeClassifyIntentHandler(deps.intentClassifier),
     'Test how a message would be classified. Usage: `:ac-classify-intent: <message>` or `:ac-classify-intent: <context> <message>`',
+  );
+  registry.register(
+    'run.set-status',
+    createSetStatusHandler({
+      findRunById: (requestId: string) => deps.runs.get(requestId),
+      overrideRunStage: deps.overrideRunStage,
+    }),
+    "Override a stuck run's stage. Usage: post the target stage name in a run thread, then react with `:ac-set-status:`",
   );
 }

--- a/src/core/commands/registry-setup.ts
+++ b/src/core/commands/registry-setup.ts
@@ -63,6 +63,6 @@ export function registerDefaultCommands(registry: CommandRegistry, deps: Default
       findRunById: (requestId: string) => deps.runs.get(requestId),
       overrideRunStage: deps.overrideRunStage,
     }),
-    "Override a stuck run's stage. Usage: post the target stage name in a run thread, then react with `:ac-set-status:`",
+    "Override a stuck run's stage. Usage: reply with `:ac-set-status: <stage>` in a run thread. E.g. `:ac-set-status: reviewing_implementation`",
   );
 }

--- a/src/core/commands/set-status-command.ts
+++ b/src/core/commands/set-status-command.ts
@@ -12,11 +12,14 @@ const VALID_STAGES_LIST = VALID_RUN_STAGES.join(', ');
 
 export function createSetStatusHandler(deps: SetStatusCommandDeps): CommandHandler {
   return async (event, reply) => {
-    const stage = (event.messageText ?? '').trim().toLowerCase();
+    // Read stage from args (text command: :ac-set-status: <stage>)
+    // or messageText (emoji reaction on a message containing the stage name)
+    const stageInput = event.args.length > 0 ? event.args.join(' ') : (event.messageText ?? '');
+    const stage = stageInput.trim().toLowerCase();
 
     if (!stage) {
       await reply(
-        `React to a message containing the target stage name. Valid stages: ${VALID_STAGES_LIST}.`,
+        `Usage: reply with \`:ac-set-status: <stage>\` in a run thread. Valid stages: ${VALID_STAGES_LIST}.`,
       );
       return;
     }

--- a/src/core/commands/set-status-command.ts
+++ b/src/core/commands/set-status-command.ts
@@ -1,0 +1,54 @@
+// src/core/commands/set-status-command.ts
+import type { CommandHandler } from '../../types/commands.js';
+import type { Run, RunStage } from '../../types/runs.js';
+import { VALID_RUN_STAGES } from '../../types/runs.js';
+
+export interface SetStatusCommandDeps {
+  findRunById: (requestId: string) => Run | undefined;
+  overrideRunStage: (requestId: string, stage: RunStage) => 'updated' | 'not_found' | 'invalid_stage';
+}
+
+const VALID_STAGES_LIST = VALID_RUN_STAGES.join(', ');
+
+export function createSetStatusHandler(deps: SetStatusCommandDeps): CommandHandler {
+  return async (event, reply) => {
+    const stage = (event.messageText ?? '').trim().toLowerCase();
+
+    if (!stage) {
+      await reply(
+        `React to a message containing the target stage name. Valid stages: ${VALID_STAGES_LIST}.`,
+      );
+      return;
+    }
+
+    const requestId = event.inferred_context?.request_id;
+    const run = requestId !== undefined ? deps.findRunById(requestId) : undefined;
+
+    if (!run) {
+      await reply(':ac-set-status: can only be used in a thread linked to an active run.');
+      return;
+    }
+
+    if (!VALID_RUN_STAGES.includes(stage as RunStage)) {
+      await reply(
+        `Unknown stage "${stage}". Valid stages: ${VALID_STAGES_LIST}.`,
+      );
+      return;
+    }
+
+    const previousStage = run.stage;
+    const result = deps.overrideRunStage(requestId!, stage as RunStage);
+
+    if (result === 'updated') {
+      await reply(
+        `Run ${run.id.slice(0, 8)}... stage updated: ${previousStage} → ${stage}. Change persisted.`,
+      );
+    } else if (result === 'not_found') {
+      await reply(':ac-set-status: can only be used in a thread linked to an active run.');
+    } else {
+      await reply(
+        `Unknown stage "${stage}". Valid stages: ${VALID_STAGES_LIST}.`,
+      );
+    }
+  };
+}

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -11,6 +11,7 @@ import type { WorkspaceManager } from './workspace-manager.js';
 import type { ArtifactAuthoringAgent, ImplementationAgent, QuestionAnsweringAgent } from '../types/ai.js';
 import type { ArtifactContentSource, ArtifactPublisher } from '../types/publisher.js';
 import type { Run, RunStage, RequestIntent } from '../types/runs.js';
+import { VALID_RUN_STAGES } from '../types/runs.js';
 import type { Request, InboundEvent } from '../types/events.js';
 import type { FeedbackSource } from '../types/feedback-source.js';
 import type { IntentClassifier, ClassificationContext, Intent } from '../types/intent.js';
@@ -571,6 +572,20 @@ export class OrchestratorImpl implements Orchestrator {
     this.transition(run, 'failed');
     this.logger.info({ event: 'run.cancelled', run_id: run.id, request_id: requestId }, 'Run cancelled via command');
     return 'cancelled';
+  }
+
+  overrideRunStage(requestId: string, stage: RunStage): 'updated' | 'not_found' | 'invalid_stage' {
+    if (!VALID_RUN_STAGES.includes(stage)) return 'invalid_stage';
+    const run = this.runs.get(requestId);
+    if (!run) return 'not_found';
+    run.stage = stage;
+    run.updated_at = new Date().toISOString();
+    this._persistRuns();
+    this.logger.info(
+      { event: 'run.stage_override', run_id: run.id, request_id: requestId, stage },
+      'Run stage overridden via operator command',
+    );
+    return 'updated';
   }
 
   private async reactToRunMessage(run: Run, reaction: string): Promise<void> {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -204,6 +204,12 @@ export class OrchestratorImpl implements Orchestrator {
     const actionableStages: RunStage[] = ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'pr_open'];
     if (!actionableStages.includes(run.stage)) {
       this.logger.debug({ event: 'classify.stage_blocked', stage: run.stage }, 'Stage blocked: discarding thread_message');
+      this.deps.adapter.react?.(event.payload.origin, 'ac-message-discarded').catch((err: unknown) => {
+        this.logger.error(
+          { event: 'adapter.react_error', error: String(err) },
+          'Failed to post ac-message-discarded reaction',
+        );
+      });
       return 'discard';
     }
     // Store original stage for routing in _handleRequest before advancing

--- a/src/core/run-store.ts
+++ b/src/core/run-store.ts
@@ -13,6 +13,7 @@ export interface RunStore {
 }
 
 const STALE_STAGES = new Set(['intake', 'speccing', 'implementing']);
+const TERMINAL_STAGES = new Set(['done', 'failed']);
 
 interface FileRunStoreOptions {
   logDestination?: pino.DestinationStream;
@@ -73,8 +74,8 @@ export class FileRunStore implements RunStore {
     let demotedCount = 0;
 
     for (const run of runs) {
-      // 4. Drop runs with missing workspace
-      if (!run.workspace_path || !fs.existsSync(run.workspace_path)) {
+      // 4. Drop runs with missing workspace (terminal runs are exempt — their workspace may be cleaned up)
+      if (!TERMINAL_STAGES.has(run.stage) && (!run.workspace_path || !fs.existsSync(run.workspace_path))) {
         this.logger.warn({ event: 'run_store.run_dropped', request_id: run.request_id, workspace_path: run.workspace_path }, 'Dropping run with missing workspace_path');
         droppedCount++;
         continue;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -8,6 +8,7 @@ export interface CommandEvent {
   origin: MessageRef;
   author: string;
   received_at: string;
+  messageText?: string;
   inferred_context?: {
     request_id?: string;
   };

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -13,6 +13,18 @@ export type RunStage =
   | 'done'
   | 'failed';
 
+export const VALID_RUN_STAGES: RunStage[] = [
+  'intake',
+  'speccing',
+  'reviewing_spec',
+  'implementing',
+  'awaiting_impl_input',
+  'reviewing_implementation',
+  'pr_open',
+  'done',
+  'failed',
+];
+
 export type RequestIntent = 'idea' | 'bug' | 'chore' | 'file_issues' | 'question';
 
 export interface LastImplementationResult {

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -25,7 +25,7 @@ function makeLogCapture() {
 function makeMockApp(opts: {
   botUserId?: string;
   channels?: Array<{ name: string; id: string }>;
-  historyMessages?: Array<{ ts: string; thread_ts?: string }>;
+  historyMessages?: Array<{ ts: string; thread_ts?: string; text?: string }>;
 }) {
   const messageHandlers: Array<(args: { message: unknown }) => Promise<void>> = [];
   const eventHandlers = new Map<string, Array<(args: { event: unknown }) => Promise<void>>>();
@@ -915,6 +915,65 @@ describe('SlackAdapter — ignored message reaction', () => {
   });
 });
 
+describe('SlackAdapter — reaction command messageText', () => {
+  it('populates messageText on CommandEvent from the text of the reacted-to message', async () => {
+    const mock = makeMockApp({
+      botUserId: 'UBOT',
+      channels: [{ name: 'ch', id: 'C1' }],
+      historyMessages: [{ ts: '111.0', thread_ts: '111.0', text: 'reviewing_implementation' }],
+    });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerReaction({
+      reaction: 'ac-set-status',
+      user: 'U1',
+      item: { type: 'message', channel: 'C1', ts: '111.0' },
+    });
+    const event = await eventPromise;
+
+    expect(event.type).toBe('command');
+    const cmd = event.payload as import('../../../src/types/commands.js').CommandEvent;
+    expect(cmd.command).toBe('run.set-status');
+    expect(cmd.messageText).toBe('reviewing_implementation');
+
+    await adapter.stop();
+  });
+
+  it('sets messageText to undefined when reacted-to message has no text', async () => {
+    const mock = makeMockApp({
+      botUserId: 'UBOT',
+      channels: [{ name: 'ch', id: 'C1' }],
+      historyMessages: [{ ts: '111.0' }],
+    });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerReaction({
+      reaction: 'ac-run-status',
+      user: 'U1',
+      item: { type: 'message', channel: 'C1', ts: '111.0' },
+    });
+    const event = await eventPromise;
+
+    expect(event.type).toBe('command');
+    const cmd = event.payload as import('../../../src/types/commands.js').CommandEvent;
+    expect(cmd.messageText).toBeUndefined();
+
+    await adapter.stop();
+  });
+});
+
 describe('SlackAdapter — reactToMessage', () => {
   const BOT_ID = 'UBOT001';
   const CHANNEL_ID = 'C123';
@@ -956,5 +1015,64 @@ describe('SlackAdapter — reactToMessage', () => {
     expect(errorLog).toBeDefined();
     expect(typeof errorLog!['error']).toBe('string');
     expect((errorLog!['error'] as string)).toContain('already_reacted');
+  });
+});
+
+describe('SlackAdapter — reaction command messageText', () => {
+  it('populates messageText on CommandEvent from the text of the reacted-to message', async () => {
+    const mock = makeMockApp({
+      botUserId: 'UBOT',
+      channels: [{ name: 'ch', id: 'C1' }],
+      historyMessages: [{ ts: '111.0', thread_ts: '111.0', text: 'reviewing_implementation' }],
+    });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerReaction({
+      reaction: 'ac-set-status',
+      user: 'U1',
+      item: { type: 'message', channel: 'C1', ts: '111.0' },
+    });
+    const event = await eventPromise;
+
+    expect(event.type).toBe('command');
+    const cmd = event.payload as import('../../../src/types/commands.js').CommandEvent;
+    expect(cmd.command).toBe('run.set-status');
+    expect(cmd.messageText).toBe('reviewing_implementation');
+
+    await adapter.stop();
+  });
+
+  it('sets messageText to undefined when reacted-to message has no text', async () => {
+    const mock = makeMockApp({
+      botUserId: 'UBOT',
+      channels: [{ name: 'ch', id: 'C1' }],
+      historyMessages: [{ ts: '111.0' }],
+    });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerReaction({
+      reaction: 'ac-run-status',
+      user: 'U1',
+      item: { type: 'message', channel: 'C1', ts: '111.0' },
+    });
+    const event = await eventPromise;
+
+    expect(event.type).toBe('command');
+    const cmd = event.payload as import('../../../src/types/commands.js').CommandEvent;
+    expect(cmd.messageText).toBeUndefined();
+
+    await adapter.stop();
   });
 });

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -853,6 +853,68 @@ describe('SlackAdapter — inbound handler ack behavior (emoji, no text)', () =>
   });
 });
 
+describe('SlackAdapter — ignored message reaction', () => {
+  it('adds ac-message-ignored reaction when message has no bot mention (root message)', async () => {
+    const mock = makeMockApp({ botUserId: 'UBOT', channels: [{ name: 'ch', id: 'C1' }] });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    // A root message with no @bot mention — will be classified as 'ignore'
+    await mock._triggerMessage({ user: 'U1', ts: '111.0', channel: 'C1', text: 'hello world' });
+
+    expect(mock.client.reactions.add).toHaveBeenCalledWith({
+      channel: 'C1',
+      timestamp: '111.0',
+      name: 'ac-message-ignored',
+    });
+
+    await adapter.stop();
+  });
+
+  it('adds ac-message-ignored reaction when thread reply has no bot mention', async () => {
+    const mock = makeMockApp({ botUserId: 'UBOT', channels: [{ name: 'ch', id: 'C1' }] });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    // A thread reply with no @bot mention — classified as 'ignore'
+    await mock._triggerMessage({ user: 'U1', ts: '222.0', thread_ts: '111.0', channel: 'C1', text: 'no mention here' });
+
+    expect(mock.client.reactions.add).toHaveBeenCalledWith({
+      channel: 'C1',
+      timestamp: '222.0',
+      name: 'ac-message-ignored',
+    });
+
+    await adapter.stop();
+  });
+
+  it('does not throw when reaction call fails', async () => {
+    const mock = makeMockApp({ botUserId: 'UBOT', channels: [{ name: 'ch', id: 'C1' }] });
+    mock.client.reactions.add.mockRejectedValueOnce(new Error('Slack API down'));
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: 'ch' },
+      { logDestination: nullDest },
+    );
+    await adapter.start();
+
+    // Should not throw even when reactions.add fails
+    await expect(
+      mock._triggerMessage({ user: 'U1', ts: '111.0', channel: 'C1', text: 'no mention' }),
+    ).resolves.not.toThrow();
+
+    await adapter.stop();
+  });
+});
+
 describe('SlackAdapter — reactToMessage', () => {
   const BOT_ID = 'UBOT001';
   const CHANNEL_ID = 'C123';

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -26,6 +26,7 @@ function makeMockApp(opts: {
   botUserId?: string;
   channels?: Array<{ name: string; id: string }>;
   historyMessages?: Array<{ ts: string; thread_ts?: string; text?: string }>;
+  repliesMessages?: Array<{ ts: string; text?: string }>;
 }) {
   const messageHandlers: Array<(args: { message: unknown }) => Promise<void>> = [];
   const eventHandlers = new Map<string, Array<(args: { event: unknown }) => Promise<void>>>();
@@ -41,6 +42,9 @@ function makeMockApp(opts: {
         }),
         history: vi.fn().mockResolvedValue({
           messages: opts.historyMessages ?? [],
+        }),
+        replies: vi.fn().mockResolvedValue({
+          messages: opts.repliesMessages ?? [],
         }),
       },
       chat: {
@@ -692,6 +696,54 @@ describe('SlackAdapter — command events (reaction-based)', () => {
       expect(event.payload.conversation.conversation_id).toBe('100.0');
       expect(event.payload.origin.message_id).toBe('100.0');
     }
+  });
+
+  it('reaction on thread reply when history returns a different message → falls back to conversations.replies to find root ts and message text', async () => {
+    // history returns the root message (ts='100.0'), not the reply (ts='200.0')
+    const mock = makeMockApp({
+      botUserId: BOT_ID,
+      historyMessages: [{ ts: '100.0', thread_ts: '100.0', text: 'original request' }],
+      repliesMessages: [{ ts: '100.0', text: 'original request' }, { ts: '200.0', text: 'reviewing_implementation' }],
+    });
+    const { ThreadRegistry } = await import('../../../src/adapters/slack/thread-registry.js');
+    const registry = new ThreadRegistry();
+    registry.register('100.0', 'req-001'); // root ts registered as known run
+
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: CHANNEL_NAME },
+      { logDestination: nullDest, registry },
+    );
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    // User reacts to the reply at ts='200.0' (not the root at '100.0')
+    await mock._triggerReaction({
+      type: 'reaction_added',
+      reaction: 'ac-set-status',
+      user: 'U123',
+      item: { type: 'message', channel: CHANNEL_ID, ts: '200.0' },
+    });
+
+    const event = await eventPromise;
+    await adapter.stop();
+
+    expect(event.type).toBe('command');
+    if (event.type === 'command') {
+      // Thread root (100.0) is used, not the reply ts (200.0)
+      expect(event.payload.conversation.conversation_id).toBe('100.0');
+      expect(event.payload.origin.message_id).toBe('200.0');
+      // Message text comes from the reply, not the root
+      expect(event.payload.messageText).toBe('reviewing_implementation');
+      // request_id resolved from thread root in registry
+      expect(event.payload.inferred_context?.request_id).toBe('req-001');
+    }
+
+    // Should have called history AND replies
+    expect(mock.client.conversations.history).toHaveBeenCalled();
+    expect(mock.client.conversations.replies).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: CHANNEL_ID, ts: '100.0', latest: '200.0', inclusive: true, limit: 1 }),
+    );
   });
 
   it('reaction_added with unrecognized emoji → no event emitted', async () => {

--- a/tests/adapters/slack/thread-registry.test.ts
+++ b/tests/adapters/slack/thread-registry.test.ts
@@ -33,4 +33,19 @@ describe('ThreadRegistry', () => {
     expect(registry.resolve('ts-one')).toBe('request-one');
     expect(registry.resolve('ts-two')).toBe('request-two');
   });
+
+  it('rootTimestamps() returns empty array when nothing registered', () => {
+    const registry = new ThreadRegistry();
+    expect(registry.rootTimestamps()).toEqual([]);
+  });
+
+  it('rootTimestamps() returns all registered timestamps', () => {
+    const registry = new ThreadRegistry();
+    registry.register('ts-one', 'request-one');
+    registry.register('ts-two', 'request-two');
+    const timestamps = registry.rootTimestamps();
+    expect(timestamps).toHaveLength(2);
+    expect(timestamps).toContain('ts-one');
+    expect(timestamps).toContain('ts-two');
+  });
 });

--- a/tests/core/commands/registry-setup.test.ts
+++ b/tests/core/commands/registry-setup.test.ts
@@ -13,6 +13,7 @@ describe('registerDefaultCommands', () => {
       isConnected: vi.fn().mockReturnValue(true),
       getActiveRunCount: vi.fn().mockReturnValue(0),
       intentClassifier: { classify: vi.fn().mockResolvedValue('idea') },
+      overrideRunStage: vi.fn(),
     });
 
     expect(registry.list()).toEqual(expect.arrayContaining([
@@ -23,6 +24,7 @@ describe('registerDefaultCommands', () => {
       'health',
       'help',
       'classify-intent',
+      'run.set-status',
     ]));
   });
 });

--- a/tests/core/commands/set-status-command.test.ts
+++ b/tests/core/commands/set-status-command.test.ts
@@ -126,43 +126,83 @@ describe('createSetStatusHandler', () => {
     expect(msg).toContain('thread linked to an active run');
   });
 
-  it('empty messageText → replies with usage error and valid stage list', async () => {
+  it('stage provided via args (text command path) → updates stage', async () => {
+    const run = makeRun({ stage: 'implementing', id: 'run-uuid-001', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn().mockReturnValue('updated');
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        args: ['reviewing_implementation'],
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'reviewing_implementation');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('reviewing_implementation');
+    expect(msg).toContain('persisted');
+  });
+
+  it('args take precedence over messageText', async () => {
+    const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn().mockReturnValue('updated');
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        args: ['reviewing_implementation'],
+        messageText: 'speccing',
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'reviewing_implementation');
+  });
+
+  it('empty args and empty messageText → replies with usage error and valid stage list', async () => {
     const findRunById = vi.fn();
     const overrideRunStage = vi.fn();
     const handler = createSetStatusHandler({ findRunById, overrideRunStage });
     const reply = vi.fn().mockResolvedValue(undefined);
 
-    await handler(makeEvent({ messageText: '' }), reply);
+    await handler(makeEvent({ args: [], messageText: '' }), reply);
 
     expect(overrideRunStage).not.toHaveBeenCalled();
     const msg = reply.mock.calls[0][0] as string;
-    expect(msg).toContain('React to a message');
+    expect(msg).toContain('ac-set-status:');
     expect(msg).toContain('Valid stages');
   });
 
-  it('whitespace-only messageText → replies with usage error', async () => {
+  it('whitespace-only messageText with no args → replies with usage error', async () => {
     const findRunById = vi.fn();
     const overrideRunStage = vi.fn();
     const handler = createSetStatusHandler({ findRunById, overrideRunStage });
     const reply = vi.fn().mockResolvedValue(undefined);
 
-    await handler(makeEvent({ messageText: '   ' }), reply);
+    await handler(makeEvent({ args: [], messageText: '   ' }), reply);
 
     expect(overrideRunStage).not.toHaveBeenCalled();
     const msg = reply.mock.calls[0][0] as string;
-    expect(msg).toContain('React to a message');
+    expect(msg).toContain('ac-set-status:');
   });
 
-  it('undefined messageText → replies with usage error', async () => {
+  it('undefined messageText with no args → replies with usage error', async () => {
     const findRunById = vi.fn();
     const overrideRunStage = vi.fn();
     const handler = createSetStatusHandler({ findRunById, overrideRunStage });
     const reply = vi.fn().mockResolvedValue(undefined);
 
-    await handler(makeEvent({ messageText: undefined }), reply);
+    await handler(makeEvent({ args: [], messageText: undefined }), reply);
 
     expect(overrideRunStage).not.toHaveBeenCalled();
     const msg = reply.mock.calls[0][0] as string;
-    expect(msg).toContain('React to a message');
+    expect(msg).toContain('ac-set-status:');
   });
 });

--- a/tests/core/commands/set-status-command.test.ts
+++ b/tests/core/commands/set-status-command.test.ts
@@ -147,6 +147,50 @@ describe('createSetStatusHandler', () => {
     expect(msg).toContain('persisted');
   });
 
+  it('run in terminal stage (done) can be updated to any valid stage', async () => {
+    const run = makeRun({ stage: 'done', id: 'run-uuid-001', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn().mockReturnValue('updated');
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        messageText: 'implementing',
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'implementing');
+    expect(reply).toHaveBeenCalledOnce();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('done');
+    expect(msg).toContain('implementing');
+    expect(msg).toContain('persisted');
+  });
+
+  it('run in terminal stage (failed) can be updated to any valid stage', async () => {
+    const run = makeRun({ stage: 'failed', id: 'run-uuid-001', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn().mockReturnValue('updated');
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        args: ['reviewing_implementation'],
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'reviewing_implementation');
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('failed');
+    expect(msg).toContain('reviewing_implementation');
+  });
+
   it('args take precedence over messageText', async () => {
     const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
     const findRunById = vi.fn().mockReturnValue(run);

--- a/tests/core/commands/set-status-command.test.ts
+++ b/tests/core/commands/set-status-command.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createSetStatusHandler } from '../../../src/core/commands/set-status-command.js';
+import { VALID_RUN_STAGES } from '../../../src/types/runs.js';
+import type { CommandEvent } from '../../../src/types/commands.js';
+import type { Run } from '../../../src/types/runs.js';
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-uuid-001',
+    request_id: 'req-001',
+    intent: 'idea',
+    stage: 'implementing',
+    workspace_path: '/ws/req-001',
+    branch: 'spec/req-001',
+    artifact: undefined,
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 0,
+    channel: { provider: 'slack', id: 'C001' },
+    conversation: { provider: 'slack', channel_id: 'C001', conversation_id: '1000.0' },
+    origin: { provider: 'slack', channel_id: 'C001', conversation_id: '1000.0', message_id: '1000.0' },
+    pr_url: undefined,
+    last_impl_result: undefined,
+    created_at: new Date(0).toISOString(),
+    updated_at: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<CommandEvent> = {}): CommandEvent {
+  return {
+    command: 'run.set-status',
+    args: [],
+    channel: { provider: 'slack', id: 'C001' },
+    conversation: { provider: 'slack', channel_id: 'C001', conversation_id: '1000.0' },
+    origin: { provider: 'slack', channel_id: 'C001', conversation_id: '1000.0', message_id: '1001.0' },
+    author: 'U001',
+    received_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('createSetStatusHandler', () => {
+  it('valid stage in known thread → calls overrideRunStage, replies with old and new stage', async () => {
+    const run = makeRun({ stage: 'implementing', id: 'run-uuid-001', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn().mockReturnValue('updated');
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        messageText: 'reviewing_implementation',
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'reviewing_implementation');
+    expect(reply).toHaveBeenCalledOnce();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('run-uuid');
+    expect(msg).toContain('implementing');
+    expect(msg).toContain('reviewing_implementation');
+    expect(msg).toContain('persisted');
+  });
+
+  it('stage text with mixed case and surrounding whitespace is normalized and accepted', async () => {
+    const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn().mockReturnValue('updated');
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        messageText: '  Reviewing_Implementation  ',
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'reviewing_implementation');
+  });
+
+  it('invalid stage → replies with valid stage list, does NOT call overrideRunStage', async () => {
+    const run = makeRun({ request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn();
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        messageText: 'implemneting',
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).not.toHaveBeenCalled();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('implemneting');
+    expect(msg).toContain('Valid stages');
+    for (const stage of VALID_RUN_STAGES) {
+      expect(msg).toContain(stage);
+    }
+  });
+
+  it('unknown thread (no inferred_context.request_id) → replies with not-in-thread error', async () => {
+    const findRunById = vi.fn().mockReturnValue(undefined);
+    const overrideRunStage = vi.fn();
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        messageText: 'reviewing_implementation',
+        inferred_context: undefined,
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).not.toHaveBeenCalled();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('thread linked to an active run');
+  });
+
+  it('empty messageText → replies with usage error and valid stage list', async () => {
+    const findRunById = vi.fn();
+    const overrideRunStage = vi.fn();
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ messageText: '' }), reply);
+
+    expect(overrideRunStage).not.toHaveBeenCalled();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('React to a message');
+    expect(msg).toContain('Valid stages');
+  });
+
+  it('whitespace-only messageText → replies with usage error', async () => {
+    const findRunById = vi.fn();
+    const overrideRunStage = vi.fn();
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ messageText: '   ' }), reply);
+
+    expect(overrideRunStage).not.toHaveBeenCalled();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('React to a message');
+  });
+
+  it('undefined messageText → replies with usage error', async () => {
+    const findRunById = vi.fn();
+    const overrideRunStage = vi.fn();
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ messageText: undefined }), reply);
+
+    expect(overrideRunStage).not.toHaveBeenCalled();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('React to a message');
+  });
+});

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -2946,6 +2946,34 @@ describe('_classify — serial classification gate', () => {
     await orch.stop();
   });
 
+  it('calls adapter.react with ac-message-discarded when thread_message is in a blocked stage', async () => {
+    const adapter = makeMockAdapter();
+    const orch = new OrchestratorImpl({
+      adapter: adapter as never,
+      workspaceManager: makeWorkspaceManager(),
+      artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+      artifactPublisher: makeArtifactPublisher(),
+      channelRepoMap: makeChannelRepoMap(),
+    }, { logDestination: nullDest });
+
+    // Inject a run in 'implementing' stage (blocked)
+    const run = makeRun({ stage: 'implementing', request_id: 'req-blocked' });
+    (orch as unknown as { runs: Map<string, Run> }).runs.set('req-blocked', run);
+
+    const event = makeEventFixture('thread_message', { request_id: 'req-blocked' });
+    await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify(event);
+
+    // Give the async react call a moment to complete
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(adapter.react).toHaveBeenCalledWith(
+      event.payload.origin,
+      'ac-message-discarded',
+    );
+
+    await orch.stop();
+  });
+
   it('thread_message in reviewing_spec advances stage to implementing and returns dispatch', async () => {
     const { records, destination } = makeLogCapture();
     const adapter = makeMockAdapter();

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -6177,4 +6177,31 @@ describe('Orchestrator — overrideRunStage', () => {
 
     await orch.stop();
   });
+
+  it('updates a done (terminal) run to a new stage successfully', async () => {
+    const adapter = makeMockAdapter();
+    const runStore = { save: vi.fn(), load: vi.fn().mockReturnValue([]) };
+    const orch = new OrchestratorImpl({
+      adapter: adapter as never,
+      workspaceManager: makeWorkspaceManager(),
+      artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+      artifactPublisher: makeArtifactPublisher(),
+      channelRepoMap: makeChannelRepoMap(),
+      runStore,
+    }, { logDestination: nullDest });
+
+    const run = makeRun({ stage: 'done', request_id: 'req-terminal' });
+    run.updated_at = '2020-01-01T00:00:00.000Z';
+    const before = run.updated_at;
+    (orch as unknown as { runs: Map<string, Run> }).runs.set('req-terminal', run);
+
+    const result = orch.overrideRunStage('req-terminal', 'reviewing_implementation');
+
+    expect(result).toBe('updated');
+    expect(run.stage).toBe('reviewing_implementation');
+    expect(run.updated_at).not.toBe(before);
+    expect(runStore.save).toHaveBeenCalled();
+
+    await orch.stop();
+  });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -6105,3 +6105,76 @@ describe('Orchestrator — completion reaction', () => {
     expect(adapter.react).not.toHaveBeenCalled();
   });
 });
+
+describe('Orchestrator — overrideRunStage', () => {
+  it('updates stage, sets updated_at, persists, and returns "updated" on valid input', async () => {
+    const adapter = makeMockAdapter();
+    const runStore = { save: vi.fn(), load: vi.fn().mockReturnValue([]) };
+    const orch = new OrchestratorImpl({
+      adapter: adapter as never,
+      workspaceManager: makeWorkspaceManager(),
+      artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+      artifactPublisher: makeArtifactPublisher(),
+      channelRepoMap: makeChannelRepoMap(),
+      runStore,
+    }, { logDestination: nullDest });
+
+    const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
+    run.updated_at = '2020-01-01T00:00:00.000Z';
+    const before = run.updated_at;
+    (orch as unknown as { runs: Map<string, Run> }).runs.set('req-001', run);
+
+    const result = orch.overrideRunStage('req-001', 'reviewing_implementation');
+
+    expect(result).toBe('updated');
+    expect(run.stage).toBe('reviewing_implementation');
+    expect(run.updated_at).not.toBe(before);
+    expect(runStore.save).toHaveBeenCalled();
+
+    await orch.stop();
+  });
+
+  it('returns "not_found" without mutating state when requestId is unknown', async () => {
+    const adapter = makeMockAdapter();
+    const runStore = { save: vi.fn(), load: vi.fn().mockReturnValue([]) };
+    const orch = new OrchestratorImpl({
+      adapter: adapter as never,
+      workspaceManager: makeWorkspaceManager(),
+      artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+      artifactPublisher: makeArtifactPublisher(),
+      channelRepoMap: makeChannelRepoMap(),
+      runStore,
+    }, { logDestination: nullDest });
+
+    const result = orch.overrideRunStage('nonexistent', 'implementing');
+
+    expect(result).toBe('not_found');
+    expect(runStore.save).not.toHaveBeenCalled();
+
+    await orch.stop();
+  });
+
+  it('returns "invalid_stage" without mutating state when stage string is not in VALID_RUN_STAGES', async () => {
+    const adapter = makeMockAdapter();
+    const runStore = { save: vi.fn(), load: vi.fn().mockReturnValue([]) };
+    const orch = new OrchestratorImpl({
+      adapter: adapter as never,
+      workspaceManager: makeWorkspaceManager(),
+      artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+      artifactPublisher: makeArtifactPublisher(),
+      channelRepoMap: makeChannelRepoMap(),
+      runStore,
+    }, { logDestination: nullDest });
+
+    const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
+    (orch as unknown as { runs: Map<string, Run> }).runs.set('req-001', run);
+
+    const result = orch.overrideRunStage('req-001', 'bogus_stage' as import('../../src/types/runs.js').RunStage);
+
+    expect(result).toBe('invalid_stage');
+    expect(run.stage).toBe('implementing');
+    expect(runStore.save).not.toHaveBeenCalled();
+
+    await orch.stop();
+  });
+});

--- a/tests/core/run-store.test.ts
+++ b/tests/core/run-store.test.ts
@@ -146,6 +146,100 @@ describe('FileRunStore.load — workspace_path missing', () => {
 });
 
 // ─────────────────────────────────────────────
+// load — terminal runs kept despite missing workspace
+// ─────────────────────────────────────────────
+
+describe('FileRunStore.load — terminal runs with missing workspace', () => {
+  it('keeps a done run even when workspace_path does not exist', () => {
+    const run = makeRun({
+      stage: 'done',
+      workspace_path: path.join(tmpDir, 'nonexistent-done-workspace'),
+    });
+
+    const dir = path.join(tmpDir, '.autocatalyst');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'runs.json'), JSON.stringify([run]));
+
+    const { lines, dest } = makeLogCapture();
+    const store = new FileRunStore(tmpDir, { logDestination: dest });
+    const result = store.load();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].request_id).toBe(run.request_id);
+    expect(result[0].stage).toBe('done');
+
+    const logs = parseLogs(lines);
+    expect(logs.find(l => l['event'] === 'run_store.run_dropped')).toBeUndefined();
+  });
+
+  it('keeps a failed run even when workspace_path does not exist', () => {
+    const run = makeRun({
+      stage: 'failed',
+      workspace_path: path.join(tmpDir, 'nonexistent-failed-workspace'),
+    });
+
+    const dir = path.join(tmpDir, '.autocatalyst');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'runs.json'), JSON.stringify([run]));
+
+    const { lines, dest } = makeLogCapture();
+    const store = new FileRunStore(tmpDir, { logDestination: dest });
+    const result = store.load();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].request_id).toBe(run.request_id);
+    expect(result[0].stage).toBe('failed');
+
+    const logs = parseLogs(lines);
+    expect(logs.find(l => l['event'] === 'run_store.run_dropped')).toBeUndefined();
+  });
+
+  it('still drops an active stage run (reviewing_implementation) with missing workspace', () => {
+    const run = makeRun({
+      stage: 'reviewing_implementation',
+      workspace_path: path.join(tmpDir, 'nonexistent-active-workspace'),
+    });
+
+    const dir = path.join(tmpDir, '.autocatalyst');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'runs.json'), JSON.stringify([run]));
+
+    const { lines, dest } = makeLogCapture();
+    const store = new FileRunStore(tmpDir, { logDestination: dest });
+    const result = store.load();
+
+    expect(result).toHaveLength(0);
+
+    const logs = parseLogs(lines);
+    const dropped = logs.find(l => l['event'] === 'run_store.run_dropped');
+    expect(dropped).toBeDefined();
+    expect(dropped!['request_id']).toBe(run.request_id);
+  });
+
+  it('both done and failed runs are retained when workspaces are missing', () => {
+    const doneRun = makeRun({
+      stage: 'done',
+      workspace_path: path.join(tmpDir, 'gone-done'),
+    });
+    const failedRun = makeRun({
+      stage: 'failed',
+      workspace_path: path.join(tmpDir, 'gone-failed'),
+    });
+
+    const dir = path.join(tmpDir, '.autocatalyst');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'runs.json'), JSON.stringify([doneRun, failedRun]));
+
+    const store = new FileRunStore(tmpDir);
+    const result = store.load();
+
+    expect(result).toHaveLength(2);
+    expect(result.find(r => r.request_id === doneRun.request_id)).toBeDefined();
+    expect(result.find(r => r.request_id === failedRun.request_id)).toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────
 // load — stale stage demotion
 // ─────────────────────────────────────────────
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -130,6 +130,7 @@ describe('src/index.ts — startup modes', () => {
         getActiveRunCount: vi.fn().mockReturnValue(0),
         cancelRun: vi.fn(),
         getRunLogs: vi.fn(),
+        overrideRunStage: vi.fn(),
       };
 
       vi.doMock('../src/core/orchestrator.js', () => ({
@@ -154,6 +155,10 @@ describe('src/index.ts — startup modes', () => {
 
       vi.doMock('../src/core/commands/classify-intent-command.js', () => ({
         makeClassifyIntentHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/core/commands/set-status-command.js', () => ({
+        createSetStatusHandler: vi.fn().mockReturnValue(vi.fn()),
       }));
 
       vi.doMock('../src/adapters/slack/canvas-publisher.js', () => ({
@@ -319,6 +324,7 @@ describe('src/index.ts — startup modes', () => {
           getActiveRunCount: vi.fn().mockReturnValue(0),
           cancelRun: vi.fn(),
           getRunLogs: vi.fn(),
+          overrideRunStage: vi.fn(),
         })),
       }));
 
@@ -340,6 +346,10 @@ describe('src/index.ts — startup modes', () => {
 
       vi.doMock('../src/core/commands/classify-intent-command.js', () => ({
         makeClassifyIntentHandler: vi.fn().mockReturnValue(vi.fn()),
+      }));
+
+      vi.doMock('../src/core/commands/set-status-command.js', () => ({
+        createSetStatusHandler: vi.fn().mockReturnValue(vi.fn()),
       }));
 
       vi.doMock('../src/adapters/slack/canvas-publisher.js', () => ({


### PR DESCRIPTION
Fixed :ac-set-status: for runs in terminal state via thread-reply emoji reaction

## Testing

Post a stage name in a terminal-state run's Slack thread then react with :ac-set-status: to verify the stage updates.

---
Spec: `context-human/specs/feature-debug-mode-slack.md`
Closes #67