### PR TITLE
fix: add branchguard to prevent branch drift in agent handlers

### DIFF
--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -660,6 +660,18 @@ milestone - emit it on its own line using this exact format:
 The goal is to keep a human informed at intervals they'd find interesting. You decide what's
 worth reporting and when.`;
 
+const BRANCH_OWNERSHIP_POLICY = `\
+Autocatalyst owns git branch and PR management for this run.
+The workspace is already checked out on the correct run branch.
+Do not create branches, switch branches, or create worktrees.
+Do not push, merge, or open PRs — Autocatalyst handles those steps.
+If a skill includes branch setup, worktree creation, push, merge, or PR steps, skip those parts and follow the rest of the skill normally.
+All files and commits must stay on the current branch.`;
+
+const MM_PLANNING_BRANCH_OVERRIDE = `\
+When using mm:planning, treat its Branch setup section as already complete.
+Do not run git checkout -b feat/..., enhancement/..., or fix/....`;
+
 function buildArtifactCreatePrompt(
   request: Request,
   artifactDir: string,
@@ -671,6 +683,8 @@ function buildArtifactCreatePrompt(
       `You are producing a bug triage document for the following report:`,
       ``,
       request.content,
+      ``,
+      BRANCH_OWNERSHIP_POLICY,
       ``,
       `Use the \`mm:issue-triage\` skill to perform a thorough investigation of this bug.`,
       `Examine relevant source files, recent commits, and related issue-tracker records to understand the`,
@@ -695,6 +709,8 @@ function buildArtifactCreatePrompt(
       ``,
       request.content,
       ``,
+      BRANCH_OWNERSHIP_POLICY,
+      ``,
       `Use the \`mm:issue-triage\` skill to investigate the current state of the relevant`,
       `code and understand why this work is needed now. Use thorough investigation.`,
       ``,
@@ -712,6 +728,10 @@ function buildArtifactCreatePrompt(
 
   return [
     `Use the \`mm:planning\` skill to create a complete product spec for the following request.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    MM_PLANNING_BRANCH_OVERRIDE,
     ``,
     `Request:`,
     `<<<`,
@@ -758,6 +778,8 @@ function buildArtifactRevisePrompt(
   return [
     `Revise the artifact below based on the following feedback.`,
     ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
     `Write the revised artifact to: ${artifact_path}`,
     `Write the result to: ${reviseResultPath}`,
     `Content must be:`,
@@ -785,6 +807,8 @@ function buildArtifactRevisePrompt(
 
 function buildImplementationPrompt(artifact_path: string, result_file_path: string, additionalContext?: string): string {
   const lines: string[] = [];
+  lines.push(BRANCH_OWNERSHIP_POLICY);
+  lines.push('');
   const hasFeedbackContext = Boolean(additionalContext) && additionalContext!.includes('[FEEDBACK_ID:');
 
   if (additionalContext) {

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -16,6 +16,7 @@ import type { ChannelRepoMap } from '../types/config.js';
 import type { WorkspaceManager } from './workspace-manager.js';
 import type { SpecCommitter } from './spec-committer.js';
 import { HandlerRegistryImpl, type HandlerRegistry } from './handler-registry.js';
+import { GitBranchGuard, type BranchGuard } from './git-branch-guard.js';
 import { ArtifactCreationHandler } from './handlers/artifact-creation-handler.js';
 import { ArtifactApprovalHandler, type ArtifactApprovalResult } from './handlers/artifact-approval-handler.js';
 import { ArtifactFeedbackHandler } from './handlers/artifact-feedback-handler.js';
@@ -52,10 +53,12 @@ export interface DefaultHandlerRegistryDeps {
   persist: () => void;
   reactToRunMessage: (run: Run, reaction: string) => Promise<void>;
   logger: Pick<pino.Logger, 'debug' | 'info' | 'warn' | 'error'>;
+  branchGuard?: BranchGuard;
 }
 
 export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): HandlerRegistry {
   const registry = new HandlerRegistryImpl();
+  const branchGuard: BranchGuard = deps.branchGuard ?? new GitBranchGuard();
   const registerNewRequest = (
     intent: RequestIntent,
     handler: (request: Request, run: Run) => Promise<void>,
@@ -76,26 +79,26 @@ export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): H
     });
   };
 
-  registerNewRequest('idea', (request, run) => startArtifactCreation(deps, run, request, 'idea'));
-  registerNewRequest('bug', (request, run) => startArtifactCreation(deps, run, request, 'bug'));
-  registerNewRequest('chore', (request, run) => startArtifactCreation(deps, run, request, 'chore'));
+  registerNewRequest('idea', (request, run) => startArtifactCreation(deps, branchGuard, run, request, 'idea'));
+  registerNewRequest('bug', (request, run) => startArtifactCreation(deps, branchGuard, run, request, 'bug'));
+  registerNewRequest('chore', (request, run) => startArtifactCreation(deps, branchGuard, run, request, 'chore'));
   registerNewRequest('file_issues', (request, run) => startFilingPipeline(deps, run, request));
   registerNewRequest('question', async (request, run) => {
     const result = await handleQuestion(deps, request.content, request.conversation, run);
     deps.transition(run, result.status === 'unavailable' ? 'failed' : 'done');
   });
 
-  registerThreadMessage('reviewing_spec', 'feedback', (feedback, run) => handleArtifactFeedback(deps, feedback, run));
-  registerThreadMessage('reviewing_implementation', 'feedback', (feedback, run) => handleImplementationFeedback(deps, feedback, run, 'reviewing_implementation'));
-  registerThreadMessage('awaiting_impl_input', 'feedback', (feedback, run) => handleImplementationFeedback(deps, feedback, run, 'awaiting_impl_input'));
+  registerThreadMessage('reviewing_spec', 'feedback', (feedback, run) => handleArtifactFeedback(deps, branchGuard, feedback, run));
+  registerThreadMessage('reviewing_implementation', 'feedback', (feedback, run) => handleImplementationFeedback(deps, branchGuard, feedback, run, 'reviewing_implementation'));
+  registerThreadMessage('awaiting_impl_input', 'feedback', (feedback, run) => handleImplementationFeedback(deps, branchGuard, feedback, run, 'awaiting_impl_input'));
   registerThreadMessage('pr_open', 'feedback', (feedback, run) => handlePrOpenFeedback(deps, feedback, run));
   registerThreadMessage('reviewing_spec', 'approval', async (feedback, run) => {
-    const result = await approveArtifact(deps, run, feedback);
+    const result = await approveArtifact(deps, branchGuard, run, feedback);
     if (result.status === 'failed') return;
     if (!result.implementation_required) return;
-    await runImplementation(deps, feedback, run);
+    await runImplementation(deps, branchGuard, feedback, run);
   });
-  registerThreadMessage('reviewing_implementation', 'approval', (feedback, run) => handleImplementationApproval(deps, feedback, run));
+  registerThreadMessage('reviewing_implementation', 'approval', (feedback, run) => handleImplementationApproval(deps, branchGuard, feedback, run));
   registerThreadMessage('pr_open', 'approval', (feedback, run) => handlePrMerge(deps, feedback, run));
   registerThreadMessage('reviewing_spec', 'question', (feedback, run) => answerQuestionAndRestoreStage(deps, feedback, run, 'reviewing_spec'));
   registerThreadMessage('reviewing_implementation', 'question', (feedback, run) => answerQuestionAndRestoreStage(deps, feedback, run, 'reviewing_implementation'));
@@ -107,6 +110,7 @@ export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): H
 
 async function startArtifactCreation(
   deps: DefaultHandlerRegistryDeps,
+  branchGuard: BranchGuard,
   run: Run,
   request: Request,
   intent: ArtifactCreationIntent,
@@ -121,12 +125,14 @@ async function startArtifactCreation(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
+    branchGuard,
   });
   await handler.handle(run, request, intent);
 }
 
 async function approveArtifact(
   deps: DefaultHandlerRegistryDeps,
+  branchGuard: BranchGuard,
   run: Run,
   feedback: ThreadMessage,
 ): Promise<ArtifactApprovalResult> {
@@ -143,12 +149,14 @@ async function approveArtifact(
     persist: deps.persist,
     logger: deps.logger,
     deleteFile: (path) => rm(path, { force: true }),
+    branchGuard,
   });
   return handler.handle(run, feedback);
 }
 
 async function handleArtifactFeedback(
   deps: DefaultHandlerRegistryDeps,
+  branchGuard: BranchGuard,
   feedback: ThreadMessage,
   run: Run,
 ): Promise<void> {
@@ -161,12 +169,14 @@ async function handleArtifactFeedback(
     transition: deps.transition,
     failRun: deps.failRun,
     logger: deps.logger,
+    branchGuard,
   });
   await handler.handle(run, feedback);
 }
 
 async function runImplementation(
   deps: DefaultHandlerRegistryDeps,
+  branchGuard: BranchGuard,
   feedback: ThreadMessage,
   run: Run,
   additionalContext?: string,
@@ -179,12 +189,14 @@ async function runImplementation(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
+    branchGuard,
   });
   await handler.handle(run, feedback, additionalContext);
 }
 
 async function handleImplementationFeedback(
   deps: DefaultHandlerRegistryDeps,
+  branchGuard: BranchGuard,
   feedback: ThreadMessage,
   run: Run,
   routingStage: RunStage,
@@ -197,12 +209,14 @@ async function handleImplementationFeedback(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
+    branchGuard,
   });
   await handler.handle(run, feedback, routingStage);
 }
 
 async function handleImplementationApproval(
   deps: DefaultHandlerRegistryDeps,
+  branchGuard: BranchGuard,
   feedback: ThreadMessage,
   run: Run,
 ): Promise<void> {
@@ -217,6 +231,7 @@ async function handleImplementationApproval(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
+    branchGuard,
   });
   await handler.handle(run, feedback);
 }

--- a/src/core/git-branch-guard.ts
+++ b/src/core/git-branch-guard.ts
@@ -1,0 +1,43 @@
+import { execFile as _execFile } from 'node:child_process';
+
+type ExecFn = (cmd: string, args: string[], opts?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }>;
+
+function defaultExec(cmd: string, args: string[], opts?: { cwd?: string }): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    _execFile(cmd, args, opts ?? {}, (err, stdout, stderr) => {
+      if (err) { reject(err); } else { resolve({ stdout, stderr }); }
+    });
+  });
+}
+
+export interface BranchGuard {
+  check(workspace_path: string, expected_branch: string): Promise<void>;
+}
+
+interface GitBranchGuardOptions {
+  execFn?: ExecFn;
+}
+
+export class GitBranchGuard implements BranchGuard {
+  private readonly execFn: ExecFn;
+
+  constructor(options?: GitBranchGuardOptions) {
+    this.execFn = options?.execFn ?? defaultExec;
+  }
+
+  async check(workspace_path: string, expected_branch: string): Promise<void> {
+    let current: string;
+    try {
+      const { stdout } = await this.execFn('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: workspace_path });
+      current = stdout.trim();
+    } catch (err) {
+      throw new Error(`Branch check failed: ${String(err)}`);
+    }
+
+    if (current !== expected_branch) {
+      throw new Error(
+        `Agent changed branches from ${expected_branch} to ${current}. Autocatalyst owns run branches; this run cannot continue safely.`,
+      );
+    }
+  }
+}

--- a/src/core/handlers/artifact-approval-handler.ts
+++ b/src/core/handlers/artifact-approval-handler.ts
@@ -10,6 +10,7 @@ import type { ChannelRepoMap } from '../../types/config.js';
 import type { ConversationRef } from '../../types/channel.js';
 import type { ArtifactRefs } from '../run-refs.js';
 import { markArtifactStatus, requireArtifactRefs, runChannelKey } from '../run-refs.js';
+import type { BranchGuard } from '../git-branch-guard.js';
 
 export interface ArtifactApprovalDeps {
   artifactPublisher: Pick<ArtifactPublisher, 'updateStatus' | 'setIssueLink'>;
@@ -24,6 +25,7 @@ export interface ArtifactApprovalDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'error'>;
   deleteFile?: (path: string) => Promise<void>;
+  branchGuard?: BranchGuard;
 }
 
 export type ArtifactApprovalResult =
@@ -154,6 +156,16 @@ export class ArtifactApprovalHandler {
     if (!this.deps.specCommitter) {
       await this.deps.failRun(run, feedback.conversation, new Error('Spec committer is required for artifact commit'));
       return false;
+    }
+
+    // Guard: fail if the workspace branch has drifted from run.branch
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return false;
+      }
     }
 
     try {

--- a/src/core/handlers/artifact-approval-handler.ts
+++ b/src/core/handlers/artifact-approval-handler.ts
@@ -85,6 +85,16 @@ export class ArtifactApprovalHandler {
   }
 
   private async syncIssueOnApproval(run: Run, feedback: ThreadMessage, refs: ArtifactRefs): Promise<boolean> {
+    // Guard: fail if the workspace branch has drifted from run.branch
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return false;
+      }
+    }
+
     if (!this.deps.issueManager) {
       await this.deps.failRun(run, feedback.conversation, new Error('Issue manager is required for artifact issue sync'));
       return false;

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -8,6 +8,7 @@ import type { Run, RunStage, RequestIntent } from '../../types/runs.js';
 import type { ChannelRepoMap } from '../../types/config.js';
 import type { WorkspaceManager } from '../workspace-manager.js';
 import { channelKey, type ConversationRef } from '../../types/channel.js';
+import type { BranchGuard } from '../git-branch-guard.js';
 
 type ArtifactCreationIntent = Extract<RequestIntent, 'idea' | 'bug' | 'chore'>;
 
@@ -21,6 +22,7 @@ export interface ArtifactCreationDeps {
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
   logger: Pick<pino.Logger, 'warn' | 'error' | 'info'>;
+  branchGuard?: BranchGuard;
 }
 
 export class ArtifactCreationHandler {
@@ -72,6 +74,17 @@ export class ArtifactCreationHandler {
       await this.deps.workspaceManager.destroy(workspace_path);
       await this.deps.failRun(run, request.conversation, err);
       return;
+    }
+
+    // Guard: fail if the agent drifted to another branch
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(workspace_path, branch);
+      } catch (err) {
+        await this.deps.workspaceManager.destroy(workspace_path);
+        await this.deps.failRun(run, request.conversation, err);
+        return;
+      }
     }
 
     let publication: ArtifactPublication;

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -6,6 +6,7 @@ import type { ArtifactContentSource, ArtifactPublisher } from '../../types/publi
 import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { requireArtifactRefs } from '../run-refs.js';
+import type { BranchGuard } from '../git-branch-guard.js';
 
 export interface ArtifactFeedbackDeps {
   artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'revise'>;
@@ -16,6 +17,7 @@ export interface ArtifactFeedbackDeps {
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   logger: Pick<pino.Logger, 'debug' | 'warn' | 'error'>;
+  branchGuard?: BranchGuard;
 }
 
 export type ArtifactFeedbackResult = { status: 'revised' } | { status: 'failed' };
@@ -66,6 +68,16 @@ export class ArtifactFeedbackHandler {
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };
+    }
+
+    // Guard: fail if the agent drifted to another branch
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
     }
 
     const { comment_responses: commentResponses, page_content } = result;

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -8,6 +8,7 @@ import type { ArtifactPublisher } from '../../types/publisher.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { markArtifactStatus, artifactPath, artifactPublisherId } from '../run-refs.js';
+import type { BranchGuard } from '../git-branch-guard.js';
 
 export interface ImplementationApprovalDeps {
   specCommitter?: Pick<SpecCommitter, 'updateStatus'>;
@@ -21,6 +22,7 @@ export interface ImplementationApprovalDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'error'>;
   now?: () => Date;
+  branchGuard?: BranchGuard;
 }
 
 export type ImplementationApprovalResult = { status: 'pr_open' } | { status: 'failed' };
@@ -71,6 +73,17 @@ export class ImplementationApprovalHandler {
       ...(run.issue !== undefined ? { issue_number: run.issue } : {}),
       ...(generatedTitle !== null ? { title: generatedTitle } : {}),
     };
+
+    // Guard: fail early if run.branch has drifted — avoids a confusing GitHub error
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
+    }
+
     let prUrl: string;
     try {
       prUrl = await this.deps.prManager.createPR(

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -59,6 +59,16 @@ export class ImplementationApprovalHandler {
         );
       }
     }
+    // Guard: fail early if run.branch has drifted — avoids a confusing PR creation error
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
+    }
+
     this.markArtifactComplete(run);
 
     const generatedTitle = await this.deps.prTitleGenerator.generate({
@@ -73,16 +83,6 @@ export class ImplementationApprovalHandler {
       ...(run.issue !== undefined ? { issue_number: run.issue } : {}),
       ...(generatedTitle !== null ? { title: generatedTitle } : {}),
     };
-
-    // Guard: fail early if run.branch has drifted — avoids a confusing PR creation error
-    if (this.deps.branchGuard) {
-      try {
-        await this.deps.branchGuard.check(run.workspace_path, run.branch);
-      } catch (err) {
-        await this.deps.failRun(run, feedback.conversation, err);
-        return { status: 'failed' };
-      }
-    }
 
     let prUrl: string;
     try {

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -74,7 +74,7 @@ export class ImplementationApprovalHandler {
       ...(generatedTitle !== null ? { title: generatedTitle } : {}),
     };
 
-    // Guard: fail early if run.branch has drifted — avoids a confusing GitHub error
+    // Guard: fail early if run.branch has drifted — avoids a confusing PR creation error
     if (this.deps.branchGuard) {
       try {
         await this.deps.branchGuard.check(run.workspace_path, run.branch);

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -5,6 +5,7 @@ import type { FeedbackItem, ImplementationReviewPublisher } from '../../types/im
 import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { artifactPath } from '../run-refs.js';
+import type { BranchGuard } from '../git-branch-guard.js';
 
 export interface ImplementationFeedbackDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -14,6 +15,7 @@ export interface ImplementationFeedbackDeps {
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error' | 'debug'>;
+  branchGuard?: BranchGuard;
 }
 
 export type ImplementationFeedbackResult =
@@ -57,6 +59,16 @@ export class ImplementationFeedbackHandler {
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };
+    }
+
+    // Guard: fail if the agent drifted to another branch
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
     }
 
     if (result.status === 'needs_input') {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -6,6 +6,7 @@ import { titleFromArtifactPath } from '../../types/publisher.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { requireArtifactRefs, artifactPublishedUrl } from '../run-refs.js';
+import type { BranchGuard } from '../git-branch-guard.js';
 
 export interface ImplementationStartDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -15,6 +16,7 @@ export interface ImplementationStartDeps {
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
+  branchGuard?: BranchGuard;
 }
 
 export type ImplementationStartResult =
@@ -60,6 +62,16 @@ export class ImplementationStartHandler {
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };
+    }
+
+    // Guard: fail if the agent drifted to another branch
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(run.workspace_path, run.branch);
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
     }
 
     if (result.status === 'needs_input') {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -26,6 +26,7 @@ import type { CommandRegistry, CommandEvent } from '../types/commands.js';
 import type { ChannelRepoMap } from '../types/config.js';
 import type { HandlerRegistry } from './handler-registry.js';
 import { buildDefaultHandlerRegistry as buildDefaultHandlers } from './default-handler-registry.js';
+import type { BranchGuard } from './git-branch-guard.js';
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
 function stageAfterApproval(stage: RunStage): RunStage {
@@ -74,6 +75,7 @@ export interface OrchestratorDeps {
   commandRegistry?: CommandRegistry;
   reacjiComplete?: string | null;
   handlerRegistry?: HandlerRegistry;
+  branchGuard?: BranchGuard;
 }
 
 interface OrchestratorOptions {
@@ -433,6 +435,7 @@ export class OrchestratorImpl implements Orchestrator {
       persist: () => this._persistRuns(),
       reactToRunMessage: (targetRun, reaction) => this.reactToRunMessage(targetRun, reaction),
       logger: this.logger,
+      branchGuard: this.deps.branchGuard,
     });
   }
 

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -133,6 +133,111 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('artifact creation prompt for idea includes Autocatalyst branch ownership policy and mm:planning override', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-branch-policy-idea-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+
+      await service.create(makeRequest(), workspace);
+
+      expect(calls[0].prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+      expect(calls[0].prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+      expect(calls[0].prompt).toContain('When using mm:planning, treat its Branch setup section as already complete.');
+      expect(calls[0].prompt).toContain('Do not run git checkout -b feat/..., enhancement/..., or fix/...');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('artifact creation prompt for bug intent includes branch ownership policy', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-branch-policy-bug-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, '.autocatalyst', 'triage', 'triage-bug-test.md') }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+
+      await service.create(makeRequest(), workspace, undefined, 'bug');
+
+      expect(calls[0].prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+      expect(calls[0].prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('artifact revision prompt includes branch ownership policy', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-branch-policy-revise-'));
+    try {
+      const artifactFilePath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      await mkdir(dirname(artifactFilePath), { recursive: true });
+      await writeFile(artifactFilePath, 'original content', 'utf8');
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(artifactFilePath, 'revised content', 'utf8');
+        await writeFile(resultPath, JSON.stringify({ comment_responses: [] }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+
+      await service.revise(makeFeedback(), [], artifactFilePath, workspace);
+
+      expect(calls[0].prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+      expect(calls[0].prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation prompt includes branch ownership policy', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-branch-policy-impl-'));
+    try {
+      const specPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          summary: 'done',
+          review_summary: { changes: ['a'], confirm: ['b'] },
+          testing_steps: [`cd ${workspace}`],
+          resolved_feedback_items: [],
+        }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await service.implement(specPath, workspace);
+
+      expect(calls[0].prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+      expect(calls[0].prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('answers questions in the provided repo directory without creating a cloned workspace', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'ac-question-'));
     try {

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -181,6 +181,29 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('artifact creation prompt for chore intent includes branch ownership policy', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-branch-policy-chore-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, '.autocatalyst', 'triage', 'triage-chore-test.md') }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+
+      await service.create(makeRequest(), workspace, undefined, 'chore');
+
+      expect(calls[0].prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+      expect(calls[0].prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('artifact revision prompt includes branch ownership policy', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'ac-branch-policy-revise-'));
     try {

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -107,6 +107,7 @@ function makeDeps() {
       warn: vi.fn(),
       error: vi.fn(),
     },
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
   };
 }
 

--- a/tests/core/git-branch-guard.test.ts
+++ b/tests/core/git-branch-guard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GitBranchGuard } from '../../src/core/git-branch-guard.js';
+
+describe('GitBranchGuard', () => {
+  it('resolves when current branch matches expected', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: 'spec/abc-123\n', stderr: '' });
+    const guard = new GitBranchGuard({ execFn });
+
+    await expect(guard.check('/ws/abc-123', 'spec/abc-123')).resolves.toBeUndefined();
+    expect(execFn).toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: '/ws/abc-123' });
+  });
+
+  it('throws with a descriptive message when the branch has drifted', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: 'feat/debug-mode-slack\n', stderr: '' });
+    const guard = new GitBranchGuard({ execFn });
+
+    await expect(guard.check('/ws/abc-123', 'spec/abc-123')).rejects.toThrow(
+      'Agent changed branches from spec/abc-123 to feat/debug-mode-slack. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+  });
+
+  it('throws when git command fails', async () => {
+    const execFn = vi.fn().mockRejectedValue(new Error('git not found'));
+    const guard = new GitBranchGuard({ execFn });
+
+    await expect(guard.check('/ws/abc-123', 'spec/abc-123')).rejects.toThrow('Branch check failed');
+  });
+});

--- a/tests/core/handlers/artifact-approval-handler.test.ts
+++ b/tests/core/handlers/artifact-approval-handler.test.ts
@@ -74,6 +74,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactApp
       info: vi.fn(),
       error: vi.fn(),
     },
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     ...overrides,
   };
 
@@ -320,5 +321,23 @@ describe('ArtifactApprovalHandler', () => {
     await handler.handle(run, makeFeedback());
 
     expect(deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('fails the run before commit when the workspace branch does not match run.branch', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/something. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+    });
+    const run = makeRun();  // uses feature_spec which has commit_on_approval
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
+    expect(deps.specCommitter?.commit).not.toHaveBeenCalled();
   });
 });

--- a/tests/core/handlers/artifact-approval-handler.test.ts
+++ b/tests/core/handlers/artifact-approval-handler.test.ts
@@ -340,4 +340,34 @@ describe('ArtifactApprovalHandler', () => {
     expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
     expect(deps.specCommitter?.commit).not.toHaveBeenCalled();
   });
+
+  it('fails the run before issue sync when the workspace branch has drifted', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/something. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+      artifactContentSource: {
+        getContent: vi.fn().mockResolvedValue('# Bug: login broken\n\nDetails here.'),
+      },
+    });
+    const run = makeRun({
+      intent: 'bug',
+      artifact: {
+        kind: 'bug_triage',
+        local_path: '/ws/request-001/context-human/specs/bug-login.md',
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
+        status: 'waiting_on_feedback',
+      },
+    });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
+    expect(deps.issueManager?.create).not.toHaveBeenCalled();
+    expect(deps.issueManager?.writeIssue).not.toHaveBeenCalled();
+  });
 });

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -67,6 +67,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactCre
       info: vi.fn(),
     },
     persist: vi.fn(),
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     ...overrides,
   };
 
@@ -139,5 +140,38 @@ describe('ArtifactCreationHandler', () => {
     expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
     expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, error);
     expect(deps.artifactPublisher.createArtifact).not.toHaveBeenCalled();
+  });
+
+  it('destroys the workspace and fails the run when the agent changes branches after creation', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/something. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+    });
+    const run = makeRun({ intent: 'idea' });
+    const request = makeRequest();
+
+    await handler.handle(run, request, 'idea');
+
+    expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
+    expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, branchDriftError);
+    expect(deps.artifactPublisher.createArtifact).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when the branch guard confirms no drift', async () => {
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun({ intent: 'idea' });
+
+    await handler.handle(run, makeRequest(), 'idea');
+
+    expect(deps.artifactPublisher.createArtifact).toHaveBeenCalled();
+    expect(deps.failRun).not.toHaveBeenCalled();
   });
 });

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -61,6 +61,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactFee
       getContent: vi.fn().mockResolvedValue(''),
     },
     feedbackSource: undefined,
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     postMessage: vi.fn().mockResolvedValue(undefined),
     transition: vi.fn((run: Run, stage: Run['stage']) => { run.stage = stage; }),
     failRun: vi.fn().mockResolvedValue(undefined),
@@ -231,6 +232,24 @@ describe('ArtifactFeedbackHandler', () => {
     expect(result).toEqual({ status: 'failed' });
     expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, error);
     expect(run.stage).toBe('speccing');
+  });
+
+  it('fails the run when the agent changes branches during revision', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/something. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
+    expect(deps.artifactPublisher.updateArtifact).not.toHaveBeenCalled();
   });
 
   it('does not fail the run when replying to a publisher comment or notifying the channel fails', async () => {

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -76,6 +76,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
       error: vi.fn(),
     },
     now: () => new Date('2026-04-25T00:00:00.000Z'),
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     ...overrides,
   };
 
@@ -265,5 +266,37 @@ describe('ImplementationApprovalHandler', () => {
 
     const callArg = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.calls[0][3] as Record<string, unknown>;
     expect(callArg['issue_number']).toBeUndefined();
+  });
+
+  it('fails the run with a branch drift error before calling createPR', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/debug-mode-slack. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, branchDriftError);
+    expect(deps.prManager.createPR).not.toHaveBeenCalled();
+  });
+
+  it('succeeds normally when the branch guard confirms no drift', async () => {
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'pr_open' });
+    expect(deps.prManager.createPR).toHaveBeenCalled();
   });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -71,6 +71,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
       error: vi.fn(),
       debug: vi.fn(),
     },
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     ...overrides,
   };
 
@@ -385,6 +386,24 @@ describe('ImplementationFeedbackHandler', () => {
         testing_steps: ['cd /workspace', 'npm test'],
       }),
     );
+  });
+
+  it('fails the run when the feedback implementation agent changes branches', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/something. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
+    expect(deps.implFeedbackPage?.update).not.toHaveBeenCalled();
   });
 
   it('logs review_contract_legacy warning when structured fields are absent from feedback result', async () => {

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -74,6 +74,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
       warn: vi.fn(),
       error: vi.fn(),
     },
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     ...overrides,
   };
 
@@ -275,6 +276,24 @@ describe('ImplementationStartHandler', () => {
       expect.objectContaining({ event: 'implementation.review_contract_legacy', run_id: 'run-001' }),
       expect.any(String),
     );
+  });
+
+  it('fails the run when the implementation agent changes branches', async () => {
+    const branchDriftError = new Error(
+      'Agent changed branches from spec/request-001 to feat/something. Autocatalyst owns run branches; this run cannot continue safely.',
+    );
+    const { handler, deps } = makeHandler({
+      branchGuard: {
+        check: vi.fn().mockRejectedValue(branchDriftError),
+      },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
+    expect(deps.implFeedbackPage?.create).not.toHaveBeenCalled();
   });
 
   it('continues in degraded mode when feedback page creation or completion notification fails', async () => {

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -1,5 +1,11 @@
 // tests/core/orchestrator.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/core/git-branch-guard.js', () => ({
+  GitBranchGuard: vi.fn().mockImplementation(() => ({
+    check: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 import { OrchestratorImpl } from '../../src/core/orchestrator.js';
 import type { WorkspaceManager } from '../../src/core/workspace-manager.js';
 import type { ArtifactAuthoringAgent } from '../../src/types/ai.js';


### PR DESCRIPTION
Added BranchGuard service and wired it into all six agent-invoking handlers to prevent branch drift (issue #126). Also added Autocatalyst branch ownership policy to all agent prompts so agents know not to create or switch branches.

## Testing

cd workspace && npm test

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/38f0e66f-d874-4ea7-ab1d-a8dd6a6e7d82/.autocatalyst/triage/triage-bug-pr-creation-branch-drift.md`
Closes #126