### PR TITLE
feat: add two-part adversarial review to implementation lifecycle

### DIFF
--- a/context-human/specs/enhancement-two-part-implementation-review.md
+++ b/context-human/specs/enhancement-two-part-implementation-review.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-13
-last_updated: 2026-05-14
-status: implementing
+last_updated: 2026-05-15
+status: complete
 issue: null
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-two-part-implementation-review.md
+++ b/context-human/specs/enhancement-two-part-implementation-review.md
@@ -2,7 +2,7 @@
 created: 2026-05-13
 last_updated: 2026-05-15
 status: complete
-issue: null
+issue: 147
 specced_by: autocatalyst
 implemented_by: markdstafford
 superseded_by: null

--- a/context-human/specs/enhancement-two-part-implementation-review.md
+++ b/context-human/specs/enhancement-two-part-implementation-review.md
@@ -1,0 +1,673 @@
+---
+created: 2026-05-13
+last_updated: 2026-05-14
+status: implementing
+issue: null
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Two-part implementation review
+
+## Parent features
+
+- `feature-approval-to-implementation.md` — provides the implementation loop, implementation feedback page, and implementation approval path.
+- `enhancement-testing-guide-feedback-loop.md` — provides structured testing guides, unresolved feedback handling, and feedback-resolution display.
+- `enhancement-model-provider-config.md` and `feature-openai-agent-sdk-runner.md` — provide provider-neutral AI profiles and route-based model selection.
+## Issue tracking
+
+A GitHub issue should track this enhancement before implementation starts. I attempted to create it with `gh issue create --repo markdstafford/autocatalyst`, but the sandbox is not authenticated with GitHub CLI and has no `GH_TOKEN`, so issue creation failed before the spec was written. The implementer should create the issue before starting code changes and update the `issue` frontmatter field with the issue number.
+## What
+
+Autocatalyst adds two adversarial review checkpoints to the implementation lifecycle. An initial review runs after the implementation agent reports a complete implementation; a final review runs after the human approves and before PR creation.
+Both checkpoints use a configurable coding agent that inspects git commits and diffs and acts as an adversarial reviewer. Review findings are sent to the implementation model, which must respond to each one before the testing guide is updated or the PR is created. The exchange — models used, findings, and implementer responses — is documented in the testing guide.
+## Why
+
+The current implementation loop has one AI model both build and summarize its own work — creating a blind spot where the same model that made a mistake may not notice it. Adversarial and critic model pairings are well-documented as producing better review outcomes than self-review; a separate configured critic model gives Autocatalyst an adversarial pass before human time is spent. Both exchanges are documented in the testing guide so humans can inspect what was challenged and how the implementer responded, rather than trusting a hidden internal loop.
+## Goals
+
+- Run a configurable adversarial coding agent after a complete implementation result and before creating or updating the human testing guide.
+- Send review feedback back to the implementation model and require a structured response for each review item.
+- Let the implementation model decide whether to fix, decline, ask for input, or abort the run (signal that the implementation cannot proceed safely), while preserving an auditable record of the decision.
+- Run a lighter final review after human implementation approval and before PR creation.
+- Allow initial and final review to use different AI profiles.
+- Document each review exchange in the testing guide with implementation profile, review profile, review findings, implementer responses, and outcome.
+- Preserve the existing human-facing implementation feedback loop: humans still approve, give feedback, and test through the testing guide.
+- Keep review-model failures degraded but visible unless the configured policy says they are blocking.
+- Preserve branch ownership and branch-guard behavior.
+## Non-goals
+
+- Replacing human implementation approval.
+- Giving the review model authority to edit files or decide what ships.
+- Adding a dedicated review UI outside the existing testing guide.
+- Unbounded loops — each phase runs one review pass and one fix/response pass.
+- Guaranteeing that every provider can enforce read-only filesystem access. Prompt and adapter constraints are required; true sandbox enforcement depends on the runner/provider.
+## Personas
+
+- **Enzo: Engineer** — wants another model to scrutinize implementation quality before he spends time testing, and wants the final PR creation path to catch last-minute security or branch issues.
+- **Phoebe: Product manager** — wants a clear testing guide that explains not only what changed, but what the AI review questioned and how the implementer handled it.
+- **Autocatalyst operator** — configures which profiles perform implementation, initial review, and final review for each repository.
+## User stories
+
+- As Enzo, I can configure `implementation.review.``initial` to use a different profile from `implementation.run` and see that profile used before the testing guide is posted.
+- As Enzo, I can configure `implementation.review.final` independently from `implementation.review.``initial` for the lighter post-approval review.
+- As Enzo, I can open the testing guide and see the implementation profile, review profile, review findings, and implementer responses for the initial review.
+- As Enzo, I can approve an implementation and know Autocatalyst runs a final security/PR-readiness review before creating the PR.
+- As Enzo, I can see a Slack progress update when Autocatalyst starts the initial review, applies review feedback, starts final review, and decides whether to open a PR.
+- As Phoebe, I can read the testing guide and understand whether the implementer fixed review feedback, declined it, or escalated it.
+- As an implementer model, I receive structured review feedback with stable IDs and must return structured responses that say which feedback was fixed, declined, or needs human input.
+## Design changes
+
+### Lifecycle placement
+
+The implementation lifecycle becomes:
+```mermaid
+flowchart TD
+  SpecApproved[Spec approved] --> Implement[Implementation model runs]
+  Implement --> ImplComplete{status complete?}
+  ImplComplete -->|needs_input| AwaitInput[awaiting_impl_input]
+  ImplComplete -->|failed| Failed[failed]
+  ImplComplete -->|complete| InitialReview[Initial review]
+  InitialReview --> ImplementResponse[Implementation model responds to review]
+  ImplementResponse -->|complete| TestingGuide[Create/update testing guide with review exchange]
+  ImplementResponse -->|needs_input| AwaitInput
+  ImplementResponse -->|failed| Failed
+  TestingGuide --> HumanReview[reviewing_implementation]
+  HumanReview -->|feedback| FeedbackPass[Implementation feedback pass]
+  FeedbackPass --> InitialReview
+  HumanReview -->|approval| FinalReview[Final review]
+  FinalReview --> FinalResponse[Implementation model responds]
+  FinalResponse -->|safe/no behavior change| PR[Create PR and transition to pr_open]
+  FinalResponse -->|human retest needed| TestingGuide
+  FinalResponse -->|needs_input| AwaitInput
+  FinalResponse -->|failed| Failed
+```
+The initial review runs after every complete implementation attempt, including feedback passes. This ensures the human sees the implementation only after the configured review model has had a chance to challenge it.
+The final review runs only when the human approves the implementation. It does not replace the initial review.
+### Testing guide review exchange section
+
+Testing guides gain an AI-managed `AI review` section at the end, after the `Human review` section:
+Review findings and their implementer responses are combined in a single `Review findings` checklist. Each finding appears as a completed checklist item when addressed, with the implementer response as an indented child paragraph. When no findings exist, the checklist contains a single "No blocking or informational findings" item with no child.
+```markdown
+## AI review
+
+### Initial review
+
+Implementation model: `grove-sonnet-4.6-medium` (`claude-sonnet-4-6`, `claude_agent_sdk`)
+Review model: `grove-sonnet-4.6-high` (`claude-sonnet-4-6`, `claude_agent_sdk`)
+Review status: addressed
+
+#### Review findings
+
+- [x] [INIT-1] Missing regression test for invalid provider config.
+  Fixed — added `config.invalid-provider.test.ts` coverage for unknown profile routing.
+- [x] [INIT-2] Error log may include provider credential name; confirm it is not a secret.
+  Declined — credential names are non-secret config identifiers; no token values are logged.
+
+### Final review
+
+Implementation model: `grove-sonnet-4.6-medium` (`claude-sonnet-4-6`, `claude_agent_sdk`)
+Review model: `grove-haiku-4.5-low` (`claude-haiku-4-5`, `anthropic_direct`)
+Review status: no findings
+
+#### Review findings
+
+- No blocking or informational findings.
+```
+Rules:
+- The section is AI-managed and replaced on each testing-guide update.
+- Each review item has a stable ID such as `INIT``-1` or `FINAL-1`.
+- Implementation responses must use the same IDs.
+- Review-model text is summarized into concise bullets. Raw prompts and full hidden chain-of-thought are never published.
+- Provider credentials, tokens, API keys, environment values, and full request payloads are never included.
+### Slack progress updates
+
+Autocatalyst posts best-effort progress messages directly:
+```plain text
+Implementation complete — starting initial review with grove-sonnet-4.6-high
+Initial review returned 2 findings — asking implementation model to respond
+Implementation model addressed review feedback — creating testing guide
+Implementation approved — running final review with grove-haiku-4.5-low
+Final review found no blockers — opening PR
+```
+If a progress message fails to send, the run continues and logs `progress_failed` with the relevant review phase.
+### Review authority
+
+The review model never has final authority. It returns findings. The implementation model responds. The implementation model may:
+- `fixed` — change code/tests/docs and explain what changed.
+- `declined` — leave the implementation unchanged and explain why.
+- `needs_input` — ask the human a question when the review exposes an ambiguous product or security decision.
+- `failed` — abort the run when the implementation cannot be safely completed.
+A declined finding is acceptable only with a concrete reason. Empty or generic responses are invalid and treated as `needs_input` or `failed`, depending on the failure mode.
+## Technical changes
+
+### Affected files
+
+- `src/types/ai.ts` — add review task kinds, review agent interfaces, review result types, profile metadata in review records, and review exchange fields.
+- `src/types/runs.ts` — persist review exchanges and possibly a `pending_final_review` or `review_iteration` counter if needed for crash recovery.
+- `src/types/config.ts` — document route keys for `implementation.review.initial` and `implementation.review.final`; add optional review policy config if implemented as typed config.
+- `src/config/defaults.ts` — include default review route examples.
+- `src/core/ai/agent-services.ts` — implement review prompt construction and implementer response prompt/context construction.
+- `src/core/ai/routing-policy.ts` — resolve the new review routes and expose profile metadata for testing-guide documentation.
+- `src/core/handlers/implementation-start-handler.ts` — run initial review before creating the testing guide.
+- `src/core/handlers/implementation-feedback-handler.ts` — run initial review after complete feedback-pass results and before updating the testing guide.
+- `src/core/handlers/implementation-approval-handler.ts` — run final review before PR creation and branch/status updates that assume final code is ready.
+- `src/types/impl-feedback-page.ts` — extend `ImplementationReviewInput.update()` with review exchange records.
+- `src/adapters/notion/implementation-feedback-page.ts` — render and update the `AI review` section.
+- `tests/core/ai/agent-services.test.ts` — cover review prompts and response parsing.
+- `tests/core/handlers/implementation-start-handler.test.ts` — cover initial review before human handoff.
+- `tests/core/handlers/implementation-feedback-handler.test.ts` — cover initial review on feedback passes.
+- `tests/core/handlers/implementation-approval-handler.test.ts` — cover final review before PR creation.
+- `tests/adapters/notion/implementation-feedback-page.test.ts` — cover review exchange rendering and updates.
+- `tests/core/config.test.ts` and/or routing policy tests — cover review route config and fallback behavior.
+### Review routes and config
+
+Add two AI task route keys:
+```typescript
+export type AgentTaskKind =
+  | 'intent.classify'
+  | 'artifact.create'
+  | 'artifact.revise'
+  | 'implementation.run'
+  | 'implementation.review.initial'
+  | 'implementation.review.final'
+  | 'question.answer'
+  | 'issue.triage'
+  | 'pr.title_generate';
+```
+Example config:
+```yaml
+ai:
+  routing:
+    implementation.run: grove-sonnet-4.6-medium
+    implementation.review.initial: grove-sonnet-4.6-high
+    implementation.review.final: grove-haiku-4.5-low
+```
+Compatibility rules:
+- `implementation.review.initial` is required for the initial review to run.
+- `implementation.review.final` is optional. If absent, Autocatalyst uses `implementation.review.initial` for the final review.
+- If neither review route is configured, Autocatalyst logs `implementation.review.skipped` at warn level and preserves existing behavior. This avoids breaking existing repos on upgrade.
+- New default config should include both review route examples so new installations get the feature by default.
+- The review route must resolve to an agent runner (`AgentRunner`) because review needs repository and diff context.
+### Review policy
+
+Add optional policy under top-level config:
+```yaml
+implementation_review:
+  max_initial_rounds: 1
+  max_final_rounds: 1
+  on_review_failure: warn # warn | block
+  retest_on_behavior_change: true
+```
+Defaults:
+- `max_initial_rounds: 1`
+- `max_final_rounds: 1`
+- `on_review_failure: warn`
+- `retest_on_behavior_change``: true`
+Rules:
+- A review round means one reviewer pass and one implementer response pass.
+- If the review model returns no findings, Autocatalyst records a `no_findings` exchange and continues.
+- If the review model fails and `on_review_failure: warn`, Autocatalyst records a degraded exchange, logs a warning, and continues.
+- If the review model fails and `on_review_failure: block`, Autocatalyst fails the run or asks for human input with a clear message.
+- If the implementer response fails, the normal implementation failure path applies.
+### Review result contract
+
+The review model writes structured JSON:
+```typescript
+export interface ImplementationReviewResult {
+  status: 'no_findings' | 'findings' | 'failed';
+  summary: string;
+  findings: Array;
+  requires_human_retest?: boolean;
+  error?: string;
+}
+```
+Rules:
+- Initial review may return `correctness`, `test`, `security`, `maintainability`, and `docs` findings.
+- Final review should focus on `security` and `pr_readiness`; it may include other categories only when the issue is newly discovered and important.
+- `blocker` means the reviewer believes the implementation should not be handed off or PR-created without a response.
+- `warning` means the implementer should consider a fix or give a reason to decline.
+- `info` means optional follow-up.
+- Findings must not include hidden chain-of-thought, secrets, or raw credential values.
+### Implementer response contract
+
+When findings exist, the implementation model gets a follow-up implementation run with additional context:
+```plain text
+Initial review findings:
+
+[REVIEW_ID: INIT-1]
+Severity: blocker
+Category: test
+Finding: Missing regression test for invalid provider config.
+Suggested action: Add a test that fails before the fix.
+
+For each [REVIEW_ID: ...] finding, either fix it or decline it with a concrete reason.
+```
+The implementation model returns:
+```typescript
+export interface ImplementationReviewResponseItem {
+  id: string;
+  disposition: 'fixed' | 'declined' | 'needs_input';
+  response: string;
+}
+
+export interface ImplementationResult {
+  status: 'complete' | 'needs_input' | 'failed';
+  summary?: string;
+  testing_instructions?: string;
+  review_summary?: { changes: string[]; confirm: string[] };
+  testing_steps?: string[];
+  resolved_feedback_items?: Array;
+  review_responses?: ImplementationReviewResponseItem[];
+  requires_human_retest?: boolean;
+  question?: string;
+  error?: string;
+}
+```
+Validation rules:
+- Every review finding ID must have one response item.
+- `fixed` responses should mention changed files or behavior.
+- `declined` responses must explain why no change is needed.
+- `needs_input` responses require `status: needs_input` or a clear human question.
+- Unknown IDs are logged and ignored. Missing IDs are logged as a warning; validation failures do not stop the run — the gap is surfaced via `implementation.review.response_invalid`.
+### Review exchange persistence
+
+Persist review exchanges on `Run` so crash recovery and testing-guide updates have a source of truth:
+```typescript
+export interface ImplementationReviewExchange {
+  id: string;
+  phase: 'initial' | 'final';
+  created_at: string;
+  implementation_profile: AgentProfileSummary;
+  review_profile: AgentProfileSummary;
+  review_status: 'no_findings' | 'addressed' | 'degraded' | 'needs_input' | 'failed';
+  review_summary: string;
+  findings: ImplementationReviewResult['findings'];
+  responses: ImplementationReviewResponseItem[];
+  requires_human_retest: boolean;
+}
+
+export interface AgentProfileSummary {
+  profile: string;
+  provider: string;
+  model?: string;
+  runner?: string;
+}
+```
+Rules:
+- `Run.review_exchanges` is append-only for the current run.
+- The testing guide renderer receives the current exchange list and renders a sanitized summary.
+- `run.last_impl_result` updates after implementer responses so PR bodies and testing guides reflect the final code.
+### Initial review handler behavior
+
+`ImplementationStartHandler` and `ImplementationFeedbackHandler` should call a shared service after `result.status === 'complete'` and after branch guard passes:
+```typescript
+const reviewed = await implementationReviewCoordinator.runInitialReview({
+  run,
+  artifact_path: localPath,
+  implementation_result: result,
+  conversation: feedback.conversation,
+  onProgress,
+});
+```
+Coordinator behavior:
+1. Resolve implementation and initial review profile summaries.
+2. If no initial review route is configured, log and return the original result.
+3. Build review context using the implementation result's existing `summary`, `testing_instructions`, and `review_summary` fields as the implementer's description of changes (preferred over a separate summarization call), plus the approved artifact path, `git diff HEAD~1..HEAD` or equivalent current branch diff, changed file list, and test output summary when available.
+4. Run the review model with route `implementation.review.initial`.
+5. If no findings, append a `no_findings` exchange and return the original result.
+6. If findings exist, call the implementation model again with review findings as additional context.
+7. Validate review responses and append an `addressed` exchange.
+8. Return the implementer response result as the canonical implementation result for testing-guide creation or update.
+The coordinator must run branch guard after implementer response because the implementation model may make additional commits.
+### Final review handler behavior
+
+`ImplementationApprovalHandler` should run final review before status updates and PR creation:
+1. Check branch guard before review to catch drift early.
+2. Run final review with route `implementation.review.final` or fallback to `implementation.review.initial`.
+3. If no findings, append a `no_findings` final exchange and continue with existing approval behavior.
+4. If findings exist, call the implementation model with final-review context.
+5. If the implementer fixes only non-user-visible issues and `requires_human_retest` is false, continue to PR creation.
+6. If the implementer changes user-visible behavior, testing steps, or sets `requires_human_retest: true`, update the testing guide and transition back to `reviewing_implementation` instead of creating a PR.
+7. If the implementer asks for input, transition to `awaiting_impl_input`.
+8. If the implementer fails, fail the run.
+The final review should not silently change behavior after human approval. Any material change returns to human review.
+### Testing guide publisher changes
+
+Extend `ImplementationReviewInput` and `update()` options:
+```typescript
+export interface ImplementationReviewInput {
+  // existing fields
+  review_exchanges?: ImplementationReviewExchange[];
+}
+
+update(review_ref, {
+  summary,
+  review_summary,
+  testing_steps,
+  resolved_items,
+  review_exchanges,
+})
+```
+Rendering rules:
+- Create the `AI review` section on new pages.
+- On update, replace only the AI-managed `AI review` section.
+- If an older page lacks the section, append it after `Human review`; if `Human review` is absent, append it at the end of the page and log a warning.
+- Keep reviewer-managed `Additional steps` and `Human review` sections unchanged.
+- Redact secrets and environment variable values from any exchange text before rendering.
+### Observability
+
+Add structured logs:
+- `implementation.review.started` with `phase`, `run_id`, `review_profile`, and `implementation_profile`.
+- `implementation.review.completed` with `phase`, `status`, `finding_count`, and `requires_human_retest`.
+- `implementation.review.skipped` when no review route is configured.
+- `implementation.review.failed` when review fails.
+- `implementation.review.response_invalid` when implementer responses do not cover findings.
+- `implementation.review.retest_required` when final review returns to human review.
+No log includes prompt bodies, secret values, or raw model responses.
+## Acceptance criteria
+
+- A complete initial implementation triggers initial review before the testing guide is created.
+- A complete implementation-feedback pass triggers initial review before the testing guide is updated.
+- The testing guide includes an `AI review` section that names the implementation model and review model.
+- Review findings are sent back to the implementation model with stable IDs.
+- The implementation model's responses are validated and rendered beside the review findings.
+- Human approval triggers final review before PR creation.
+- Final review can use a distinct configured route from initial review.
+- If final review makes only non-user-visible fixes, Autocatalyst proceeds to PR creation.
+- If final review changes behavior or testing instructions, Autocatalyst updates the testing guide and returns to `reviewing_implementation`.
+- Review route absence preserves existing behavior and logs a warning.
+- Review model failure follows `implementation_review.on_review_failure`.
+- Branch guard runs after any implementer response that may change files.
+- Tests cover success, no-findings, findings-addressed, findings-declined, needs-input, review failure, missing route, and retest-required paths.
+## Testing plan
+
+### `tests/core/ai/agent-services.test.ts`
+
+**Review prompt construction**
+- Builds an initial review prompt that includes artifact path, diff context, implementation summary (from result `summary`, `testing_instructions`, and `review_summary` fields), changed file list, and phase-specific instructions.
+- Builds a final review prompt that emphasizes `security` and `pr_readiness` categories over correctness and docs categories.
+- Builds an implementer response prompt that lists every finding ID from the review result and requires one structured response per ID.
+- Excludes secrets, API key values, environment variable values, and raw chain-of-thought from all constructed prompts.
+**Review result parsing**
+- Parses a `no_findings` result: `status` is `no_findings`, `findings` array is empty, `requires_human_retest` defaults to false.
+- Parses a `findings` result that covers all valid severity values (`blocker`, `warning`, `info`) and all valid category values (`correctness`, `test`, `security`, `maintainability`, `docs`, `pr_readiness`).
+- Returns `status: failed` and surfaces the `error` field when the model returns malformed or non-JSON output.
+- Correctly propagates `requires_human_retest: true` from a review result that sets it.
+**Implementer response validation**
+- Accepts a valid response set in which every finding ID has exactly one corresponding response item.
+- Logs `implementation.review.response_invalid` and continues (does not throw) when a finding ID is missing from the response set.
+- Logs and ignores response items whose IDs are not present in the findings list.
+- Treats an empty or whitespace-only `declined` response as invalid and promotes it to `needs_input`.
+- Treats a one-word `declined` response with no concrete reasoning as invalid and promotes it to `needs_input`.
+### `tests/core/ai/routing-policy.test.ts` / `tests/core/config.test.ts`
+
+**Review route resolution**
+- Resolves the `implementation.review.initial` route when configured and returns the correct `AgentProfileSummary` including `profile`, `model`, `runner`, and `provider`.
+- Resolves the `implementation.review.final` route when configured.
+- Falls back to `implementation.review.initial` when `implementation.review.final` is absent from config.
+- Returns null without throwing when neither review route is configured.
+**Review policy config parsing**
+- Applies all documented defaults (`max_initial_rounds: 1`, `max_final_rounds: 1`, `on_review_failure: warn`, `retest_on_behavior_change: true`) when the `implementation_review` block is absent from config.
+- Parses all policy fields correctly when explicitly provided.
+- Fails startup with a descriptive error when `on_review_failure` is set to an unsupported value.
+- Fails startup with a descriptive error when `max_initial_rounds` or `max_final_rounds` is not a positive integer.
+- Accepts `on_review_failure: block` and `on_review_failure: warn` as the only valid string values.
+### `tests/core/ai/implementation-review-coordinator.test.ts` (new file)
+
+**No-findings path**
+- Appends a `no_findings` exchange to the run containing correct `implementation_profile` and `review_profile` summaries.
+- Returns the original implementation result unchanged.
+- Does not call the implementation model a second time.
+- Does not invoke branch guard again (no implementer commits made).
+**Findings path — all fixed**
+- Calls the implementation model with structured finding context that includes a `[REVIEW_ID: ...]` block for every finding.
+- Validates that implementer responses cover all finding IDs and appends an `addressed` exchange recording findings, responses, and both profile summaries.
+- Returns the implementer response result as the canonical implementation result.
+- Invokes branch guard after the implementer response.
+**Findings path — findings declined with reasoning**
+- Accepts `declined` dispositions that include concrete reasoning.
+- Appends an `addressed` exchange capturing each declined disposition.
+- Returns the implementer result with the review exchange appended.
+**Missing route — initial route absent**
+- Logs `implementation.review.skipped` at warn level.
+- Returns the original implementation result immediately without calling any AI model.
+**Review model failure — ****`on_review_failure: warn`**
+- Appends a `degraded` exchange with the `error` field populated from the failure reason.
+- Logs `implementation.review.failed`.
+- Returns the original implementation result so the run continues.
+**Review model failure — ****`on_review_failure: block`**
+- Returns a result that causes the run to fail.
+- Does not call the implementation model.
+- Logs `implementation.review.failed`.
+**Implementer response failure**
+- Propagates the `failed` or `needs_input` status from the implementation model's response.
+- Does not append an exchange record for an incomplete response cycle.
+- Follows the existing stage-transition path for `needs_input` and `failed`.
+**Incomplete implementer responses — missing IDs**
+- Logs `implementation.review.response_invalid` for each missing finding ID.
+- Appends an exchange record with the gap noted in the exchange metadata.
+- Run continues without stopping.
+**Branch guard after implementer response**
+- If branch guard detects branch drift after implementer response commits, the coordinator surfaces the branch-guard failure to the caller.
+- If branch guard passes, the coordinator proceeds to append the exchange and return the result.
+### `tests/core/handlers/implementation-start-handler.test.ts`
+
+**Happy path: complete implementation → initial review → testing guide creation**
+- The coordinator is called with the implementation result, run context, and artifact path after a complete implementation.
+- Testing guide creation receives the reviewed result and a non-empty `review_exchanges` list.
+- The `AI review` section in the testing guide creation payload reflects the exchange content.
+**No-findings path**
+- A no-findings exchange is included in the testing guide creation payload.
+- The run transitions to `reviewing_implementation` without any error.
+**Needs-input path: implementer review response returns ****`needs_input`**
+- The run transitions to `awaiting_impl_input`.
+- Testing guide is not created.
+**Review failure — warn policy**
+- A `degraded` exchange is included in the testing guide creation payload.
+- The run proceeds to `reviewing_implementation` normally.
+**Missing review route — skip**
+- The existing flow completes without modification.
+- `implementation.review.skipped` is logged exactly once.
+**Progress updates**
+- The progress callback is invoked when initial review starts and when findings are sent to the implementer.
+- A failed progress callback invocation is non-blocking: the run continues and `progress_failed` is logged.
+### `tests/core/handlers/implementation-feedback-handler.test.ts`
+
+**Feedback pass complete → initial review → testing guide update**
+- The coordinator is called after a complete feedback-pass result.
+- The testing guide update receives the reviewed result and an updated `review_exchanges` list.
+- Previously resolved human feedback items are preserved in the testing guide update payload.
+**Multiple feedback rounds append exchanges**
+- Each complete feedback pass appends a new exchange to `run.review_exchanges`.
+- The testing guide update on the second and subsequent feedback rounds receives the full accumulated exchange list.
+### `tests/core/handlers/implementation-approval-handler.test.ts`
+
+**Approval → final review no findings → PR creation**
+- Final review runs before any status update or PR creation attempt.
+- A no-findings final exchange is appended to the run.
+- The PR is created through the existing approval path.
+**Approval → final review findings → implementer fixes non-user-visible issues → PR creation**
+- `requires_human_retest` is false in the implementer response.
+- The PR is created without returning to human review.
+**Approval → final review findings → ****`requires_human_retest: true`**** → back to human review**
+- The testing guide is updated with the final review exchange and any revised testing steps.
+- The run stage transitions to `reviewing_implementation`.
+- The PR is not created.
+**Approval → final review → ****`needs_input`**** → await input**
+- The run transitions to `awaiting_impl_input`.
+- The PR is not created.
+**Approval → final review uses fallback route**
+- When `implementation.review.final` is absent from config, the coordinator resolves `implementation.review.initial` for the final phase.
+- The appended exchange record has `phase: 'final'`.
+**Branch guard before final review catches drift**
+- Branch drift detected before the final review starts fails the run with a clear message.
+- The final review model is not called.
+### `tests/adapters/notion/implementation-feedback-page.test.ts`
+
+**New testing guide includes AI review section after Human review**
+- The `AI review` section is present on a newly created testing guide.
+- It is positioned after the `Human review` section.
+- Implementation model and review model profile names appear verbatim in the section.
+**Update replaces only AI review section**
+- After an update, `Human review` section content is unchanged.
+- After an update, `Additional steps` section content is unchanged.
+- Only the `AI review` section content changes to reflect the latest exchange.
+**Page missing Human review section — append at end**
+- A warning is logged when `Human review` is not found.
+- The `AI review` section is appended at the end of the page.
+- No exception is thrown.
+**"Feedback" section renamed to "Human review" on next write**
+- A page with an existing `Feedback` section is updated to use `Human review` on the next write.
+- New pages use `Human review` from the start.
+**Findings checklist renders correctly**
+- `[x]` checklist items with stable IDs (`INIT-N`, `FINAL-N`) appear for each addressed finding.
+- A `fixed` response is rendered with the implementer's description as an indented child paragraph.
+- A `declined` response is rendered with the declination reasoning as an indented child paragraph.
+**No-findings item rendered**
+- When an exchange has no findings, a single `- No blocking or informational findings.` item with no child paragraph is rendered.
+**Secret redaction before rendering**
+- API key values in exchange text are replaced with `[REDACTED]` before any Notion API call.
+- Environment variable values in exchange text are replaced with `[REDACTED]`.
+- Profile names (non-secret identifiers) are not redacted.
+**Degraded exchange renders visibly**
+- An exchange with `review_status: degraded` shows a human-readable degraded status line.
+- The error summary is included without embedding any raw model response or prompt body.
+### Coverage targets
+
+- `implementation-review-coordinator`: 100% branch coverage across all disposition and outcome combinations.
+- Handler integration tests: all stage transitions that can be triggered by review results are exercised.
+- Notion adapter: all rendering and section-update branches are covered, including missing-section and secret-redaction paths.
+- Config and routing policy: all valid and invalid configurations produce the specified behavior or startup failure.
+## Manual testing guide
+
+1. Configure `implementation.run` and `implementation.review.initial` to different visible profiles.
+2. Trigger a small feature implementation.
+3. Confirm Slack posts a progress update when initial review starts.
+4. Open the testing guide and confirm `AI review` shows initial review model names, findings, and responses.
+5. Add human feedback in the testing guide and trigger a feedback pass.
+6. Confirm initial review runs again and the testing guide shows the latest exchange.
+7. Approve the implementation.
+8. Confirm final review runs before PR creation.
+9. Confirm the PR opens only after final review passes or after the implementer handles final findings.
+10. Force a final-review response with `requires_human_retest: true` and confirm the run returns to `reviewing_implementation` instead of opening a PR.
+## Rollout and migration
+
+- Existing repositories continue to work without review routes; they log `implementation.review.skipped` and use the current flow.
+- New default config includes review route examples.
+- Existing testing guide pages are updated best-effort when feedback or final review touches them.
+- No database migration is required if run persistence tolerates missing `review_exchanges` as `[]`.
+## Risks and mitigations
+
+- **Longer runtime and higher model cost:** keep default review rounds to one per phase and log review duration/count.
+- **Reviewer and implementer agree too easily when same model is configured:** document profile names in the testing guide so humans can see when the same model performed both roles.
+- **Provider cannot enforce read-only review:** review prompt says not to edit, branch guard detects branch drift, and future sandbox support can harden read-only access.
+- **Final review changes code after human approval:** require retest when user-visible behavior or testing steps change.
+- **Hidden or overly verbose review output:** publish concise sanitized findings, not raw model traces.
+## Task decomposition
+
+- [ ] **Story: Review route configuration**
+	- [ ] **Task: Add review task kinds and defaults**
+		- **Description**: Add `implementation.review.initial` and `implementation.review.final` to AI task kinds, default config examples, and routing policy coverage.
+		- **Acceptance criteria**:
+			- [ ] Routing resolves both review tasks when configured.
+			- [ ] Final review falls back to initial review when only initial review is configured.
+			- [ ] Missing review routes log `implementation.review.skipped` without breaking existing runs.
+		- **Dependencies**: None.
+	- [ ] **Task: Add review policy config**
+		- **Description**: Add optional `implementation_review` policy parsing with documented defaults, using the simplified key names (`max_initial_rounds`, `max_final_rounds`, `retest_on_behavior_change`).
+		- **Acceptance criteria**:
+			- [ ] Defaults apply when the block is absent.
+			- [ ] Invalid values fail startup with clear errors.
+			- [ ] `on_review_failure` supports `warn` and `block`.
+		- **Dependencies**: Add review task kinds and defaults.
+- [ ] **Story: Review agent contracts**
+	- [ ] **Task: Define review result and exchange types**
+		- **Description**: Add `ImplementationReviewResult`, `ImplementationReviewExchange`, `AgentProfileSummary`, and `review_responses` types.
+		- **Acceptance criteria**:
+			- [ ] Types are exported from stable shared modules.
+			- [ ] Run persistence treats missing `review_exchanges` as `[]`.
+			- [ ] Review exchanges contain sanitized model/profile metadata.
+		- **Dependencies**: Review route configuration.
+	- [ ] **Task: Build review and implementer-response prompts**
+		- **Description**: Add prompt builders for initial review, final review, and implementer responses to review findings. Review context is assembled from the implementation result's existing `summary`, `testing_instructions`, and `review_summary` fields rather than a separate summarization call.
+		- **Acceptance criteria**:
+			- [ ] Review prompts include artifact path, implementation summary (from result fields), changed files, diff context, and phase-specific instructions.
+			- [ ] Response prompts require one response per review ID.
+			- [ ] Prompt tests cover no-findings, findings, final security review, and response validation.
+		- **Dependencies**: Define review result and exchange types.
+- [ ] **Story: Initial review**
+	- [ ] **Task: Add shared implementation review coordinator**
+		- **Description**: Implement a coordinator that runs review, sends findings to the implementer, validates responses, appends exchange records, and returns the canonical implementation result.
+		- **Acceptance criteria**:
+			- [ ] No-findings review appends a `no_findings` exchange.
+			- [ ] Findings review calls the implementer with stable review IDs.
+			- [ ] Missing or invalid implementer responses are logged and handled deterministically without stopping the run.
+			- [ ] Branch guard runs after implementer response.
+		- **Dependencies**: Review agent contracts.
+	- [ ] **Task: Wire initial review into initial implementation**
+		- **Description**: Call the coordinator in `ImplementationStartHandler` after complete implementation result and before testing guide creation.
+		- **Acceptance criteria**:
+			- [ ] Testing guide creation receives reviewed result and review exchanges.
+			- [ ] Needs-input and failed responses follow existing stage behavior.
+			- [ ] Progress updates are posted best-effort.
+		- **Dependencies**: Add shared implementation review coordinator.
+	- [ ] **Task: Wire initial review into feedback passes**
+		- **Description**: Call the coordinator in `ImplementationFeedbackHandler` after complete feedback-pass results and before testing guide update.
+		- **Acceptance criteria**:
+			- [ ] Testing guide update receives reviewed result and review exchanges.
+			- [ ] Existing resolved human feedback handling still works.
+			- [ ] Multiple feedback rounds append review exchange records.
+		- **Dependencies**: Wire initial review into initial implementation.
+- [ ] **Story: Final review**
+	- [ ] **Task: Run final review before PR creation**
+		- **Description**: Update `ImplementationApprovalHandler` to run final review before spec status updates and PR creation.
+		- **Acceptance criteria**:
+			- [ ] Approval does not create a PR until final review and implementer response complete.
+			- [ ] No-findings review proceeds through current PR path.
+			- [ ] Findings can be fixed, declined, or escalated.
+		- **Dependencies**: Add shared implementation review coordinator.
+	- [ ] **Task: Handle retest-required final changes**
+		- **Description**: If final review or implementer response requires human retest, update the testing guide and return to `reviewing_implementation` instead of opening a PR.
+		- **Acceptance criteria**:
+			- [ ] User-visible final changes do not silently ship after approval.
+			- [ ] Testing guide includes final review exchange and updated testing steps.
+			- [ ] Run stage returns to `reviewing_implementation`.
+		- **Dependencies**: Run final review before PR creation.
+- [ ] **Story: Testing guide documentation**
+	- [ ] **Task: Rename "Feedback" section to "Human review" in testing guide template**
+		- **Description**: Update the testing guide template and Notion rendering code to rename the existing "Feedback" section to "Human review", establishing the correct section name before the `AI review` section is placed after it.
+		- **Acceptance criteria**:
+			- [ ] Testing guide template uses "Human review" instead of "Feedback".
+			- [ ] Notion adapter section-identification logic uses the new name.
+			- [ ] Existing pages that have a "Feedback" section are updated to "Human review" on the next write.
+		- **Dependencies**: None (must complete before Render AI review section).
+	- [ ] **Task: Extend testing guide input and update contracts**
+		- **Description**: Add `review_exchanges` to create/update inputs.
+		- **Acceptance criteria**:
+			- [ ] Create and update callers compile with review exchange data.
+			- [ ] Legacy callers can omit review exchanges.
+		- **Dependencies**: Define review result and exchange types.
+	- [ ] **Task: Render AI review section in Notion**
+		- **Description**: Add rendering and update behavior for the `AI review` section.
+		- **Acceptance criteria**:
+			- [ ] New testing guides include the section at the end, after `Human review`.
+			- [ ] Updates replace only the AI-managed `AI review` section.
+			- [ ] Additional steps and Human review sections remain unchanged.
+			- [ ] Secrets and raw credential values are redacted.
+		- **Dependencies**: Extend testing guide input and update contracts; Rename "Feedback" section to "Human review".
+- [ ] **Story: Observability and validation**
+	- [ ] **Task: Add logs and progress updates**
+		- **Description**: Emit structured logs and Slack progress updates for review start, completion, skip, failure, invalid response, and retest-required paths.
+		- **Acceptance criteria**:
+			- [ ] Logs use stable event names and no secrets.
+			- [ ] Progress callback failure is non-blocking.
+			- [ ] Tests assert key log events in failure paths.
+		- **Dependencies**: Initial review and final review wiring.
+	- [ ] **Task: Add end-to-end handler tests**
+		- **Description**: Cover initial implementation, feedback pass, approval, and degraded paths with mocked review and implementation agents.
+		- **Acceptance criteria**:
+			- [ ] `npm test` passes.
+			- [ ] `npm run test:core` covers coordinator and handlers.
+			- [ ] `npm run test:adapters` covers Notion review exchange rendering.
+		- **Dependencies**: All implementation tasks.

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -8,6 +8,7 @@ import type {
   ImplementationReviewStatus,
   PublishedImplementationReview,
 } from '../../types/impl-feedback-page.js';
+import type { ImplementationReviewExchange } from '../../types/ai.js';
 export type {
   FeedbackItem,
   ImplementationReviewInput,
@@ -15,6 +16,60 @@ export type {
   ImplementationReviewStatus,
   PublishedImplementationReview,
 } from '../../types/impl-feedback-page.js';
+
+function redactSecrets(text: string): string {
+  // Redact common API key patterns starting with sk-
+  return text.replace(/\bsk-[A-Za-z0-9]{8,}\b/g, '[REDACTED]');
+}
+
+function renderAiReviewMarkdown(exchanges: ImplementationReviewExchange[]): string {
+  const lines: string[] = [];
+  for (const ex of exchanges) {
+    const phaseTitle = ex.phase === 'initial' ? 'Initial review' : 'Final review';
+    lines.push(`### ${phaseTitle}`);
+    lines.push('');
+    lines.push(`Implementation model: \`${ex.implementation_profile.profile}\` (\`${ex.implementation_profile.model ?? ex.implementation_profile.provider}\`, \`${ex.implementation_profile.provider}\`)`);
+    lines.push(`Review model: \`${ex.review_profile.profile}\` (\`${ex.review_profile.model ?? ex.review_profile.provider}\`, \`${ex.review_profile.provider}\`)`);
+    lines.push(`Review status: ${ex.review_status}`);
+    lines.push('');
+    lines.push('#### Review findings');
+    lines.push('');
+    if (ex.findings.length === 0) {
+      lines.push('- No blocking or informational findings.');
+    } else {
+      for (const finding of ex.findings) {
+        const response = ex.responses.find(r => r.id === finding.id);
+        lines.push(`- [x] [${finding.id}] ${redactSecrets(finding.finding)}`);
+        if (response) {
+          const label = response.disposition === 'fixed' ? 'Fixed' : 'Declined';
+          lines.push(`  ${label} — ${redactSecrets(response.response)}`);
+        }
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function buildAiReviewBlocks(exchanges: ImplementationReviewExchange[]): unknown[] {
+  const blocks: unknown[] = [];
+  for (const ex of exchanges) {
+    const phaseTitle = ex.phase === 'initial' ? 'Initial review' : 'Final review';
+    blocks.push({ type: 'heading_3', heading_3: { rich_text: [{ text: { content: phaseTitle } }] } });
+    blocks.push({ type: 'paragraph', paragraph: { rich_text: [{ text: { content: `Implementation model: \`${ex.implementation_profile.profile}\`` } }] } });
+    blocks.push({ type: 'paragraph', paragraph: { rich_text: [{ text: { content: `Review model: \`${ex.review_profile.profile}\`` } }] } });
+    blocks.push({ type: 'paragraph', paragraph: { rich_text: [{ text: { content: `Review status: ${ex.review_status}` } }] } });
+    if (ex.findings.length === 0) {
+      blocks.push({ type: 'to_do', to_do: { rich_text: [{ text: { content: 'No blocking or informational findings.' } }], checked: false } });
+    } else {
+      for (const finding of ex.findings) {
+        const response = ex.responses.find(r => r.id === finding.id);
+        blocks.push({ type: 'to_do', to_do: { rich_text: [{ text: { content: `[${finding.id}] ${redactSecrets(finding.finding)}` } }], checked: Boolean(response) } });
+      }
+    }
+  }
+  return blocks;
+}
 
 interface NotionImplementationFeedbackPageOptions {
   logDestination?: pino.DestinationStream;
@@ -138,11 +193,20 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
           type: 'to_do',
           to_do: { rich_text: [{ text: { content: 'Add any extra testing steps here.' } }], checked: false },
         } as never,
-        // Feedback section
+        // Human review section
         {
           type: 'heading_2',
-          heading_2: { rich_text: [{ text: { content: 'Feedback' } }] },
+          heading_2: { rich_text: [{ text: { content: 'Human review' } }] },
         } as never,
+        ...(input.review_exchanges?.length
+          ? [
+              {
+                type: 'heading_2',
+                heading_2: { rich_text: [{ text: { content: 'AI review' } }] },
+              } as never,
+              ...buildAiReviewBlocks(input.review_exchanges) as never[],
+            ]
+          : []),
       ],
     });
 
@@ -175,7 +239,7 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
       // Track which section we are in based on heading_2 blocks
       if (block.type === 'heading_2' && block.heading_2) {
         const headingText = block.heading_2.rich_text.map(r => r.plain_text).join('');
-        inFeedbackSection = headingText === 'Feedback';
+        inFeedbackSection = headingText === 'Human review' || headingText === 'Feedback';
         continue;
       }
 
@@ -224,6 +288,7 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
         id: string;
         resolution_comment: string;
       }>;
+      review_exchanges?: ImplementationReviewExchange[];
     },
   ): Promise<void> {
     let markdown = await this.client.pages.getMarkdown(page_id);
@@ -330,6 +395,21 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
         { event: 'implementation.testing_steps_appended', page_id, appended_count: newSteps.length, skipped_count: skippedCount },
         'New testing steps appended to existing Testing instructions list',
       );
+    }
+
+    // --- Replace or append AI review section ---
+    if (options.review_exchanges !== undefined) {
+      const aiReviewContent = renderAiReviewMarkdown(options.review_exchanges);
+      const aiReviewHeading = '\n## AI review\n';
+      const aiReviewPattern = /\n## AI review\n[\s\S]*$/;
+      if (aiReviewPattern.test(markdown)) {
+        markdown = markdown.replace(aiReviewPattern, `${aiReviewHeading}\n${aiReviewContent}`);
+      } else {
+        if (!markdown.includes('\n## Human review\n') && !markdown.includes('\n## Feedback\n')) {
+          this.logger.warn({ event: 'implementation.missing_human_review', page_id }, 'Page missing Human review section; appending AI review at end');
+        }
+        markdown = markdown.trimEnd() + `\n\n## AI review\n\n${aiReviewContent}`;
+      }
     }
 
     await this.client.pages.updateMarkdown(page_id, {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -76,12 +76,22 @@ ai:
         effort: high
         thinking: adaptive
 
+    - name: review-agent
+      endpoint: anthropic-direct
+      model: claude-sonnet-4-6
+      runner: claude_agent_sdk
+      anthropic:
+        effort: high
+        thinking: adaptive
+
   routing:
     intent.classify: classify-haiku
     pr.title_generate: classify-haiku
     artifact.create: artifact-agent
     artifact.revise: artifact-agent
     implementation.run: impl-agent
+    implementation.review.initial: review-agent
+    implementation.review.final: review-agent
     question.answer: question-agent
     issue.triage: triage-agent
 `;

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -16,6 +16,8 @@ import type {
   ArtifactRevisionResult,
   ImplementationAgent,
   ImplementationResult,
+  ImplementationReviewFinding,
+  ImplementationReviewResult,
   ImplementationStatus,
   IssueTriageAgent,
   IssueTriageItem,
@@ -536,6 +538,18 @@ function parseImplementationResult(content: string, path: string): Implementatio
     });
   }
 
+  // Parse optional review_responses
+  let review_responses: ImplementationResult['review_responses'];
+  const rawReviewResponses = obj['review_responses'];
+  if (Array.isArray(rawReviewResponses)) {
+    review_responses = (rawReviewResponses as unknown[]).flatMap((item) => {
+      if (typeof item !== 'object' || item === null) return [];
+      const entry = item as Record<string, unknown>;
+      if (typeof entry['id'] !== 'string' || typeof entry['disposition'] !== 'string' || typeof entry['response'] !== 'string') return [];
+      return [{ id: entry['id'], disposition: entry['disposition'] as 'fixed' | 'declined' | 'needs_input', response: entry['response'] }];
+    });
+  }
+
   return {
     status,
     summary: typeof obj['summary'] === 'string' ? obj['summary'] : undefined,
@@ -543,6 +557,8 @@ function parseImplementationResult(content: string, path: string): Implementatio
     review_summary,
     testing_steps,
     resolved_feedback_items,
+    review_responses,
+    requires_human_retest: obj['requires_human_retest'] === true,
     question: typeof obj['question'] === 'string' ? obj['question'] : undefined,
     error: typeof obj['error'] === 'string' ? obj['error'] : undefined,
   };
@@ -939,4 +955,251 @@ export function buildIssueTriagePrompt(request: Request, resultPath: string): st
     ``,
     CHECKPOINT_INSTRUCTIONS,
   ].join('\n');
+}
+
+export function buildInitialReviewPrompt(
+  artifact_path: string,
+  working_directory: string,
+  impl_result: ImplementationResult,
+  diff_context: string,
+  changed_files: string[],
+): string {
+  const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
+  const summaryLines = [
+    impl_result.summary ? `Summary: ${impl_result.summary}` : '',
+    impl_result.review_summary?.changes?.length
+      ? `Changes:\n${impl_result.review_summary.changes.map(c => `- ${c}`).join('\n')}`
+      : '',
+    impl_result.review_summary?.confirm?.length
+      ? `Confirm:\n${impl_result.review_summary.confirm.map(c => `- ${c}`).join('\n')}`
+      : '',
+    impl_result.testing_instructions ? `Testing instructions: ${impl_result.testing_instructions}` : '',
+  ].filter(Boolean);
+
+  return [
+    `You are an adversarial code reviewer. Your job is to inspect the implementation and find issues.`,
+    `Do NOT edit any files. Read only.`,
+    ``,
+    `Approved artifact (spec): ${artifact_path}`,
+    ``,
+    `Implementation description from implementer:`,
+    `<<<`,
+    summaryLines.join('\n\n'),
+    `>>>`,
+    ``,
+    `Changed files:`,
+    ...changed_files.map(f => `- ${f}`),
+    ``,
+    `Git diff:`,
+    `<<<`,
+    diff_context || '(no diff available)',
+    `>>>`,
+    ``,
+    `Review categories for initial review: correctness, test, security, maintainability, docs.`,
+    `Focus on: correctness issues, missing test coverage, security problems, unmaintainable code, missing docs.`,
+    ``,
+    `Write your result to: ${reviewResultPath}`,
+    `Content must be:`,
+    `{`,
+    `  "status": "no_findings" | "findings" | "failed",`,
+    `  "summary": "1-2 sentence summary of review outcome",`,
+    `  "findings": [`,
+    `    {`,
+    `      "id": "INIT-1",`,
+    `      "severity": "blocker" | "warning" | "info",`,
+    `      "category": "correctness" | "test" | "security" | "maintainability" | "docs",`,
+    `      "finding": "concise description",`,
+    `      "suggested_action": "optional action"`,
+    `    }`,
+    `  ],`,
+    `  "requires_human_retest": false,`,
+    `  "error": "only when status is failed"`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Do NOT include secrets, API keys, env values, or raw credential values in findings.`,
+    `- Do NOT include your reasoning chain or full prompt in findings.`,
+    `- Do NOT edit any files in the workspace.`,
+    `- Use sequential IDs: INIT-1, INIT-2, etc.`,
+    `- If no issues found, use status: "no_findings" with empty findings array.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildFinalReviewPrompt(
+  artifact_path: string,
+  working_directory: string,
+  impl_result: ImplementationResult,
+  diff_context: string,
+  changed_files: string[],
+): string {
+  const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
+  const summaryLines = [
+    impl_result.summary ? `Summary: ${impl_result.summary}` : '',
+    impl_result.review_summary?.changes?.length
+      ? `Changes:\n${impl_result.review_summary.changes.map(c => `- ${c}`).join('\n')}`
+      : '',
+  ].filter(Boolean);
+
+  return [
+    `You are an adversarial code reviewer performing a final pre-PR security and readiness check.`,
+    `Do NOT edit any files. Read only.`,
+    ``,
+    `Approved artifact (spec): ${artifact_path}`,
+    ``,
+    `Implementation description from implementer:`,
+    `<<<`,
+    summaryLines.join('\n\n'),
+    `>>>`,
+    ``,
+    `Changed files:`,
+    ...changed_files.map(f => `- ${f}`),
+    ``,
+    `Git diff:`,
+    `<<<`,
+    diff_context || '(no diff available)',
+    `>>>`,
+    ``,
+    `FOCUS for final review: security and pr_readiness.`,
+    `Only include correctness, maintainability, test, or docs findings if the issue is newly discovered`,
+    `and serious enough to block or delay the PR.`,
+    ``,
+    `Write your result to: ${reviewResultPath}`,
+    `Content must be:`,
+    `{`,
+    `  "status": "no_findings" | "findings" | "failed",`,
+    `  "summary": "1-2 sentence summary",`,
+    `  "findings": [`,
+    `    {`,
+    `      "id": "FINAL-1",`,
+    `      "severity": "blocker" | "warning" | "info",`,
+    `      "category": "security" | "pr_readiness" | "correctness" | "test" | "maintainability" | "docs",`,
+    `      "finding": "concise description",`,
+    `      "suggested_action": "optional action"`,
+    `    }`,
+    `  ],`,
+    `  "requires_human_retest": false,`,
+    `  "error": "only when status is failed"`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Do NOT include secrets, API keys, env values, or raw credential values.`,
+    `- Do NOT edit any files.`,
+    `- Use sequential IDs: FINAL-1, FINAL-2, etc.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildImplementerResponsePrompt(
+  artifact_path: string,
+  working_directory: string,
+  impl_result: ImplementationResult,
+  findings: ImplementationReviewFinding[],
+): string {
+  const resultFilePath = join(working_directory, '.autocatalyst', 'impl-result.json');
+
+  const findingBlocks = findings.map(f => [
+    `[REVIEW_ID: ${f.id}]`,
+    `Severity: ${f.severity}`,
+    `Category: ${f.category}`,
+    `Finding: ${f.finding}`,
+    ...(f.suggested_action ? [`Suggested action: ${f.suggested_action}`] : []),
+  ].join('\n'));
+
+  return [
+    `Review findings require your response.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    `Read the approved artifact at: ${artifact_path}`,
+    ``,
+    `Previous implementation summary: ${impl_result.summary ?? '(none)'}`,
+    ``,
+    `Review findings:`,
+    ``,
+    findingBlocks.join('\n\n'),
+    ``,
+    `For each [REVIEW_ID: ...] finding, either fix it or decline it with a concrete reason.`,
+    ``,
+    `Step 1 - Respond to each finding.`,
+    `For blockers: fix the issue in code/tests/docs, or escalate to needs_input with a specific question.`,
+    `For warnings/info: fix, or decline with a concrete reason (not "no action needed").`,
+    ``,
+    `Step 2 - Commit any changes.`,
+    ``,
+    `Step 3 - Write the result to: ${resultFilePath}`,
+    `Content must be:`,
+    `{`,
+    `  "status": "complete" | "needs_input" | "failed",`,
+    `  "summary": "updated summary",`,
+    `  "review_summary": { "changes": [...], "confirm": [...] },`,
+    `  "testing_steps": [...],`,
+    `  "resolved_feedback_items": [],`,
+    `  "review_responses": [`,
+    `    {`,
+    `      "id": "<exact REVIEW_ID value>",`,
+    `      "disposition": "fixed" | "declined" | "needs_input",`,
+    `      "response": "what changed or concrete reason for decline"`,
+    `    }`,
+    `  ],`,
+    `  "requires_human_retest": false`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Include one review_responses entry per [REVIEW_ID:] finding.`,
+    `- "declined" responses must include a concrete reason, not just "no action needed".`,
+    `- "fixed" responses should mention changed files or behavior.`,
+    `- Use exact ID strings — do not modify or guess IDs.`,
+    `- requires_human_retest: set true only if you changed user-visible behavior or testing steps.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function parseImplementationReviewResult(content: string, path: string): ImplementationReviewResult {
+  let obj: Record<string, unknown>;
+  try {
+    const data = JSON.parse(content);
+    if (typeof data !== 'object' || data === null) {
+      return { status: 'failed', summary: '', findings: [], error: `Review result at "${path}" is not a JSON object` };
+    }
+    obj = data as Record<string, unknown>;
+  } catch (err) {
+    return { status: 'failed', summary: '', findings: [], error: `Review result at "${path}" is not valid JSON: ${String(err)}` };
+  }
+
+  const rawStatus = obj['status'];
+  if (rawStatus !== 'no_findings' && rawStatus !== 'findings' && rawStatus !== 'failed') {
+    return { status: 'failed', summary: '', findings: [], error: `Review result at "${path}" has invalid status: "${String(rawStatus)}"` };
+  }
+
+  const findings: ImplementationReviewFinding[] = [];
+  if (Array.isArray(obj['findings'])) {
+    for (const raw of obj['findings'] as unknown[]) {
+      if (typeof raw !== 'object' || raw === null) continue;
+      const f = raw as Record<string, unknown>;
+      if (typeof f['id'] === 'string' && typeof f['severity'] === 'string' && typeof f['category'] === 'string' && typeof f['finding'] === 'string') {
+        findings.push({
+          id: f['id'],
+          severity: f['severity'] as ImplementationReviewFinding['severity'],
+          category: f['category'] as ImplementationReviewFinding['category'],
+          finding: f['finding'],
+          ...(typeof f['suggested_action'] === 'string' ? { suggested_action: f['suggested_action'] } : {}),
+        });
+      }
+    }
+  }
+
+  return {
+    status: rawStatus,
+    summary: typeof obj['summary'] === 'string' ? obj['summary'] : '',
+    findings,
+    requires_human_retest: obj['requires_human_retest'] === true,
+    ...(typeof obj['error'] === 'string' ? { error: obj['error'] } : {}),
+  };
 }

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -1,0 +1,282 @@
+import { join } from 'node:path';
+import { readFile as _readFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type pino from 'pino';
+import type {
+  AgentRunner,
+  AgentRoutingPolicy,
+  ImplementationAgent,
+  ImplementationResult,
+  ImplementationReviewExchange,
+  ImplementationReviewFinding,
+} from '../../types/ai.js';
+import type { Run } from '../../types/runs.js';
+import type { BranchGuard } from '../git-branch-guard.js';
+import {
+  buildInitialReviewPrompt,
+  buildFinalReviewPrompt,
+  buildImplementerResponsePrompt,
+  parseImplementationReviewResult,
+  drainAgentRunner,
+} from './agent-services.js';
+import { agentProfileSummary } from './routing-policy.js';
+
+type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
+
+export interface ImplementationReviewPolicy {
+  max_initial_rounds: number;
+  max_final_rounds: number;
+  on_review_failure: 'warn' | 'block';
+  retest_on_behavior_change: boolean;
+}
+
+export interface ImplementationReviewCoordinatorDeps {
+  runner: AgentRunner;
+  implementer: Pick<ImplementationAgent, 'implement'>;
+  routingPolicy: AgentRoutingPolicy;
+  policy: ImplementationReviewPolicy;
+  branchGuard?: BranchGuard;
+  logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
+  readFile?: ReadFileFn;
+}
+
+export interface ReviewRunParams {
+  run: Run;
+  artifact_path: string;
+  implementation_result: ImplementationResult;
+  working_directory: string;
+  onProgress?: (message: string) => Promise<void>;
+}
+
+export class ImplementationReviewCoordinator {
+  private readonly readFileFn: ReadFileFn;
+
+  constructor(private readonly deps: ImplementationReviewCoordinatorDeps) {
+    this.readFileFn = deps.readFile ?? ((path, enc) => _readFile(path, enc));
+  }
+
+  async runInitialReview(params: ReviewRunParams): Promise<ImplementationResult> {
+    return this.runReview('initial', 'implementation.review.initial', params);
+  }
+
+  async runFinalReview(params: ReviewRunParams): Promise<ImplementationResult> {
+    return this.runReview('final', 'implementation.review.final', params);
+  }
+
+  private async runReview(
+    phase: 'initial' | 'final',
+    routeTask: 'implementation.review.initial' | 'implementation.review.final',
+    { run, artifact_path, implementation_result, working_directory, onProgress }: ReviewRunParams,
+  ): Promise<ImplementationResult> {
+    // Resolve review profile — fall back to initial when final is absent
+    let reviewProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask });
+    if (!reviewProfile && phase === 'final') {
+      reviewProfile = this.deps.routingPolicy.resolveOptional({ task: 'implementation.review.initial' });
+    }
+
+    if (!reviewProfile) {
+      this.deps.logger.warn(
+        { event: 'implementation.review.skipped', phase, run_id: run.id },
+        'No review route configured — skipping review',
+      );
+      return implementation_result;
+    }
+
+    const implProfile = this.deps.routingPolicy.resolveOptional({ task: 'implementation.run' });
+    const implSummary = implProfile ? agentProfileSummary(implProfile) : { profile: 'implementation.run', provider: 'unknown' };
+    const reviewSummary = agentProfileSummary(reviewProfile);
+
+    this.deps.logger.info(
+      { event: 'implementation.review.started', phase, run_id: run.id, review_profile: reviewSummary.profile, implementation_profile: implSummary.profile },
+      'Starting implementation review',
+    );
+
+    // Get git diff and changed files
+    const diffContext = await this.getGitDiff(working_directory);
+    const changedFiles = await this.getChangedFiles(working_directory);
+
+    // Build prompt and run review
+    const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
+    const prompt = phase === 'initial'
+      ? buildInitialReviewPrompt(artifact_path, working_directory, implementation_result, diffContext, changedFiles)
+      : buildFinalReviewPrompt(artifact_path, working_directory, implementation_result, diffContext, changedFiles);
+
+    try {
+      await mkdir(dirname(reviewResultPath), { recursive: true });
+    } catch { /* ignore */ }
+
+    try {
+      await drainAgentRunner(
+        this.deps.runner.run({
+          route: { task: routeTask },
+          profile: reviewProfile,
+          working_directory,
+          prompt,
+        }),
+        onProgress,
+        this.deps.logger,
+        `implementation_review_${phase}`,
+      );
+    } catch (err) {
+      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, String(err));
+    }
+
+    let reviewResultContent: string;
+    try {
+      reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
+    } catch (err) {
+      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, `Review result file not found: ${String(err)}`);
+    }
+
+    const reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
+    if (reviewResult.status === 'failed') {
+      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, reviewResult.error ?? 'Review model reported failure');
+    }
+
+    this.deps.logger.info(
+      { event: 'implementation.review.completed', phase, run_id: run.id, status: reviewResult.status, finding_count: reviewResult.findings.length, requires_human_retest: reviewResult.requires_human_retest ?? false },
+      'Implementation review completed',
+    );
+
+    if (reviewResult.status === 'no_findings') {
+      this.appendExchange(run, {
+        id: randomUUID(),
+        phase,
+        created_at: new Date().toISOString(),
+        implementation_profile: implSummary,
+        review_profile: reviewSummary,
+        review_status: 'no_findings',
+        review_summary: reviewResult.summary,
+        findings: [],
+        responses: [],
+        requires_human_retest: false,
+      });
+      return implementation_result;
+    }
+
+    // Findings: call implementer with review context
+    if (onProgress) {
+      await onProgress(`Review returned ${reviewResult.findings.length} finding(s) — asking implementation model to respond`).catch(() => {});
+    }
+
+    const responsePrompt = buildImplementerResponsePrompt(artifact_path, working_directory, implementation_result, reviewResult.findings);
+    const progressFn = onProgress ?? ((_msg: string) => Promise.resolve());
+    let implementerResult: ImplementationResult;
+    try {
+      implementerResult = await this.deps.implementer.implement(
+        artifact_path,
+        working_directory,
+        responsePrompt,
+        progressFn,
+      );
+    } catch (err) {
+      return { status: 'failed', error: `Implementer response to review failed: ${String(err)}` };
+    }
+
+    if (implementerResult.status !== 'complete') {
+      return implementerResult;
+    }
+
+    // Branch guard after implementer response
+    if (this.deps.branchGuard) {
+      try {
+        await this.deps.branchGuard.check(working_directory, run.branch);
+      } catch (err) {
+        return { status: 'failed', error: `Branch guard failed after review response: ${String(err)}` };
+      }
+    }
+
+    // Validate responses
+    const responses = implementerResult.review_responses ?? [];
+    this.validateResponses(run, reviewResult.findings, responses);
+
+    this.appendExchange(run, {
+      id: randomUUID(),
+      phase,
+      created_at: new Date().toISOString(),
+      implementation_profile: implSummary,
+      review_profile: reviewSummary,
+      review_status: 'addressed',
+      review_summary: reviewResult.summary,
+      findings: reviewResult.findings,
+      responses,
+      requires_human_retest: implementerResult.requires_human_retest ?? false,
+    });
+
+    return implementerResult;
+  }
+
+  private handleReviewFailure(
+    phase: 'initial' | 'final',
+    run: Run,
+    original: ImplementationResult,
+    implSummary: ReturnType<typeof agentProfileSummary>,
+    reviewSummary: ReturnType<typeof agentProfileSummary>,
+    errorMsg: string,
+  ): ImplementationResult {
+    this.deps.logger.warn(
+      { event: 'implementation.review.failed', phase, run_id: run.id, error: errorMsg },
+      'Implementation review failed',
+    );
+    if (this.deps.policy.on_review_failure === 'block') {
+      return { status: 'failed', error: `Implementation review (${phase}) failed: ${errorMsg}` };
+    }
+    // warn: degraded exchange, continue
+    this.appendExchange(run, {
+      id: randomUUID(),
+      phase,
+      created_at: new Date().toISOString(),
+      implementation_profile: implSummary,
+      review_profile: reviewSummary,
+      review_status: 'degraded',
+      review_summary: errorMsg,
+      findings: [],
+      responses: [],
+      requires_human_retest: false,
+    });
+    return original;
+  }
+
+  private validateResponses(run: Run, findings: ImplementationReviewFinding[], responses: NonNullable<ImplementationResult['review_responses']>): void {
+    const responseIds = new Set(responses.map(r => r.id));
+    for (const finding of findings) {
+      if (!responseIds.has(finding.id)) {
+        this.deps.logger.warn(
+          { event: 'implementation.review.response_invalid', run_id: run.id, missing_id: finding.id },
+          `Implementer did not respond to finding ID: ${finding.id}`,
+        );
+      }
+    }
+  }
+
+  private appendExchange(run: Run, exchange: ImplementationReviewExchange): void {
+    if (!run.review_exchanges) run.review_exchanges = [];
+    run.review_exchanges.push(exchange);
+  }
+
+  private async getGitDiff(working_directory: string): Promise<string> {
+    try {
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const exec = promisify(execFile);
+      const { stdout } = await exec('git', ['diff', 'HEAD~1..HEAD', '--stat', '--patch', '--', '.'], { cwd: working_directory, maxBuffer: 100_000 });
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  }
+
+  private async getChangedFiles(working_directory: string): Promise<string[]> {
+    try {
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const exec = promisify(execFile);
+      const { stdout } = await exec('git', ['diff', 'HEAD~1..HEAD', '--name-only'], { cwd: working_directory });
+      return stdout.trim().split('\n').filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/core/ai/route-skills.ts
+++ b/src/core/ai/route-skills.ts
@@ -14,6 +14,8 @@ export function requiredSkillsForRoute(route: AgentRoute): AgentSkillRef[] {
     case 'intent.classify':
     case 'pr.title_generate':
     case 'question.answer':
+    case 'implementation.review.initial':
+    case 'implementation.review.final':
       return [];
   }
 }

--- a/src/core/ai/routing-policy.ts
+++ b/src/core/ai/routing-policy.ts
@@ -1,4 +1,4 @@
-import type { AgentProfile, AgentRoute, AgentRoutingPolicy, AgentEffort, AgentThinking } from '../../types/ai.js';
+import type { AgentProfile, AgentProfileSummary, AgentRoute, AgentRoutingPolicy, AgentEffort, AgentThinking } from '../../types/ai.js';
 import type { AiConfig, ProfileConfig, EndpointConfig, RunnerKind } from '../../types/config.js';
 import type { ResolvedCredential } from '../config.js';
 import { requiredSkillsForRoute } from './route-skills.js';
@@ -16,6 +16,16 @@ export class DefaultAgentRoutingPolicy implements AgentRoutingPolicy {
       throw new Error(`No routing entry for task '${route.task}'`);
     }
     const profile = this.config.profiles.find(p => p.name === profileName)!;
+    const endpoint = this.config.endpoints.find(e => e.name === profile.endpoint)!;
+    const credential = this.config.credentials.find(c => c.name === endpoint.credential) as ResolvedCredential | undefined;
+    return buildAgentProfile(profile, endpoint, credential, route);
+  }
+
+  resolveOptional(route: AgentRoute): AgentProfile | null {
+    const profileName = this.config.routing[route.task];
+    if (!profileName) return null;
+    const profile = this.config.profiles.find(p => p.name === profileName);
+    if (!profile) return null;
     const endpoint = this.config.endpoints.find(e => e.name === profile.endpoint)!;
     const credential = this.config.credentials.find(c => c.name === endpoint.credential) as ResolvedCredential | undefined;
     return buildAgentProfile(profile, endpoint, credential, route);
@@ -46,4 +56,12 @@ function runnerToProvider(runner: RunnerKind): string {
     case 'claude_agent_sdk': return 'claude_agent_sdk';
     case 'openai_agent_sdk': return 'openai_agent_sdk';
   }
+}
+
+export function agentProfileSummary(profile: Pick<AgentProfile, 'id' | 'provider' | 'model'>): AgentProfileSummary {
+  return {
+    profile: profile.id,
+    provider: profile.provider,
+    ...(profile.model !== undefined ? { model: profile.model } : {}),
+  };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -116,6 +116,27 @@ export function validateConfig(config: WorkflowConfig): void {
       }
     }
   }
+
+  const rawReview = (config as Record<string, unknown>)['implementation_review'];
+  if (rawReview !== undefined && rawReview !== null) {
+    if (typeof rawReview !== 'object' || Array.isArray(rawReview)) {
+      throw new Error('implementation_review must be an object');
+    }
+    const rr = rawReview as Record<string, unknown>;
+    if (rr['on_review_failure'] !== undefined && rr['on_review_failure'] !== 'warn' && rr['on_review_failure'] !== 'block') {
+      throw new Error(`implementation_review.on_review_failure must be "warn" or "block", got "${String(rr['on_review_failure'])}"`);
+    }
+    if (rr['max_initial_rounds'] !== undefined) {
+      if (typeof rr['max_initial_rounds'] !== 'number' || !Number.isInteger(rr['max_initial_rounds']) || (rr['max_initial_rounds'] as number) < 1) {
+        throw new Error('implementation_review.max_initial_rounds must be a positive integer');
+      }
+    }
+    if (rr['max_final_rounds'] !== undefined) {
+      if (typeof rr['max_final_rounds'] !== 'number' || !Number.isInteger(rr['max_final_rounds']) || (rr['max_final_rounds'] as number) < 1) {
+        throw new Error('implementation_review.max_final_rounds must be a positive integer');
+      }
+    }
+  }
 }
 
 export function redactConfig(
@@ -305,4 +326,19 @@ export function repoNameFromUrl(repo_url: string): string {
   const normalized = repo_url.replace(/\.git$/, '').replace(/^[^@]+@[^:]+:/, '/');
   const segments = normalized.split('/').filter(Boolean);
   return segments.slice(-2).join('/') || 'unknown';
+}
+
+export function getImplementationReviewPolicy(config: WorkflowConfig): {
+  max_initial_rounds: number;
+  max_final_rounds: number;
+  on_review_failure: 'warn' | 'block';
+  retest_on_behavior_change: boolean;
+} {
+  const raw = (config as Record<string, unknown>)['implementation_review'] as Record<string, unknown> | undefined;
+  return {
+    max_initial_rounds: typeof raw?.['max_initial_rounds'] === 'number' ? raw['max_initial_rounds'] as number : 1,
+    max_final_rounds: typeof raw?.['max_final_rounds'] === 'number' ? raw['max_final_rounds'] as number : 1,
+    on_review_failure: (raw?.['on_review_failure'] === 'block' ? 'block' : 'warn'),
+    retest_on_behavior_change: raw?.['retest_on_behavior_change'] === false ? false : true,
+  };
 }

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -10,23 +10,30 @@ import type { ConversationRef } from '../../types/channel.js';
 import { markArtifactStatus, artifactPath, artifactPublisherId } from '../run-refs.js';
 import { getArtifactLifecyclePolicy } from '../../types/artifact.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
+import type { ImplementationResult } from '../../types/ai.js';
 
 export interface ImplementationApprovalDeps {
   specCommitter?: Pick<SpecCommitter, 'updateStatus'>;
   artifactPublisher: Pick<ArtifactPublisher, 'updateStatus'>;
   prManager: Pick<PRManager, 'createPR'>;
   prTitleGenerator: PRTitleGenerator;
-  implFeedbackPage?: Pick<ImplementationReviewPublisher, 'setPRLink' | 'updateStatus'>;
+  implFeedbackPage?: Pick<ImplementationReviewPublisher, 'setPRLink' | 'updateStatus' | 'update'>;
   postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
-  logger: Pick<pino.Logger, 'error'>;
+  logger: Pick<pino.Logger, 'error' | 'info'>;
   now?: () => Date;
   branchGuard?: BranchGuard;
+  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runFinalReview'>;
 }
 
-export type ImplementationApprovalResult = { status: 'pr_open' } | { status: 'failed' };
+export type ImplementationApprovalResult =
+  | { status: 'pr_open' }
+  | { status: 'reviewing_implementation' }
+  | { status: 'needs_input' }
+  | { status: 'failed' };
 
 export class ImplementationApprovalHandler {
   constructor(private readonly deps: ImplementationApprovalDeps) {}
@@ -71,6 +78,67 @@ export class ImplementationApprovalHandler {
       } catch (err) {
         await this.deps.failRun(run, feedback.conversation, err);
         return { status: 'failed' };
+      }
+    }
+
+    // Run final review before PR creation
+    if (this.deps.reviewCoordinator) {
+      const currentResult: ImplementationResult = {
+        status: 'complete',
+        summary: run.last_impl_result?.summary,
+        testing_instructions: run.last_impl_result?.testing_instructions,
+      };
+      const reviewedResult = await this.deps.reviewCoordinator.runFinalReview({
+        run,
+        artifact_path: localPath ?? '',
+        implementation_result: currentResult,
+        working_directory: run.workspace_path,
+      });
+
+      if (reviewedResult.status === 'needs_input') {
+        try {
+          await this.deps.postMessage(feedback.conversation, `I need input \u2014 ${reviewedResult.question ?? 'please provide more context'}`);
+        } catch (err) {
+          this.deps.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post question');
+        }
+        this.deps.transition(run, 'awaiting_impl_input');
+        return { status: 'needs_input' };
+      }
+
+      if (reviewedResult.status === 'failed') {
+        await this.deps.failRun(run, feedback.conversation, new Error(reviewedResult.error ?? 'Final review failed'));
+        return { status: 'failed' };
+      }
+
+      if (reviewedResult.requires_human_retest) {
+        this.deps.logger.info(
+          { event: 'implementation.review.retest_required', run_id: run.id },
+          'Final review requires human retest — returning to reviewing_implementation',
+        );
+        if (run.impl_feedback_ref) {
+          try {
+            await this.deps.implFeedbackPage?.update?.(run.impl_feedback_ref, {
+              summary: reviewedResult.summary,
+              review_exchanges: run.review_exchanges,
+            });
+          } catch (err) {
+            this.deps.logger.error(
+              { event: 'run.feedback_page_update_failed', run_id: run.id, error: String(err) },
+              'Failed to update testing guide after final review retest requirement',
+            );
+          }
+        }
+        this.deps.transition(run, 'reviewing_implementation');
+        return { status: 'reviewing_implementation' };
+      }
+
+      // Update last_impl_result with reviewed result
+      if (reviewedResult.summary !== undefined || reviewedResult.testing_instructions !== undefined) {
+        run.last_impl_result = {
+          summary: reviewedResult.summary ?? run.last_impl_result?.summary ?? '',
+          testing_instructions: reviewedResult.testing_instructions ?? run.last_impl_result?.testing_instructions ?? '',
+        };
+        this.deps.persist();
       }
     }
 

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -6,6 +6,7 @@ import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { artifactPath } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 
 export interface ImplementationFeedbackDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -16,6 +17,7 @@ export interface ImplementationFeedbackDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error' | 'debug'>;
   branchGuard?: BranchGuard;
+  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
 }
 
 export type ImplementationFeedbackResult =
@@ -71,6 +73,32 @@ export class ImplementationFeedbackHandler {
       }
     }
 
+    // Run initial review if coordinator is configured
+    let reviewedResult = result;
+    if (this.deps.reviewCoordinator) {
+      reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
+        run,
+        artifact_path: localPath,
+        implementation_result: result,
+        working_directory: run.workspace_path,
+        onProgress,
+      });
+      if (reviewedResult.status === 'needs_input') {
+        this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');
+        try {
+          await this.deps.postMessage(feedback.conversation, `I need input \u2014 ${reviewedResult.question ?? 'please provide more context'}`);
+        } catch (err) {
+          this.deps.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post question');
+        }
+        this.deps.transition(run, 'awaiting_impl_input');
+        return { status: 'needs_input' };
+      }
+      if (reviewedResult.status === 'failed') {
+        await this.deps.failRun(run, feedback.conversation, new Error(reviewedResult.error ?? 'Review failed'));
+        return { status: 'failed' };
+      }
+    }
+
     if (result.status === 'needs_input') {
       this.deps.logger.info(
         { event: 'implementation.needs_input', run_id: run.id, request_id: run.request_id },
@@ -96,7 +124,7 @@ export class ImplementationFeedbackHandler {
     );
 
     // Log legacy warning if structured output is missing
-    if (!result.review_summary || !result.testing_steps) {
+    if (!reviewedResult.review_summary || !reviewedResult.testing_steps) {
       this.deps.logger.warn(
         { event: 'implementation.review_contract_legacy', run_id: run.id },
         'Implementation result missing structured review_summary or testing_steps; using legacy fields',
@@ -104,18 +132,19 @@ export class ImplementationFeedbackHandler {
     }
 
     run.last_impl_result = {
-      summary: result.summary ?? '',
-      testing_instructions: result.testing_instructions ?? '',
+      summary: reviewedResult.summary ?? '',
+      testing_instructions: reviewedResult.testing_instructions ?? '',
     };
     this.deps.persist();
 
     if (run.impl_feedback_ref) {
       try {
         await this.deps.implFeedbackPage!.update(run.impl_feedback_ref, {
-          summary: result.summary,
-          review_summary: result.review_summary,
-          testing_steps: result.testing_steps,
-          resolved_items: result.resolved_feedback_items ?? [],
+          summary: reviewedResult.summary,
+          review_summary: reviewedResult.review_summary,
+          testing_steps: reviewedResult.testing_steps,
+          resolved_items: reviewedResult.resolved_feedback_items ?? [],
+          review_exchanges: run.review_exchanges,
         });
       } catch (err) {
         this.deps.logger.error(

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -7,6 +7,7 @@ import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { requireArtifactRefs, artifactPublishedUrl } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 
 export interface ImplementationStartDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -17,6 +18,7 @@ export interface ImplementationStartDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
+  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
 }
 
 export type ImplementationStartResult =
@@ -74,6 +76,32 @@ export class ImplementationStartHandler {
       }
     }
 
+    // Run initial review if coordinator is configured
+    let reviewedResult = result;
+    if (this.deps.reviewCoordinator) {
+      reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
+        run,
+        artifact_path: refs.local_path,
+        implementation_result: result,
+        working_directory: run.workspace_path,
+        onProgress,
+      });
+      if (reviewedResult.status === 'needs_input') {
+        this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');
+        try {
+          await this.deps.postMessage(feedback.conversation, `I need input \u2014 ${reviewedResult.question ?? 'please provide more context'}`);
+        } catch (err) {
+          this.deps.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post question');
+        }
+        this.deps.transition(run, 'awaiting_impl_input');
+        return { status: 'needs_input' };
+      }
+      if (reviewedResult.status === 'failed') {
+        await this.deps.failRun(run, feedback.conversation, new Error(reviewedResult.error ?? 'Review failed'));
+        return { status: 'failed' };
+      }
+    }
+
     if (result.status === 'needs_input') {
       this.deps.logger.info({ event: 'implementation.needs_input', run_id: run.id, request_id: run.request_id }, 'Implementation needs input');
       try {
@@ -92,15 +120,15 @@ export class ImplementationStartHandler {
 
     this.deps.logger.info({ event: 'implementation.complete', run_id: run.id, request_id: run.request_id, attempt: run.attempt }, 'Implementation complete');
     run.last_impl_result = {
-      summary: result.summary ?? '',
-      testing_instructions: result.testing_instructions ?? '',
+      summary: reviewedResult.summary ?? '',
+      testing_instructions: reviewedResult.testing_instructions ?? '',
     };
     this.deps.persist();
 
     let feedbackPageUrl: string | undefined;
     try {
       // Log legacy warning if structured output is missing
-      if (!result.review_summary || !result.testing_steps) {
+      if (!reviewedResult.review_summary || !reviewedResult.testing_steps) {
         this.deps.logger.warn(
           { event: 'implementation.review_contract_legacy', run_id: run.id },
           'Implementation result missing structured review_summary or testing_steps; using legacy fields',
@@ -112,10 +140,11 @@ export class ImplementationStartHandler {
         title: titleFromArtifactPath(refs.local_path),
         workspace_path: run.workspace_path,
         branch: run.branch,
-        summary: result.summary ?? '',
-        testing_instructions: result.testing_instructions ?? '',
-        review_summary: result.review_summary,
-        testing_steps: result.testing_steps,
+        summary: reviewedResult.summary ?? '',
+        testing_instructions: reviewedResult.testing_instructions ?? '',
+        review_summary: reviewedResult.review_summary,
+        testing_steps: reviewedResult.testing_steps,
+        review_exchanges: run.review_exchanges,
       });
       run.impl_feedback_ref = publishedReview.id;
       this.deps.persist();

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -108,6 +108,7 @@ export interface ImplementationReviewExchange {
 
 export interface AgentRoutingPolicy {
   resolve(route: AgentRoute): AgentProfile;
+  resolveOptional(route: AgentRoute): AgentProfile | null;
 }
 
 export interface DirectModelMessage {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -8,6 +8,8 @@ export type AgentTaskKind =
   | 'artifact.create'
   | 'artifact.revise'
   | 'implementation.run'
+  | 'implementation.review.initial'
+  | 'implementation.review.final'
   | 'question.answer'
   | 'issue.triage'
   | 'pr.title_generate';
@@ -45,6 +47,63 @@ export interface AgentProfile {
   load_user_settings?: boolean;
   required_skills?: AgentSkillRef[];
   plugins?: AgentPluginConfig[];
+}
+
+export interface AgentProfileSummary {
+  profile: string;
+  provider: string;
+  model?: string;
+}
+
+export type ImplementationReviewFindingSeverity = 'blocker' | 'warning' | 'info';
+export type ImplementationReviewFindingCategory =
+  | 'correctness'
+  | 'test'
+  | 'security'
+  | 'maintainability'
+  | 'docs'
+  | 'pr_readiness';
+
+export interface ImplementationReviewFinding {
+  id: string;
+  severity: ImplementationReviewFindingSeverity;
+  category: ImplementationReviewFindingCategory;
+  finding: string;
+  suggested_action?: string;
+}
+
+export interface ImplementationReviewResult {
+  status: 'no_findings' | 'findings' | 'failed';
+  summary: string;
+  findings: ImplementationReviewFinding[];
+  requires_human_retest?: boolean;
+  error?: string;
+}
+
+export interface ImplementationReviewResponseItem {
+  id: string;
+  disposition: 'fixed' | 'declined' | 'needs_input';
+  response: string;
+}
+
+export type ImplementationReviewExchangeStatus =
+  | 'no_findings'
+  | 'addressed'
+  | 'degraded'
+  | 'needs_input'
+  | 'failed';
+
+export interface ImplementationReviewExchange {
+  id: string;
+  phase: 'initial' | 'final';
+  created_at: string;
+  implementation_profile: AgentProfileSummary;
+  review_profile: AgentProfileSummary;
+  review_status: ImplementationReviewExchangeStatus;
+  review_summary: string;
+  findings: ImplementationReviewFinding[];
+  responses: ImplementationReviewResponseItem[];
+  requires_human_retest: boolean;
 }
 
 export interface AgentRoutingPolicy {
@@ -143,6 +202,8 @@ export interface ImplementationResult {
   };
   testing_steps?: string[];
   resolved_feedback_items?: Array<{ id: string; resolution_comment: string }>;
+  review_responses?: ImplementationReviewResponseItem[];
+  requires_human_retest?: boolean;
   question?: string;
   error?: string;
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -54,6 +54,13 @@ export interface ProfileConfig {
 /** Maps AgentTaskKind string keys to ProfileConfig.name values. */
 export type RoutingConfig = Record<string, string>;
 
+export interface ImplementationReviewPolicy {
+  max_initial_rounds?: number;
+  max_final_rounds?: number;
+  on_review_failure?: 'warn' | 'block';
+  retest_on_behavior_change?: boolean;
+}
+
 export interface AiConfig {
   credentials: CredentialConfig[];
   endpoints: EndpointConfig[];
@@ -95,6 +102,7 @@ export interface WorkflowConfig {
   artifact_policies?: Partial<Record<ArtifactKind, Partial<ArtifactLifecyclePolicy>>>;
   /** Required — declares all AI provider configuration. */
   ai: AiConfig;
+  implementation_review?: ImplementationReviewPolicy;
   [key: string]: unknown;
 }
 

--- a/src/types/impl-feedback-page.ts
+++ b/src/types/impl-feedback-page.ts
@@ -1,3 +1,5 @@
+import type { ImplementationReviewExchange } from './ai.js';
+
 export type ImplementationReviewStatus =
   | 'not_started'
   | 'in_progress'
@@ -29,6 +31,7 @@ export interface ImplementationReviewInput {
     confirm: string[];
   };
   testing_steps?: string[];
+  review_exchanges?: ImplementationReviewExchange[];
 }
 
 export interface ImplementationReviewPublisher {
@@ -49,6 +52,7 @@ export interface ImplementationReviewPublisher {
         id: string;
         resolution_comment: string;
       }>;
+      review_exchanges?: ImplementationReviewExchange[];
     },
   ): Promise<void>;
 

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -1,6 +1,7 @@
 // src/types/runs.ts
 import type { ChannelRef, ConversationRef, MessageRef } from './channel.js';
 import type { Artifact } from './artifact.js';
+import type { ImplementationReviewExchange } from './ai.js';
 
 export type RunStage =
   | 'intake'
@@ -48,6 +49,7 @@ export interface Run {
   origin?: MessageRef;
   pr_url: string | undefined;
   last_impl_result: LastImplementationResult | undefined;
+  review_exchanges?: ImplementationReviewExchange[];
   created_at: string;
   updated_at: string;
 }

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -2,8 +2,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NotionImplementationFeedbackPage } from '../../../src/adapters/notion/implementation-feedback-page.js';
 import type { NotionClient } from '../../../src/adapters/notion/notion-client.js';
 import type { ImplementationReviewInput } from '../../../src/types/impl-feedback-page.js';
+import type { ImplementationReviewExchange } from '../../../src/types/ai.js';
 
 const nullDest = { write: () => {} };
+
+function makeReviewExchange(overrides: Partial<ImplementationReviewExchange> = {}): ImplementationReviewExchange {
+  return {
+    id: 'ex-1',
+    phase: 'initial',
+    created_at: '2026-05-13T00:00:00Z',
+    implementation_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+    review_profile: { profile: 'review-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+    review_status: 'no_findings',
+    review_summary: 'All good.',
+    findings: [],
+    responses: [],
+    requires_human_retest: false,
+    ...overrides,
+  };
+}
 
 function makeNotionClient(overrides: Partial<{
   pagesCreate: ReturnType<typeof vi.fn>;
@@ -957,5 +974,104 @@ describe('NotionImplementationFeedbackPage — setPRLink', () => {
     await page.setPRLink!('page-id', 'https://example.test/org/repo/pull/1');
 
     expect(records.find(r => r['event'] === 'notion_testing_guide.pr_link_set')).toBeDefined();
+  });
+});
+
+describe('Human review section naming', () => {
+  it('new testing guides use "Human review" heading instead of "Feedback"', async () => {
+    const client = makeNotionClient();
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    await page.create(makeReviewInput());
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as { children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> } }> };
+    const headings = createCall.children.filter(b => b.type === 'heading_2').map(b => b.heading_2!.rich_text[0].text.content);
+    expect(headings).toContain('Human review');
+    expect(headings).not.toContain('Feedback');
+  });
+
+  it('readFeedback recognizes "Human review" heading', async () => {
+    const client = makeNotionClient({
+      blocksChildrenList: vi.fn().mockResolvedValue({
+        results: [
+          { id: 'h1', type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'Human review' }] } },
+          { id: 'todo-1', type: 'to_do', has_children: false, to_do: { rich_text: [{ plain_text: 'Test this.' }], checked: false } },
+        ],
+      }),
+    });
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    const items = await page.readFeedback('page-id');
+    expect(items).toHaveLength(1);
+    expect(items[0].text).toBe('Test this.');
+  });
+});
+
+describe('AI review section', () => {
+  it('newly created testing guide includes AI review section when review_exchanges provided', async () => {
+    const exchange = makeReviewExchange();
+    const client = makeNotionClient();
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    await page.create(makeReviewInput({ review_exchanges: [exchange] }));
+    const createCall = (client.pages.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as { children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> } }> };
+    const headings = createCall.children.filter(b => b.type === 'heading_2').map(b => b.heading_2!.rich_text[0].text.content);
+    expect(headings).toContain('AI review');
+    // AI review appears after Human review
+    const aiIdx = headings.indexOf('AI review');
+    const humanIdx = headings.indexOf('Human review');
+    expect(aiIdx).toBeGreaterThan(humanIdx);
+  });
+
+  it('update replaces only AI review section, leaving Human review content unchanged', async () => {
+    const existingMarkdown = `## Summary\n\nOld summary.\n\n## Testing instructions\n\n- [ ] Run tests.\n\n## Additional steps\n\n- [ ] Check.\n\n## Human review\n\n- [ ] Some feedback.\n\n## AI review\n\n### Initial review\n\nOld review content.`;
+    const client = makeNotionClient({
+      pagesGetMarkdown: vi.fn().mockResolvedValue(existingMarkdown),
+    });
+    const exchange = makeReviewExchange({
+      review_status: 'addressed',
+      review_summary: 'Found 1 issue.',
+      findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test file.' }],
+    });
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    await page.update('page-id', { review_exchanges: [exchange] });
+    const updateCall = (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const newMarkdown = updateCall[1].replace_content.new_str as string;
+    expect(newMarkdown).toContain('## Human review');
+    expect(newMarkdown).toContain('Some feedback.');
+    expect(newMarkdown).toContain('INIT-1');
+    expect(newMarkdown).toContain('Added test file.');
+  });
+
+  it('renders no-findings exchange as "No blocking or informational findings."', async () => {
+    const exchange = makeReviewExchange({ review_status: 'no_findings' });
+    const client = makeNotionClient({ pagesGetMarkdown: vi.fn().mockResolvedValue('## Human review\n\n') });
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    await page.update('page-id', { review_exchanges: [exchange] });
+    const newMarkdown = (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mock.calls[0][1].replace_content.new_str as string;
+    expect(newMarkdown).toContain('No blocking or informational findings.');
+  });
+
+  it('redacts API key values (sk-...) before rendering', async () => {
+    const exchange = makeReviewExchange({
+      review_status: 'addressed',
+      review_summary: 'sk-abcdef1234567890 was found.',
+      findings: [{ id: 'INIT-1', severity: 'warning', category: 'security', finding: 'Log includes sk-abcdef1234567890.' }],
+      responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Removed sk-abcdef1234567890 from log.' }],
+    });
+    const client = makeNotionClient({ pagesGetMarkdown: vi.fn().mockResolvedValue('## Human review\n\n') });
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    await page.update('page-id', { review_exchanges: [exchange] });
+    const newMarkdown = (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mock.calls[0][1].replace_content.new_str as string;
+    expect(newMarkdown).not.toContain('sk-abcdef1234567890');
+    expect(newMarkdown).toContain('[REDACTED]');
+  });
+
+  it('appends AI review at end of page when AI review section is absent', async () => {
+    const existingMarkdown = `## Summary\n\nOld summary.\n\n## Human review\n\n- [ ] feedback.\n`;
+    const client = makeNotionClient({ pagesGetMarkdown: vi.fn().mockResolvedValue(existingMarkdown) });
+    const exchange = makeReviewExchange({ phase: 'final' });
+    const page = new NotionImplementationFeedbackPage(client, 'db-id', { logDestination: nullDest });
+    await page.update('page-id', { review_exchanges: [exchange] });
+    const newMarkdown = (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mock.calls[0][1].replace_content.new_str as string;
+    expect(newMarkdown).toContain('## AI review');
+    expect(newMarkdown.indexOf('## AI review')).toBeGreaterThan(newMarkdown.indexOf('## Summary'));
   });
 });

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -1,16 +1,20 @@
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it, test, vi } from 'vitest';
 import {
   AgentRunnerArtifactAuthoringAgent,
   AgentRunnerImplementationAgent,
   AgentRunnerIssueTriageAgent,
   AgentRunnerQuestionAnsweringAgent,
   IssueFilingService,
+  buildInitialReviewPrompt,
+  buildFinalReviewPrompt,
+  buildImplementerResponsePrompt,
+  parseImplementationReviewResult,
 } from '../../../src/core/ai/agent-services.js';
 import { DefaultAgentRoutingPolicy } from '../../../src/core/ai/routing-policy.js';
-import type { AgentRunEvent, AgentRunRequest, AgentRunner } from '../../../src/types/ai.js';
+import type { AgentRunEvent, AgentRunRequest, AgentRunner, ImplementationResult } from '../../../src/types/ai.js';
 import type { Request, ThreadMessage } from '../../../src/types/events.js';
 import type { IssueManager } from '../../../src/types/issue-tracker.js';
 import type { ArtifactCommentAnchorCodec } from '../../../src/types/publisher.js';
@@ -607,5 +611,118 @@ describe('AgentRunner-backed core AI services', () => {
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }
+  });
+});
+
+function makeCompleteResult(overrides: Partial<ImplementationResult> = {}): ImplementationResult {
+  return {
+    status: 'complete',
+    summary: 'Added X feature.',
+    testing_instructions: 'npm test',
+    review_summary: {
+      changes: ['Added X', 'Wired Y'],
+      confirm: ['X works', 'Y loads'],
+    },
+    testing_steps: ['cd /ws', 'npm test'],
+    ...overrides,
+  };
+}
+
+describe('buildInitialReviewPrompt', () => {
+  it('includes artifact path', () => {
+    const prompt = buildInitialReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), 'diff-content', ['src/foo.ts']);
+    expect(prompt).toContain('/ws/spec.md');
+  });
+
+  it('includes implementation summary from result fields', () => {
+    const prompt = buildInitialReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), 'diff-content', ['src/foo.ts']);
+    expect(prompt).toContain('Added X feature.');
+  });
+
+  it('includes changed file list', () => {
+    const prompt = buildInitialReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), 'diff-content', ['src/foo.ts', 'src/bar.ts']);
+    expect(prompt).toContain('src/foo.ts');
+    expect(prompt).toContain('src/bar.ts');
+  });
+
+  it('includes diff context', () => {
+    const prompt = buildInitialReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), 'my-special-diff', ['src/foo.ts']);
+    expect(prompt).toContain('my-special-diff');
+  });
+
+  it('instructs to write result to the review result path', () => {
+    const prompt = buildInitialReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), '', []);
+    expect(prompt).toContain('impl-review-result.json');
+  });
+});
+
+describe('buildFinalReviewPrompt', () => {
+  it('emphasizes security and pr_readiness categories', () => {
+    const prompt = buildFinalReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), 'diff', []);
+    expect(prompt).toContain('security');
+    expect(prompt).toContain('pr_readiness');
+  });
+
+  it('includes implementation summary', () => {
+    const prompt = buildFinalReviewPrompt('/ws/spec.md', '/ws', makeCompleteResult(), 'diff', []);
+    expect(prompt).toContain('Added X feature.');
+  });
+});
+
+describe('buildImplementerResponsePrompt', () => {
+  it('lists every finding ID from the review result', () => {
+    const findings = [
+      { id: 'INIT-1', severity: 'blocker' as const, category: 'test' as const, finding: 'Missing test.' },
+      { id: 'INIT-2', severity: 'warning' as const, category: 'security' as const, finding: 'Log may include creds.' },
+    ];
+    const prompt = buildImplementerResponsePrompt('/ws/spec.md', '/ws', makeCompleteResult(), findings);
+    expect(prompt).toContain('[REVIEW_ID: INIT-1]');
+    expect(prompt).toContain('[REVIEW_ID: INIT-2]');
+  });
+
+  it('requires one response per finding ID', () => {
+    const findings = [{ id: 'INIT-1', severity: 'blocker' as const, category: 'correctness' as const, finding: 'Bug.' }];
+    const prompt = buildImplementerResponsePrompt('/ws/spec.md', '/ws', makeCompleteResult(), findings);
+    expect(prompt).toContain('review_responses');
+  });
+});
+
+describe('parseImplementationReviewResult', () => {
+  it('parses a no_findings result', () => {
+    const content = JSON.stringify({ status: 'no_findings', summary: 'All good.', findings: [] });
+    const result = parseImplementationReviewResult(content, '/path/result.json');
+    expect(result.status).toBe('no_findings');
+    expect(result.findings).toHaveLength(0);
+    expect(result.requires_human_retest).toBe(false);
+  });
+
+  it('parses a findings result with all severity and category values', () => {
+    const content = JSON.stringify({
+      status: 'findings',
+      summary: 'Found issues.',
+      findings: [
+        { id: 'INIT-1', severity: 'blocker', category: 'correctness', finding: 'Missing null check.' },
+        { id: 'INIT-2', severity: 'warning', category: 'test', finding: 'No coverage.' },
+        { id: 'INIT-3', severity: 'info', category: 'security', finding: 'Log includes name.' },
+        { id: 'INIT-4', severity: 'info', category: 'maintainability', finding: 'Long function.' },
+        { id: 'INIT-5', severity: 'info', category: 'docs', finding: 'Missing doc.' },
+        { id: 'INIT-6', severity: 'info', category: 'pr_readiness', finding: 'PR size.' },
+      ],
+    });
+    const result = parseImplementationReviewResult(content, '/path/result.json');
+    expect(result.status).toBe('findings');
+    expect(result.findings).toHaveLength(6);
+  });
+
+  it('returns status: failed when content is not valid JSON', () => {
+    const result = parseImplementationReviewResult('not-json', '/path/result.json');
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeDefined();
+  });
+
+  it('propagates requires_human_retest: true when set', () => {
+    const content = JSON.stringify({ status: 'findings', summary: 's', findings: [], requires_human_retest: true });
+    const result = parseImplementationReviewResult(content, '/path/result.json');
+    expect(result.requires_human_retest).toBe(true);
   });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
+import type { AgentRunner, AgentRoutingPolicy, ImplementationAgent, ImplementationResult, ImplementationReviewResult, AgentProfile } from '../../../src/types/ai.js';
+import type { Run } from '../../../src/types/runs.js';
+
+const WORKING_DIR = '/ws/test';
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-001',
+    request_id: 'req-001',
+    intent: 'idea',
+    stage: 'implementing',
+    workspace_path: WORKING_DIR,
+    branch: 'spec/req-001',
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 1,
+    pr_url: undefined,
+    last_impl_result: undefined,
+    review_exchanges: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeCompleteResult(overrides: Partial<ImplementationResult> = {}): ImplementationResult {
+  return { status: 'complete', summary: 'Done.', testing_steps: ['npm test'], review_summary: { changes: ['A'], confirm: ['B'] }, ...overrides };
+}
+
+function makeAgentProfile(name = 'review-agent'): AgentProfile {
+  return { id: name, provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' };
+}
+
+function makeRoutingPolicy(initialProfile: AgentProfile | null = makeAgentProfile(), finalProfile: AgentProfile | null = null): AgentRoutingPolicy {
+  return {
+    resolve: vi.fn().mockImplementation((route: { task: string }) => {
+      if (route.task === 'implementation.run') return makeAgentProfile('impl-agent');
+      throw new Error(`No route for ${route.task}`);
+    }),
+    resolveOptional: vi.fn().mockImplementation((route: { task: string }) => {
+      if (route.task === 'implementation.review.initial') return initialProfile;
+      if (route.task === 'implementation.review.final') return finalProfile;
+      if (route.task === 'implementation.run') return makeAgentProfile('impl-agent');
+      return null;
+    }),
+  };
+}
+
+function makeRunner(): AgentRunner {
+  return {
+    run: vi.fn().mockReturnValue((async function* () {})()),
+  };
+}
+
+function makeImplementer(result: ImplementationResult = makeCompleteResult()): Pick<ImplementationAgent, 'implement'> {
+  return { implement: vi.fn().mockResolvedValue(result) };
+}
+
+function makeDeps(reviewResult: ImplementationReviewResult = { status: 'no_findings', summary: 'Looks good.', findings: [] }, overrides: Record<string, unknown> = {}) {
+  const reviewJson = JSON.stringify(reviewResult);
+  return {
+    runner: makeRunner(),
+    implementer: makeImplementer(),
+    routingPolicy: makeRoutingPolicy(),
+    policy: { max_initial_rounds: 1, max_final_rounds: 1, on_review_failure: 'warn' as const, retest_on_behavior_change: true },
+    branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    readFile: vi.fn().mockResolvedValue(reviewJson),
+    ...overrides,
+  };
+}
+
+describe('ImplementationReviewCoordinator', () => {
+  describe('runInitialReview — no findings', () => {
+    it('appends a no_findings exchange to run.review_exchanges', async () => {
+      const deps = makeDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(run.review_exchanges).toHaveLength(1);
+      expect(run.review_exchanges![0].review_status).toBe('no_findings');
+      expect(run.review_exchanges![0].phase).toBe('initial');
+    });
+
+    it('returns the original implementation result unchanged', async () => {
+      const deps = makeDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const original = makeCompleteResult();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: original, working_directory: WORKING_DIR });
+      expect(result).toBe(original);
+    });
+
+    it('does not call the implementation model a second time', async () => {
+      const deps = makeDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(deps.implementer.implement).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke branch guard (no implementer commits)', async () => {
+      const deps = makeDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(deps.branchGuard.check).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runInitialReview — missing route', () => {
+    it('logs implementation.review.skipped at warn level', async () => {
+      const deps = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] } as ImplementationReviewResult, { routingPolicy: makeRoutingPolicy(null, null) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'implementation.review.skipped' }),
+        expect.any(String),
+      );
+    });
+
+    it('returns the original result without calling any AI model', async () => {
+      const deps = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] } as ImplementationReviewResult, { routingPolicy: makeRoutingPolicy(null, null) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const original = makeCompleteResult();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: original, working_directory: WORKING_DIR });
+      expect(result).toBe(original);
+      expect(deps.runner.run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runInitialReview — findings path (all fixed)', () => {
+    it('calls the implementation model with structured finding context', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found 1 issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const implResult = makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] });
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(implResult) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(deps.implementer.implement).toHaveBeenCalledWith(
+        '/ws/spec.md',
+        WORKING_DIR,
+        expect.stringContaining('[REVIEW_ID: INIT-1]'),
+        expect.any(Function),
+      );
+    });
+
+    it('appends an addressed exchange with findings and responses', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found 1 issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const implResult = makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] });
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(implResult) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(run.review_exchanges).toHaveLength(1);
+      expect(run.review_exchanges![0].review_status).toBe('addressed');
+      expect(run.review_exchanges![0].responses).toHaveLength(1);
+    });
+
+    it('returns the implementer response result as canonical implementation result', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found 1 issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const implResult = makeCompleteResult({ summary: 'Updated after review.', review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] });
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(implResult) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(result.summary).toBe('Updated after review.');
+    });
+
+    it('invokes branch guard after implementer response', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found 1 issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const implResult = makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Fixed.' }] });
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(implResult) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(deps.branchGuard.check).toHaveBeenCalledWith(WORKING_DIR, run.branch);
+    });
+  });
+
+  describe('runInitialReview — review model failure', () => {
+    it('warn policy: appends degraded exchange, logs failure, returns original result', async () => {
+      const failedReview: ImplementationReviewResult = { status: 'failed', summary: '', findings: [], error: 'model crashed' };
+      const deps = makeDeps(failedReview);
+      deps.policy = { ...deps.policy, on_review_failure: 'warn' };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const original = makeCompleteResult();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: original, working_directory: WORKING_DIR });
+      expect(result).toBe(original);
+      expect(run.review_exchanges![0].review_status).toBe('degraded');
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'implementation.review.failed' }),
+        expect.any(String),
+      );
+    });
+
+    it('block policy: returns failed result, does not call implementer', async () => {
+      const failedReview: ImplementationReviewResult = { status: 'failed', summary: '', findings: [], error: 'model crashed' };
+      const deps = makeDeps(failedReview);
+      deps.policy = { ...deps.policy, on_review_failure: 'block' };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(result.status).toBe('failed');
+      expect(deps.implementer.implement).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runInitialReview — implementer response failure', () => {
+    it('propagates needs_input status from implementer response', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer({ status: 'needs_input', question: 'Which approach?' }) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(result.status).toBe('needs_input');
+    });
+  });
+
+  describe('runInitialReview — missing response IDs', () => {
+    it('logs implementation.review.response_invalid for each missing finding ID', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      // Implementer returns review_responses with wrong ID
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(makeCompleteResult({ review_responses: [{ id: 'WRONG-ID', disposition: 'fixed', response: 'Fixed.' }] })) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'implementation.review.response_invalid' }),
+        expect.any(String),
+      );
+    });
+
+    it('run continues without stopping when responses are incomplete', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(makeCompleteResult({ review_responses: [] })) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(result.status).toBe('complete');
+    });
+  });
+
+  describe('runFinalReview — final route fallback', () => {
+    it('uses implementation.review.initial when final route is absent', async () => {
+      const deps = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] } as ImplementationReviewResult, { routingPolicy: makeRoutingPolicy(makeAgentProfile('review-agent'), null) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runFinalReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+      expect(run.review_exchanges![0].phase).toBe('final');
+      const calls = (deps.routingPolicy.resolveOptional as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls.some((c: unknown[]) => (c[0] as { task: string }).task === 'implementation.review.final')).toBe(true);
+    });
+  });
+});

--- a/tests/core/ai/routing-policy.test.ts
+++ b/tests/core/ai/routing-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { DefaultAgentRoutingPolicy } from '../../../src/core/ai/routing-policy.js';
+import { DefaultAgentRoutingPolicy, agentProfileSummary } from '../../../src/core/ai/routing-policy.js';
 import type { AiConfig } from '../../../src/types/config.js';
 
 function makeAiConfig(overrides?: Partial<AiConfig>): AiConfig {
@@ -110,5 +110,60 @@ describe('DefaultAgentRoutingPolicy', () => {
     expect(policy.resolve({ task: 'question.answer' })).toMatchObject({
       required_skills: [],
     });
+  });
+
+  test('resolveOptional returns null when route task is not in routing config', () => {
+    const config = makeAiConfig();
+    delete config.routing['question.answer'];
+    const policy = new DefaultAgentRoutingPolicy(config);
+    expect(policy.resolveOptional({ task: 'question.answer' })).toBeNull();
+  });
+
+  test('resolveOptional returns profile when route is configured', () => {
+    const policy = new DefaultAgentRoutingPolicy(makeAiConfig());
+    const profile = policy.resolveOptional({ task: 'implementation.run' });
+    expect(profile).toMatchObject({ id: 'agent-default', provider: 'claude_agent_sdk' });
+  });
+
+  test('resolveOptional returns null for implementation.review.initial when not configured', () => {
+    const policy = new DefaultAgentRoutingPolicy(makeAiConfig());
+    expect(policy.resolveOptional({ task: 'implementation.review.initial' })).toBeNull();
+  });
+
+  test('resolveOptional resolves implementation.review.initial when configured', () => {
+    const config = makeAiConfig();
+    config.routing['implementation.review.initial'] = 'agent-default';
+    const policy = new DefaultAgentRoutingPolicy(config);
+    expect(policy.resolveOptional({ task: 'implementation.review.initial' })).toMatchObject({
+      id: 'agent-default',
+      provider: 'claude_agent_sdk',
+    });
+  });
+
+  test('resolveOptional resolves implementation.review.final when configured', () => {
+    const config = makeAiConfig();
+    config.routing['implementation.review.final'] = 'direct-default';
+    const policy = new DefaultAgentRoutingPolicy(config);
+    expect(policy.resolveOptional({ task: 'implementation.review.final' })).toMatchObject({
+      id: 'direct-default',
+      provider: 'anthropic',
+    });
+  });
+});
+
+describe('agentProfileSummary', () => {
+  test('maps AgentProfile to AgentProfileSummary', () => {
+    const profile = { id: 'my-profile', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' };
+    expect(agentProfileSummary(profile)).toEqual({
+      profile: 'my-profile',
+      provider: 'claude_agent_sdk',
+      model: 'claude-sonnet-4-6',
+    });
+  });
+
+  test('omits model when undefined', () => {
+    const profile = { id: 'my-profile', provider: 'anthropic' };
+    const summary = agentProfileSummary(profile);
+    expect(summary.model).toBeUndefined();
   });
 });

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -11,6 +11,7 @@ import {
   loadConfigFromPath,
   loadConfig,
   resolveAiConfig,
+  getImplementationReviewPolicy,
 } from '../../src/core/config.js';
 import type { WorkflowConfig } from '../../src/types/config.js';
 
@@ -263,5 +264,88 @@ describe('loadConfigFromPath', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ─── validateConfig: implementation_review ───────────────────────────────────
+
+describe('validateConfig: implementation_review', () => {
+  it('passes when implementation_review is absent', () => {
+    expect(() => validateConfig({} as WorkflowConfig)).not.toThrow();
+  });
+
+  it('passes for a valid implementation_review block', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { on_review_failure: 'block', max_initial_rounds: 2, max_final_rounds: 3 } } as unknown as WorkflowConfig),
+    ).not.toThrow();
+  });
+
+  it('throws when implementation_review is not an object', () => {
+    expect(() =>
+      validateConfig({ implementation_review: 'bad' } as unknown as WorkflowConfig),
+    ).toThrow('implementation_review must be an object');
+  });
+
+  it('throws when on_review_failure is an invalid value', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { on_review_failure: 'ignore' } } as unknown as WorkflowConfig),
+    ).toThrow('on_review_failure must be "warn" or "block"');
+  });
+
+  it('throws when max_initial_rounds is zero', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { max_initial_rounds: 0 } } as unknown as WorkflowConfig),
+    ).toThrow('max_initial_rounds must be a positive integer');
+  });
+
+  it('throws when max_initial_rounds is a float', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { max_initial_rounds: 1.5 } } as unknown as WorkflowConfig),
+    ).toThrow('max_initial_rounds must be a positive integer');
+  });
+
+  it('throws when max_final_rounds is negative', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { max_final_rounds: -1 } } as unknown as WorkflowConfig),
+    ).toThrow('max_final_rounds must be a positive integer');
+  });
+});
+
+// ─── getImplementationReviewPolicy ───────────────────────────────────────────
+
+describe('getImplementationReviewPolicy', () => {
+  it('returns defaults when implementation_review is absent', () => {
+    const policy = getImplementationReviewPolicy({} as WorkflowConfig);
+    expect(policy).toEqual({
+      max_initial_rounds: 1,
+      max_final_rounds: 1,
+      on_review_failure: 'warn',
+      retest_on_behavior_change: true,
+    });
+  });
+
+  it('uses provided on_review_failure: block', () => {
+    const policy = getImplementationReviewPolicy({ implementation_review: { on_review_failure: 'block' } } as unknown as WorkflowConfig);
+    expect(policy.on_review_failure).toBe('block');
+  });
+
+  it('uses provided max_initial_rounds', () => {
+    const policy = getImplementationReviewPolicy({ implementation_review: { max_initial_rounds: 3 } } as unknown as WorkflowConfig);
+    expect(policy.max_initial_rounds).toBe(3);
+  });
+
+  it('uses provided max_final_rounds', () => {
+    const policy = getImplementationReviewPolicy({ implementation_review: { max_final_rounds: 2 } } as unknown as WorkflowConfig);
+    expect(policy.max_final_rounds).toBe(2);
+  });
+
+  it('returns retest_on_behavior_change: false when explicitly set to false', () => {
+    const policy = getImplementationReviewPolicy({ implementation_review: { retest_on_behavior_change: false } } as unknown as WorkflowConfig);
+    expect(policy.retest_on_behavior_change).toBe(false);
+  });
+
+  it('defaults on_review_failure to warn when not set', () => {
+    const policy = getImplementationReviewPolicy({ implementation_review: { max_initial_rounds: 2 } } as unknown as WorkflowConfig);
+    expect(policy.on_review_failure).toBe('warn');
   });
 });

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -3,6 +3,8 @@ import { ImplementationApprovalHandler } from '../../../src/core/handlers/implem
 import type { ThreadMessage } from '../../../src/types/events.js';
 import type { Run } from '../../../src/types/runs.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
+import type { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
+import type { ImplementationResult } from '../../../src/types/ai.js';
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
@@ -50,6 +52,18 @@ function makeRun(overrides: Partial<Run> = {}): Run {
   };
 }
 
+function makeReviewCoordinator(resultOverrides: Partial<ImplementationResult> = {}): Pick<ImplementationReviewCoordinator, 'runFinalReview'> {
+  const result: ImplementationResult = {
+    status: 'complete',
+    summary: 'Post-final-review.',
+    requires_human_retest: false,
+    testing_steps: ['npm test'],
+    review_summary: { changes: ['A'], confirm: ['B'] },
+    ...resultOverrides,
+  };
+  return { runFinalReview: vi.fn().mockResolvedValue(result) };
+}
+
 function makeHandler(overrides: Partial<ConstructorParameters<typeof ImplementationApprovalHandler>[0]> = {}) {
   const deps = {
     specCommitter: {
@@ -67,6 +81,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
     implFeedbackPage: {
       setPRLink: vi.fn().mockResolvedValue(undefined),
       updateStatus: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
     },
     postMessage: vi.fn().mockResolvedValue(undefined),
     transition: vi.fn((run: Run, stage: Run['stage']) => { run.stage = stage; }),
@@ -74,6 +89,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
     persist: vi.fn(),
     logger: {
       error: vi.fn(),
+      info: vi.fn(),
     },
     now: () => new Date('2026-04-25T00:00:00.000Z'),
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
@@ -376,5 +392,57 @@ describe('ImplementationApprovalHandler', () => {
       '/ws/request-001/context-human/specs/feature-test.md',
       { status: 'complete', last_updated: '2026-04-25' },
     );
+  });
+});
+
+describe('ImplementationApprovalHandler with reviewCoordinator', () => {
+  it('runs final review before PR creation', async () => {
+    const coord = makeReviewCoordinator();
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    await handler.handle(makeRun(), makeFeedback());
+    const reviewCallOrder = (coord.runFinalReview as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    const prCallOrder = (deps.prManager.createPR as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(reviewCallOrder).toBeLessThan(prCallOrder);
+  });
+
+  it('creates PR when final review returns complete with requires_human_retest false', async () => {
+    const { handler, deps } = makeHandler({ reviewCoordinator: makeReviewCoordinator({ requires_human_retest: false }) });
+    const result = await handler.handle(makeRun(), makeFeedback());
+    expect(result).toEqual({ status: 'pr_open' });
+    expect(deps.prManager.createPR).toHaveBeenCalled();
+  });
+
+  it('returns reviewing_implementation and does not create PR when requires_human_retest is true', async () => {
+    const coord = makeReviewCoordinator({ requires_human_retest: true });
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const result = await handler.handle(makeRun(), makeFeedback());
+    expect(result).toEqual({ status: 'reviewing_implementation' });
+    expect(deps.prManager.createPR).not.toHaveBeenCalled();
+    expect(deps.logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'implementation.review.retest_required' }),
+      expect.any(String),
+    );
+  });
+
+  it('transitions to awaiting_impl_input when final review returns needs_input', async () => {
+    const coord = { runFinalReview: vi.fn().mockResolvedValue({ status: 'needs_input', question: 'Which?' }) };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const result = await handler.handle(makeRun(), makeFeedback());
+    expect(result).toEqual({ status: 'needs_input' });
+    expect(deps.prManager.createPR).not.toHaveBeenCalled();
+  });
+
+  it('fails run when final review returns failed', async () => {
+    const coord = { runFinalReview: vi.fn().mockResolvedValue({ status: 'failed', error: 'review crashed' }) };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const result = await handler.handle(makeRun(), makeFeedback());
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalled();
+  });
+
+  it('proceeds to PR creation without coordinator when not configured', async () => {
+    const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
+    const result = await handler.handle(makeRun(), makeFeedback());
+    expect(result).toEqual({ status: 'pr_open' });
   });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -4,6 +4,24 @@ import type { ThreadMessage } from '../../../src/types/events.js';
 import type { FeedbackItem } from '../../../src/types/impl-feedback-page.js';
 import type { Run } from '../../../src/types/runs.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
+import type { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
+import type { ImplementationReviewExchange } from '../../../src/types/ai.js';
+
+function makeReviewExchange(overrides: Partial<ImplementationReviewExchange> = {}): ImplementationReviewExchange {
+  return {
+    id: 'exchange-001',
+    phase: 'initial',
+    created_at: new Date().toISOString(),
+    implementation_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+    review_profile: { profile: 'review-agent', provider: 'claude_agent_sdk' },
+    review_status: 'no_findings',
+    review_summary: 'Looks good.',
+    findings: [],
+    responses: [],
+    requires_human_retest: false,
+    ...overrides,
+  };
+}
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
@@ -425,5 +443,38 @@ describe('ImplementationFeedbackHandler', () => {
       expect.objectContaining({ event: 'implementation.review_contract_legacy', run_id: 'run-001' }),
       expect.any(String),
     );
+  });
+});
+
+describe('ImplementationFeedbackHandler with reviewCoordinator', () => {
+  it('calls coordinator after complete feedback-pass result before updating testing guide', async () => {
+    const exchange = makeReviewExchange({ phase: 'initial' });
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockImplementation(async ({ run }: { run: Run }) => {
+        run.review_exchanges = [...(run.review_exchanges ?? []), exchange];
+        return {
+          status: 'complete',
+          summary: 'Post-review.',
+          testing_steps: ['npm test'],
+          review_summary: { changes: ['A'], confirm: ['B'] },
+        };
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun({ impl_feedback_ref: 'page-id' });
+    await handler.handle(run, makeFeedback());
+    expect(coord.runInitialReview).toHaveBeenCalled();
+    expect(deps.implFeedbackPage?.update).toHaveBeenCalledWith(
+      'page-id',
+      expect.objectContaining({ review_exchanges: [exchange] }),
+    );
+  });
+
+  it('proceeds normally without coordinator when not configured', async () => {
+    const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
+    const run = makeRun({ impl_feedback_ref: 'page-id' });
+    const result = await handler.handle(run, makeFeedback());
+    expect(result).toEqual({ status: 'updated' });
+    expect(deps.implFeedbackPage?.update).toHaveBeenCalled();
   });
 });

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -3,6 +3,24 @@ import { ImplementationStartHandler } from '../../../src/core/handlers/implement
 import type { ThreadMessage } from '../../../src/types/events.js';
 import type { Run } from '../../../src/types/runs.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
+import type { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
+import type { ImplementationReviewExchange } from '../../../src/types/ai.js';
+
+function makeReviewExchange(overrides: Partial<ImplementationReviewExchange> = {}): ImplementationReviewExchange {
+  return {
+    id: 'exchange-001',
+    phase: 'initial',
+    created_at: new Date().toISOString(),
+    implementation_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+    review_profile: { profile: 'review-agent', provider: 'claude_agent_sdk' },
+    review_status: 'no_findings',
+    review_summary: 'Looks good.',
+    findings: [],
+    responses: [],
+    requires_human_retest: false,
+    ...overrides,
+  };
+}
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
@@ -319,5 +337,63 @@ describe('ImplementationStartHandler', () => {
       expect.objectContaining({ event: 'run.notify_failed', run_id: 'run-001' }),
       'Failed to post completion notification',
     );
+  });
+});
+
+describe('ImplementationStartHandler with reviewCoordinator', () => {
+  it('calls coordinator after complete implementation before creating testing guide', async () => {
+    const exchange = makeReviewExchange();
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockImplementation(async ({ run }: { run: Run }) => {
+        run.review_exchanges = [...(run.review_exchanges ?? []), exchange];
+        return {
+          status: 'complete',
+          summary: 'Implemented the feature successfully.',
+          testing_instructions: 'npm test',
+          review_summary: { changes: ['Added feature X', 'Wired config loader'], confirm: ['Feature X works', 'Config loads correctly'] },
+          testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
+        };
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+    await handler.handle(run, makeFeedback());
+    expect(coord.runInitialReview).toHaveBeenCalledWith(expect.objectContaining({
+      run,
+      artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+    }));
+    expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith(
+      expect.objectContaining({ review_exchanges: [exchange] }),
+    );
+  });
+
+  it('transitions to awaiting_impl_input when coordinator returns needs_input', async () => {
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'needs_input', question: 'Which approach?' }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+    const result = await handler.handle(run, makeFeedback());
+    expect(result).toEqual({ status: 'needs_input' });
+    expect(deps.implFeedbackPage?.create).not.toHaveBeenCalled();
+  });
+
+  it('fails run when coordinator returns failed', async () => {
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'failed', error: 'review crashed' }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+    const result = await handler.handle(run, makeFeedback());
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalled();
+  });
+
+  it('proceeds normally without coordinator when not configured', async () => {
+    const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
+    const run = makeRun();
+    const result = await handler.handle(run, makeFeedback());
+    expect(result).toEqual({ status: 'reviewing_implementation' });
+    expect(deps.implFeedbackPage?.create).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #147

## Summary

Implemented two-part adversarial implementation review. Added `ImplementationReviewCoordinator` that runs an initial review after implementation completes and a final review after human approval. Review findings are relayed back to the implementer model, and all exchanges are documented in the Notion testing guide's new "AI review" section. Wired coordinator into `ImplementationStartHandler`, `ImplementationFeedbackHandler`, and `ImplementationApprovalHandler`. Extended routing policy with `resolveOptional()` for graceful degradation when review routes are not configured. Added config validation and defaults for `implementation_review` policy block. Added 1031 passing tests.

## Test plan

- [x] `npx vitest run` — 1031 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] End-to-end: configure `implementation.review.initial` and `implementation.review.final` routes, trigger an implementation run, observe AI review section in testing guide