### PR TITLE
fix: forward GH token to sandbox and add validation

### DIFF
--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -1,5 +1,8 @@
 workspace:
   root: ~/.autocatalyst/workspaces/autocatalyst
+sandbox:
+  env_tokens:
+    - AC_GITHUB_TOKEN
 ai:
   credentials:
     - name: bedrock

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -11,10 +11,13 @@ import type {
 } from '@anthropic-ai/claude-agent-sdk';
 import type { Meter, Counter, Histogram } from '@opentelemetry/api';
 import { metrics } from '@opentelemetry/api';
+import type { LoggerProvider } from '@opentelemetry/api-logs';
 import { performance } from 'node:perf_hooks';
+import type pino from 'pino';
 import type {
   AgentProfile,
   AgentPluginConfig,
+  AgentRoute,
   AgentRunContentBlock,
   AgentRunEvent,
   AgentRunRequest,
@@ -23,6 +26,7 @@ import type {
   AgentSkillRef,
   AgentThinking,
 } from '../../types/ai.js';
+import { createLogger } from '../../core/logger.js';
 import { materializeClaudeRuntimeSkillPlugins } from './claude-runtime-skill-materializer.js';
 import { buildSandboxEnvironment } from '../sandbox-environment.js';
 
@@ -63,6 +67,8 @@ export interface ClaudeAgentSdkAgentRunnerOptions {
   materializeRuntimeSkills?: (refs: AgentSkillRef[]) => Promise<AgentPluginConfig[]>;
   meter?: Meter;
   sandboxEnvTokens?: string[];
+  logDestination?: pino.DestinationStream;
+  loggerProvider?: LoggerProvider;
 }
 
 export class ClaudeAgentSdkAgentRunner implements AgentRunner {
@@ -73,11 +79,16 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   private readonly _agentRunOutcome: Counter;
   private readonly _agentTokenUsage: Histogram;
   private readonly sandboxEnvTokens: string[];
+  private readonly logger: pino.Logger;
 
   constructor(options?: ClaudeAgentSdkAgentRunnerOptions) {
     this.queryFn = options?.queryFn ?? _query;
     this.materializeRuntimeSkills = options?.materializeRuntimeSkills ?? materializeClaudeRuntimeSkillPlugins;
     this.sandboxEnvTokens = options?.sandboxEnvTokens ?? [];
+    this.logger = createLogger('claude-agent-sdk', {
+      destination: options?.logDestination,
+      loggerProvider: options?.loggerProvider,
+    });
     const meter = options?.meter ?? metrics.getMeter('autocatalyst');
     this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
       unit: '{turn}',
@@ -99,6 +110,16 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
 
   async *run(request: AgentRunRequest): AsyncIterable<AgentRunEvent> {
     const model = request.profile?.model ?? 'unknown';
+    const sandboxEnv = buildSandboxEnvironment(this.sandboxEnvTokens);
+    if (isGitHubDependentRoute(request.route) && !sandboxEnv['GH_TOKEN'] && !sandboxEnv['GITHUB_TOKEN']) {
+      this.logger.warn(
+        {
+          event: 'sandbox.no_github_token',
+          route_task: request.route.task,
+        },
+        `Sandbox route ${request.route.task} requires GitHub CLI authentication. Add AC_GH_TOKEN to sandbox.env_tokens in autocatalyst.yaml and set AC_GH_TOKEN before starting Autocatalyst.`,
+      );
+    }
     const profile = await this.profileWithRuntimeSkillPlugins(request.profile);
     const startMs = performance.now();
     for await (const message of this.queryFn({
@@ -159,6 +180,10 @@ export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile, s
     settings: automatedSettings(cwd),
     env: {
       PATH: process.env['PATH'] ?? '',
+      // HOME is required: Claude Code CLI resolves its own config, plugins, and keybindings
+      // from ~/.claude. Without it the CLI cannot load user-level settings and will fail to
+      // start. This is an explicit, documented exception to the sandbox-token allowlist —
+      // it exposes only Claude Code's own configuration, not general host credential stores.
       HOME: process.env['HOME'] ?? '',
       ...buildSandboxEnvironment(sandboxEnvTokens),
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] ?? '128000',
@@ -204,4 +229,10 @@ function settingSourcesForProfile(profile: AgentProfile | undefined): AgentSetti
   if (profile?.setting_sources) return [...profile.setting_sources];
   if (profile?.load_user_settings === true) return ['user', 'project'];
   return ['project'];
+}
+
+function isGitHubDependentRoute(route: AgentRoute): boolean {
+  if (route.task === 'issue.triage') return true;
+  if (route.task === 'artifact.create' && (route.intent === 'bug' || route.intent === 'chore')) return true;
+  return false;
 }

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -24,6 +24,7 @@ import type {
   AgentThinking,
 } from '../../types/ai.js';
 import { materializeClaudeRuntimeSkillPlugins } from './claude-runtime-skill-materializer.js';
+import { buildSandboxEnvironment } from '../sandbox-environment.js';
 
 type QueryFn = typeof _query;
 
@@ -61,6 +62,7 @@ export interface ClaudeAgentSdkAgentRunnerOptions {
   queryFn?: QueryFn;
   materializeRuntimeSkills?: (refs: AgentSkillRef[]) => Promise<AgentPluginConfig[]>;
   meter?: Meter;
+  sandboxEnvTokens?: string[];
 }
 
 export class ClaudeAgentSdkAgentRunner implements AgentRunner {
@@ -70,10 +72,12 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   private readonly _adapterLatency: Histogram;
   private readonly _agentRunOutcome: Counter;
   private readonly _agentTokenUsage: Histogram;
+  private readonly sandboxEnvTokens: string[];
 
   constructor(options?: ClaudeAgentSdkAgentRunnerOptions) {
     this.queryFn = options?.queryFn ?? _query;
     this.materializeRuntimeSkills = options?.materializeRuntimeSkills ?? materializeClaudeRuntimeSkillPlugins;
+    this.sandboxEnvTokens = options?.sandboxEnvTokens ?? [];
     const meter = options?.meter ?? metrics.getMeter('autocatalyst');
     this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
       unit: '{turn}',
@@ -99,7 +103,7 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
     const startMs = performance.now();
     for await (const message of this.queryFn({
       prompt: request.prompt,
-      options: makeClaudeAgentSdkOptions(request.working_directory, profile),
+      options: makeClaudeAgentSdkOptions(request.working_directory, profile, this.sandboxEnvTokens),
     })) {
       if ((message as SDKMessage).type === 'result') {
         const result = message as unknown as SDKResultMessage;
@@ -140,7 +144,7 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   }
 }
 
-export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile): Options {
+export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile, sandboxEnvTokens: string[] = []): Options {
   const settingSources = settingSourcesForProfile(profile);
   return {
     cwd,
@@ -154,7 +158,9 @@ export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile): 
     systemPrompt: { type: 'preset', preset: 'claude_code' },
     settings: automatedSettings(cwd),
     env: {
-      ...process.env,
+      PATH: process.env['PATH'] ?? '',
+      HOME: process.env['HOME'] ?? '',
+      ...buildSandboxEnvironment(sandboxEnvTokens),
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] ?? '128000',
     },
     ...(profile?.model ? { model: profile.model } : {}),

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -11,11 +11,13 @@ import type { Counter, Histogram, Meter } from '@opentelemetry/api';
 import type { AgentRunEvent, AgentRunRequest, AgentRunner, AgentRoute, AgentSkillRef } from '../../types/ai.js';
 import { createLogger } from '../../core/logger.js';
 import { materializeOpenAIRuntimeSkills } from './openai-runtime-skill-materializer.js';
+import { buildSandboxEnvironment } from '../sandbox-environment.js';
 
 const DEFAULT_OPENAI_AGENT_MAX_TURNS = 50;
 
 interface RunFnOptions {
   maxTurns: number;
+  environment: Record<string, string>;
 }
 
 type RunFn = (
@@ -32,6 +34,7 @@ export interface OpenAIAgentSdkAgentRunnerOptions {
   logDestination?: pino.DestinationStream;
   loggerProvider?: LoggerProvider;
   maxTurns?: number;
+  sandboxEnvTokens?: string[];
 }
 
 export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
@@ -56,6 +59,7 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
   private readonly _agentRunOutcome: Counter;
   private readonly logger: pino.Logger;
   private readonly maxTurns: number;
+  private readonly sandboxEnvTokens: string[];
 
   constructor(
     private readonly apiKey: string,
@@ -71,6 +75,7 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
       loggerProvider: options?.loggerProvider,
     });
     this.maxTurns = options?.maxTurns ?? DEFAULT_OPENAI_AGENT_MAX_TURNS;
+    this.sandboxEnvTokens = options?.sandboxEnvTokens ?? [];
     const meter = options?.meter ?? metrics.getMeter('autocatalyst');
     this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
       unit: '{turn}',
@@ -126,6 +131,18 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
       capabilities,
     });
 
+    const sandboxEnv = buildSandboxEnvironment(this.sandboxEnvTokens);
+
+    if (isGitHubDependentRoute(request.route) && !sandboxEnv['GH_TOKEN'] && !sandboxEnv['GITHUB_TOKEN']) {
+      this.logger.warn(
+        {
+          event: 'sandbox.no_github_token',
+          route_task: request.route.task,
+        },
+        `Sandbox route ${request.route.task} requires GitHub CLI authentication. Add AC_GH_TOKEN to sandbox.env_tokens in autocatalyst.yaml and set AC_GH_TOKEN before starting Autocatalyst.`,
+      );
+    }
+
     const startMs = performance.now();
     let outcome: 'success' | 'error' = 'success';
 
@@ -143,7 +160,7 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
     );
 
     try {
-      const stream = await Promise.resolve(this.runFn(agent, request.prompt, request.working_directory, { maxTurns: this.maxTurns }));
+      const stream = await Promise.resolve(this.runFn(agent, request.prompt, request.working_directory, { maxTurns: this.maxTurns, environment: sandboxEnv }));
       for await (const event of stream) {
         this.logger.debug(
           {
@@ -207,7 +224,7 @@ async function* defaultRunFn(
     manifest: new Manifest(),
     workspaceRootPath: workingDirectory,
     workspaceRootOwned: false,
-    environment: {},
+    environment: options.environment,
   };
   const session = await client.resume(state);
   const sandbox = { client, session };
@@ -274,6 +291,12 @@ function normalizeOpenAIEvent(event: unknown): AgentRunEvent | null {
     return { type: e['type'], ...e } as AgentRunEvent;
   }
   return null;
+}
+
+function isGitHubDependentRoute(route: AgentRoute): boolean {
+  if (route.task === 'issue.triage') return true;
+  if (route.task === 'artifact.create' && (route.intent === 'bug' || route.intent === 'chore')) return true;
+  return false;
 }
 
 function routeLogAttributes(route: AgentRoute): Record<string, string> {

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -118,7 +118,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
 
   const aiRoutingPolicy = buildAgentRoutingPolicy(resolvedAi);
   const directModelRunner = buildDirectModelRunner(resolvedAi, logger, options.loggerProvider);
-  const agentRunner = buildAgentRunner(resolvedAi, logger, options.meter);
+  const agentRunner = buildAgentRunner(resolvedAi, logger, options.meter, currentConfig.config.sandbox?.env_tokens);
   const intentClassifier = new ModelIntentClassifier(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const prTitleGenerator = new ModelPRTitleGenerator(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const questionAnswerer = new AgentRunnerQuestionAnsweringAgent(agentRunner, aiRoutingPolicy, repoPath);
@@ -238,6 +238,7 @@ export function buildAgentRunner(
   resolvedAi: ResolvedAiConfig,
   logger: RuntimeLogger,
   meter?: Meter,
+  sandboxEnvTokens?: string[],
 ): AgentRunner {
   const claudeProfile = resolvedAi.profiles.find(p => p.runner === 'claude_agent_sdk');
   const openAiAgentProfile = resolvedAi.profiles.find(p => p.runner === 'openai_agent_sdk');
@@ -249,7 +250,7 @@ export function buildAgentRunner(
     );
   }
 
-  const claudeRunner = claudeProfile ? new ClaudeAgentSdkAgentRunner({ meter }) : null;
+  const claudeRunner = claudeProfile ? new ClaudeAgentSdkAgentRunner({ meter, sandboxEnvTokens }) : null;
 
   let openAiRunner: AgentRunner | null = null;
   if (openAiAgentProfile) {
@@ -277,7 +278,7 @@ export function buildAgentRunner(
       credential.resolvedValue!,
       endpoint.base_url,
       openAiAgentProfile.model,
-      { meter },
+      { meter, sandboxEnvTokens },
     );
   }
 

--- a/src/adapters/sandbox-environment.ts
+++ b/src/adapters/sandbox-environment.ts
@@ -1,0 +1,14 @@
+export function buildSandboxEnvironment(
+  acTokenNames: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const acKey of acTokenNames) {
+    const sandboxKey = acKey.startsWith('AC_') ? acKey.slice(3) : acKey;
+    const value = env[acKey];
+    if (typeof value === 'string' && value.length > 0) {
+      result[sandboxKey] = value;
+    }
+  }
+  return result;
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -94,5 +94,9 @@ ai:
     implementation.review.final: review-agent
     question.answer: question-agent
     issue.triage: triage-agent
+
+sandbox:
+  env_tokens:
+    - AC_GITHUB_TOKEN
 `;
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -117,6 +117,24 @@ export function validateConfig(config: WorkflowConfig): void {
     }
   }
 
+  const rawSandbox = (config as Record<string, unknown>)['sandbox'];
+  if (rawSandbox !== undefined && rawSandbox !== null) {
+    if (typeof rawSandbox !== 'object' || Array.isArray(rawSandbox)) {
+      throw new Error('sandbox must be an object');
+    }
+    const sandbox = rawSandbox as Record<string, unknown>;
+    if (sandbox['env_tokens'] !== undefined) {
+      if (!Array.isArray(sandbox['env_tokens'])) {
+        throw new Error('sandbox.env_tokens must be an array');
+      }
+      for (const [i, token] of (sandbox['env_tokens'] as unknown[]).entries()) {
+        if (typeof token !== 'string' || (token as string).trim() === '') {
+          throw new Error(`sandbox.env_tokens[${i}] must be a non-empty string`);
+        }
+      }
+    }
+  }
+
   const rawReview = (config as Record<string, unknown>)['implementation_review'];
   if (rawReview !== undefined && rawReview !== null) {
     if (typeof rawReview !== 'object' || Array.isArray(rawReview)) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -89,6 +89,10 @@ export interface TelemetryConfig {
   export_interval_ms?: number;
 }
 
+export interface SandboxConfig {
+  env_tokens?: string[];
+}
+
 export interface WorkflowConfig {
   polling?: {
     interval_ms?: number;
@@ -103,6 +107,7 @@ export interface WorkflowConfig {
   /** Required — declares all AI provider configuration. */
   ai: AiConfig;
   implementation_review?: ImplementationReviewPolicy;
+  sandbox?: SandboxConfig;
   [key: string]: unknown;
 }
 

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -311,4 +311,66 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     const call = queryFn.mock.calls[0][0];
     expect(call.options.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS']).toBe('64000');
   });
+
+  test('passes config-declared AC_GH_TOKEN as GH_TOKEN in sandbox env', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn, sandboxEnvTokens: ['AC_GH_TOKEN'] });
+
+    const originalToken = process.env['AC_GH_TOKEN'];
+    process.env['AC_GH_TOKEN'] = 'ghp_claude_test_token';
+    try {
+      await collect(runner.run({
+        route: { task: 'implementation.run' },
+        working_directory: '/tmp/workspace',
+        prompt: 'implement',
+        profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+      }));
+    } finally {
+      if (originalToken !== undefined) {
+        process.env['AC_GH_TOKEN'] = originalToken;
+      } else {
+        delete process.env['AC_GH_TOKEN'];
+      }
+    }
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env['GH_TOKEN']).toBe('ghp_claude_test_token');
+  });
+
+  test('does not forward unrelated process env vars to sandbox', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn, sandboxEnvTokens: ['AC_GH_TOKEN'] });
+
+    const originalToken = process.env['AC_GH_TOKEN'];
+    const originalUnrelated = process.env['UNRELATED_SECRET'];
+    process.env['AC_GH_TOKEN'] = 'ghp_some_token';
+    process.env['UNRELATED_SECRET'] = 'should-not-appear';
+    try {
+      await collect(runner.run({
+        route: { task: 'implementation.run' },
+        working_directory: '/tmp/workspace',
+        prompt: 'implement',
+        profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+      }));
+    } finally {
+      if (originalToken !== undefined) {
+        process.env['AC_GH_TOKEN'] = originalToken;
+      } else {
+        delete process.env['AC_GH_TOKEN'];
+      }
+      if (originalUnrelated !== undefined) {
+        process.env['UNRELATED_SECRET'] = originalUnrelated;
+      } else {
+        delete process.env['UNRELATED_SECRET'];
+      }
+    }
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env).not.toHaveProperty('UNRELATED_SECRET');
+    expect(call.options.env).not.toHaveProperty('AC_GH_TOKEN');
+  });
 });

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'node:stream';
 import { describe, expect, test, vi } from 'vitest';
 import { ClaudeAgentSdkAgentRunner } from '../../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
 import type { AgentRunEvent } from '../../../src/types/ai.js';
@@ -7,6 +8,20 @@ async function collect(events: AsyncIterable<AgentRunEvent>): Promise<AgentRunEv
   const collected: AgentRunEvent[] = [];
   for await (const event of events) collected.push(event);
   return collected;
+}
+
+function makeLogCapture(): { dest: import('pino').DestinationStream; getLogs: () => Record<string, unknown>[] } {
+  const stream = new PassThrough();
+  const logs: Record<string, unknown>[] = [];
+  stream.on('data', (chunk: Buffer) => {
+    for (const line of chunk.toString().split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        try { logs.push(JSON.parse(trimmed)); } catch { /* skip non-JSON */ }
+      }
+    }
+  });
+  return { dest: stream as unknown as import('pino').DestinationStream, getLogs: () => logs };
 }
 
 /** Build a stub Meter that records all metric calls for assertion. */
@@ -339,6 +354,24 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     expect(call.options.env['GH_TOKEN']).toBe('ghp_claude_test_token');
   });
 
+  test('passes HOME in sandbox env so Claude Code CLI can locate its config', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+    }));
+
+    const call = queryFn.mock.calls[0][0];
+    // HOME is an explicit documented exception: Claude Code CLI requires it to find ~/.claude config
+    expect(call.options.env).toHaveProperty('HOME');
+  });
+
   test('does not forward unrelated process env vars to sandbox', async () => {
     const queryFn = vi.fn().mockImplementation(async function* () {
       yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
@@ -372,5 +405,61 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     const call = queryFn.mock.calls[0][0];
     expect(call.options.env).not.toHaveProperty('UNRELATED_SECRET');
     expect(call.options.env).not.toHaveProperty('AC_GH_TOKEN');
+  });
+
+  test('logs a warning for issue.triage when no GitHub token is in the sandbox environment', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn, logDestination: dest });
+
+    await collect(runner.run({
+      route: { task: 'issue.triage' },
+      working_directory: '/tmp/workspace',
+      prompt: 'triage issue',
+      profile: { id: 'triage', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+    }));
+
+    const warning = getLogs().find(
+      log => log['level'] === 'warn' && log['event'] === 'sandbox.no_github_token',
+    );
+    expect(warning).toBeDefined();
+    expect(warning?.['route_task']).toBe('issue.triage');
+  });
+
+  test('does not log a GitHub token warning when GH_TOKEN is present in sandbox environment', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+
+    const originalToken = process.env['AC_GH_TOKEN'];
+    process.env['AC_GH_TOKEN'] = 'ghp_present_token';
+    try {
+      const runner = new ClaudeAgentSdkAgentRunner({
+        queryFn,
+        logDestination: dest,
+        sandboxEnvTokens: ['AC_GH_TOKEN'],
+      });
+
+      await collect(runner.run({
+        route: { task: 'issue.triage' },
+        working_directory: '/tmp/workspace',
+        prompt: 'triage issue',
+        profile: { id: 'triage', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-5', effort: 'high' },
+      }));
+    } finally {
+      if (originalToken !== undefined) {
+        process.env['AC_GH_TOKEN'] = originalToken;
+      } else {
+        delete process.env['AC_GH_TOKEN'];
+      }
+    }
+
+    const warning = getLogs().find(
+      log => log['level'] === 'warn' && log['event'] === 'sandbox.no_github_token',
+    );
+    expect(warning).toBeUndefined();
   });
 });

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -16,9 +16,14 @@ vi.mock('@openai/agents', async importOriginal => {
   };
 });
 
+let capturedResumeState: unknown;
+
 vi.mock('@openai/agents/sandbox/local', () => ({
   UnixLocalSandboxClient: class {
-    resume = vi.fn().mockResolvedValue({});
+    resume = vi.fn().mockImplementation((state: unknown) => {
+      capturedResumeState = state;
+      return Promise.resolve({});
+    });
   },
 }));
 
@@ -554,5 +559,112 @@ describe('OpenAIAgentSdkAgentRunner', () => {
 
     expect(vi.mocked(setTracingDisabled)).toHaveBeenCalledOnce();
     expect(vi.mocked(setTracingDisabled)).toHaveBeenCalledWith(true);
+  });
+
+  test('default run function passes AC_GH_TOKEN from config into sandbox environment as GH_TOKEN', async () => {
+    capturedResumeState = undefined;
+    vi.mocked(sdkRun).mockResolvedValue({ newItems: [], output: [] } as never);
+
+    const originalToken = process.env['AC_GH_TOKEN'];
+    process.env['AC_GH_TOKEN'] = 'ghp_test_token_123';
+    try {
+      const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+        materializeSkills: vi.fn().mockResolvedValue([]),
+        logDestination: nullDest,
+        sandboxEnvTokens: ['AC_GH_TOKEN'],
+      });
+
+      await collect(runner.run({
+        route: { task: 'question.answer' },
+        working_directory: '/tmp/ws',
+        prompt: 'test',
+      }));
+    } finally {
+      if (originalToken !== undefined) {
+        process.env['AC_GH_TOKEN'] = originalToken;
+      } else {
+        delete process.env['AC_GH_TOKEN'];
+      }
+    }
+
+    expect((capturedResumeState as { environment?: Record<string, string> })?.environment).toEqual({
+      GH_TOKEN: 'ghp_test_token_123',
+    });
+  });
+
+  test('default run function produces empty sandbox environment when no tokens configured', async () => {
+    capturedResumeState = undefined;
+    vi.mocked(sdkRun).mockResolvedValue({ newItems: [], output: [] } as never);
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      materializeSkills: vi.fn().mockResolvedValue([]),
+      logDestination: nullDest,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    expect((capturedResumeState as { environment?: Record<string, string> })?.environment).toEqual({});
+  });
+
+  test('run() logs a warning for issue.triage when no GitHub token is in the sandbox environment', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      runFn,
+      materializeSkills,
+      logDestination: dest,
+    });
+
+    await collect(runner.run({
+      route: { task: 'issue.triage' },
+      working_directory: '/tmp/ws',
+      prompt: 'triage issue',
+    }));
+
+    const warning = getLogs().find(
+      log => log['level'] === 'warn' && log['event'] === 'sandbox.no_github_token',
+    );
+    expect(warning).toBeDefined();
+    expect(warning?.['route_task']).toBe('issue.triage');
+  });
+
+  test('run() does not log a GitHub token warning when GH_TOKEN is present in sandbox environment', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const originalToken = process.env['AC_GH_TOKEN'];
+    process.env['AC_GH_TOKEN'] = 'ghp_present';
+    try {
+      const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+        runFn,
+        materializeSkills,
+        logDestination: dest,
+        sandboxEnvTokens: ['AC_GH_TOKEN'],
+      });
+
+      await collect(runner.run({
+        route: { task: 'issue.triage' },
+        working_directory: '/tmp/ws',
+        prompt: 'triage issue',
+      }));
+    } finally {
+      if (originalToken !== undefined) {
+        process.env['AC_GH_TOKEN'] = originalToken;
+      } else {
+        delete process.env['AC_GH_TOKEN'];
+      }
+    }
+
+    const warning = getLogs().find(
+      log => log['level'] === 'warn' && log['event'] === 'sandbox.no_github_token',
+    );
+    expect(warning).toBeUndefined();
   });
 });

--- a/tests/adapters/sandbox-environment.test.ts
+++ b/tests/adapters/sandbox-environment.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest';
+import { buildSandboxEnvironment } from '../../src/adapters/sandbox-environment.js';
+
+describe('buildSandboxEnvironment', () => {
+  test('strips AC_ prefix and maps token value from env', () => {
+    const result = buildSandboxEnvironment(['AC_GH_TOKEN'], { AC_GH_TOKEN: 'ghp_abc123' });
+    expect(result).toEqual({ GH_TOKEN: 'ghp_abc123' });
+  });
+
+  test('strips AC_ prefix for GITHUB_TOKEN variant', () => {
+    const result = buildSandboxEnvironment(['AC_GITHUB_TOKEN'], { AC_GITHUB_TOKEN: 'ghp_xyz789' });
+    expect(result).toEqual({ GITHUB_TOKEN: 'ghp_xyz789' });
+  });
+
+  test('returns empty object when acTokenNames is empty', () => {
+    const result = buildSandboxEnvironment([], { AC_GH_TOKEN: 'ghp_abc123', SOME_SECRET: 'value' });
+    expect(result).toEqual({});
+  });
+
+  test('excludes env vars not listed in acTokenNames', () => {
+    const result = buildSandboxEnvironment(['AC_GH_TOKEN'], {
+      AC_GH_TOKEN: 'ghp_abc123',
+      UNLISTED_SECRET: 'should-not-appear',
+    });
+    expect(result).not.toHaveProperty('UNLISTED_SECRET');
+    expect(result).not.toHaveProperty('AC_GH_TOKEN');
+  });
+
+  test('forwards key unchanged when name does not start with AC_', () => {
+    const result = buildSandboxEnvironment(['MY_VAR'], { MY_VAR: 'some-value' });
+    expect(result).toEqual({ MY_VAR: 'some-value' });
+  });
+
+  test('omits token when env var is not set', () => {
+    const result = buildSandboxEnvironment(['AC_GH_TOKEN'], {});
+    expect(result).toEqual({});
+  });
+
+  test('omits token when env var is empty string', () => {
+    const result = buildSandboxEnvironment(['AC_GH_TOKEN'], { AC_GH_TOKEN: '' });
+    expect(result).toEqual({});
+  });
+
+  test('maps multiple tokens when all are present', () => {
+    const result = buildSandboxEnvironment(['AC_GH_TOKEN', 'AC_GITHUB_TOKEN'], {
+      AC_GH_TOKEN: 'token-a',
+      AC_GITHUB_TOKEN: 'token-b',
+    });
+    expect(result).toEqual({ GH_TOKEN: 'token-a', GITHUB_TOKEN: 'token-b' });
+  });
+
+  test('uses process.env by default when no env argument provided', () => {
+    const originalToken = process.env['AC_GH_TOKEN'];
+    process.env['AC_GH_TOKEN'] = 'default-env-token';
+    try {
+      const result = buildSandboxEnvironment(['AC_GH_TOKEN']);
+      expect(result['GH_TOKEN']).toBe('default-env-token');
+    } finally {
+      if (originalToken !== undefined) {
+        process.env['AC_GH_TOKEN'] = originalToken;
+      } else {
+        delete process.env['AC_GH_TOKEN'];
+      }
+    }
+  });
+});

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -267,6 +267,62 @@ describe('loadConfigFromPath', () => {
   });
 });
 
+// ─── validateConfig: sandbox ─────────────────────────────────────────────────
+
+describe('validateConfig: sandbox', () => {
+  it('passes when sandbox is absent', () => {
+    expect(() => validateConfig({} as WorkflowConfig)).not.toThrow();
+  });
+
+  it('passes for a valid sandbox block with env_tokens array', () => {
+    expect(() =>
+      validateConfig({ sandbox: { env_tokens: ['AC_GH_TOKEN', 'AC_GITHUB_TOKEN'] } } as unknown as WorkflowConfig),
+    ).not.toThrow();
+  });
+
+  it('passes when sandbox.env_tokens is an empty array', () => {
+    expect(() =>
+      validateConfig({ sandbox: { env_tokens: [] } } as unknown as WorkflowConfig),
+    ).not.toThrow();
+  });
+
+  it('throws when sandbox is not an object', () => {
+    expect(() =>
+      validateConfig({ sandbox: 'bad' } as unknown as WorkflowConfig),
+    ).toThrow('sandbox must be an object');
+  });
+
+  it('throws when sandbox is an array', () => {
+    expect(() =>
+      validateConfig({ sandbox: ['AC_GH_TOKEN'] } as unknown as WorkflowConfig),
+    ).toThrow('sandbox must be an object');
+  });
+
+  it('throws when sandbox.env_tokens is not an array', () => {
+    expect(() =>
+      validateConfig({ sandbox: { env_tokens: 'AC_GH_TOKEN' } } as unknown as WorkflowConfig),
+    ).toThrow('sandbox.env_tokens must be an array');
+  });
+
+  it('throws when sandbox.env_tokens contains a non-string entry', () => {
+    expect(() =>
+      validateConfig({ sandbox: { env_tokens: ['AC_GH_TOKEN', 42] } } as unknown as WorkflowConfig),
+    ).toThrow('sandbox.env_tokens[1] must be a non-empty string');
+  });
+
+  it('throws when sandbox.env_tokens contains an empty string', () => {
+    expect(() =>
+      validateConfig({ sandbox: { env_tokens: ['AC_GH_TOKEN', ''] } } as unknown as WorkflowConfig),
+    ).toThrow('sandbox.env_tokens[1] must be a non-empty string');
+  });
+
+  it('throws when sandbox.env_tokens contains a whitespace-only string', () => {
+    expect(() =>
+      validateConfig({ sandbox: { env_tokens: ['   '] } } as unknown as WorkflowConfig),
+    ).toThrow('sandbox.env_tokens[0] must be a non-empty string');
+  });
+});
+
 // ─── validateConfig: implementation_review ───────────────────────────────────
 
 describe('validateConfig: implementation_review', () => {


### PR DESCRIPTION
## Summary

- Forward `AC_`-prefixed tokens into the sandbox environment for all agent runners
- Document the HOME exception in the Claude runner
- Add GH token warning to Claude runner matching OpenAI runner behavior
- Add `AC_GITHUB_TOKEN` to `sandbox.env_tokens` in config

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Trigger a run that uses `gh` CLI in the sandbox and verify it authenticates correctly