### PR TITLE
fix: wire ImplementationReviewCoordinator into handler registry

### DIFF
--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -7,7 +7,7 @@ import { App } from '@slack/bolt';
 import Anthropic from '@anthropic-ai/sdk';
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { loadConfigFromPath, repoNameFromUrl, resolveEnvVars, resolveAiConfig, type ResolvedAiConfig } from '../core/config.js';
+import { loadConfigFromPath, repoNameFromUrl, resolveEnvVars, resolveAiConfig, getImplementationReviewPolicy, type ResolvedAiConfig } from '../core/config.js';
 import { bootstrapWorkflowRuntime } from '../core/bootstrap.js';
 import { normalizeWorkflowConfig } from '../core/config-normalizer.js';
 import { configExists, runInit } from '../core/init.js';
@@ -46,6 +46,7 @@ import { OpenAIDirectModelRunner } from './openai/direct-model-runner.js';
 import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner, AgentRunner, AgentRunRequest, AgentRunEvent } from '../types/ai.js';
 import { ClaudeAgentSdkAgentRunner } from './anthropic/claude-agent-sdk-agent-runner.js';
 import { OpenAIAgentSdkAgentRunner } from './openai/agent-sdk-agent-runner.js';
+import { ImplementationReviewCoordinator } from '../core/ai/implementation-review-coordinator.js';
 
 export type RuntimeLogger = Pick<pino.Logger, 'debug' | 'error' | 'info' | 'warn'>;
 
@@ -166,6 +167,14 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     commentAnchorCodec: artifactDeps.commentAnchorCodec,
   });
 
+  const reviewCoordinator = new ImplementationReviewCoordinator({
+    runner: agentRunner,
+    implementer,
+    routingPolicy: aiRoutingPolicy,
+    policy: getImplementationReviewPolicy(currentConfig.config),
+    logger,
+  });
+
   return bootstrapWorkflowRuntime(currentConfig, {
     adapter,
     workspaceManager,
@@ -186,6 +195,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     runStore,
     channelRepoMap,
     reacjiComplete,
+    reviewCoordinator,
     isConnected: () => adapter.isConnected(),
     meter: options.meter,
   });

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -16,6 +16,7 @@ import type { WorkspaceManager } from './workspace-manager.js';
 import type { SpecCommitter } from './spec-committer.js';
 import { HandlerRegistryImpl, type HandlerRegistry } from './handler-registry.js';
 import { GitBranchGuard, type BranchGuard } from './git-branch-guard.js';
+import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
 import { ArtifactCreationHandler } from './handlers/artifact-creation-handler.js';
 import { ArtifactApprovalHandler, type ArtifactApprovalResult } from './handlers/artifact-approval-handler.js';
 import { ArtifactFeedbackHandler } from './handlers/artifact-feedback-handler.js';
@@ -53,6 +54,7 @@ export interface DefaultHandlerRegistryDeps {
   reactToRunMessage: (run: Run, reaction: string) => Promise<void>;
   logger: Pick<pino.Logger, 'debug' | 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
+  reviewCoordinator?: ImplementationReviewCoordinator;
 }
 
 export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): HandlerRegistry {
@@ -188,6 +190,7 @@ async function runImplementation(
     persist: deps.persist,
     logger: deps.logger,
     branchGuard,
+    reviewCoordinator: deps.reviewCoordinator,
   });
   await handler.handle(run, feedback, additionalContext);
 }
@@ -208,6 +211,7 @@ async function handleImplementationFeedback(
     persist: deps.persist,
     logger: deps.logger,
     branchGuard,
+    reviewCoordinator: deps.reviewCoordinator,
   });
   await handler.handle(run, feedback, routingStage);
 }
@@ -230,6 +234,7 @@ async function handleImplementationApproval(
     persist: deps.persist,
     logger: deps.logger,
     branchGuard,
+    reviewCoordinator: deps.reviewCoordinator,
   });
   await handler.handle(run, feedback);
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -27,6 +27,7 @@ import type { ChannelRepoMap } from '../types/config.js';
 import type { HandlerRegistry } from './handler-registry.js';
 import { buildDefaultHandlerRegistry as buildDefaultHandlers } from './default-handler-registry.js';
 import type { BranchGuard } from './git-branch-guard.js';
+import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
@@ -77,6 +78,7 @@ export interface OrchestratorDeps {
   reacjiComplete?: string | null;
   handlerRegistry?: HandlerRegistry;
   branchGuard?: BranchGuard;
+  reviewCoordinator?: ImplementationReviewCoordinator;
 }
 
 interface OrchestratorOptions {
@@ -558,6 +560,7 @@ export class OrchestratorImpl implements Orchestrator {
       reactToRunMessage: (targetRun, reaction) => this.reactToRunMessage(targetRun, reaction),
       logger: this.logger,
       branchGuard: this.deps.branchGuard,
+      reviewCoordinator: this.deps.reviewCoordinator,
     });
   }
 


### PR DESCRIPTION
Closes #150

## Summary
- Instantiate `ImplementationReviewCoordinator` in `runtime-composition.ts`
- Pass it through orchestrator deps to `default-handler-registry.ts`
- Wire it into `ImplementationStartHandler`, `ImplementationFeedbackHandler`, and `ImplementationApprovalHandler`

Without this, the review coordinator was never constructed or passed to handlers, so the `if (this.deps.reviewCoordinator)` guard was always false and reviews were silently skipped.

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1072 tests pass
- [ ] Configure `implementation.review.initial` route, trigger implementation, observe AI review in testing guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)