### PR TITLE
chore: skip spec status commits for gitignored triage artifacts

### DIFF
--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -8,6 +8,7 @@ import type { ArtifactPublisher } from '../../types/publisher.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { markArtifactStatus, artifactPath, artifactPublisherId } from '../run-refs.js';
+import { getArtifactLifecyclePolicy } from '../../types/artifact.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 
 export interface ImplementationApprovalDeps {
@@ -35,7 +36,11 @@ export class ImplementationApprovalHandler {
     const localPath = artifactPath(run);
     const publisherRef = artifactPublisherId(run);
 
-    if (localPath) {
+    const shouldCommitArtifactStatus = run.artifact
+      ? getArtifactLifecyclePolicy(run.artifact.kind).commit_on_approval
+      : Boolean(localPath);
+
+    if (localPath && shouldCommitArtifactStatus) {
       try {
         await this.deps.specCommitter!.updateStatus(run.workspace_path, localPath, {
           status: 'complete',

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -299,4 +299,82 @@ describe('ImplementationApprovalHandler', () => {
     expect(result).toEqual({ status: 'pr_open' });
     expect(deps.prManager.createPR).toHaveBeenCalled();
   });
+
+  it('skips specCommitter.updateStatus for bug_triage artifacts but still creates a PR and marks artifact complete', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({
+      spec_path: undefined,
+      publisher_ref: undefined,
+      issue: 77,
+      artifact: {
+        kind: 'bug_triage',
+        local_path: '/ws/request-001/.autocatalyst/triage/triage-bug-77.md',
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS-BUG' },
+        status: 'approved',
+      },
+    });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'pr_open' });
+    expect(deps.specCommitter?.updateStatus).not.toHaveBeenCalled();
+    expect(deps.artifactPublisher.updateStatus).toHaveBeenCalledWith('CANVAS-BUG', 'complete');
+    expect(deps.prManager.createPR).toHaveBeenCalledWith(
+      '/ws/request-001',
+      'spec/request-001',
+      '/ws/request-001/.autocatalyst/triage/triage-bug-77.md',
+      expect.objectContaining({ issue_number: 77 }),
+    );
+    expect(run.artifact?.status).toBe('complete');
+    expect(run.stage).toBe('pr_open');
+  });
+
+  it('skips specCommitter.updateStatus for chore_plan artifacts but still creates a PR and marks artifact complete', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({
+      spec_path: undefined,
+      publisher_ref: undefined,
+      issue: 88,
+      artifact: {
+        kind: 'chore_plan',
+        local_path: '/ws/request-001/.autocatalyst/triage/triage-chore-88.md',
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS-CHORE' },
+        status: 'approved',
+      },
+    });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'pr_open' });
+    expect(deps.specCommitter?.updateStatus).not.toHaveBeenCalled();
+    expect(deps.artifactPublisher.updateStatus).toHaveBeenCalledWith('CANVAS-CHORE', 'complete');
+    expect(deps.prManager.createPR).toHaveBeenCalledWith(
+      '/ws/request-001',
+      'spec/request-001',
+      '/ws/request-001/.autocatalyst/triage/triage-chore-88.md',
+      expect.objectContaining({ issue_number: 88 }),
+    );
+    expect(run.artifact?.status).toBe('complete');
+    expect(run.stage).toBe('pr_open');
+  });
+
+  it('still calls specCommitter.updateStatus for feature_spec artifacts', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({
+      artifact: {
+        kind: 'feature_spec',
+        local_path: '/ws/request-001/context-human/specs/feature-test.md',
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
+        status: 'approved',
+      },
+    });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.specCommitter?.updateStatus).toHaveBeenCalledWith(
+      '/ws/request-001',
+      '/ws/request-001/context-human/specs/feature-test.md',
+      { status: 'complete', last_updated: '2026-04-25' },
+    );
+  });
 });


### PR DESCRIPTION
Added lifecycle policy guard in ImplementationApprovalHandler to skip specCommitter.updateStatus() for bug_triage and chore_plan artifacts, which live under .autocatalyst/triage/ (gitignored).

## Testing

cd to workspace, run npm test and npm run lint

---
Spec: `/Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/8a3c5b27-fbfc-486f-bdbc-f8824191e720/.autocatalyst/triage/triage-chore-gitignored-triage-status-update.md`
Closes #140