### PR TITLE
fix: set claude_code_max_output_tokens=128000 in agent subprocess

### DIFF
--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -153,6 +153,10 @@ export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile): 
     tools: { type: 'preset', preset: 'claude_code' },
     systemPrompt: { type: 'preset', preset: 'claude_code' },
     settings: automatedSettings(cwd),
+    env: {
+      ...process.env,
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] ?? '128000',
+    },
     ...(profile?.model ? { model: profile.model } : {}),
     thinking: thinkingForProfile(profile?.thinking),
     effort: (profile?.effort ?? 'high') as EffortLevel,

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -212,7 +212,14 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
       );
     } catch (err) {
       this.logger.error({ event: 'impl.agent_failed', error: String(err) }, 'Agent exited with error during implementation');
-      throw new Error(`Implementation failed: ${String(err)}`);
+      const msg = String(err);
+      if (msg.includes('exceeded') && msg.includes('output token')) {
+        throw new Error(
+          `Implementation failed: Claude Code hit its output token limit. ` +
+          `Increase CLAUDE_CODE_MAX_OUTPUT_TOKENS (current default: 32000).`,
+        );
+      }
+      throw new Error(`Implementation failed: ${msg}`);
     }
 
     const content = await readRequiredFile(this.readFileFn, resultFilePath, 'Implementation');

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -216,7 +216,7 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
       if (msg.includes('exceeded') && msg.includes('output token')) {
         throw new Error(
           `Implementation failed: Claude Code hit its output token limit. ` +
-          `Increase CLAUDE_CODE_MAX_OUTPUT_TOKENS (current default: 32000).`,
+          `Increase CLAUDE_CODE_MAX_OUTPUT_TOKENS (Autocatalyst default: 128000).`,
         );
       }
       throw new Error(`Implementation failed: ${msg}`);

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -256,4 +256,59 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     expect(outcomeAdd).toBeDefined();
     expect(outcomeAdd!.attrs).toMatchObject({ model: 'unknown' });
   });
+
+  test('injects CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000 by default when not set in process.env', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    const originalEnv = process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'];
+    delete process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'];
+
+    try {
+      await collect(runner.run({
+        route: { task: 'implementation.run' },
+        working_directory: '/tmp/workspace',
+        prompt: 'implement',
+        profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+      }));
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] = originalEnv;
+      }
+    }
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env).toBeDefined();
+    expect(call.options.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS']).toBe('128000');
+  });
+
+  test('respects caller-provided CLAUDE_CODE_MAX_OUTPUT_TOKENS in process.env', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    const originalEnv = process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'];
+    process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] = '64000';
+
+    try {
+      await collect(runner.run({
+        route: { task: 'implementation.run' },
+        working_directory: '/tmp/workspace',
+        prompt: 'implement',
+        profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+      }));
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] = originalEnv;
+      } else {
+        delete process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'];
+      }
+    }
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS']).toBe('64000');
+  });
 });


### PR DESCRIPTION
## Summary

- Inject `CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000` into the Claude Code subprocess environment to prevent crashes when output exceeds the default 32K limit
- Surface actionable error message when the output token limit is hit
- Correct error message default from 32000 to 128000 to match the injected value

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Trigger an implementation run that produces large output (e.g., multi-file plan) and verify no crash