### PR TITLE
fix: suppress OpenAI Agents SDK tracing exporter log noise

### DIFF
--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -1,4 +1,4 @@
-import { run as _run, OpenAIResponsesModel, type Agent } from '@openai/agents';
+import { run as _run, OpenAIResponsesModel, setTracingDisabled, type Agent } from '@openai/agents';
 import { SandboxAgent, type Capability, filesystem, shell, compaction } from '@openai/agents/sandbox';
 import { UnixLocalSandboxClient, type UnixLocalSandboxSessionState } from '@openai/agents/sandbox/local';
 import { Manifest } from '@openai/agents/sandbox';
@@ -63,6 +63,7 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
     private readonly defaultModel: string | undefined,
     options?: OpenAIAgentSdkAgentRunnerOptions,
   ) {
+    setTracingDisabled(true);
     this.runFn = options?.runFn ?? defaultRunFn;
     this.materializeSkillsFn = options?.materializeSkills ?? materializeOpenAIRuntimeSkills;
     this.logger = createLogger('openai-agent-sdk', {

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -1,6 +1,6 @@
 import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { run as sdkRun } from '@openai/agents';
+import { run as sdkRun, setTracingDisabled } from '@openai/agents';
 import { skillRefsForRoute, OpenAIAgentSdkAgentRunner } from '../../../src/adapters/openai/agent-sdk-agent-runner.js';
 import type { AgentRunEvent } from '../../../src/types/ai.js';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';
@@ -12,6 +12,7 @@ vi.mock('@openai/agents', async importOriginal => {
   return {
     ...actual,
     run: vi.fn(),
+    setTracingDisabled: vi.fn(),
   };
 });
 
@@ -148,6 +149,7 @@ function makeRunFnYieldingText(text: string) {
 describe('OpenAIAgentSdkAgentRunner', () => {
   beforeEach(() => {
     vi.mocked(sdkRun).mockReset();
+    vi.mocked(setTracingDisabled).mockReset();
   });
 
   test('run() calls materializeSkills with skill refs matching the route', async () => {
@@ -543,5 +545,14 @@ describe('OpenAIAgentSdkAgentRunner', () => {
 
     expect(runFn).toHaveBeenCalled();
     expect(capturedAgent).toBeDefined();
+  });
+
+  test('constructor calls setTracingDisabled(true) to suppress SDK tracing log noise', () => {
+    new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      logDestination: nullDest,
+    });
+
+    expect(vi.mocked(setTracingDisabled)).toHaveBeenCalledOnce();
+    expect(vi.mocked(setTracingDisabled)).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add `setTracingDisabled(true)` to `OpenAIAgentSdkAgentRunner` constructor
- Suppresses noisy tracing exporter errors in Grove/Azure APIM deployments where `OPENAI_API_KEY` is not set in the expected format

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Start autocatalyst with Grove OpenAI endpoint, verify no tracing exporter warnings in logs