### PR TITLE
feat: improve testing guide and implementation feedback loop quality

### DIFF
--- a/context-human/specs/enhancement-testing-guide-feedback-loop.md
+++ b/context-human/specs/enhancement-testing-guide-feedback-loop.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-11
-last_updated: 2026-05-11
-status: implementing
+last_updated: 2026-05-12
+status: complete
 issue: null
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-testing-guide-feedback-loop.md
+++ b/context-human/specs/enhancement-testing-guide-feedback-loop.md
@@ -1,0 +1,501 @@
+---
+created: 2026-05-11
+last_updated: 2026-05-11
+status: implementing
+issue: null
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Testing guide and implementation feedback loop quality
+
+## Parent features
+
+- `feature-approval-to-implementation.md` — creates the implementation loop, implementation result contract, and implementation review page.
+- `enhancement-notion-database-publishing.md` — publishes testing guides as Notion database entries.
+- `enhancement-agent-progress-updates.md` — forwards agent `[Relay]` progress updates to Slack during spec generation and initial implementation.
+## What
+
+Autocatalyst improves the implementation review experience in four related ways:
+1. Testing guides become more useful and consistent. They show the workspace first, always show the branch second, summarize the code changes in 2-5 bullets, list what the reviewer should confirm in 2-5 bullets, and render concrete testing steps as Notion to-do items.
+2. Implementation feedback items become a real closed loop. When the agent addresses feedback from the testing guide, Autocatalyst checks off the completed to-do items and adds a short resolution comment under each item.
+3. Completed feedback items are never sent back to the implementer in later feedback rounds.
+4. Implementation-feedback runs forward `[Relay]` progress updates to Slack, matching spec creation and initial implementation runs.
+The result is that a reviewer can open the testing guide, find the correct workspace immediately, follow a concrete checklist, add feedback as to-do items, and see which feedback was addressed after each iteration.
+## Why
+
+The implementation review page is the main handoff from agent work to human testing. Today it often contains a broad summary, inconsistent instructions, and a Feedback section that accepts input but does not reliably close the loop. Reviewers lose time finding the workspace, translating prose into a local test plan, and deleting old feedback so the agent does not process it again.
+This is especially painful across multiple feedback rounds. The human should not have to remember which items were already fixed or manually clean up the page after the agent completes a pass. Autocatalyst should keep the review artifact current: open items are actionable, completed items are checked off with context, and testing instructions reflect the latest implementation when the fix changes how the feature should be tested.
+## Goals
+
+- Put the workspace path at the top of every testing guide, before branch information or setup steps.
+- Always show the branch immediately after the workspace for consistent reviewer orientation.
+- Make the summary section useful without requiring the reviewer to read a test-pass narrative.
+- Render concrete test steps as checkboxes that can be completed while testing.
+- Preserve reviewer testing progress when new steps are added after a feedback pass.
+- Provide a dedicated section for reviewer-added testing steps that the AI never overwrites.
+- Preserve a simple Feedback section where humans add new to-do items.
+- Pass only unresolved feedback items to the implementer.
+- Let the implementer report exactly which feedback items were fixed.
+- Check off fixed feedback items and add a resolution comment after implementation feedback is addressed.
+- Forward progress updates during implementation-feedback work.
+## Non-goals
+
+- Building a dedicated web UI for implementation review.
+- Polling the testing guide automatically without a Slack trigger. The reviewer still signals feedback processing from Slack.
+- Automatically approving or merging a PR when all testing-guide checklist items are checked.
+- Guaranteeing Notion comment resolution for unsupported API behavior. This enhancement uses to-do checked state and child blocks, not Notion comment resolution.
+- Rewriting the spec review feedback loop, except where shared progress-update patterns are reused.
+## User stories
+
+- As Enzo, I can open a testing guide and immediately see which workspace directory to `cd` into.
+- As Enzo, I can see the branch name immediately below the workspace path without searching for it.
+- As Enzo, I can see a short list of what changed and a short list of what I should confirm before approving the implementation.
+- As Enzo, I can follow testing instructions as a Notion checklist and check off steps as I complete them.
+- As Enzo, I can add my own extra testing steps in the Additional steps section without them being overwritten when the AI updates Testing instructions.
+- As Enzo, I can add implementation feedback as to-do items in the Feedback section and trigger a feedback pass from Slack.
+- As Enzo, I can see completed feedback items checked off with a short comment explaining what changed.
+- As Enzo, I can leave a second round of feedback without deleting completed items from the first round.
+- As Enzo, my progress on testing instruction checkboxes is preserved when the AI appends new steps after a feedback pass.
+- As Phoebe, I can see Slack progress updates while Autocatalyst is working through implementation feedback.
+## Design changes
+
+### Testing guide structure
+
+A testing guide page body uses this structure:
+```markdown
+[Spec bookmark, when available]
+
+## Workspace
+
+Workspace: `/absolute/path/to/workspace`
+Branch: `spec/abc123`
+
+## Summary
+
+### Changes
+
+- Added direct model runner configuration for OpenAI-compatible providers.
+- Wired provider selection into the runtime configuration loader.
+- Added tests for provider validation and error handling.
+
+### Confirm
+
+- The configured provider is used for new implementation runs.
+- Existing Anthropic-backed runs still work without config changes.
+- Invalid provider config fails with a clear error.
+
+## Testing instructions
+
+- [ ] `cd /absolute/path/to/workspace`
+- [ ] Run `npm install`.
+- [ ] Run `npm test`.
+- [ ] Update `autocatalyst.yaml` with an OpenAI-compatible provider config.
+- [ ] Start Autocatalyst and trigger a small implementation run.
+- [ ] Confirm the run completes and the provider-specific logs look correct.
+
+## Additional steps
+
+- [ ] Add any extra testing steps here.
+
+## Feedback
+
+- [ ] Add feedback here as to-do items.
+```
+Rules:
+- `Workspace` is always the first content section after the spec bookmark.
+- `Workspace` is required and uses `run.workspace_path`.
+- `Branch` is always shown immediately after workspace using `run.branch`. It appears in this fixed position so every testing guide has a consistent, predictable layout.
+- `Summary` contains two subsections: `Changes` and `Confirm`.
+- `Changes` contains 2-5 bullets describing user-visible or reviewer-relevant changes.
+- `Confirm` contains 2-5 bullets describing what the human should verify.
+- `Summary` does not include the agent's test-pass narrative. Test pass details can appear in Slack progress or logs, not in the review summary.
+- `Testing instructions` renders as Notion to-do blocks, not a paragraph blob. This section is AI-managed.
+- Testing instructions should be concrete commands and manual checks, not generic advice like "test the feature".
+- `Additional steps` is a reviewer-managed section for extra testing items the reviewer wants to track. The AI never reads from or writes to this section. It is created with a placeholder to-do item so the section is immediately usable in the Notion editor.
+- `Feedback` remains a section of to-do blocks that reviewers can add to.
+### Partially completed testing instruction checklists
+
+When a feedback pass results in new testing steps (because the fix changes how the feature should be tested), `update()` **appends** new items to the end of the existing `Testing instructions` list rather than replacing the whole list. This preserves checked state for steps the reviewer has already completed.
+Rules:
+- `update()` never removes or unchecks existing `Testing instructions` to-dos.
+- New `testing_steps` returned from a feedback implementation are appended at the end of the section.
+- If the updated steps would duplicate a step already present (same text, case-insensitive), skip the duplicate.
+- The `## Additional steps` section is never modified by `update()`.
+### Feedback completion display
+
+When implementation feedback is addressed, completed feedback items are checked and receive a child paragraph comment:
+```markdown
+- [x] Custom transformation step is swallowed on add.
+  - ✓ Fixed by wiring custom step persistence through `WorkflowStepRepository`; added regression coverage in `workflow-steps.test.ts`.
+```
+The resolution comment should be 1-2 sentences, specific, and written for the reviewer. It should say what changed, not repeat that tests passed.
+### Slack progress during implementation feedback
+
+When a reviewer triggers an implementation-feedback pass, the Slack thread receives progress updates such as:
+```plain text
+Reviewing 2 unresolved feedback items from the testing guide
+Addressing feedback item 1 of 2 — custom transformation persistence
+Feedback fixes implemented — updating the testing guide
+```
+These messages use the existing `[Relay]` path. They are best-effort and must not fail the implementation-feedback run.
+## Technical changes
+
+### Affected files
+
+- `src/types/ai.ts` — extend `ImplementationResult` with structured review-summary and resolved-feedback fields.
+- `src/types/impl-feedback-page.ts` — extend `ImplementationReviewInput` and update `ImplementationReviewPublisher.update()` options where needed.
+- `src/core/ai/agent-services.ts` — update the implementation prompt and feedback prompt contract.
+- `src/core/handlers/implementation-start-handler.ts` — pass workspace and branch into testing guide creation.
+- `src/core/handlers/implementation-feedback-handler.ts` — pass progress callback, serialize unresolved feedback with IDs, update testing guide instructions and resolved items.
+- `src/adapters/notion/implementation-feedback-page.ts` — render the new page structure, read only actionable to-dos, check off resolved feedback items, and append resolution comments.
+- `tests/core/ai/agent-services.test.ts` — cover prompt/result contract changes.
+- `tests/core/handlers/implementation-start-handler.test.ts` — cover workspace-first testing guide input.
+- `tests/core/handlers/implementation-feedback-handler.test.ts` — cover unresolved filtering, resolved item updates, and progress wiring.
+- `tests/adapters/notion/implementation-feedback-page.test.ts` — cover Notion rendering, feedback reading, and feedback resolution updates.
+- `tests/core/orchestrator.test.ts` — update integration-style assertions around implementation feedback and testing guide content.
+### Result contract
+
+Extend `ImplementationResult` so the implementer can return structured testing-guide content and feedback-resolution metadata:
+```typescript
+export interface ImplementationResult {
+  status: 'complete' | 'needs_input' | 'failed';
+  summary?: string;
+  testing_instructions?: string;
+  review_summary?: {
+    changes: string[];
+    confirm: string[];
+  };
+  testing_steps?: string[];
+  resolved_feedback_items?: Array;
+  question?: string;
+  error?: string;
+}
+```
+Compatibility rules:
+- `summary` and `testing_instructions` remain supported during migration.
+- `review_summary.changes` and `review_summary.confirm` are preferred for testing guide rendering.
+- `testing_steps` is preferred for checklist rendering.
+- If the implementer omits structured fields, Autocatalyst falls back to the legacy strings and logs `implementation.review_contract_legacy` at warn level.
+- `resolved_feedback_items` is optional on initial implementation and expected on implementation-feedback runs that receive feedback item IDs.
+### Implementation prompt changes
+
+Update `buildImplementationPrompt()` in `src/core/ai/agent-services.ts` so the JSON shape requests structured output:
+```json
+{
+  "status": "complete | needs_input | failed",
+  "summary": "short fallback summary",
+  "review_summary": {
+    "changes": ["2-5 bullets describing what changed"],
+    "confirm": ["2-5 bullets describing what the human should confirm"]
+  },
+  "testing_instructions": "legacy fallback instructions",
+  "testing_steps": ["concrete checklist item", "concrete checklist item"],
+  "resolved_feedback_items": [
+    { "id": "feedback item id", "resolution_comment": "what was fixed" }
+  ],
+  "question": "only when needs_input",
+  "error": "only when failed"
+}
+```
+Prompt rules:
+- On initial implementation, include `resolved_feedback_items: []`.
+- On implementation-feedback runs, only include an item in `resolved_feedback_items` when the implementation addressed that specific feedback item.
+- Use item IDs exactly as provided in the additional context.
+- `review_summary.changes` and `review_summary.confirm` must each contain 2-5 bullets when `status === "complete"`.
+- `testing_steps` must start with `cd ` when the workspace path is available to the agent, or the renderer will add it.
+- Do not put the workspace in `summary`; workspace is rendered by the review page from trusted run state.
+### Feedback context serialization
+
+Change `ImplementationFeedbackHandler.additionalContext()` for `reviewing_implementation` so unresolved feedback is serialized with stable IDs. This follows the same pattern used in spec feedback processing, where each comment is tagged with its source ID so the agent can reference specific items in its response:
+```plain text
+Unresolved implementation feedback from the testing guide:
+
+[FEEDBACK_ID: block-id-1]
+Custom transformation step isn't working — gets swallowed on add.
+Conversation:
+- I tested with a custom transform and it disappears after save.
+
+[FEEDBACK_ID: block-id-2]
+The config example is missing the new provider field.
+```
+Rules:
+- Include only `FeedbackItem` values where `resolved === false`.
+- Include `conversation` child paragraphs under that item's ID when present.
+- If there are no unresolved feedback items, use the Slack message content as the only additional context and log `implementation.feedback_empty` at info level.
+- For `awaiting_impl_input`, keep the existing behavior: use the Slack message directly and do not read the testing guide.
+### Progress callback for implementation feedback
+
+`ImplementationFeedbackHandler.handle()` must construct the same `onProgress` callback pattern used by `ImplementationStartHandler`:
+```typescript
+const onProgress = (message: string): Promise =>
+  this.deps.postMessage(feedback.conversation, message).catch(err => {
+    this.deps.logger.warn(
+      { event: 'progress_failed', phase: 'implementation_feedback', run_id: run.id, error: String(err) },
+      'Failed to post progress update',
+    );
+  });
+```
+Then pass it to `implementer.implement(localPath, run.workspace_path, additionalContext.value, onProgress)` for all implementation-feedback calls. Callback failure is non-blocking.
+### Testing guide creation and update
+
+Extend `ImplementationReviewInput`:
+```typescript
+export interface ImplementationReviewInput {
+  artifact_ref: string;
+  artifact_url?: string;
+  title: string;
+  workspace_path: string;
+  branch: string;
+  summary: string;
+  testing_instructions: string;
+  review_summary?: {
+    changes: string[];
+    confirm: string[];
+  };
+  testing_steps?: string[];
+}
+```
+`ImplementationStartHandler` passes `run.workspace_path` and `run.branch` when creating the testing guide. It also maps `result.review_summary` and `result.testing_steps` into `ImplementationReviewInput`.
+`NotionImplementationFeedbackPage.create()` renders:
+- bookmark block when `artifact_url` is present;
+- `Workspace` heading;
+- workspace paragraph with code-formatted workspace path;
+- branch paragraph immediately after workspace;
+- `Summary` heading;
+- `Changes` and `Confirm` subheadings with bulleted lists;
+- `Testing instructions` heading with Notion `to_do` blocks;
+- `Additional steps` heading with a single placeholder to-do item (`Add any extra testing steps here.`);
+- `Feedback` heading with no default feedback item, unless a placeholder is needed for Notion editor usability.
+If only legacy strings are available, the renderer:
+- wraps `summary` under `Changes` as a single bullet if no structured changes exist;
+- adds `Confirm the implemented behavior matches the approved spec.` as the fallback confirm bullet;
+- splits `testing_instructions` on newlines into checklist items;
+- prepends `cd ` when no step starts with `cd ` and the workspace path is available.
+`ImplementationFeedbackHandler` calls `implFeedbackPage.update()` with:
+```typescript
+{
+  summary: result.summary,
+  review_summary: result.review_summary,
+  testing_instructions: result.testing_instructions,
+  testing_steps: result.testing_steps,
+  resolved_items: result.resolved_feedback_items ?? []
+}
+```
+`NotionImplementationFeedbackPage.update()` updates sections independently:
+- If `review_summary` is present, replace only the content under `## Summary`.
+- If `testing_steps` is present, append new items to the end of `## Testing instructions`. Do not remove or uncheck existing items. Skip items whose text matches an existing step (case-insensitive).
+- If `resolved_items` is present, check the matching to-do blocks and append resolution comments under them.
+- Do not modify `## Additional steps` under any circumstances.
+- Do not remove existing unresolved feedback to-dos.
+- Do not alter already checked feedback items except to avoid duplicate resolution comments.
+### Reading feedback
+
+`NotionImplementationFeedbackPage.readFeedback()` must continue to return all feedback to-do items with `resolved` state, because the handler owns filtering. It must not return testing-instruction checklist items or additional-steps checklist items.
+Implementation guidance:
+- Read top-level page blocks in order.
+- Treat `to_do` blocks after the `Feedback` heading as feedback items.
+- Ignore `to_do` blocks under `Testing instructions`.
+- Ignore `to_do` blocks under `Additional steps`.
+- Preserve current child paragraph collection as `conversation`.
+- Return `resolved: block.to_do.checked`.
+This is important because the page now contains three separate to-do regions: AI-generated testing steps, reviewer-added testing steps, and actionable feedback.
+### Observability
+
+Add or update structured logs:
+
+Event
+Level
+Component
+Meaning
+
+`implementation.review_contract_legacy`
+warn
+implementation-feedback/start handler
+Result used legacy summary or testing instruction fields because structured fields were missing
+
+`implementation.feedback_empty`
+info
+implementation-feedback handler
+Feedback trigger found no unresolved Notion feedback items
+
+`implementation.feedback_context_built`
+debug
+implementation-feedback handler
+Unresolved feedback was serialized for the implementer; includes count only
+
+`implementation.feedback_resolved`
+info
+implementation-feedback-page
+Testing guide checked off resolved feedback items; includes resolved count
+
+`implementation.testing_steps_appended`
+debug
+implementation-feedback-page
+New testing steps appended to existing Testing instructions list; includes appended count and skipped-duplicate count
+
+`progress_failed` with `phase: 'implementation_feedback'`
+warn
+implementation-feedback handler
+Slack progress post failed but the run continued
+
+Do not log feedback text, testing instructions, or resolution comments at info level or above.
+## Acceptance criteria
+
+- New testing guides show `Workspace` before `Summary`, `Testing instructions`, `Additional steps`, and `Feedback`.
+- New testing guides include the workspace path from `run.workspace_path`.
+- Branch always appears immediately after workspace.
+- Summary renders `Changes` and `Confirm` subsections with 2-5 bullets each when structured output is available.
+- Testing instructions render as Notion to-do blocks.
+- An `Additional steps` section is created with a placeholder to-do item for reviewer use.
+- Implementation-feedback context includes only unchecked feedback to-do items from the Feedback section.
+- Checked feedback to-dos are excluded from later implementation-feedback prompts.
+- Testing-instruction to-dos are never sent to the implementer as feedback.
+- Additional-steps to-dos are never sent to the implementer as feedback.
+- When the implementer returns `resolved_feedback_items`, matching feedback to-dos are checked and receive a resolution comment.
+- Re-running an update with the same resolved item does not duplicate its resolution comment.
+- When a feedback pass returns new `testing_steps`, those steps are appended to the existing Testing instructions list; existing checked items remain checked.
+- Steps with text matching an already-present item are not duplicated.
+- The `Additional steps` section is never modified by `update()`.
+- Implementation-feedback runs pass an `onProgress` callback to the implementer.
+- `[Relay]` messages emitted during implementation feedback are posted to Slack best-effort.
+- Slack progress post failures do not fail the run.
+- Legacy implementer results still create a usable testing guide.
+## Test plan
+
+### Unit tests — `NotionImplementationFeedbackPage`
+
+- `create()` writes a `Workspace` heading before `Summary`.
+- `create()` writes workspace path and branch in that order.
+- `create()` renders `Changes` and `Confirm` as bulleted lists from `review_summary`.
+- `create()` renders `testing_steps` as Notion `to_do` blocks.
+- `create()` renders an `Additional steps` heading with a placeholder to-do item.
+- `create()` falls back from legacy `summary` and `testing_instructions` when structured fields are missing.
+- `readFeedback()` ignores testing-instruction to-do blocks.
+- `readFeedback()` ignores additional-steps to-do blocks.
+- `readFeedback()` returns unchecked to-dos from the Feedback section with `resolved: false`.
+- `readFeedback()` returns checked to-dos from the Feedback section with `resolved: true`.
+- `readFeedback()` preserves child paragraph conversation lines.
+- `update()` checks matching feedback to-dos and appends one resolution child paragraph.
+- `update()` does not duplicate a resolution child paragraph when called twice.
+- `update()` replaces Summary content without removing Feedback items.
+- `update()` appends new testing steps to Testing instructions without removing or unchecking existing items.
+- `update()` does not append a testing step whose text matches an existing step.
+- `update()` does not touch the Additional steps section.
+### Unit tests — `ImplementationFeedbackHandler`
+
+- Serializes unresolved feedback with `[FEEDBACK_ID: ...]` markers.
+- Filters out resolved feedback items before calling `implementer.implement()`.
+- Uses Slack message content when no unresolved feedback exists.
+- Does not call `readFeedback()` for `awaiting_impl_input`.
+- Passes `onProgress` to `implementer.implement()` during implementation feedback.
+- `onProgress` posts to Slack with the original conversation ref.
+- `postMessage` rejection inside `onProgress` logs `progress_failed` and does not fail the run.
+- Calls `implFeedbackPage.update()` with `resolved_items` from the implementation result.
+- Calls `implFeedbackPage.update()` with updated structured summary and testing steps when present.
+### Unit tests — `ImplementationStartHandler`
+
+- Passes `workspace_path` and `branch` to `implFeedbackPage.create()`.
+- Maps `review_summary` and `testing_steps` from the implementation result into `ImplementationReviewInput`.
+- Falls back to legacy fields when structured fields are omitted.
+### Unit tests — `agent-services`
+
+- Initial implementation prompt requests `review_summary`, `testing_steps`, and `resolved_feedback_items`.
+- Feedback implementation prompt instructs the agent to preserve feedback IDs exactly.
+- Result parsing accepts structured fields.
+- Result parsing rejects invalid `resolved_feedback_items` entries with missing `id` or `resolution_comment`.
+- Result parsing tolerates omitted structured fields for backward compatibility.
+### Integration-style tests — orchestrator
+
+- First implementation creates a testing guide with workspace-first content, branch after workspace, and an Additional steps section.
+- Implementation feedback with one unchecked item sends that item to the implementer, updates the page with a checked to-do, and transitions back to `reviewing_implementation`.
+- Second implementation feedback after the item is checked does not resend it to the implementer.
+- A feedback pass that returns new `testing_steps` appends them to the existing list; previously checked steps remain checked.
+- Implementation-feedback `[Relay]` messages are forwarded to Slack.
+### Manual test
+
+1. Seed and approve a small feature.
+2. Open the generated testing guide.
+3. Confirm the first section is `Workspace` and the path points to the run workspace.
+4. Confirm the branch name appears immediately below the workspace path.
+5. Confirm Summary has `Changes` and `Confirm` bullets.
+6. Confirm Testing instructions are checkboxes.
+7. Confirm an `Additional steps` section exists with a placeholder item.
+8. Check off the first two Testing instructions items.
+9. Add two Feedback to-do items.
+10. Trigger implementation feedback from Slack.
+11. Confirm Slack receives at least one progress update while feedback is being processed.
+12. Confirm addressed feedback items are checked with resolution comments.
+13. Confirm the first two Testing instructions remain checked.
+14. If new testing steps were added, confirm they appear at the end of the Testing instructions list.
+15. Add an item to Additional steps; trigger another feedback pass and confirm the Additional steps section is unchanged after the pass.
+16. Add a second Feedback item and trigger another pass; confirm previously checked items are not sent to the implementer again.
+## Rollout
+
+- This is backward-compatible with existing implementation agents because legacy `summary` and `testing_instructions` remain accepted.
+- Existing testing guide pages keep their current shape. The new renderer applies to newly created testing guides and to pages updated after feedback where the expected headings can be found.
+- If an older testing guide does not contain the expected headings, `update()` should still resolve feedback to-dos by block ID and log a warning before skipping summary/testing-instruction replacement.
+- `branch` is now a required field in `ImplementationReviewInput`. Call sites that previously omitted it must be updated to pass `run.branch`.
+## Risks and mitigations
+
+- **Notion markdown replacement could disturb manually edited content.** Limit replacement to known sections and preserve the Feedback and Additional steps sections. Add tests around section boundaries.
+- **The implementer may omit ****`resolved_feedback_items`****.** The page will remain unchecked, but unresolved filtering still prevents checked items from being resent. Prompt strongly instructs the agent to return resolved IDs.
+- **The implementer may return an unknown feedback ID.** Ignore unknown IDs and log a warning with the ID and run ID, without failing the run.
+- **Testing-guide pages now contain three to-do sections.** `readFeedback()` must scope itself to the Feedback section so testing checklist items and additional steps are not treated as feedback.
+- **Appended testing steps may duplicate existing steps.** Use case-insensitive text comparison to skip duplicates before appending.
+- **Notion child-block APIs may not allow appending under a to-do block in some workspaces.** If appending a resolution comment fails, still check the item when possible and log a warning. If checking also fails, leave the item unchanged and surface the degraded state in logs.
+## Task list
+
+- [ ] **Story: Structured implementation review result**
+	- [ ] **Task: Extend ****`ImplementationResult`**
+		- **Description**: Add `review_summary`, `testing_steps`, and `resolved_feedback_items` to `src/types/ai.ts`. Keep legacy fields optional and supported.
+		- **Acceptance criteria**: Types compile; legacy call sites still compile; invalid resolved item shapes are rejected by result parsing tests.
+		- **Dependencies**: None.
+	- [ ] **Task: Update implementation prompts and result parsing**
+		- **Description**: Update `buildImplementationPrompt()` and implementation-result parsing to request and validate the structured fields. Include explicit instructions for returning feedback IDs on feedback runs.
+		- **Acceptance criteria**: Prompt tests cover new fields; parser accepts valid structured output; parser tolerates legacy output; parser rejects malformed resolved items.
+		- **Dependencies**: Extend `ImplementationResult`.
+- [ ] **Story: Workspace-first testing guide rendering**
+	- [ ] **Task: Extend testing guide input**
+		- **Description**: Make `branch` a required field in `ImplementationReviewInput` and add optional `review_summary` and `testing_steps`. Update `ImplementationStartHandler` to always pass `run.branch`.
+		- **Acceptance criteria**: `ImplementationStartHandler` passes run workspace and branch; tests assert input shape; TypeScript compile passes.
+		- **Dependencies**: Structured implementation review result.
+	- [ ] **Task: Render new Notion testing guide structure**
+		- **Description**: Update `NotionImplementationFeedbackPage.create()` to render bookmark, Workspace, Summary with Changes/Confirm, Testing instructions as to-dos, Additional steps with placeholder, and Feedback.
+		- **Acceptance criteria**: Unit tests assert heading order, workspace/branch order, bullet rendering, checkbox rendering, Additional steps section creation, and legacy fallback.
+		- **Dependencies**: Extend testing guide input.
+- [ ] **Story: Feedback item closed loop**
+	- [ ] **Task: Scope feedback reading to the Feedback section**
+		- **Description**: Update `readFeedback()` to ignore Testing instructions to-dos and Additional steps to-dos, returning only Feedback-section to-dos with checked state and child conversation text.
+		- **Acceptance criteria**: Tests prove testing checklist items and additional steps items are ignored and feedback to-dos are returned with correct `resolved` values.
+		- **Dependencies**: Render new Notion testing guide structure.
+	- [ ] **Task: Serialize unresolved feedback with IDs**
+		- **Description**: Update `ImplementationFeedbackHandler.additionalContext()` to include only unresolved feedback items with `[FEEDBACK_ID: ...]` markers, following the same ID-tagged serialization pattern used in spec feedback processing.
+		- **Acceptance criteria**: Implementer receives only unchecked feedback; checked items are omitted; no unresolved items falls back to Slack message content.
+		- **Dependencies**: Scope feedback reading.
+	- [ ] **Task: Check off resolved feedback items**
+		- **Description**: Update `ImplementationFeedbackHandler` to pass `resolved_feedback_items` to `implFeedbackPage.update()`. Update Notion page update logic to check matching to-dos and append resolution comments.
+		- **Acceptance criteria**: Matching to-dos become checked; resolution comment is appended once; unknown IDs are ignored with a warning; update failures are degraded and do not fail completed implementations.
+		- **Dependencies**: Serialize unresolved feedback with IDs.
+	- [ ] **Task: Update summary and testing instructions after feedback**
+		- **Description**: When feedback implementation returns updated structured summary or new testing steps, replace Summary content and append new testing steps to the existing checklist without touching Additional steps or unresolved feedback.
+		- **Acceptance criteria**: Tests show Summary updates; new testing steps are appended; existing checked testing steps remain checked; Additional steps and Feedback to-dos remain intact.
+		- **Dependencies**: Check off resolved feedback items.
+- [ ] **Story: Progress updates during implementation feedback**
+	- [ ] **Task: Wire ****`onProgress`**** in ****`ImplementationFeedbackHandler`**
+		- **Description**: Construct an `onProgress` callback using `postMessage`, log `progress_failed` with `phase: 'implementation_feedback'` on failure, and pass it to every feedback-run `implementer.implement()` call.
+		- **Acceptance criteria**: Tests capture the callback, verify Slack posting, and verify post failure does not fail the run.
+		- **Dependencies**: None.
+	- [ ] **Task: Add implementation-feedback relay prompt examples**
+		- **Description**: Ensure the feedback implementation prompt includes examples that fit feedback iteration, such as reading unresolved items, fixing item N of M, and updating the testing guide.
+		- **Acceptance criteria**: Prompt tests include implementation-feedback examples; existing initial implementation progress behavior remains unchanged.
+		- **Dependencies**: Wire `onProgress` in `ImplementationFeedbackHandler`.
+- [ ] **Story: Validation and regression coverage**
+	- [ ] **Task: Add handler and orchestrator regression tests**
+		- **Description**: Cover first implementation guide creation, first feedback round resolution, second feedback round filtering, testing-step append behavior, and progress forwarding.
+		- **Acceptance criteria**: Tests fail on current behavior and pass after implementation.
+		- **Dependencies**: Previous stories.
+	- [ ] **Task: Run full project validation**
+		- **Description**: Run typecheck and the full Vitest suite.
+		- **Acceptance criteria**: `npm test` and any configured typecheck pass; skipped checks are documented with reason.
+		- **Dependencies**: All implementation tasks.

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -163,13 +163,24 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
       id: string;
       type: string;
       has_children?: boolean;
+      heading_2?: { rich_text: Array<{ plain_text: string }> };
       to_do?: { rich_text: Array<{ plain_text: string }>; checked: boolean };
-      _children?: unknown[]; // test helper only
+      _children?: unknown[];
     }>;
 
     const feedbackItems: FeedbackItem[] = [];
+    let inFeedbackSection = false;
 
     for (const block of blocks) {
+      // Track which section we are in based on heading_2 blocks
+      if (block.type === 'heading_2' && block.heading_2) {
+        const headingText = block.heading_2.rich_text.map(r => r.plain_text).join('');
+        inFeedbackSection = headingText === 'Feedback';
+        continue;
+      }
+
+      // Only collect to_do blocks inside the Feedback section
+      if (!inFeedbackSection) continue;
       if (block.type !== 'to_do' || !block.to_do) continue;
 
       const text = block.to_do.rich_text.map((r: { plain_text: string }) => r.plain_text).join('');

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -215,24 +215,26 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
     page_id: string,
     options: {
       summary?: string;
+      review_summary?: {
+        changes: string[];
+        confirm: string[];
+      };
+      testing_steps?: string[];
       resolved_items?: Array<{
         id: string;
         resolution_comment: string;
       }>;
     },
   ): Promise<void> {
-    // Fetch current markdown content
     let markdown = await this.client.pages.getMarkdown(page_id);
 
-    // If resolved items provided, build a map of block id → resolution info
-    // We need to read current blocks to find which to-do items match by ID
-    const resolvedMap = new Map<string, string>();
+    // --- Resolve feedback items (scoped to Feedback section) ---
     if (options.resolved_items && options.resolved_items.length > 0) {
+      const resolvedMap = new Map<string, string>();
       for (const item of options.resolved_items) {
         resolvedMap.set(item.id, item.resolution_comment);
       }
 
-      // Read current blocks to get the to-do item text for each resolved ID
       const blocksResponse = await this.client.blocks.children.list({ block_id: page_id });
       const blocks = blocksResponse.results as Array<{
         id: string;
@@ -240,30 +242,94 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
         to_do?: { rich_text: Array<{ plain_text: string }>; checked: boolean };
       }>;
 
-      // Apply resolutions to markdown: find `- [ ] <text>` lines and check them, add sub-bullet
+      // Split markdown at Feedback heading to scope replacements
+      const feedbackSplit = '\n## Feedback\n';
+      const feedbackStartIdx = markdown.indexOf(feedbackSplit);
+      let beforeFeedback = feedbackStartIdx === -1
+        ? markdown
+        : markdown.substring(0, feedbackStartIdx + feedbackSplit.length);
+      let feedbackContent = feedbackStartIdx === -1
+        ? ''
+        : markdown.substring(feedbackStartIdx + feedbackSplit.length);
+
+      if (feedbackStartIdx === -1) {
+        this.logger.warn(
+          { event: 'implementation.legacy_page_structure', page_id },
+          'Page missing Feedback heading; applying resolved items globally',
+        );
+      }
+
       for (const block of blocks) {
         if (block.type !== 'to_do' || !block.to_do) continue;
         const resolutionComment = resolvedMap.get(block.id);
         if (!resolutionComment) continue;
 
         const itemText = block.to_do.rich_text.map((r: { plain_text: string }) => r.plain_text).join('');
-        // Replace `- [ ] <text>` with `- [x] <text>\n  - ✓ <resolutionComment>`
-        const uncheckedPattern = new RegExp(
-          `(^- \\[ \\] ${escapeRegex(itemText)})`,
-          'm',
-        );
-        markdown = markdown.replace(
-          uncheckedPattern,
-          `- [x] ${itemText}\n  - ✓ ${resolutionComment}`,
-        );
+        const alreadyCheckedRegex = new RegExp(`^- \\[x\\] ${escapeRegex(itemText)}`, 'm');
+        const uncheckedPattern = new RegExp(`(^- \\[ \\] ${escapeRegex(itemText)})`, 'm');
+        const targetContent = feedbackStartIdx !== -1 ? feedbackContent : markdown;
+
+        if (!alreadyCheckedRegex.test(targetContent)) {
+          const replacement = `- [x] ${itemText}\n  - ✓ ${resolutionComment}`;
+          if (feedbackStartIdx !== -1) {
+            feedbackContent = feedbackContent.replace(uncheckedPattern, replacement);
+          } else {
+            markdown = markdown.replace(uncheckedPattern, replacement);
+          }
+        }
       }
+
+      if (feedbackStartIdx !== -1) {
+        markdown = beforeFeedback + feedbackContent;
+      }
+
+      this.logger.info(
+        { event: 'implementation.feedback_resolved', page_id, resolved_count: options.resolved_items.length },
+        'Testing guide checked off resolved feedback items',
+      );
     }
 
-    // Replace summary if provided
-    if (options.summary !== undefined) {
-      // Replace content between ## Summary heading and next ## heading or EOF
-      const summaryPattern = /(## Summary\n\n)[\s\S]*?(?=\n## |\n*$)/;
+    // --- Replace Summary with review_summary or legacy summary ---
+    if (options.review_summary) {
+      const changesMarkdown = options.review_summary.changes.map(c => `- ${c}`).join('\n');
+      const confirmMarkdown = options.review_summary.confirm.map(c => `- ${c}`).join('\n');
+      const newSummaryContent = `### Changes\n\n${changesMarkdown}\n\n### Confirm\n\n${confirmMarkdown}\n`;
+      const summaryPattern = /(## Summary\n\n?)[\s\S]*?(?=\n## |\n*$)/;
+      markdown = markdown.replace(summaryPattern, `$1${newSummaryContent}`);
+    } else if (options.summary !== undefined) {
+      const summaryPattern = /(## Summary\n\n?)[\s\S]*?(?=\n## |\n*$)/;
       markdown = markdown.replace(summaryPattern, `$1${options.summary}\n`);
+    }
+
+    // --- Append new testing steps (deduplicating, before Additional steps / Feedback) ---
+    if (options.testing_steps && options.testing_steps.length > 0) {
+      const testingInstructionsPattern = /## Testing instructions\n\n([\s\S]*?)(?=\n## (?:Additional steps|Feedback)|$)/;
+      const testingMatch = markdown.match(testingInstructionsPattern);
+      const existingItemsText = testingMatch
+        ? (testingMatch[1].match(/^- \[[ x]\] .+/gm) ?? []).map(item => item.replace(/^- \[[ x]\] /, '').toLowerCase())
+        : [];
+      const existingSet = new Set(existingItemsText);
+
+      const newSteps = options.testing_steps.filter(step => !existingSet.has(step.toLowerCase()));
+      const skippedCount = options.testing_steps.length - newSteps.length;
+
+      if (newSteps.length > 0) {
+        const newStepsMarkdown = newSteps.map(s => `- [ ] ${s}`).join('\n');
+        // Insert just before ## Additional steps or ## Feedback (whichever comes first after testing instructions)
+        const insertBefore = /(\n## (?:Additional steps|Feedback))/;
+        const match = markdown.match(insertBefore);
+        if (match && match.index !== undefined) {
+          const insertIdx = match.index;
+          markdown = markdown.substring(0, insertIdx) + '\n' + newStepsMarkdown + markdown.substring(insertIdx);
+        } else {
+          markdown += '\n' + newStepsMarkdown;
+        }
+      }
+
+      this.logger.debug(
+        { event: 'implementation.testing_steps_appended', page_id, appended_count: newSteps.length, skipped_count: skippedCount },
+        'New testing steps appended to existing Testing instructions list',
+      );
     }
 
     await this.client.pages.updateMarkdown(page_id, {

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -47,6 +47,28 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
 
   async create(input: ImplementationReviewInput): Promise<PublishedImplementationReview> {
     const dataSourceId = await this.getTestingGuidesDataSourceId();
+
+    // Build Changes bullets (structured or legacy fallback)
+    const changesBullets: string[] = input.review_summary?.changes?.length
+      ? input.review_summary.changes
+      : [input.summary || 'See implementation details.'];
+
+    // Build Confirm bullets (structured or legacy fallback)
+    const confirmBullets: string[] = input.review_summary?.confirm?.length
+      ? input.review_summary.confirm
+      : ['Confirm the implemented behavior matches the approved spec.'];
+
+    // Build testing steps (structured or split from legacy testing_instructions)
+    const rawSteps: string[] = input.testing_steps?.length
+      ? input.testing_steps
+      : (input.testing_instructions || '').split('\n').filter(s => s.trim());
+
+    // Prepend cd step if workspace_path is available and no step starts with 'cd '
+    const hasWorkspaceStep = rawSteps.some(s => s.trim().startsWith('cd '));
+    const testingSteps: string[] = !hasWorkspaceStep && input.workspace_path
+      ? [`cd ${input.workspace_path}`, ...rawSteps]
+      : rawSteps;
+
     const response = await this.client.pages.create({
       parent: { type: 'data_source_id', data_source_id: dataSourceId } as never,
       properties: {
@@ -62,28 +84,59 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
       } as never,
       children: [
         ...(input.artifact_url
-          ? [{
-              type: 'bookmark',
-              bookmark: { url: input.artifact_url },
-            } as never]
+          ? [{ type: 'bookmark', bookmark: { url: input.artifact_url } } as never]
           : []),
+        // Workspace section
+        {
+          type: 'heading_2',
+          heading_2: { rich_text: [{ text: { content: 'Workspace' } }] },
+        } as never,
+        {
+          type: 'paragraph',
+          paragraph: { rich_text: [{ text: { content: `Workspace: \`${input.workspace_path}\`` } }] },
+        } as never,
+        {
+          type: 'paragraph',
+          paragraph: { rich_text: [{ text: { content: `Branch: \`${input.branch}\`` } }] },
+        } as never,
         // Summary section
         {
           type: 'heading_2',
           heading_2: { rich_text: [{ text: { content: 'Summary' } }] },
         } as never,
         {
-          type: 'paragraph',
-          paragraph: { rich_text: [{ text: { content: input.summary } }] },
+          type: 'heading_3',
+          heading_3: { rich_text: [{ text: { content: 'Changes' } }] },
         } as never,
+        ...changesBullets.map(text => ({
+          type: 'bulleted_list_item',
+          bulleted_list_item: { rich_text: [{ text: { content: text } }] },
+        } as never)),
+        {
+          type: 'heading_3',
+          heading_3: { rich_text: [{ text: { content: 'Confirm' } }] },
+        } as never,
+        ...confirmBullets.map(text => ({
+          type: 'bulleted_list_item',
+          bulleted_list_item: { rich_text: [{ text: { content: text } }] },
+        } as never)),
         // Testing instructions section
         {
           type: 'heading_2',
           heading_2: { rich_text: [{ text: { content: 'Testing instructions' } }] },
         } as never,
+        ...testingSteps.map(text => ({
+          type: 'to_do',
+          to_do: { rich_text: [{ text: { content: text } }], checked: false },
+        } as never)),
+        // Additional steps section
         {
-          type: 'paragraph',
-          paragraph: { rich_text: [{ text: { content: input.testing_instructions } }] },
+          type: 'heading_2',
+          heading_2: { rich_text: [{ text: { content: 'Additional steps' } }] },
+        } as never,
+        {
+          type: 'to_do',
+          to_do: { rich_text: [{ text: { content: 'Add any extra testing steps here.' } }], checked: false },
         } as never,
         // Feedback section
         {

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -785,16 +785,27 @@ function buildArtifactRevisePrompt(
 
 function buildImplementationPrompt(artifact_path: string, result_file_path: string, additionalContext?: string): string {
   const lines: string[] = [];
+  const hasFeedbackContext = Boolean(additionalContext) && additionalContext!.includes('[FEEDBACK_ID:');
 
   if (additionalContext) {
     lines.push('The working directory already contains partial implementation from a previous attempt.');
     lines.push('Skip Step 1 (the plan exists) - go directly to Step 2.');
     lines.push('');
-    lines.push('Additional context from the human:');
+    if (hasFeedbackContext) {
+      lines.push('Implementation feedback from the testing guide (address each item):');
+    } else {
+      lines.push('Additional context from the human:');
+    }
     lines.push('<<<');
     lines.push(additionalContext);
     lines.push('>>>');
     lines.push('');
+    if (hasFeedbackContext) {
+      lines.push('For each [FEEDBACK_ID: ...] item you address, include it in resolved_feedback_items');
+      lines.push('using the exact ID string as provided — do not modify or guess IDs.');
+      lines.push('Only include an item in resolved_feedback_items when you actually fixed that specific issue.');
+      lines.push('');
+    }
   }
 
   lines.push(`Read the approved artifact at: ${artifact_path}`);
@@ -823,14 +834,27 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
   lines.push('Create the directory if it does not exist. The JSON must have this structure:');
   lines.push('{');
   lines.push('  "status": "complete" | "needs_input" | "failed",');
-  lines.push('  "summary": "what was built",');
-  lines.push('  "testing_instructions": "Branch: <branch-name>\\nSetup: <install/build commands>\\nTest: <specific steps to exercise the feature>",');
-  lines.push('  "question": "the decision needed from the human (only when needs_input)",');
-  lines.push('  "error": "what went wrong (only when failed)"');
+  lines.push('  "summary": "short fallback summary",');
+  lines.push('  "review_summary": {');
+  lines.push('    "changes": ["2-5 bullets describing what changed (user-visible or reviewer-relevant)"],');
+  lines.push('    "confirm": ["2-5 bullets describing what the human should verify"]');
+  lines.push('  },');
+  lines.push('  "testing_instructions": "legacy fallback — use testing_steps instead",');
+  lines.push('  "testing_steps": ["cd /path/to/workspace", "npm install", "concrete step 3"],');
+  lines.push('  "resolved_feedback_items": [');
+  lines.push('    { "id": "<exact FEEDBACK_ID value>", "resolution_comment": "1-2 sentences: what changed" }');
+  lines.push('  ],');
+  lines.push('  "question": "only when needs_input",');
+  lines.push('  "error": "only when failed"');
   lines.push('}');
   lines.push('');
-  lines.push('Use only the exact canonical status values: "complete", "needs_input", or "failed".');
-  lines.push('Do not signal completion until the result file has been written.');
+  lines.push('Rules:');
+  lines.push('- review_summary.changes and review_summary.confirm must each contain 2-5 bullets when status is "complete".');
+  lines.push('- testing_steps must start with a `cd ` step when a workspace path is available.');
+  lines.push('- resolved_feedback_items: include [] on initial implementation; on feedback runs, only include items you actually fixed.');
+  lines.push('- Use IDs exactly as provided — do not modify or guess IDs.');
+  lines.push('- Use only the exact canonical status values: "complete", "needs_input", or "failed".');
+  lines.push('- Do not signal completion until the result file has been written.');
   lines.push('');
   lines.push(CHECKPOINT_INSTRUCTIONS);
 

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -495,10 +495,54 @@ function parseImplementationResult(content: string, path: string): Implementatio
   if (status !== 'complete' && status !== 'needs_input' && status !== 'failed') {
     throw new Error(`Implementation: invalid STATUS value "${String(rawStatus)}" in result file`);
   }
+
+  // Parse optional review_summary
+  let review_summary: ImplementationResult['review_summary'];
+  const rawReviewSummary = obj['review_summary'];
+  if (rawReviewSummary !== undefined && rawReviewSummary !== null) {
+    if (typeof rawReviewSummary !== 'object') {
+      throw new Error(`Implementation: review_summary must be an object`);
+    }
+    const rs = rawReviewSummary as Record<string, unknown>;
+    review_summary = {
+      changes: Array.isArray(rs['changes']) ? (rs['changes'] as unknown[]).filter((s): s is string => typeof s === 'string') : [],
+      confirm: Array.isArray(rs['confirm']) ? (rs['confirm'] as unknown[]).filter((s): s is string => typeof s === 'string') : [],
+    };
+  }
+
+  // Parse optional testing_steps
+  let testing_steps: string[] | undefined;
+  const rawSteps = obj['testing_steps'];
+  if (Array.isArray(rawSteps)) {
+    testing_steps = (rawSteps as unknown[]).filter((s): s is string => typeof s === 'string');
+  }
+
+  // Parse optional resolved_feedback_items
+  let resolved_feedback_items: Array<{ id: string; resolution_comment: string }> | undefined;
+  const rawResolved = obj['resolved_feedback_items'];
+  if (Array.isArray(rawResolved)) {
+    resolved_feedback_items = (rawResolved as unknown[]).map((item, index) => {
+      if (typeof item !== 'object' || item === null) {
+        throw new Error(`Implementation: resolved_feedback_items[${index}] is not an object`);
+      }
+      const entry = item as Record<string, unknown>;
+      if (typeof entry['id'] !== 'string') {
+        throw new Error(`Implementation: resolved_feedback_items[${index}] missing string "id"`);
+      }
+      if (typeof entry['resolution_comment'] !== 'string') {
+        throw new Error(`Implementation: resolved_feedback_items[${index}] missing string "resolution_comment"`);
+      }
+      return { id: entry['id'], resolution_comment: entry['resolution_comment'] };
+    });
+  }
+
   return {
     status,
     summary: typeof obj['summary'] === 'string' ? obj['summary'] : undefined,
     testing_instructions: typeof obj['testing_instructions'] === 'string' ? obj['testing_instructions'] : undefined,
+    review_summary,
+    testing_steps,
+    resolved_feedback_items,
     question: typeof obj['question'] === 'string' ? obj['question'] : undefined,
     error: typeof obj['error'] === 'string' ? obj['error'] : undefined,
   };

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -13,7 +13,7 @@ export interface ImplementationFeedbackDeps {
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
-  logger: Pick<pino.Logger, 'info' | 'error'>;
+  logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
 }
 
 export type ImplementationFeedbackResult =
@@ -34,15 +34,26 @@ export class ImplementationFeedbackHandler {
     const additionalContext = await this.additionalContext(run, feedback, routingStage);
     if (additionalContext.status === 'failed') return { status: 'failed' };
 
+    const onProgress = (message: string): Promise<void> =>
+      this.deps.postMessage(feedback.conversation, message).catch(err => {
+        this.deps.logger.warn(
+          { event: 'progress_failed', phase: 'implementation_feedback', run_id: run.id, error: String(err) },
+          'Failed to post progress update',
+        );
+      });
+
     this.deps.transition(run, 'implementing');
     run.attempt += 1;
     this.deps.persist();
 
     let result;
     try {
-      result = additionalContext.value
-        ? await this.deps.implementer.implement(localPath, run.workspace_path, additionalContext.value)
-        : await this.deps.implementer.implement(localPath, run.workspace_path);
+      result = await this.deps.implementer.implement(
+        localPath,
+        run.workspace_path,
+        additionalContext.value,
+        onProgress,
+      );
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };
@@ -72,6 +83,14 @@ export class ImplementationFeedbackHandler {
       'Implementation complete',
     );
 
+    // Log legacy warning if structured output is missing
+    if (!result.review_summary || !result.testing_steps) {
+      this.deps.logger.warn(
+        { event: 'implementation.review_contract_legacy', run_id: run.id },
+        'Implementation result missing structured review_summary or testing_steps; using legacy fields',
+      );
+    }
+
     run.last_impl_result = {
       summary: result.summary ?? '',
       testing_instructions: result.testing_instructions ?? '',
@@ -80,7 +99,12 @@ export class ImplementationFeedbackHandler {
 
     if (run.impl_feedback_ref) {
       try {
-        await this.deps.implFeedbackPage!.update(run.impl_feedback_ref, { summary: result.summary });
+        await this.deps.implFeedbackPage!.update(run.impl_feedback_ref, {
+          summary: result.summary,
+          review_summary: result.review_summary,
+          testing_steps: result.testing_steps,
+          resolved_items: result.resolved_feedback_items ?? [],
+        });
       } catch (err) {
         this.deps.logger.error(
           { event: 'run.feedback_page_update_failed', run_id: run.id, error: String(err) },
@@ -119,13 +143,30 @@ export class ImplementationFeedbackHandler {
     }
 
     const unresolved = feedbackItems.filter(item => !item.resolved);
-    return {
-      status: 'ok',
-      value: unresolved
-        .map(item =>
-          `- ${item.text}${item.conversation.length > 0 ? '\n  ' + item.conversation.join('\n  ') : ''}`,
-        )
-        .join('\n'),
-    };
+
+    if (unresolved.length === 0) {
+      this.deps.logger.info(
+        { event: 'implementation.feedback_empty', run_id: run.id },
+        'No unresolved feedback items found; using Slack message as context',
+      );
+      return { status: 'ok', value: feedback.content };
+    }
+
+    const serialized = [
+      'Unresolved implementation feedback from the testing guide:',
+      '',
+      ...unresolved.map(item => {
+        const lines = [`[FEEDBACK_ID: ${item.id}]`, item.text];
+        if (item.conversation.length > 0) {
+          lines.push('Conversation:');
+          for (const line of item.conversation) {
+            lines.push(`- ${line}`);
+          }
+        }
+        return lines.join('\n');
+      }),
+    ].join('\n\n');
+
+    return { status: 'ok', value: serialized };
   }
 }

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -147,7 +147,7 @@ export class ImplementationFeedbackHandler {
     if (unresolved.length === 0) {
       this.deps.logger.info(
         { event: 'implementation.feedback_empty', run_id: run.id },
-        'No unresolved feedback items found; using Slack message as context',
+        'No unresolved feedback items found; using inbound message as context',
       );
       return { status: 'ok', value: feedback.content };
     }

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -13,7 +13,7 @@ export interface ImplementationFeedbackDeps {
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
-  logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
+  logger: Pick<pino.Logger, 'info' | 'warn' | 'error' | 'debug'>;
 }
 
 export type ImplementationFeedbackResult =
@@ -166,6 +166,11 @@ export class ImplementationFeedbackHandler {
         return lines.join('\n');
       }),
     ].join('\n\n');
+
+    this.deps.logger.debug(
+      { event: 'implementation.feedback_context_built', run_id: run.id, unresolved_count: unresolved.length },
+      'Serialized unresolved feedback for implementer',
+    );
 
     return { status: 'ok', value: serialized };
   }

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -87,12 +87,23 @@ export class ImplementationStartHandler {
 
     let feedbackPageUrl: string | undefined;
     try {
+      // Log legacy warning if structured output is missing
+      if (!result.review_summary || !result.testing_steps) {
+        this.deps.logger.warn(
+          { event: 'implementation.review_contract_legacy', run_id: run.id },
+          'Implementation result missing structured review_summary or testing_steps; using legacy fields',
+        );
+      }
       const publishedReview = await this.deps.implFeedbackPage!.create({
         artifact_ref: refs.publication_ref,
         artifact_url: artifactPublishedUrl(run),
         title: titleFromArtifactPath(refs.local_path),
+        workspace_path: run.workspace_path,
+        branch: run.branch,
         summary: result.summary ?? '',
         testing_instructions: result.testing_instructions ?? '',
+        review_summary: result.review_summary,
+        testing_steps: result.testing_steps,
       });
       run.impl_feedback_ref = publishedReview.id;
       this.deps.persist();

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -137,6 +137,12 @@ export interface ImplementationResult {
   status: ImplementationStatus;
   summary?: string;
   testing_instructions?: string;
+  review_summary?: {
+    changes: string[];
+    confirm: string[];
+  };
+  testing_steps?: string[];
+  resolved_feedback_items?: Array<{ id: string; resolution_comment: string }>;
   question?: string;
   error?: string;
 }

--- a/src/types/impl-feedback-page.ts
+++ b/src/types/impl-feedback-page.ts
@@ -20,8 +20,15 @@ export interface ImplementationReviewInput {
   artifact_ref: string;
   artifact_url?: string;
   title: string;
+  workspace_path: string;
+  branch: string;
   summary: string;
   testing_instructions: string;
+  review_summary?: {
+    changes: string[];
+    confirm: string[];
+  };
+  testing_steps?: string[];
 }
 
 export interface ImplementationReviewPublisher {
@@ -33,6 +40,11 @@ export interface ImplementationReviewPublisher {
     review_ref: string,
     options: {
       summary?: string;
+      review_summary?: {
+        changes: string[];
+        confirm: string[];
+      };
+      testing_steps?: string[];
       resolved_items?: Array<{
         id: string;
         resolution_comment: string;

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -338,9 +338,10 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
   });
 
   it('returns unchecked to-do item with resolved: false', async () => {
+    const feedbackHeading = { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } };
     const todoBlock = makeTodoBlock('block-1', 'Fix the bug', false);
     const client = makeNotionClient({
-      blocksChildrenList: makeBlocksChildrenListFn([todoBlock]),
+      blocksChildrenList: makeBlocksChildrenListFn([feedbackHeading, todoBlock]),
     });
     const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
@@ -352,9 +353,10 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
   });
 
   it('returns checked to-do item with resolved: true', async () => {
+    const feedbackHeading = { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } };
     const todoBlock = makeTodoBlock('block-2', 'Already done', true);
     const client = makeNotionClient({
-      blocksChildrenList: makeBlocksChildrenListFn([todoBlock]),
+      blocksChildrenList: makeBlocksChildrenListFn([feedbackHeading, todoBlock]),
     });
     const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
@@ -366,9 +368,10 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const para1 = makeParagraphBlock('Comment A');
     const para2 = makeParagraphBlock('Comment B');
     const todoBlock = makeTodoBlock('block-3', 'The item', false, [para1, para2]);
+    const feedbackHeading = { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } };
 
     const blocksChildrenList = vi.fn().mockImplementation(async ({ block_id }: { block_id: string }) => {
-      if (block_id === 'page-id') return { results: [todoBlock] };
+      if (block_id === 'page-id') return { results: [feedbackHeading, todoBlock] };
       if (block_id === 'block-3') return { results: [para1, para2] };
       return { results: [] };
     });
@@ -381,11 +384,12 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
   });
 
   it('returns multiple to-do items in document order', async () => {
+    const feedbackHeading = { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } };
     const block1 = makeTodoBlock('b1', 'First', false);
     const block2 = makeTodoBlock('b2', 'Second', true);
     const block3 = makeTodoBlock('b3', 'Third', false);
     const client = makeNotionClient({
-      blocksChildrenList: makeBlocksChildrenListFn([block1, block2, block3]),
+      blocksChildrenList: makeBlocksChildrenListFn([feedbackHeading, block1, block2, block3]),
     });
     const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
 
@@ -408,6 +412,64 @@ describe('NotionImplementationFeedbackPage — readFeedback', () => {
     const result = await page.readFeedback('page-id');
     expect(result).toHaveLength(1);
     expect(result[0].text).toBe('Actual feedback');
+  });
+
+  it('ignores to_do blocks under Testing instructions heading', async () => {
+    const blocks = [
+      { id: 'h-testing', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Testing instructions' }] } },
+      makeTodoBlock('t-testing-1', 'npm install', false),
+      makeTodoBlock('t-testing-2', 'npm test', false),
+      { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } },
+      makeTodoBlock('f-1', 'Real feedback item', false),
+    ];
+    const client = makeNotionClient({
+      blocksChildrenList: makeBlocksChildrenListFn(blocks),
+    });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    const result = await page.readFeedback('page-id');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('f-1');
+    expect(result[0].text).toBe('Real feedback item');
+  });
+
+  it('ignores to_do blocks under Additional steps heading', async () => {
+    const blocks = [
+      { id: 'h-add', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Additional steps' }] } },
+      makeTodoBlock('a-1', 'Reviewer step', false),
+      { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } },
+      makeTodoBlock('f-1', 'Real feedback', false),
+    ];
+    const client = makeNotionClient({
+      blocksChildrenList: makeBlocksChildrenListFn(blocks),
+    });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    const result = await page.readFeedback('page-id');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('Real feedback');
+  });
+
+  it('returns all to_do blocks in Feedback section with correct resolved values', async () => {
+    const blocks = [
+      { id: 'h-testing', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Testing instructions' }] } },
+      makeTodoBlock('t-1', 'Testing step', true),
+      { id: 'h-feedback', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Feedback' }] } },
+      makeTodoBlock('f-1', 'Unchecked feedback', false),
+      makeTodoBlock('f-2', 'Checked feedback', true),
+    ];
+    const client = makeNotionClient({
+      blocksChildrenList: makeBlocksChildrenListFn(blocks),
+    });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    const result = await page.readFeedback('page-id');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ id: 'f-1', resolved: false });
+    expect(result[1]).toMatchObject({ id: 'f-2', resolved: true });
   });
 });
 

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -42,6 +42,8 @@ function makeReviewInput(overrides: Partial<ImplementationReviewInput> = {}): Im
     artifact_ref: 'spec-page-id',
     artifact_url: 'https://notion.so/spec',
     title: 'Setup wizard',
+    workspace_path: '/ws/test-workspace',
+    branch: 'spec/test-branch',
     summary: 'sum',
     testing_instructions: 'test',
     ...overrides,

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -574,6 +574,241 @@ describe('NotionImplementationFeedbackPage — update', () => {
 
     await expect(page.update('page-id', { summary: 'New summary' })).rejects.toThrow();
   });
+
+  it('replaces Summary with structured Changes and Confirm when review_summary is provided', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue([
+      '## Workspace',
+      '',
+      'Workspace: `/ws`',
+      '',
+      '## Summary',
+      '',
+      '### Changes',
+      '',
+      '- Old change',
+      '',
+      '### Confirm',
+      '',
+      '- Old confirm',
+      '',
+      '## Testing instructions',
+      '',
+      '- [ ] npm test',
+      '',
+      '## Feedback',
+      '',
+    ].join('\n'));
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    await page.update('page-id', {
+      review_summary: {
+        changes: ['New change A', 'New change B'],
+        confirm: ['Confirm X', 'Confirm Y'],
+      },
+    });
+
+    const updated = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(updated).toContain('New change A');
+    expect(updated).toContain('New change B');
+    expect(updated).toContain('Confirm X');
+    expect(updated).toContain('Confirm Y');
+    expect(updated).not.toContain('Old change');
+    expect(updated).not.toContain('Old confirm');
+    expect(updated).toContain('## Testing instructions');
+    expect(updated).toContain('npm test');
+    expect(updated).toContain('## Feedback');
+  });
+
+  it('appends new testing steps without removing or unchecking existing items', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue([
+      '## Testing instructions',
+      '',
+      '- [x] cd /workspace',
+      '- [ ] npm install',
+      '',
+      '## Additional steps',
+      '',
+      '- [ ] Add any extra testing steps here.',
+      '',
+      '## Feedback',
+      '',
+    ].join('\n'));
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    await page.update('page-id', {
+      testing_steps: ['npm test', 'Check the logs'],
+    });
+
+    const updated = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(updated).toContain('- [x] cd /workspace');
+    expect(updated).toContain('- [ ] npm install');
+    expect(updated).toContain('npm test');
+    expect(updated).toContain('Check the logs');
+    expect(updated).toContain('## Additional steps');
+    expect(updated).toContain('Add any extra testing steps here.');
+    expect(updated).toContain('## Feedback');
+  });
+
+  it('does not append a testing step whose text matches an existing step (case-insensitive)', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue([
+      '## Testing instructions',
+      '',
+      '- [ ] npm install',
+      '- [x] npm test',
+      '',
+      '## Feedback',
+      '',
+    ].join('\n'));
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    await page.update('page-id', {
+      testing_steps: ['npm install', 'NPM TEST', 'New unique step'],
+    });
+
+    const updated = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect((updated.match(/npm install/gi) ?? []).length).toBe(1);
+    expect((updated.match(/npm test/gi) ?? []).length).toBe(1);
+    expect(updated).toContain('New unique step');
+  });
+
+  it('does not modify Additional steps section when appending testing steps', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue([
+      '## Testing instructions',
+      '',
+      '- [ ] npm test',
+      '',
+      '## Additional steps',
+      '',
+      '- [ ] My custom step',
+      '',
+      '## Feedback',
+      '',
+    ].join('\n'));
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    await page.update('page-id', {
+      testing_steps: ['New step'],
+    });
+
+    const updated = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(updated).toContain('## Additional steps');
+    expect(updated).toContain('My custom step');
+    const newStepIdx = updated.indexOf('New step');
+    const additionalStepsIdx = updated.indexOf('## Additional steps');
+    expect(newStepIdx).toBeLessThan(additionalStepsIdx);
+  });
+
+  it('resolves feedback items only within the Feedback section (not testing instructions)', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue([
+      '## Testing instructions',
+      '',
+      '- [ ] Run the feature',
+      '',
+      '## Feedback',
+      '',
+      '- [ ] Run the feature',
+      '',
+    ].join('\n'));
+    const blocksChildrenList = vi.fn().mockImplementation(async ({ block_id }: { block_id: string }) => {
+      if (block_id === 'page-id') {
+        return {
+          results: [
+            makeTodoBlock('feedback-todo-id', 'Run the feature', false),
+          ],
+        };
+      }
+      return { results: [] };
+    });
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    await page.update('page-id', {
+      resolved_items: [{ id: 'feedback-todo-id', resolution_comment: 'Fixed' }],
+    });
+
+    const updated = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    const checkedCount = (updated.match(/- \[x\] Run the feature/g) ?? []).length;
+    const uncheckedCount = (updated.match(/- \[ \] Run the feature/g) ?? []).length;
+    expect(checkedCount).toBe(1);
+    expect(uncheckedCount).toBe(1);
+  });
+
+  it('does not duplicate resolution comment when called twice with same item', async () => {
+    const pageMarkdownAfterFirst = [
+      '## Feedback',
+      '',
+      '- [x] Fix the bug',
+      '  - ✓ Fixed via config',
+      '',
+    ].join('\n');
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue(pageMarkdownAfterFirst);
+    const blocksChildrenList = vi.fn().mockImplementation(async ({ block_id }: { block_id: string }) => {
+      if (block_id === 'page-id') {
+        return { results: [makeTodoBlock('todo-1', 'Fix the bug', true)] };
+      }
+      return { results: [] };
+    });
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+
+    await page.update('page-id', {
+      resolved_items: [{ id: 'todo-1', resolution_comment: 'Fixed via config' }],
+    });
+
+    if (pagesUpdateMarkdown.mock.calls.length > 0) {
+      const updated = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+      expect((updated.match(/✓ Fixed via config/g) ?? []).length).toBe(1);
+    }
+  });
+
+  it('emits implementation.feedback_resolved log after resolving items', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { try { logs.push(JSON.parse(line)); } catch { /* ignore */ } } };
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Feedback\n\n- [ ] Fix it\n');
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const blocksChildrenList = vi.fn().mockImplementation(async ({ block_id }: { block_id: string }) => {
+      if (block_id === 'page-id') {
+        return { results: [makeTodoBlock('t1', 'Fix it', false)] };
+      }
+      return { results: [] };
+    });
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: dest });
+
+    await page.update('page-id', { resolved_items: [{ id: 't1', resolution_comment: 'Done' }] });
+
+    expect((logs as Array<Record<string, unknown>>).find(l => l['event'] === 'implementation.feedback_resolved')).toBeDefined();
+  });
+
+  it('emits implementation.testing_steps_appended log when new steps are added', async () => {
+    const logs: unknown[] = [];
+    const dest = { write: (line: string) => { try { logs.push(JSON.parse(line)); } catch { /* ignore */ } } };
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Testing instructions\n\n- [ ] Step 1\n\n## Feedback\n\n');
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const client = makeNotionClient({
+      pagesGetMarkdown,
+      pagesUpdateMarkdown,
+      blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }),
+    });
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: dest });
+
+    await page.update('page-id', { testing_steps: ['Step 2', 'Step 1'] }); // Step 1 is duplicate
+
+    const appended = (logs as Array<Record<string, unknown>>).find(l => l['event'] === 'implementation.testing_steps_appended');
+    expect(appended).toBeDefined();
+    expect(appended?.['appended_count']).toBe(1);
+    expect(appended?.['skipped_count']).toBe(1);
+  });
 });
 
 describe('NotionImplementationFeedbackPage — logging', () => {

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -196,6 +196,134 @@ describe('NotionImplementationFeedbackPage — create', () => {
 
     expect(records.find(r => r['event'] === 'notion_testing_guide.created')).toBeDefined();
   });
+
+  it('writes Workspace heading before Summary heading', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create(makeReviewInput());
+
+    const children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> } }> =
+      pagesCreate.mock.calls[0][0].children;
+    const headingTexts = children
+      .filter(b => b.type === 'heading_2')
+      .map(b => b.heading_2!.rich_text[0].text.content);
+    const workspaceIdx = headingTexts.indexOf('Workspace');
+    const summaryIdx = headingTexts.indexOf('Summary');
+    expect(workspaceIdx).toBeGreaterThanOrEqual(0);
+    expect(summaryIdx).toBeGreaterThan(workspaceIdx);
+  });
+
+  it('writes workspace_path and branch in that order after Workspace heading', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create(makeReviewInput({
+      workspace_path: '/my/workspace',
+      branch: 'spec/abc123',
+    }));
+
+    const children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> }; paragraph?: { rich_text: Array<{ text: { content: string } }> } }> =
+      pagesCreate.mock.calls[0][0].children;
+    const workspaceHeadingIdx = children.findIndex(
+      b => b.type === 'heading_2' && b.heading_2!.rich_text[0].text.content === 'Workspace',
+    );
+    const workspaceParagraph = children[workspaceHeadingIdx + 1];
+    const branchParagraph = children[workspaceHeadingIdx + 2];
+    expect(workspaceParagraph?.paragraph?.rich_text[0].text.content).toContain('/my/workspace');
+    expect(branchParagraph?.paragraph?.rich_text[0].text.content).toContain('spec/abc123');
+  });
+
+  it('renders Changes and Confirm as bulleted_list_item blocks from review_summary', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create(makeReviewInput({
+      review_summary: {
+        changes: ['Added config loader', 'Wired provider'],
+        confirm: ['Provider is used', 'Old runs work'],
+      },
+    }));
+
+    const children: Array<{ type: string; bulleted_list_item?: { rich_text: Array<{ text: { content: string } }> } }> =
+      pagesCreate.mock.calls[0][0].children;
+    const bulletTexts = children
+      .filter(b => b.type === 'bulleted_list_item')
+      .map(b => b.bulleted_list_item!.rich_text[0].text.content);
+    expect(bulletTexts).toContain('Added config loader');
+    expect(bulletTexts).toContain('Wired provider');
+    expect(bulletTexts).toContain('Provider is used');
+    expect(bulletTexts).toContain('Old runs work');
+  });
+
+  it('renders testing_steps as Notion to_do blocks', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create(makeReviewInput({
+      testing_steps: ['cd /workspace', 'npm install', 'npm test'],
+    }));
+
+    const children: Array<{ type: string; to_do?: { rich_text: Array<{ text: { content: string } }>; checked: boolean } }> =
+      pagesCreate.mock.calls[0][0].children;
+    const allTodos = children.filter(b => b.type === 'to_do');
+    const todoTexts = allTodos.map(b => b.to_do!.rich_text[0].text.content);
+    expect(todoTexts).toContain('cd /workspace');
+    expect(todoTexts).toContain('npm install');
+    expect(todoTexts).toContain('npm test');
+    allTodos.filter(b => ['cd /workspace', 'npm install', 'npm test'].includes(b.to_do!.rich_text[0].text.content))
+      .forEach(b => expect(b.to_do!.checked).toBe(false));
+  });
+
+  it('renders an Additional steps heading with a placeholder to_do item', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create(makeReviewInput());
+
+    const children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> }; to_do?: { rich_text: Array<{ text: { content: string } }>; checked: boolean } }> =
+      pagesCreate.mock.calls[0][0].children;
+    const additionalStepsIdx = children.findIndex(
+      b => b.type === 'heading_2' && b.heading_2!.rich_text[0].text.content === 'Additional steps',
+    );
+    expect(additionalStepsIdx).toBeGreaterThanOrEqual(0);
+    const placeholder = children[additionalStepsIdx + 1];
+    expect(placeholder?.type).toBe('to_do');
+    expect(placeholder?.to_do!.rich_text[0].text.content).toBe('Add any extra testing steps here.');
+    expect(placeholder?.to_do!.checked).toBe(false);
+  });
+
+  it('falls back to legacy summary as single Changes bullet and fixed Confirm bullet', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    await page.create(makeReviewInput({
+      review_summary: undefined,
+      summary: 'Legacy summary text',
+      testing_steps: undefined,
+      testing_instructions: 'Step one\nStep two',
+    }));
+
+    const children: Array<{ type: string; bulleted_list_item?: { rich_text: Array<{ text: { content: string } }> }; to_do?: { rich_text: Array<{ text: { content: string } }>; checked: boolean } }> =
+      pagesCreate.mock.calls[0][0].children;
+    const bulletTexts = children
+      .filter(b => b.type === 'bulleted_list_item')
+      .map(b => b.bulleted_list_item!.rich_text[0].text.content);
+    expect(bulletTexts).toContain('Legacy summary text');
+    expect(bulletTexts).toContain('Confirm the implemented behavior matches the approved spec.');
+
+    const todoTexts = children
+      .filter(b => b.type === 'to_do')
+      .map(b => b.to_do!.rich_text[0].text.content);
+    expect(todoTexts).toContain('Step one');
+    expect(todoTexts).toContain('Step two');
+  });
 });
 
 describe('NotionImplementationFeedbackPage — readFeedback', () => {

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -370,6 +370,29 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('parseImplementationResult rejects review_summary that is not an object', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-invalid-summary-'));
+    try {
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          review_summary: 'not an object',
+        }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await expect(service.implement('/tmp/spec.md', workspace)).rejects.toThrow(
+        /review_summary must be an object/i,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('uses issue triage agent output before creating issues through IssueManager', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'ac-issue-'));
     try {

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -281,6 +281,95 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('parseImplementationResult accepts structured review_summary, testing_steps, and resolved_feedback_items', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-structured-'));
+    try {
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          summary: 'short fallback',
+          review_summary: {
+            changes: ['Added provider config', 'Wired runtime loader'],
+            confirm: ['Provider is used for new runs', 'Old runs unaffected'],
+          },
+          testing_steps: ['cd /workspace', 'npm install', 'npm test'],
+          resolved_feedback_items: [
+            { id: 'block-abc', resolution_comment: 'Fixed via config loader' },
+          ],
+        }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      const result = await service.implement('/tmp/spec.md', workspace);
+
+      expect(result.review_summary).toEqual({
+        changes: ['Added provider config', 'Wired runtime loader'],
+        confirm: ['Provider is used for new runs', 'Old runs unaffected'],
+      });
+      expect(result.testing_steps).toEqual(['cd /workspace', 'npm install', 'npm test']);
+      expect(result.resolved_feedback_items).toEqual([
+        { id: 'block-abc', resolution_comment: 'Fixed via config loader' },
+      ]);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('parseImplementationResult tolerates omitted structured fields for backward compatibility', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-legacy-'));
+    try {
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          summary: 'Done',
+          testing_instructions: 'npm test',
+        }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      const result = await service.implement('/tmp/spec.md', workspace);
+
+      expect(result.review_summary).toBeUndefined();
+      expect(result.testing_steps).toBeUndefined();
+      expect(result.resolved_feedback_items).toBeUndefined();
+      expect(result.summary).toBe('Done');
+      expect(result.testing_instructions).toBe('npm test');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('parseImplementationResult rejects resolved_feedback_items entries missing id or resolution_comment', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-invalid-resolved-'));
+    try {
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          resolved_feedback_items: [{ id: 'block-1' }], // missing resolution_comment
+        }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await expect(service.implement('/tmp/spec.md', workspace)).rejects.toThrow(
+        /resolved_feedback_items.*resolution_comment/i,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('uses issue triage agent output before creating issues through IssueManager', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'ac-issue-'));
     try {

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -393,6 +393,58 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('implementation prompt requests review_summary, testing_steps, and resolved_feedback_items', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-prompt-structured-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'Done' }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await service.implement('/tmp/spec.md', workspace);
+
+      expect(calls[0].prompt).toContain('review_summary');
+      expect(calls[0].prompt).toContain('testing_steps');
+      expect(calls[0].prompt).toContain('resolved_feedback_items');
+      expect(calls[0].prompt).toContain('changes');
+      expect(calls[0].prompt).toContain('confirm');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('feedback implementation prompt instructs agent to preserve feedback IDs exactly', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-feedback-prompt-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'Done' }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+      const feedbackContext = '[FEEDBACK_ID: block-1]\nFix the crash\n[FEEDBACK_ID: block-2]\nUpdate config example';
+
+      await service.implement('/tmp/spec.md', workspace, feedbackContext);
+
+      // The prompt should instruct the agent to use IDs exactly as given
+      expect(calls[0].prompt).toContain('FEEDBACK_ID');
+      expect(calls[0].prompt).toContain('resolved_feedback_items');
+      expect(calls[0].prompt).toMatch(/id.*exactly|use.*id.*as.*provided|preserve.*id/i);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('uses issue triage agent output before creating issues through IssueManager', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'ac-issue-'));
     try {

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -67,6 +67,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
     persist: vi.fn(),
     logger: {
       info: vi.fn(),
+      warn: vi.fn(),   // <-- added
       error: vi.fn(),
     },
     ...overrides,
@@ -95,6 +96,8 @@ describe('ImplementationFeedbackHandler', () => {
     expect(deps.implementer.implement).toHaveBeenCalledWith(
       '/ws/request-001/context-human/specs/typed-feature.md',
       '/ws/request-001',
+      expect.any(String),     // additionalContext
+      expect.any(Function),   // onProgress
     );
     expect(deps.failRun).not.toHaveBeenCalled();
   });
@@ -120,6 +123,7 @@ describe('ImplementationFeedbackHandler', () => {
       '/ws/request-001/context-human/specs/feature-test.md',
       '/ws/request-001',
       expect.stringContaining('Fix the bug'),
+      expect.any(Function),   // onProgress
     );
     const context = (deps.implementer.implement as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
     expect(context).toContain('Some context');
@@ -142,6 +146,7 @@ describe('ImplementationFeedbackHandler', () => {
       '/ws/request-001/context-human/specs/feature-test.md',
       '/ws/request-001',
       'use adapter composition',
+      expect.any(Function),   // onProgress
     );
   });
 
@@ -214,6 +219,191 @@ describe('ImplementationFeedbackHandler', () => {
     expect(deps.logger.error).toHaveBeenCalledWith(
       expect.objectContaining({ event: 'run.notify_failed', run_id: 'run-001' }),
       'Failed to post completion notification',
+    );
+  });
+
+  it('serializes unresolved feedback with [FEEDBACK_ID: ...] markers', async () => {
+    const feedbackItems: FeedbackItem[] = [
+      { id: 'block-id-1', text: 'Custom transform swallowed on add', resolved: false, conversation: ['I tested and it disappears'] },
+      { id: 'block-id-2', text: 'Config example missing provider field', resolved: false, conversation: [] },
+      { id: 'block-id-3', text: 'Already resolved', resolved: true, conversation: [] },
+    ];
+    const { handler, deps } = makeHandler({
+      implFeedbackPage: {
+        readFeedback: vi.fn().mockResolvedValue(feedbackItems),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    const context = (deps.implementer.implement as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+    expect(context).toContain('[FEEDBACK_ID: block-id-1]');
+    expect(context).toContain('Custom transform swallowed on add');
+    expect(context).toContain('I tested and it disappears');
+    expect(context).toContain('[FEEDBACK_ID: block-id-2]');
+    expect(context).toContain('Config example missing provider field');
+    expect(context).not.toContain('block-id-3');
+    expect(context).not.toContain('Already resolved');
+  });
+
+  it('uses Slack message content when no unresolved feedback exists and logs feedback_empty', async () => {
+    const { handler, deps } = makeHandler({
+      implFeedbackPage: {
+        readFeedback: vi.fn().mockResolvedValue([
+          { id: 'block-1', text: 'Already done', resolved: true, conversation: [] },
+        ]),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun();
+    const feedback = makeFeedback({ content: 'please check the edge case' });
+
+    await handler.handle(run, feedback, 'reviewing_implementation');
+
+    const context = (deps.implementer.implement as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+    expect(context).toBe('please check the edge case');
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'implementation.feedback_empty', run_id: 'run-001' }),
+      expect.any(String),
+    );
+  });
+
+  it('passes onProgress callback to implementer.implement() during feedback', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(deps.implementer.implement).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(Function),
+    );
+  });
+
+  it('onProgress posts to Slack with the original conversation ref', async () => {
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const { handler, deps } = makeHandler({
+      implementer: {
+        implement: vi.fn().mockImplementation(async (_spec, _workspace, _ctx, onProgress: (msg: string) => Promise<void>) => {
+          capturedOnProgress = onProgress;
+          return { status: 'complete', summary: 'Done', testing_instructions: 'npm test' };
+        }),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+    await capturedOnProgress!('Reviewing 2 feedback items');
+
+    expect(deps.postMessage).toHaveBeenCalledWith(TEST_CONVERSATION, 'Reviewing 2 feedback items');
+  });
+
+  it('onProgress postMessage failure logs progress_failed and does not fail the run', async () => {
+    let capturedOnProgress: ((msg: string) => Promise<void>) | undefined;
+    const { handler, deps } = makeHandler({
+      implementer: {
+        implement: vi.fn().mockImplementation(async (_spec, _workspace, _ctx, onProgress: (msg: string) => Promise<void>) => {
+          capturedOnProgress = onProgress;
+          return { status: 'complete', summary: 'Done', testing_instructions: 'npm test' };
+        }),
+      },
+      postMessage: vi.fn().mockRejectedValue(new Error('Slack timeout')),
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+    // Should not throw
+    await expect(capturedOnProgress!('Progress message')).resolves.toBeUndefined();
+
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'progress_failed', phase: 'implementation_feedback', run_id: 'run-001' }),
+      expect.any(String),
+    );
+  });
+
+  it('calls implFeedbackPage.update() with resolved_items from the implementation result', async () => {
+    const { handler, deps } = makeHandler({
+      implementer: {
+        implement: vi.fn().mockResolvedValue({
+          status: 'complete',
+          summary: 'Fixed',
+          resolved_feedback_items: [
+            { id: 'block-id-1', resolution_comment: 'Fixed by wiring persistence' },
+          ],
+        }),
+      },
+      implFeedbackPage: {
+        readFeedback: vi.fn().mockResolvedValue([
+          { id: 'block-id-1', text: 'Persistence broken', resolved: false, conversation: [] },
+        ]),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(deps.implFeedbackPage?.update).toHaveBeenCalledWith(
+      'feedback-page-id',
+      expect.objectContaining({
+        resolved_items: [{ id: 'block-id-1', resolution_comment: 'Fixed by wiring persistence' }],
+      }),
+    );
+  });
+
+  it('calls implFeedbackPage.update() with review_summary and testing_steps when present', async () => {
+    const { handler, deps } = makeHandler({
+      implementer: {
+        implement: vi.fn().mockResolvedValue({
+          status: 'complete',
+          summary: 'Done',
+          review_summary: {
+            changes: ['Added config', 'Updated tests'],
+            confirm: ['Config loads', 'Tests pass'],
+          },
+          testing_steps: ['cd /workspace', 'npm test'],
+          resolved_feedback_items: [],
+        }),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(deps.implFeedbackPage?.update).toHaveBeenCalledWith(
+      'feedback-page-id',
+      expect.objectContaining({
+        review_summary: {
+          changes: ['Added config', 'Updated tests'],
+          confirm: ['Config loads', 'Tests pass'],
+        },
+        testing_steps: ['cd /workspace', 'npm test'],
+      }),
+    );
+  });
+
+  it('logs review_contract_legacy warning when structured fields are absent from feedback result', async () => {
+    const { handler, deps } = makeHandler({
+      implementer: {
+        implement: vi.fn().mockResolvedValue({
+          status: 'complete',
+          summary: 'Legacy only',
+          testing_instructions: 'npm test',
+          // no review_summary or testing_steps
+        }),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'implementation.review_contract_legacy', run_id: 'run-001' }),
+      expect.any(String),
     );
   });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -67,8 +67,9 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
     persist: vi.fn(),
     logger: {
       info: vi.fn(),
-      warn: vi.fn(),   // <-- added
+      warn: vi.fn(),
       error: vi.fn(),
+      debug: vi.fn(),
     },
     ...overrides,
   };

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -54,6 +54,11 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
         status: 'complete',
         summary: 'Implemented the feature successfully.',
         testing_instructions: 'npm test',
+        review_summary: {
+          changes: ['Added feature X', 'Wired config loader'],
+          confirm: ['Feature X works', 'Config loads correctly'],
+        },
+        testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
       }),
     },
     implFeedbackPage: {
@@ -102,8 +107,15 @@ describe('ImplementationStartHandler', () => {
       artifact_ref: 'CANVAS-TYPED',
       artifact_url: undefined,
       title: 'Typed feature',
+      workspace_path: '/ws/request-001',
+      branch: 'spec/request-001',
       summary: 'Implemented the feature successfully.',
       testing_instructions: 'npm test',
+      review_summary: {
+        changes: ['Added feature X', 'Wired config loader'],
+        confirm: ['Feature X works', 'Config loads correctly'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
     });
     expect(deps.failRun).not.toHaveBeenCalled();
   });
@@ -126,8 +138,15 @@ describe('ImplementationStartHandler', () => {
       artifact_ref: 'CANVAS001',
       artifact_url: undefined,
       title: 'Test',
+      workspace_path: '/ws/request-001',
+      branch: 'spec/request-001',
       summary: 'Implemented the feature successfully.',
       testing_instructions: 'npm test',
+      review_summary: {
+        changes: ['Added feature X', 'Wired config loader'],
+        confirm: ['Feature X works', 'Config loads correctly'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
     });
     expect(run.impl_feedback_ref).toBe('feedback-page-id');
     expect(run.last_impl_result).toEqual({
@@ -197,6 +216,65 @@ describe('ImplementationStartHandler', () => {
     expect(result).toEqual({ status: 'failed' });
     expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.any(Error));
     expect(deps.implFeedbackPage?.create).not.toHaveBeenCalled();
+  });
+
+  it('passes workspace_path and branch to implFeedbackPage.create()', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace_path: '/ws/request-001',
+        branch: 'spec/request-001',
+      }),
+    );
+  });
+
+  it('maps review_summary and testing_steps from result into ImplementationReviewInput', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        review_summary: {
+          changes: ['Added feature X', 'Wired config loader'],
+          confirm: ['Feature X works', 'Config loads correctly'],
+        },
+        testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
+      }),
+    );
+  });
+
+  it('falls back to legacy fields when structured fields are omitted and logs review_contract_legacy', async () => {
+    const { handler, deps } = makeHandler({
+      implementer: {
+        implement: vi.fn().mockResolvedValue({
+          status: 'complete',
+          summary: 'Legacy summary.',
+          testing_instructions: 'Legacy instructions.',
+        }),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'Legacy summary.',
+        testing_instructions: 'Legacy instructions.',
+        review_summary: undefined,
+        testing_steps: undefined,
+      }),
+    );
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'implementation.review_contract_legacy', run_id: 'run-001' }),
+      expect.any(String),
+    );
   });
 
   it('continues in degraded mode when feedback page creation or completion notification fails', async () => {


### PR DESCRIPTION
Improves the testing guide structure and implementation feedback loop quality.

## Changes

- Render workspace-first testing guide structure in Notion `create()`
- Pass workspace, branch, and structured fields to testing guide `create()`
- Extend `ImplementationReviewInput` with `workspace_path`, `branch`, `review_summary`, `testing_steps`
- Update implementation prompt to request structured `review_summary` and `testing_steps`
- Extend `ImplementationResult` with `review_summary`, `testing_steps`, `resolved_feedback_items`
- Scope `readFeedback()` to Feedback section, ignore testing-instruction and additional-steps todos
- Extend `update()` with `review_summary` replacement, testing step append, section-scoped resolution
- Wire `onProgress`, serialize feedback IDs, and pass resolved items in `ImplementationFeedbackHandler`
- Add debug logger to `ImplementationFeedbackDeps` and emit `feedback_context_built` log

## Testing

```
npm install && npx tsc --noEmit
npx vitest run
```