### PR TITLE
fix: keep triage artifacts on disk for implementation to read

### DIFF
--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -1,4 +1,3 @@
-import { rm } from 'node:fs/promises';
 import type pino from 'pino';
 import type { IssueFiler } from '../types/issue-filing.js';
 import type { IssueManager, PRManager } from '../types/issue-tracker.js';
@@ -148,7 +147,6 @@ async function approveArtifact(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
-    deleteFile: (path) => rm(path, { force: true }),
     branchGuard,
   });
   return handler.handle(run, feedback);

--- a/src/core/handlers/artifact-approval-handler.ts
+++ b/src/core/handlers/artifact-approval-handler.ts
@@ -24,7 +24,6 @@ export interface ArtifactApprovalDeps {
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'error'>;
-  deleteFile?: (path: string) => Promise<void>;
   branchGuard?: BranchGuard;
 }
 
@@ -126,16 +125,6 @@ export class ArtifactApprovalHandler {
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return false;
-    }
-
-    // Remove the triage file from disk now that its content lives in the issue tracker.
-    if (this.deps.deleteFile) {
-      await this.deps.deleteFile(refs.local_path).catch(err =>
-        this.deps.logger.error(
-          { event: 'triage.delete_failed', run_id: run.id, path: refs.local_path, error: String(err) },
-          'Failed to delete triage artifact from disk; continuing',
-        ),
-      );
     }
 
     this.markArtifactApproved(run, issue_number);

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -195,4 +195,45 @@ describe('buildDefaultHandlerRegistry', () => {
     expect(deps.persist).not.toHaveBeenCalled();
     expect(run.stage).toBe('pr_open');
   });
+
+  it('passes the artifact local_path to the implementer after bug triage approval without deleting it', async () => {
+    const bugLocalPath = '/ws/request-001/.autocatalyst/triage/triage-bug-login.md';
+    const deps = {
+      ...makeDeps(),
+      artifactContentSource: {
+        getContent: vi.fn().mockResolvedValue('# Bug: login broken\n\nDetails here.'),
+      },
+    };
+    (deps.issueManager.create as ReturnType<typeof vi.fn>).mockResolvedValue({ number: 42 });
+
+    const registry = buildDefaultHandlerRegistry(deps);
+    const run = makeRun({
+      intent: 'bug',
+      artifact: {
+        kind: 'bug_triage',
+        local_path: bugLocalPath,
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS-BUG' },
+        status: 'waiting_on_feedback',
+      },
+    });
+    const feedback = makeFeedback();
+    const event: InboundEvent = { type: 'thread_message', payload: feedback };
+
+    const handler = registry.resolve({
+      event_type: 'thread_message',
+      stage: 'reviewing_spec',
+      intent: 'approval',
+    });
+
+    expect(handler).toBeDefined();
+    await handler?.(event, run);
+
+    expect(deps.implementer.implement).toHaveBeenCalledWith(
+      bugLocalPath,
+      '/ws/request-001',
+      undefined,
+      expect.any(Function),
+    );
+    expect(run.stage).toBe('reviewing_implementation');
+  });
 });

--- a/tests/core/handlers/artifact-approval-handler.test.ts
+++ b/tests/core/handlers/artifact-approval-handler.test.ts
@@ -290,14 +290,12 @@ describe('ArtifactApprovalHandler', () => {
     );
   });
 
-  it('deletes the triage artifact from disk after syncing it to an issue', async () => {
-    const deleteFile = vi.fn().mockResolvedValue(undefined);
-    const { handler, deps } = makeHandler({
+  it('does not delete the triage artifact from disk after syncing it to an issue', async () => {
+    const { handler } = makeHandler({
       artifactContentSource: {
         getContent: vi.fn().mockResolvedValue('---\nstatus: triaged\n---\n# Bug: login broken\n\nDetails here.'),
       },
-      deleteFile,
-    } as Partial<ConstructorParameters<typeof ArtifactApprovalHandler>[0]>);
+    });
     const run = makeRun({
       intent: 'bug',
       artifact: {
@@ -308,19 +306,11 @@ describe('ArtifactApprovalHandler', () => {
       },
     });
 
-    await handler.handle(run, makeFeedback());
+    // Should succeed without error — no deleteFile dep means no deletion attempt
+    const result = await handler.handle(run, makeFeedback());
 
-    expect(deleteFile).toHaveBeenCalledWith('/ws/request-001/.autocatalyst/triage/triage-bug-login.md');
-  });
-
-  it('does not delete artifacts for kinds that are committed rather than synced', async () => {
-    const deleteFile = vi.fn().mockResolvedValue(undefined);
-    const { handler } = makeHandler({ deleteFile } as Partial<ConstructorParameters<typeof ArtifactApprovalHandler>[0]>);
-    const run = makeRun(); // intent: 'idea', kind: 'feature_spec' — uses commit_on_approval
-
-    await handler.handle(run, makeFeedback());
-
-    expect(deleteFile).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: 'approved', implementation_required: true });
+    expect(run.artifact?.local_path).toBe('/ws/request-001/.autocatalyst/triage/triage-bug-login.md');
   });
 
   it('fails the run before commit when the workspace branch does not match run.branch', async () => {


### PR DESCRIPTION
Removed deleteFile from ArtifactApprovalHandler so triage artifacts remain on disk for implementation to read.

## Testing

cd to workspace, run npm run test:core — all 573 tests should pass.

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/e35006c0-5320-4282-a4e9-a15dd21d4ddb/.autocatalyst/triage/triage-bug-artifact-deleted-before-implementation.md`
Closes #115