### PR TITLE
fix: use --repo flag in getIssue to avoid git cwd dependency

### DIFF
--- a/src/adapters/github/issue-manager.ts
+++ b/src/adapters/github/issue-manager.ts
@@ -1,38 +1,29 @@
 // src/adapters/github/issue-manager.ts
 import { promisify } from 'node:util';
 import { execFile as _execFile } from 'node:child_process';
-import { accessSync, constants } from 'node:fs';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 import type { IssueManager, TrackedIssue } from '../../types/issue-tracker.js';
 
 const _promisifiedExecFile = promisify(_execFile);
 
-// Resolve the absolute path to the `gh` binary at module load time.
-// This avoids relying on PATH resolution in execFile, which can fail in
-// non-interactive environments (e.g. LaunchAgent, systemd) where PATH is minimal.
-const _ghCandidates = ['/opt/homebrew/bin/gh', '/opt/homebrew/sbin/gh', '/usr/local/bin/gh', '/usr/bin/gh'];
-function _resolveGhBinary(): string {
-  for (const candidate of _ghCandidates) {
-    try {
-      accessSync(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      // not found or not executable at this path
-    }
-  }
-  return 'gh'; // fallback: rely on PATH
-}
-const GH_BINARY = _resolveGhBinary();
+const _extraPaths = process.platform === 'win32'
+  ? []
+  : ['/opt/homebrew/bin', '/opt/homebrew/sbin', '/usr/local/bin'];
 
 async function defaultExecFile(
   cmd: string,
   args: string[],
   opts?: { cwd?: string },
 ): Promise<{ stdout: string; stderr: string }> {
-  // Resolve gh to its absolute path to avoid PATH lookup failures in headless environments.
-  const resolvedCmd = cmd === 'gh' ? GH_BINARY : cmd;
-  return _promisifiedExecFile(resolvedCmd, args, { ...opts });
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const currentPath = process.env.PATH ?? '';
+  const currentParts = new Set(currentPath.split(sep));
+  const newParts = _extraPaths.filter(p => !currentParts.has(p));
+  const augmentedPath = newParts.length > 0
+    ? [...newParts, currentPath].filter(Boolean).join(sep)
+    : currentPath;
+  return _promisifiedExecFile(cmd, args, { ...opts, env: { ...process.env, PATH: augmentedPath } });
 }
 
 type ExecFn = (cmd: string, args: string[], opts?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }>;
@@ -51,13 +42,13 @@ export class GHIssueManager implements IssueManager {
     this.logger = createLogger('issue-manager', { destination: options?.logDestination });
   }
 
-  async getIssue(workspace_path: string, issue_number: number): Promise<TrackedIssue> {
+  async getIssue(repo_url: string, issue_number: number): Promise<TrackedIssue> {
     let stdout: string;
     try {
       ({ stdout } = await this.execFn(
         'gh',
-        ['issue', 'view', String(issue_number), '--json', 'number,title,body,labels,state,url'],
-        { cwd: workspace_path },
+        ['issue', 'view', String(issue_number), '--repo', repo_url, '--json', 'number,title,body,labels,state,url'],
+        {},
       ));
     } catch (err) {
       this.logger.error(

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -365,8 +365,8 @@ export class OrchestratorImpl implements Orchestrator {
         let issue;
         try {
           const channelEntry = this.deps.channelRepoMap.get(requestChannelKey);
-          const workspacePath = channelEntry?.workspace_root ?? '/';
-          issue = await this.deps.issueManager.getIssue(workspacePath, ref.number);
+          const repoUrl = channelEntry?.repo_url ?? '';
+          issue = await this.deps.issueManager.getIssue(repoUrl, ref.number);
         } catch (err) {
           this.logger.error(
             { event: 'issue_reference.load_failed', request_id: request.id, issue_number: ref.number, error: String(err) },

--- a/src/types/issue-tracker.ts
+++ b/src/types/issue-tracker.ts
@@ -10,7 +10,7 @@ export interface TrackedIssue {
 }
 
 export interface IssueManager {
-  getIssue(workspace_path: string, issue_number: number): Promise<TrackedIssue>;
+  getIssue(repo_url: string, issue_number: number): Promise<TrackedIssue>;
   writeIssue(workspace_path: string, issue_number: number, body: string): Promise<void>;
   create(workspace_path: string, title: string, body: string, labels?: string[]): Promise<{ number: number }>;
 }

--- a/tests/adapters/github/issue-manager.test.ts
+++ b/tests/adapters/github/issue-manager.test.ts
@@ -44,7 +44,7 @@ describe('GHIssueManager.getIssue', () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: ghResponse, stderr: '' });
     const manager = new GHIssueManager({ execFn, logDestination: nullDest });
 
-    const issue = await manager.getIssue('/repo', 42);
+    const issue = await manager.getIssue('https://github.com/org/repo.git', 42);
 
     expect(issue).toEqual({
       number: 42,
@@ -56,8 +56,8 @@ describe('GHIssueManager.getIssue', () => {
     });
     expect(execFn).toHaveBeenCalledWith(
       'gh',
-      ['issue', 'view', '42', '--json', 'number,title,body,labels,state,url'],
-      { cwd: '/repo' },
+      ['issue', 'view', '42', '--repo', 'https://github.com/org/repo.git', '--json', 'number,title,body,labels,state,url'],
+      {},
     );
   });
 


### PR DESCRIPTION
Closes #129

## Summary
- `getIssue` now takes `repo_url` and passes `--repo` to `gh issue view` — no git cwd needed
- Replaces macOS-only absolute binary resolution with OS-agnostic PATH augmentation
- Orchestrator passes `channelEntry.repo_url` instead of `workspace_root`

## Root cause
`getIssue` is called during intake before workspace creation. The `cwd` was `workspace_root` (a parent directory, not a git repo), causing `gh` to fail with "not a git repository".

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1072 tests pass
- [ ] Trigger "work on issue 127" in Slack, observe successful issue load

🤖 Generated with [Claude Code](https://claude.com/claude-code)