### PR TITLE
fix: thread Grove credentials into Claude Agent SDK subprocess

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "enabledPlugins": {
+    "mm@micromanager": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${HOME}/.claude/plugins/marketplaces/micromanager/plugins/mm/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,12 @@ docs/superpowers/
 # Friction logs
 context-human/.friction-logs/
 
-# Claude Code local config
-.claude/settings.local.json
-.claude/skills/
-.claude/CLAUDE.md
+# Claude Code — track shared settings, ignore everything else
+.claude/*
+!.claude/settings.json
+
+# npm cache
+.npm/
 
 # OMC ephemeral state
 .omc/

--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -48,14 +48,36 @@ ai:
       anthropic:
         effort: low
         thinking: adaptive
+    - name: grove-gpt5.4-nano
+      endpoint: grove-openai
+      model: gpt-5.4-nano
+      runner: openai_direct
+    - name: grove-gpt5.5-low
+      endpoint: grove-openai
+      model: gpt-5.5
+      runner: openai_agent_sdk
+      openai:
+        reasoning_effort: low
+    - name: grove-gpt5.5-medium
+      endpoint: grove-openai
+      model: gpt-5.5
+      runner: openai_agent_sdk
+      openai:
+        reasoning_effort: medium
+    - name: grove-gpt5.5-high
+      endpoint: grove-openai
+      model: gpt-5.5
+      runner: openai_agent_sdk
+      openai:
+        reasoning_effort: high
   routing:
-    intent.classify: grove-haiku-4.5-low
-    pr.title_generate: grove-haiku-4.5-low
-    artifact.create: grove-sonnet-4.6-high
-    artifact.revise: grove-sonnet-4.6-high
+    intent.classify: grove-gpt5.4-nano
+    pr.title_generate: grove-gpt5.4-nano
+    artifact.create: grove-gpt5.5-high
+    artifact.revise: grove-gpt5.5-high
     implementation.run: grove-sonnet-4.6-medium
-    implementation.review.initial: grove-sonnet-4.6-high
-    implementation.review.final: grove-sonnet-4.6-medium
+    implementation.review.initial: grove-gpt5.5-high
+    implementation.review.final: grove-gpt5.5-medium
     question.answer: grove-sonnet-4.6-low
     issue.triage: grove-sonnet-4.6-high
 polling:

--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -16,6 +16,9 @@ ai:
       protocol: anthropic
       base_url: https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic
       credential: grove
+      anthropic_beta_header_filter:
+        strip:
+          - advisor-tool-2026-03-01
     - name: grove-openai
       protocol: openai
       base_url: https://grove-gateway-prod.azure-api.net/grove-foundry-prod/openai/v1
@@ -48,37 +51,41 @@ ai:
       anthropic:
         effort: low
         thinking: adaptive
-    - name: grove-gpt5.4-nano
+    - name: grove-gpt-5.4-nano
       endpoint: grove-openai
       model: gpt-5.4-nano
       runner: openai_direct
-    - name: grove-gpt5.5-low
+    - name: grove-gpt-5.5-low
       endpoint: grove-openai
       model: gpt-5.5
       runner: openai_agent_sdk
       openai:
         reasoning_effort: low
-    - name: grove-gpt5.5-medium
+    - name: grove-gpt-5.5-medium
       endpoint: grove-openai
       model: gpt-5.5
       runner: openai_agent_sdk
       openai:
         reasoning_effort: medium
-    - name: grove-gpt5.5-high
+    - name: grove-gpt-5.5-high
       endpoint: grove-openai
       model: gpt-5.5
       runner: openai_agent_sdk
       openai:
         reasoning_effort: high
   routing:
-    intent.classify: grove-gpt5.4-nano
-    pr.title_generate: grove-gpt5.4-nano
-    artifact.create: grove-gpt5.5-high
-    artifact.revise: grove-gpt5.5-high
+    # grove-gpt-5.4-nano
+    # grove-haiku-4.5-low
+    # grove-gpt-5.5-low|medium|high
+    # grove-sonnet-4.6-low|medium|high
+    intent.classify: grove-gpt-5.4-nano
+    pr.title_generate: grove-gpt-5.4-nano
+    artifact.create: grove-gpt-5.5-high
+    artifact.revise: grove-gpt-5.5-high
     implementation.run: grove-sonnet-4.6-medium
-    implementation.review.initial: grove-gpt5.5-high
-    implementation.review.final: grove-gpt5.5-medium
-    question.answer: grove-gpt5.5-low
+    implementation.review.initial: grove-gpt-5.5-high
+    implementation.review.final: grove-gpt-5.5-medium
+    question.answer: grove-sonnet-4.6-low
     issue.triage: grove-sonnet-4.6-high
 polling:
   interval_ms: 30000

--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -78,7 +78,7 @@ ai:
     implementation.run: grove-sonnet-4.6-medium
     implementation.review.initial: grove-gpt5.5-high
     implementation.review.final: grove-gpt5.5-medium
-    question.answer: grove-sonnet-4.6-low
+    question.answer: grove-gpt5.5-low
     issue.triage: grove-sonnet-4.6-high
 polling:
   interval_ms: 30000

--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -54,6 +54,8 @@ ai:
     artifact.create: grove-sonnet-4.6-high
     artifact.revise: grove-sonnet-4.6-high
     implementation.run: grove-sonnet-4.6-medium
+    implementation.review.initial: grove-sonnet-4.6-high
+    implementation.review.final: grove-sonnet-4.6-medium
     question.answer: grove-sonnet-4.6-low
     issue.triage: grove-sonnet-4.6-high
 polling:

--- a/context-agent/decisions/claude-code-grove-beta-header-filter.md
+++ b/context-agent/decisions/claude-code-grove-beta-header-filter.md
@@ -1,0 +1,17 @@
+---
+date: 2026-05-17
+status: accepted
+superseded_by: null
+---
+# Claude Code Grove beta header filter
+**Decision:** The Claude Agent SDK loopback beta-header filter is enabled by endpoint config: Anthropic endpoints with `anthropic_beta_header_filter.strip` route SDK traffic through loopback and remove only those configured values.
+**Rationale:**
+- Claude Code sends `advisor-tool-2026-03-01` in model API requests even when Autocatalyst did not request that beta.
+- Grove Azure APIM rejects unknown `anthropic-beta` values before the request reaches the Anthropic-compatible backend.
+- The SDK bump to `@anthropic-ai/claude-agent-sdk` 0.3.143 still requires removing the advisor beta for Grove-routed Claude Agent SDK calls.
+- The denylist belongs on the endpoint because the compatibility issue is with a gateway route, not with a task profile.
+**Constraints:** The proxy must not affect Anthropic direct model calls. When configured, the proxy binds only to `127.0.0.1`, forwards to the configured `base_url`, preserves non-hop-by-hop headers and streaming responses, and filters no beta value except values listed in endpoint config.
+**Rejected:**
+- Patching `node_modules` or the Claude Code binary: not durable across installs or upgrades.
+- Removing all beta headers: would break supported betas such as context, effort, or task budgets.
+- Moving affected tasks to OpenAI routes: avoids this incident but leaves the Claude adapter broken for configured Claude Agent SDK profiles.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "autocatalyst",
       "version": "0.0.1",
       "dependencies": {
-        "@anthropic-ai/bedrock-sdk": "^0.28.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.2.105",
-        "@anthropic-ai/sdk": "^0.88.0",
+        "@anthropic-ai/bedrock-sdk": "0.29.1",
+        "@anthropic-ai/claude-agent-sdk": "0.3.143",
+        "@anthropic-ai/sdk": "0.96.0",
         "@aws-sdk/credential-providers": "^3.1029.0",
         "@notionhq/client": "^5.17.0",
         "@openai/agents": "^0.11.1",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@anthropic-ai/bedrock-sdk": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.28.1.tgz",
-      "integrity": "sha512-aoDcMjeRBZK+f8nIUquJE/7pyanFKbnv99kF3k0RRpron+W745M9MhNAbTc7tjMQ9y4ETVwQqdc94/aCOGtxcQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.29.1.tgz",
+      "integrity": "sha512-eV3vqNvMEy9C5nBgZMlKFewgXoBcIuV/PERRQJIlot3Vd5lU8dVUS7YqkkbXLw8p/gkDmam3PPoPNYsEAmqivw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.50.3 <1",
@@ -60,59 +60,153 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.105",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.105.tgz",
-      "integrity": "sha512-gPn7UEX6WrnIqCclNzfER6Of0mQ1ruxcNe0jrVXR9kOG09qFfaGzd6hy2qr3envCAB/dACkS7UDJoCm4/jg5Dg==",
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.143.tgz",
+      "integrity": "sha512-JnxOTRpSBpFqKFMfV5cW4QjpeDOHUNr31rRislmOVWEPsRmCjsy9jYwKxDf7kxcwxyZ6h/YHz1ACvMaUWy6o6A==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.81.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.143"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.143.tgz",
+      "integrity": "sha512-41WuTuP+bk4NxrjpG9IJGffsjh1ivyiiAmqgb5QoxPltDAA0p3gs+iZ3lTgDmY4Ga68wDoN05Lt18oCE+DQb7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.143.tgz",
+      "integrity": "sha512-3WrJ6MjjwQKvPnPbzUOm08qftlHYobkp/tmM1P/Vk/ldSjoPfFIgLFfzSzUmCKJiKEh2ZlHLJr8ORNrTxXhgQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.143.tgz",
+      "integrity": "sha512-/9oP/FCewrPnwVN+QUS5rlO3kMa07w+hOrpWrz24aEpBYhcHzr0zoNMBriPDAkTr3ao/z1k40UZ2dHmgsSODzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.143.tgz",
+      "integrity": "sha512-9UeV1W2vjOVwJSJrq9aw3UeMo82Ir59FfJ5mchh7OXZEaevkANvHYn25bTCnIpqfqOx7qFEosJW2ELIoV1nprg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.143.tgz",
+      "integrity": "sha512-kwqnbHo4Zj6TzO1V/83uLhsTt0xBp/BN5V/aHIX+khM4UuNO6NOKNaZvr8Int3sF0ARF95Hjr4l/hMKxry6DhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.143.tgz",
+      "integrity": "sha512-rr4334GOLl9caYDeyWsbwMaVJCiNvKHE9nLdey8opIkq7/FHHu712U6tDk0tcoCdsGU/S3/BBaZParOgF+s5qw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.143.tgz",
+      "integrity": "sha512-q5UaLZ9ABbqQN8UXpqHUqjW6akI1zMrV5Jvtq0yueKP4nIRbBBZBQ80M4bpdrc0+SiRmjVRV3p8lsCCAd8azgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.143",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.143.tgz",
+      "integrity": "sha512-46L2mkskvIRfwzHP3p0uUE5u9Oc7Eb/DRVmXuGNk5Z8jiahlDSv0SHP1vnWSWw5nWIu4DWOKyXZelRmYc9LxCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
-      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
+      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -2559,340 +2653,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -5715,6 +5475,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -6620,6 +6386,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -8051,6 +7823,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/bedrock-sdk": "^0.28.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.105",
-    "@anthropic-ai/sdk": "^0.88.0",
+    "@anthropic-ai/bedrock-sdk": "0.29.1",
+    "@anthropic-ai/claude-agent-sdk": "0.3.143",
+    "@anthropic-ai/sdk": "0.96.0",
     "@aws-sdk/credential-providers": "^3.1029.0",
     "@notionhq/client": "^5.17.0",
     "@openai/agents": "^0.11.1",

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -1,0 +1,192 @@
+import { once } from 'node:events';
+import { createServer, type IncomingHttpHeaders, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+export interface AnthropicBetaHeaderFilterProxy {
+  baseUrl: string;
+  server: Server;
+  close: () => Promise<void>;
+}
+
+export interface AnthropicBetaHeaderFilterProxyOptions {
+  stripBetaValues: string[];
+}
+
+/**
+ * Starts a loopback proxy that removes configured beta header values before forwarding requests.
+ *
+ * @param targetBaseUrl Anthropic-compatible upstream base URL.
+ * @param options Beta header values to remove from proxied requests.
+ * @returns Proxy handle with a loopback base URL and close function.
+ */
+export async function startAnthropicBetaHeaderFilterProxy(
+  targetBaseUrl: string,
+  options: AnthropicBetaHeaderFilterProxyOptions,
+): Promise<AnthropicBetaHeaderFilterProxy> {
+  const targetBase = new URL(targetBaseUrl);
+  const stripBetaValues = normalizedStripBetaValues(options.stripBetaValues);
+  const server = createServer((req, res) => {
+    handleProxyRequest(req, res, targetBase, stripBetaValues).catch(err => {
+      if (res.headersSent) {
+        res.destroy(err);
+        return;
+      }
+      res.writeHead(502, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        type: 'error',
+        error: {
+          type: 'proxy_error',
+          message: `Failed to proxy Anthropic request: ${String(err)}`,
+        },
+      }));
+    });
+  });
+
+  server.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', (err) => {
+      server.close();
+      reject(new Error(`Anthropic beta header filter proxy failed to bind: ${err.message}`));
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Anthropic beta header filter proxy did not bind to a TCP port');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    server,
+    close: () => closeServer(server),
+  };
+}
+
+async function handleProxyRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  targetBase: URL,
+  stripBetaValues: ReadonlySet<string>,
+): Promise<void> {
+  const targetUrl = targetUrlForRequest(targetBase, req.url);
+  const response = await fetch(targetUrl, {
+    method: req.method,
+    headers: requestHeaders(req.headers, stripBetaValues),
+    body: await requestBody(req),
+  });
+
+  res.writeHead(response.status, response.statusText, responseHeaders(response.headers));
+  if (!response.body) {
+    res.end();
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0])
+      .on('error', reject)
+      .pipe(res)
+      .on('error', reject)
+      .on('finish', resolve);
+  });
+}
+
+function targetUrlForRequest(targetBase: URL, requestUrl: string | undefined): URL {
+  const incoming = new URL(requestUrl ?? '/', 'http://127.0.0.1');
+  const target = new URL(targetBase.toString());
+  const basePath = target.pathname.replace(/\/$/, '');
+  target.pathname = `${basePath}${incoming.pathname}`;
+  target.search = incoming.search;
+  return target;
+}
+
+function requestHeaders(headers: IncomingHttpHeaders, stripBetaValues: ReadonlySet<string>): Headers {
+  const forwarded = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    const lowerName = name.toLowerCase();
+    if (HOP_BY_HOP_REQUEST_HEADERS.has(lowerName)) continue;
+    if (lowerName === 'accept-encoding') {
+      forwarded.set('accept-encoding', 'identity');
+      continue;
+    }
+    if (lowerName === 'anthropic-beta') {
+      const filtered = filteredAnthropicBetaHeader(value, stripBetaValues);
+      if (filtered) forwarded.set(name, filtered);
+      continue;
+    }
+    appendHeaderValues(forwarded, name, value);
+  }
+  if (!forwarded.has('accept-encoding')) forwarded.set('accept-encoding', 'identity');
+  return forwarded;
+}
+
+function responseHeaders(headers: Headers): Record<string, string> {
+  const forwarded: Record<string, string> = {};
+  headers.forEach((value, name) => {
+    if (!HOP_BY_HOP_RESPONSE_HEADERS.has(name.toLowerCase())) {
+      forwarded[name] = value;
+    }
+  });
+  return forwarded;
+}
+
+function filteredAnthropicBetaHeader(value: string | string[] | undefined, stripBetaValues: ReadonlySet<string>): string | undefined {
+  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const filtered = values
+    .flatMap(headerValue => headerValue.split(','))
+    .map(beta => beta.trim())
+    .filter(beta => beta.length > 0 && !stripBetaValues.has(beta));
+  return filtered.length > 0 ? filtered.join(', ') : undefined;
+}
+
+function normalizedStripBetaValues(values: string[]): ReadonlySet<string> {
+  return new Set(values.map(value => value.trim()).filter(value => value.length > 0));
+}
+
+function appendHeaderValues(headers: Headers, name: string, value: string | string[] | undefined): void {
+  if (value === undefined) return;
+  if (Array.isArray(value)) {
+    for (const item of value) headers.append(name, item);
+    return;
+  }
+  headers.set(name, value);
+}
+
+async function requestBody(req: IncomingMessage): Promise<ArrayBuffer | undefined> {
+  if (req.method === 'GET' || req.method === 'HEAD') return undefined;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  if (chunks.length === 0) return undefined;
+  const body = Buffer.concat(chunks);
+  return body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) as ArrayBuffer;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  server.close();
+  await once(server, 'close');
+}

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -32,6 +32,23 @@ import { buildSandboxEnvironment } from '../sandbox-environment.js';
 
 type QueryFn = typeof _query;
 
+const MAX_STDERR_LINES = 50;
+
+const SECRET_PATTERNS = [
+  /(?:api[_-]?key|secret|password|credential)\s*[=:]\s*\S+/gi,
+  /ghp_[A-Za-z0-9_]+/g,
+  /sk-[A-Za-z0-9_-]+/g,
+  /xox[bpras]-[A-Za-z0-9-]+/g,
+];
+
+function redactSecrets(text: string): string {
+  let redacted = text;
+  for (const pattern of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, '[REDACTED]');
+  }
+  return redacted;
+}
+
 const AUTOMATED_ALLOWED_TOOLS = [
   'Bash',
   'Edit',
@@ -121,10 +138,23 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
       );
     }
     const profile = await this.profileWithRuntimeSkillPlugins(request.profile);
+    const stderrLines: string[] = [];
+    const options = {
+      ...makeClaudeAgentSdkOptions(request.working_directory, profile, this.sandboxEnvTokens),
+      stderr: (data: string) => {
+        for (const line of data.split('\n')) {
+          const trimmed = line.trim();
+          if (trimmed) stderrLines.push(trimmed);
+        }
+        if (stderrLines.length > MAX_STDERR_LINES) {
+          stderrLines.splice(0, stderrLines.length - MAX_STDERR_LINES);
+        }
+      },
+    };
     const startMs = performance.now();
     for await (const message of this.queryFn({
       prompt: request.prompt,
-      options: makeClaudeAgentSdkOptions(request.working_directory, profile, this.sandboxEnvTokens),
+      options,
     })) {
       if ((message as SDKMessage).type === 'result') {
         const result = message as unknown as SDKResultMessage;
@@ -136,12 +166,35 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
         this._agentTokenUsage.record(result.usage.output_tokens, {
           component: 'claude-agent-sdk', model, token_type: 'output',
         });
+        if (result.is_error && stderrLines.length > 0) {
+          this.logger.error(
+            {
+              event: 'sdk.stderr_on_error',
+              route_task: request.route.task,
+              model,
+              stderr_excerpt: redactSecrets(stderrLines.join('\n')),
+            },
+            'Claude Code subprocess stderr captured on error exit',
+          );
+        }
       }
       const event = normalizeSdkMessage(message as SDKMessage);
       if (event.type === 'assistant') {
         this._agentTurns.add(1, { component: 'claude-agent-sdk', model });
       }
       yield event;
+    }
+    if (stderrLines.length > 0) {
+      this.logger.debug(
+        {
+          event: 'sdk.stderr',
+          route_task: request.route.task,
+          model,
+          stderr_line_count: stderrLines.length,
+          stderr_excerpt: redactSecrets(stderrLines.slice(-5).join('\n')),
+        },
+        'Claude Code subprocess stderr',
+      );
     }
     this._adapterLatency.record(performance.now() - startMs, {
       adapter: 'agent-sdk',

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -187,6 +187,8 @@ export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile, s
       HOME: process.env['HOME'] ?? '',
       ...buildSandboxEnvironment(sandboxEnvTokens),
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] ?? '128000',
+      ...(profile?.api_key ? { ANTHROPIC_API_KEY: profile.api_key } : {}),
+      ...(profile?.base_url ? { ANTHROPIC_BASE_URL: profile.base_url } : {}),
     },
     ...(profile?.model ? { model: profile.model } : {}),
     thinking: thinkingForProfile(profile?.thinking),

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -98,8 +98,7 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   private readonly _agentTokenUsage: Histogram;
   private readonly sandboxEnvTokens: string[];
   private readonly logger: pino.Logger;
-  private _betaFilterProxy: AnthropicBetaHeaderFilterProxy | null = null;
-  private _betaFilterProxyKey: string | null = null;
+  private _betaFilterProxy: Promise<AnthropicBetaHeaderFilterProxy> | null = null;
 
   constructor(options?: ClaudeAgentSdkAgentRunnerOptions) {
     this.queryFn = options?.queryFn ?? _query;
@@ -219,17 +218,19 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
       .filter(value => value.length > 0) ?? [];
     if (stripBetaValues.length === 0) return null;
 
-    const cacheKey = `${profile.base_url}::${stripBetaValues.sort().join(',')}`;
-    if (this._betaFilterProxy && this._betaFilterProxyKey === cacheKey) {
-      return this._betaFilterProxy.baseUrl;
+    if (!this._betaFilterProxy) {
+      this._betaFilterProxy = startAnthropicBetaHeaderFilterProxy(profile.base_url, { stripBetaValues });
     }
+    const proxy = await this._betaFilterProxy;
+    return proxy.baseUrl;
+  }
 
+  async close(): Promise<void> {
     if (this._betaFilterProxy) {
-      await this._betaFilterProxy.close();
+      const proxy = await this._betaFilterProxy;
+      await proxy.close();
+      this._betaFilterProxy = null;
     }
-    this._betaFilterProxy = await startAnthropicBetaHeaderFilterProxy(profile.base_url, { stripBetaValues });
-    this._betaFilterProxyKey = cacheKey;
-    return this._betaFilterProxy.baseUrl;
   }
 
   private async profileWithRuntimeSkillPlugins(profile: AgentProfile | undefined): Promise<AgentProfile | undefined> {

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -29,6 +29,7 @@ import type {
 import { createLogger } from '../../core/logger.js';
 import { materializeClaudeRuntimeSkillPlugins } from './claude-runtime-skill-materializer.js';
 import { buildSandboxEnvironment } from '../sandbox-environment.js';
+import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy } from './anthropic-beta-header-filter-proxy.js';
 
 type QueryFn = typeof _query;
 
@@ -97,6 +98,8 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   private readonly _agentTokenUsage: Histogram;
   private readonly sandboxEnvTokens: string[];
   private readonly logger: pino.Logger;
+  private _betaFilterProxy: AnthropicBetaHeaderFilterProxy | null = null;
+  private _betaFilterProxyKey: string | null = null;
 
   constructor(options?: ClaudeAgentSdkAgentRunnerOptions) {
     this.queryFn = options?.queryFn ?? _query;
@@ -138,9 +141,15 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
       );
     }
     const profile = await this.profileWithRuntimeSkillPlugins(request.profile);
+    const proxyBaseUrl = await this.betaFilterProxyUrl(profile);
+    const effectiveProfile = proxyBaseUrl && profile
+      ? { ...profile, base_url: proxyBaseUrl }
+      : profile;
     const stderrLines: string[] = [];
+    const sdkOptions = makeClaudeAgentSdkOptions(request.working_directory, effectiveProfile, this.sandboxEnvTokens);
     const options = {
-      ...makeClaudeAgentSdkOptions(request.working_directory, profile, this.sandboxEnvTokens),
+      ...sdkOptions,
+      ...(process.env['AUTOCATALYST_SDK_DEBUG'] ? { debug: true } : {}),
       stderr: (data: string) => {
         for (const line of data.split('\n')) {
           const trimmed = line.trim();
@@ -201,6 +210,26 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
       operation: 'query',
       model,
     });
+  }
+
+  private async betaFilterProxyUrl(profile: AgentProfile | undefined): Promise<string | null> {
+    if (!profile?.base_url) return null;
+    const stripBetaValues = profile.anthropic_beta_header_filter?.strip
+      .map(value => value.trim())
+      .filter(value => value.length > 0) ?? [];
+    if (stripBetaValues.length === 0) return null;
+
+    const cacheKey = `${profile.base_url}::${stripBetaValues.sort().join(',')}`;
+    if (this._betaFilterProxy && this._betaFilterProxyKey === cacheKey) {
+      return this._betaFilterProxy.baseUrl;
+    }
+
+    if (this._betaFilterProxy) {
+      await this._betaFilterProxy.close();
+    }
+    this._betaFilterProxy = await startAnthropicBetaHeaderFilterProxy(profile.base_url, { stripBetaValues });
+    this._betaFilterProxyKey = cacheKey;
+    return this._betaFilterProxy.baseUrl;
   }
 
   private async profileWithRuntimeSkillPlugins(profile: AgentProfile | undefined): Promise<AgentProfile | undefined> {

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -219,7 +219,13 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
     if (stripBetaValues.length === 0) return null;
 
     if (!this._betaFilterProxy) {
-      this._betaFilterProxy = startAnthropicBetaHeaderFilterProxy(profile.base_url, { stripBetaValues });
+      const pending = startAnthropicBetaHeaderFilterProxy(profile.base_url, { stripBetaValues });
+      this._betaFilterProxy = pending;
+      pending.catch(() => {
+        if (this._betaFilterProxy === pending) {
+          this._betaFilterProxy = null;
+        }
+      });
     }
     const proxy = await this._betaFilterProxy;
     return proxy.baseUrl;
@@ -227,8 +233,12 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
 
   async close(): Promise<void> {
     if (this._betaFilterProxy) {
-      const proxy = await this._betaFilterProxy;
-      await proxy.close();
+      try {
+        const proxy = await this._betaFilterProxy;
+        await proxy.close();
+      } catch {
+        // proxy never started successfully — nothing to close
+      }
       this._betaFilterProxy = null;
     }
   }

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -189,6 +189,7 @@ export function makeClaudeAgentSdkOptions(cwd: string, profile?: AgentProfile, s
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] ?? '128000',
       ...(profile?.api_key ? { ANTHROPIC_API_KEY: profile.api_key } : {}),
       ...(profile?.base_url ? { ANTHROPIC_BASE_URL: profile.base_url } : {}),
+      ...(profile?.api_key && profile?.base_url ? { ANTHROPIC_CUSTOM_HEADERS: `api-key: ${profile.api_key}` } : {}),
     },
     ...(profile?.model ? { model: profile.model } : {}),
     thinking: thinkingForProfile(profile?.thinking),

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -198,6 +198,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     reviewCoordinator,
     isConnected: () => adapter.isConnected(),
     meter: options.meter,
+    onStop: () => agentRunner.close?.() ?? Promise.resolve(),
   });
 }
 
@@ -325,6 +326,13 @@ export class RoutingAwareAgentRunner implements AgentRunner {
       return this.openAiRunner.run(request);
     }
     return this.claudeRunner.run(request);
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([
+      this.claudeRunner.close?.(),
+      this.openAiRunner.close?.(),
+    ]);
   }
 }
 

--- a/src/core/ai/routing-policy.ts
+++ b/src/core/ai/routing-policy.ts
@@ -34,8 +34,8 @@ export class DefaultAgentRoutingPolicy implements AgentRoutingPolicy {
 
 function buildAgentProfile(
   profile: ProfileConfig,
-  _endpoint: EndpointConfig,
-  _credential: ResolvedCredential | undefined,
+  endpoint: EndpointConfig,
+  credential: ResolvedCredential | undefined,
   route: AgentRoute,
 ): AgentProfile {
   return {
@@ -46,6 +46,8 @@ function buildAgentProfile(
     thinking: profile.anthropic?.thinking as AgentThinking | undefined,
     required_skills: requiredSkillsForRoute(route),
     plugins: profile.plugins,
+    api_key: credential?.resolvedValue,
+    base_url: endpoint.base_url,
   };
 }
 

--- a/src/core/ai/routing-policy.ts
+++ b/src/core/ai/routing-policy.ts
@@ -38,6 +38,7 @@ function buildAgentProfile(
   credential: ResolvedCredential | undefined,
   route: AgentRoute,
 ): AgentProfile {
+  const anthropicBetaHeaderFilter = betaHeaderFilterForEndpoint(endpoint);
   return {
     id: profile.name,
     provider: runnerToProvider(profile.runner),
@@ -48,7 +49,15 @@ function buildAgentProfile(
     plugins: profile.plugins,
     api_key: credential?.resolvedValue,
     base_url: endpoint.base_url,
+    ...(anthropicBetaHeaderFilter ? { anthropic_beta_header_filter: anthropicBetaHeaderFilter } : {}),
   };
+}
+
+function betaHeaderFilterForEndpoint(endpoint: EndpointConfig): AgentProfile['anthropic_beta_header_filter'] | undefined {
+  const strip = endpoint.anthropic_beta_header_filter?.strip
+    .map(value => value.trim())
+    .filter(value => value.length > 0) ?? [];
+  return strip.length > 0 ? { strip } : undefined;
 }
 
 function runnerToProvider(runner: RunnerKind): string {

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -12,6 +12,7 @@ export interface BootstrapWorkflowRuntimeDeps extends Omit<OrchestratorDeps, 'co
   intentClassifier: IntentClassifier;
   isConnected: () => boolean;
   meter?: Meter;
+  onStop?: () => Promise<void>;
 }
 
 export function bootstrapWorkflowRuntime(
@@ -41,6 +42,6 @@ export function bootstrapWorkflowRuntime(
     overrideRunStage: (requestId, stage) => orchestrator.overrideRunStage(requestId, stage),
   });
 
-  const service = new Service(config, { orchestrator });
+  const service = new Service(config, { orchestrator, onStop: deps.onStop });
   return { commandRegistry, orchestrator, service };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -281,6 +281,22 @@ export function resolveAiConfig(
     }
   }
 
+  // Validate that all claude_agent_sdk profiles share one beta filter config.
+  // The runner uses a single shared proxy — divergent configs would silently misroute.
+  const claudeSdkFilters = profiles
+    .filter(p => p.runner === 'claude_agent_sdk')
+    .map(p => {
+      const ep = endpoints.find(e => e.name === p.endpoint)!;
+      const strip = ep.anthropic_beta_header_filter?.strip ?? [];
+      return { profile: p.name, key: `${ep.base_url ?? ''}::${[...strip].sort().join(',')}` };
+    });
+  const distinctFilterKeys = new Set(claudeSdkFilters.map(f => f.key));
+  if (distinctFilterKeys.size > 1) {
+    throw new Error(
+      `All claude_agent_sdk profiles must share the same endpoint beta filter config. Found divergent configs across: ${claudeSdkFilters.map(f => f.profile).join(', ')}`,
+    );
+  }
+
   // Resolve and validate credentials
   const resolvedCredentials: ResolvedCredential[] = credentials.map(cred => {
     if (cred.type === 'workload_identity') {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -117,6 +117,31 @@ export function validateConfig(config: WorkflowConfig): void {
     }
   }
 
+  const rawAi = (config as Record<string, unknown>)['ai'];
+  if (rawAi !== undefined && rawAi !== null && typeof rawAi === 'object' && !Array.isArray(rawAi)) {
+    const endpoints = (rawAi as Record<string, unknown>)['endpoints'];
+    if (endpoints !== undefined) {
+      if (!Array.isArray(endpoints)) throw new Error('ai.endpoints must be an array');
+      for (const [endpointIndex, rawEndpoint] of endpoints.entries()) {
+        if (typeof rawEndpoint !== 'object' || rawEndpoint === null || Array.isArray(rawEndpoint)) continue;
+        const filter = (rawEndpoint as Record<string, unknown>)['anthropic_beta_header_filter'];
+        if (filter === undefined) continue;
+        if (typeof filter !== 'object' || filter === null || Array.isArray(filter)) {
+          throw new Error(`ai.endpoints[${endpointIndex}].anthropic_beta_header_filter must be an object`);
+        }
+        const strip = (filter as Record<string, unknown>)['strip'];
+        if (!Array.isArray(strip)) {
+          throw new Error(`ai.endpoints[${endpointIndex}].anthropic_beta_header_filter.strip must be an array`);
+        }
+        for (const [stripIndex, value] of strip.entries()) {
+          if (typeof value !== 'string' || value.trim() === '') {
+            throw new Error(`ai.endpoints[${endpointIndex}].anthropic_beta_header_filter.strip[${stripIndex}] must be a non-empty string`);
+          }
+        }
+      }
+    }
+  }
+
   const rawSandbox = (config as Record<string, unknown>)['sandbox'];
   if (rawSandbox !== undefined && rawSandbox !== null) {
     if (typeof rawSandbox !== 'object' || Array.isArray(rawSandbox)) {

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -6,6 +6,7 @@ import type { Orchestrator } from './orchestrator.js';
 interface ServiceOptions {
   logDestination?: pino.DestinationStream;
   orchestrator?: Orchestrator;
+  onStop?: () => Promise<void>;
 }
 
 export class Service {
@@ -17,10 +18,12 @@ export class Service {
   private _stopped: Promise<void>;
   private _resolveStopped!: () => void;
   private readonly orchestrator: Orchestrator | undefined;
+  private readonly onStop: (() => Promise<void>) | undefined;
 
   constructor(config: LoadedConfig, options?: ServiceOptions) {
     this.config = config;
     this.orchestrator = options?.orchestrator;
+    this.onStop = options?.onStop;
     this.logger = createLogger('service', { destination: options?.logDestination });
     this._stopped = new Promise(resolve => {
       this._resolveStopped = resolve;
@@ -68,19 +71,25 @@ export class Service {
     this.running = false;
     this.stopping = false;
 
-    if (this.orchestrator) {
-      this.orchestrator.stop()
-        .catch(err => {
+    const cleanup = async () => {
+      if (this.orchestrator) {
+        try {
+          await this.orchestrator.stop();
+        } catch (err) {
           this.logger.error({ event: 'service.orchestrator_stop_failed', error: String(err) }, 'Orchestrator failed to stop');
-        })
-        .finally(() => {
-          this.logger.info({ event: 'service.stopped' }, 'Shutdown complete');
-          this._resolveStopped();
-        });
-    } else {
+        }
+      }
+      if (this.onStop) {
+        try {
+          await this.onStop();
+        } catch (err) {
+          this.logger.error({ event: 'service.onstop_failed', error: String(err) }, 'onStop callback failed');
+        }
+      }
       this.logger.info({ event: 'service.stopped' }, 'Shutdown complete');
       this._resolveStopped();
-    }
+    };
+    cleanup();
   }
 
   private tick(): void {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -49,6 +49,9 @@ export interface AgentProfile {
   plugins?: AgentPluginConfig[];
   api_key?: string;
   base_url?: string;
+  anthropic_beta_header_filter?: {
+    strip: string[];
+  };
 }
 
 export interface AgentProfileSummary {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -47,6 +47,8 @@ export interface AgentProfile {
   load_user_settings?: boolean;
   required_skills?: AgentSkillRef[];
   plugins?: AgentPluginConfig[];
+  api_key?: string;
+  base_url?: string;
 }
 
 export interface AgentProfileSummary {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -157,6 +157,7 @@ export interface AgentRunRequest {
 
 export interface AgentRunner {
   run(request: AgentRunRequest): AsyncIterable<AgentRunEvent>;
+  close?(): Promise<void>;
 }
 
 export interface ArtifactComment {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -30,6 +30,11 @@ export interface EndpointConfig {
   base_url?: string;
   /** Bedrock-specific region */
   region?: string;
+  /** Anthropic-specific beta header filter for gateway compatibility. */
+  anthropic_beta_header_filter?: {
+    /** Beta values to remove from the anthropic-beta request header. */
+    strip: string[];
+  };
 }
 
 export interface ProfileConfig {

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -1,0 +1,91 @@
+import { once } from 'node:events';
+import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
+import { afterEach, describe, expect, test } from 'vitest';
+import { startAnthropicBetaHeaderFilterProxy } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
+
+async function listen(server: Server): Promise<number> {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('test server did not bind to a TCP port');
+  return address.port;
+}
+
+async function close(server: Server): Promise<void> {
+  if (!server.listening) return;
+  server.close();
+  await once(server, 'close');
+}
+
+describe('Anthropic beta header filter proxy', () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map(server => close(server)));
+    servers.length = 0;
+  });
+
+  test('removes configured beta values from proxied requests', async () => {
+    const received: Array<{ url: string | undefined; headers: IncomingHttpHeaders; body: string }> = [];
+    const upstream = createServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => {
+        received.push({ url: req.url, headers: req.headers, body });
+        res.writeHead(200, { 'content-type': 'application/json', 'x-upstream': 'ok' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    servers.push(upstream);
+    const upstreamPort = await listen(upstream);
+
+    const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}/anthropic`, {
+      stripBetaValues: ['advisor-tool-2026-03-01', 'context-management-2025-06-27'],
+    });
+    servers.push(proxy.server);
+
+    const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'api-key': 'sk-test',
+        'anthropic-beta': 'context-1m-2025-08-07, context-management-2025-06-27, advisor-tool-2026-03-01, task-budgets-2026-03-13',
+      },
+      body: JSON.stringify({ stream: false }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(received).toHaveLength(1);
+    expect(received[0].url).toBe('/anthropic/v1/messages');
+    expect(received[0].body).toBe(JSON.stringify({ stream: false }));
+    expect(received[0].headers['api-key']).toBe('sk-test');
+    expect(received[0].headers['anthropic-beta']).toBe('context-1m-2025-08-07, task-budgets-2026-03-13');
+  });
+
+  test('omits anthropic-beta when configured strip values remove all beta values', async () => {
+    const receivedHeaders: IncomingHttpHeaders[] = [];
+    const upstream = createServer((req, res) => {
+      receivedHeaders.push(req.headers);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+    servers.push(upstream);
+    const upstreamPort = await listen(upstream);
+
+    const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+      stripBetaValues: ['advisor-tool-2026-03-01'],
+    });
+    servers.push(proxy.server);
+
+    const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: { 'anthropic-beta': 'advisor-tool-2026-03-01' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(receivedHeaders).toHaveLength(1);
+    expect(receivedHeaders[0]).not.toHaveProperty('anthropic-beta');
+  });
+});

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -512,4 +512,81 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     );
     expect(warning).toBeUndefined();
   });
+
+  test('captures stderr and logs it when SDK exits with error', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const queryFn = vi.fn().mockImplementation(function ({ options }: { options: { stderr?: (data: string) => void } }) {
+      options.stderr?.('Unable to verify organization\n');
+      options.stderr?.('Token may lack user:profile scope\n');
+      return (async function* () {
+        yield { type: 'result', subtype: 'error_max_turns', is_error: true, usage: { input_tokens: 5, output_tokens: 2 } };
+      })();
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn, logDestination: dest });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6', effort: 'high' },
+    }));
+
+    const stderrLog = getLogs().find(
+      log => log['event'] === 'sdk.stderr_on_error',
+    );
+    expect(stderrLog).toBeDefined();
+    expect(stderrLog!['stderr_excerpt']).toContain('Unable to verify organization');
+    expect(stderrLog!['stderr_excerpt']).toContain('Token may lack user:profile scope');
+    expect(stderrLog!['route_task']).toBe('implementation.run');
+  });
+
+  test('redacts secrets from stderr output', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const queryFn = vi.fn().mockImplementation(function ({ options }: { options: { stderr?: (data: string) => void } }) {
+      options.stderr?.('Error: api_key=sk-ant-secret123 is invalid\n');
+      options.stderr?.('Token ghp_R862tsYUn7O33OQqABC leaked\n');
+      return (async function* () {
+        yield { type: 'result', subtype: 'error_max_turns', is_error: true, usage: { input_tokens: 5, output_tokens: 2 } };
+      })();
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn, logDestination: dest });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6', effort: 'high' },
+    }));
+
+    const stderrLog = getLogs().find(
+      log => log['event'] === 'sdk.stderr_on_error',
+    );
+    expect(stderrLog).toBeDefined();
+    expect(stderrLog!['stderr_excerpt']).not.toContain('sk-ant-secret123');
+    expect(stderrLog!['stderr_excerpt']).not.toContain('ghp_R862tsYUn7O33OQq');
+    expect(stderrLog!['stderr_excerpt']).toContain('[REDACTED]');
+  });
+
+  test('does not log stderr when SDK exits successfully', async () => {
+    const { dest, getLogs } = makeLogCapture();
+    const queryFn = vi.fn().mockImplementation(function ({ options }: { options: { stderr?: (data: string) => void } }) {
+      options.stderr?.('some debug noise\n');
+      return (async function* () {
+        yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 5, output_tokens: 2 } };
+      })();
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn, logDestination: dest });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6', effort: 'high' },
+    }));
+
+    const errorLog = getLogs().find(
+      log => log['event'] === 'sdk.stderr_on_error',
+    );
+    expect(errorLog).toBeUndefined();
+  });
 });

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -430,6 +430,7 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     const call = queryFn.mock.calls[0][0];
     expect(call.options.env['ANTHROPIC_API_KEY']).toBe('sk-grove-test-key');
     expect(call.options.env['ANTHROPIC_BASE_URL']).toBe('https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic');
+    expect(call.options.env['ANTHROPIC_CUSTOM_HEADERS']).toBe('api-key: sk-grove-test-key');
   });
 
   test('omits ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL when profile has no credentials', async () => {
@@ -453,6 +454,7 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     const call = queryFn.mock.calls[0][0];
     expect(call.options.env).not.toHaveProperty('ANTHROPIC_API_KEY');
     expect(call.options.env).not.toHaveProperty('ANTHROPIC_BASE_URL');
+    expect(call.options.env).not.toHaveProperty('ANTHROPIC_CUSTOM_HEADERS');
   });
 
   test('logs a warning for issue.triage when no GitHub token is in the sandbox environment', async () => {

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -407,7 +407,7 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     expect(call.options.env).not.toHaveProperty('AC_GH_TOKEN');
   });
 
-  test('injects ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL from profile credentials', async () => {
+  test('injects ANTHROPIC_API_KEY and custom headers from profile credentials', async () => {
     const queryFn = vi.fn().mockImplementation(async function* () {
       yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
     });
@@ -429,8 +429,66 @@ describe('ClaudeAgentSdkAgentRunner', () => {
 
     const call = queryFn.mock.calls[0][0];
     expect(call.options.env['ANTHROPIC_API_KEY']).toBe('sk-grove-test-key');
-    expect(call.options.env['ANTHROPIC_BASE_URL']).toBe('https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic');
+    expect(call.options.env['ANTHROPIC_BASE_URL']).toBeDefined();
     expect(call.options.env['ANTHROPIC_CUSTOM_HEADERS']).toBe('api-key: sk-grove-test-key');
+  });
+
+  test('passes custom Anthropic base URLs through unchanged without configured beta values to strip', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+    const groveBaseUrl = 'https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic';
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: {
+        id: 'impl',
+        provider: 'claude_agent_sdk',
+        model: 'claude-sonnet-4-6',
+        effort: 'high',
+        api_key: 'sk-grove-test-key',
+        base_url: groveBaseUrl,
+      },
+    }));
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env['ANTHROPIC_API_KEY']).toBe('sk-grove-test-key');
+    expect(call.options.env['ANTHROPIC_CUSTOM_HEADERS']).toBe('api-key: sk-grove-test-key');
+    expect(call.options.env['ANTHROPIC_BASE_URL']).toBe(groveBaseUrl);
+  });
+
+  test('routes custom Anthropic base URLs through a loopback beta-header filter when beta values are configured to strip', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+    const groveBaseUrl = 'https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic';
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: {
+        id: 'impl',
+        provider: 'claude_agent_sdk',
+        model: 'claude-sonnet-4-6',
+        effort: 'high',
+        api_key: 'sk-grove-test-key',
+        base_url: groveBaseUrl,
+        anthropic_beta_header_filter: {
+          strip: ['advisor-tool-2026-03-01'],
+        },
+      },
+    }));
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env['ANTHROPIC_API_KEY']).toBe('sk-grove-test-key');
+    expect(call.options.env['ANTHROPIC_CUSTOM_HEADERS']).toBe('api-key: sk-grove-test-key');
+    expect(call.options.env['ANTHROPIC_BASE_URL']).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(call.options.env['ANTHROPIC_BASE_URL']).not.toBe(groveBaseUrl);
   });
 
   test('omits ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL when profile has no credentials', async () => {

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -407,6 +407,54 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     expect(call.options.env).not.toHaveProperty('AC_GH_TOKEN');
   });
 
+  test('injects ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL from profile credentials', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: {
+        id: 'impl',
+        provider: 'claude_agent_sdk',
+        model: 'claude-sonnet-4-6',
+        effort: 'high',
+        api_key: 'sk-grove-test-key',
+        base_url: 'https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic',
+      },
+    }));
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env['ANTHROPIC_API_KEY']).toBe('sk-grove-test-key');
+    expect(call.options.env['ANTHROPIC_BASE_URL']).toBe('https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic');
+  });
+
+  test('omits ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL when profile has no credentials', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: {
+        id: 'impl',
+        provider: 'claude_agent_sdk',
+        model: 'claude-sonnet-4-6',
+        effort: 'high',
+      },
+    }));
+
+    const call = queryFn.mock.calls[0][0];
+    expect(call.options.env).not.toHaveProperty('ANTHROPIC_API_KEY');
+    expect(call.options.env).not.toHaveProperty('ANTHROPIC_BASE_URL');
+  });
+
   test('logs a warning for issue.triage when no GitHub token is in the sandbox environment', async () => {
     const { dest, getLogs } = makeLogCapture();
     const queryFn = vi.fn().mockImplementation(async function* () {

--- a/tests/core/ai/routing-policy.test.ts
+++ b/tests/core/ai/routing-policy.test.ts
@@ -125,6 +125,45 @@ describe('DefaultAgentRoutingPolicy', () => {
     expect(profile.base_url).toBe('https://custom.endpoint/v1');
   });
 
+  test('passes endpoint beta header filter config through to AgentProfile', () => {
+    const config = makeAiConfig({
+      endpoints: [
+        {
+          name: 'ep',
+          protocol: 'anthropic',
+          credential: 'my-key',
+          base_url: 'https://custom.endpoint',
+          anthropic_beta_header_filter: {
+            strip: ['advisor-tool-2026-03-01', 'context-management-2025-06-27'],
+          },
+        },
+      ],
+    });
+    const policy = new DefaultAgentRoutingPolicy(config);
+    const profile = policy.resolve({ task: 'implementation.run' });
+
+    expect(profile.anthropic_beta_header_filter).toEqual({
+      strip: ['advisor-tool-2026-03-01', 'context-management-2025-06-27'],
+    });
+  });
+
+  test('omits beta header filter config when endpoint strip list is empty', () => {
+    const config = makeAiConfig({
+      endpoints: [
+        {
+          name: 'ep',
+          protocol: 'anthropic',
+          credential: 'my-key',
+          anthropic_beta_header_filter: { strip: [] },
+        },
+      ],
+    });
+    const policy = new DefaultAgentRoutingPolicy(config);
+    const profile = policy.resolve({ task: 'implementation.run' });
+
+    expect(profile.anthropic_beta_header_filter).toBeUndefined();
+  });
+
   test('api_key is undefined when credential has no resolvedValue', () => {
     const policy = new DefaultAgentRoutingPolicy(makeAiConfig());
     const profile = policy.resolve({ task: 'intent.classify' });

--- a/tests/core/ai/routing-policy.test.ts
+++ b/tests/core/ai/routing-policy.test.ts
@@ -112,6 +112,34 @@ describe('DefaultAgentRoutingPolicy', () => {
     });
   });
 
+  test('passes credential and endpoint base_url through to AgentProfile', () => {
+    const config = makeAiConfig({
+      credentials: [{ name: 'my-key', type: 'api_key', value: 'sk-test' }],
+      endpoints: [{ name: 'ep', protocol: 'anthropic', credential: 'my-key', base_url: 'https://custom.endpoint/v1' }],
+    });
+    // Simulate resolved credentials (as runtime-composition would provide)
+    (config.credentials as unknown as Array<{ name: string; type: string; resolvedValue: string }>)[0].resolvedValue = 'sk-resolved';
+    const policy = new DefaultAgentRoutingPolicy(config);
+    const profile = policy.resolve({ task: 'intent.classify' });
+    expect(profile.api_key).toBe('sk-resolved');
+    expect(profile.base_url).toBe('https://custom.endpoint/v1');
+  });
+
+  test('api_key is undefined when credential has no resolvedValue', () => {
+    const policy = new DefaultAgentRoutingPolicy(makeAiConfig());
+    const profile = policy.resolve({ task: 'intent.classify' });
+    expect(profile.api_key).toBeUndefined();
+  });
+
+  test('base_url is undefined when endpoint has no base_url', () => {
+    const config = makeAiConfig({
+      endpoints: [{ name: 'ep', protocol: 'anthropic', credential: 'my-key' }],
+    });
+    const policy = new DefaultAgentRoutingPolicy(config);
+    const profile = policy.resolve({ task: 'intent.classify' });
+    expect(profile.base_url).toBeUndefined();
+  });
+
   test('resolveOptional returns null when route task is not in routing config', () => {
     const config = makeAiConfig();
     delete config.routing['question.answer'];

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -209,6 +209,60 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ polling: { interval_ms: -1 } } as WorkflowConfig))
       .toThrow(/interval_ms/);
   });
+
+  it('passes for endpoint beta header filter strip config', () => {
+    expect(() => validateConfig({
+      ai: {
+        credentials: [],
+        profiles: [],
+        routing: {},
+        endpoints: [{
+          name: 'grove-anthropic',
+          protocol: 'anthropic',
+          credential: 'grove',
+          anthropic_beta_header_filter: {
+            strip: ['advisor-tool-2026-03-01'],
+          },
+        }],
+      },
+    } as unknown as WorkflowConfig)).not.toThrow();
+  });
+
+  it('throws when endpoint beta header filter strip config is not an array', () => {
+    expect(() => validateConfig({
+      ai: {
+        credentials: [],
+        profiles: [],
+        routing: {},
+        endpoints: [{
+          name: 'grove-anthropic',
+          protocol: 'anthropic',
+          credential: 'grove',
+          anthropic_beta_header_filter: {
+            strip: 'advisor-tool-2026-03-01',
+          },
+        }],
+      },
+    } as unknown as WorkflowConfig)).toThrow('ai.endpoints[0].anthropic_beta_header_filter.strip must be an array');
+  });
+
+  it('throws when endpoint beta header filter strip config contains an empty value', () => {
+    expect(() => validateConfig({
+      ai: {
+        credentials: [],
+        profiles: [],
+        routing: {},
+        endpoints: [{
+          name: 'grove-anthropic',
+          protocol: 'anthropic',
+          credential: 'grove',
+          anthropic_beta_header_filter: {
+            strip: ['advisor-tool-2026-03-01', ''],
+          },
+        }],
+      },
+    } as unknown as WorkflowConfig)).toThrow('ai.endpoints[0].anthropic_beta_header_filter.strip[1] must be a non-empty string');
+  });
 });
 
 // ─── redactConfig (unchanged) ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #156

- Thread resolved endpoint credentials (`api_key`, `base_url`) into the Claude Agent SDK subprocess env as `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, and `ANTHROPIC_CUSTOM_HEADERS` (Grove expects `api-key` header, not `x-api-key`)
- Add configurable loopback proxy (`anthropic_beta_header_filter` on endpoint config) that strips specific `anthropic-beta` header values before forwarding — Claude Code sends `advisor-tool-2026-03-01` unconditionally and Grove rejects it
- Capture Claude Code subprocess stderr in structured logs on error exit (#153 partial)
- Add missing `implementation.review.initial` / `implementation.review.final` routing entries
- Add OpenAI gpt-5.5 and gpt-5.4-nano profiles
- Wire proxy shutdown into service stop lifecycle
- Startup validation ensures all `claude_agent_sdk` profiles share one beta filter config

## Test plan

- [x] `npm test` — 1116 tests pass across 75 files
- [x] `tsc --noEmit` — clean
- [x] Manual verification: Claude Agent SDK routes authenticate and complete against Grove
- [ ] Verify `AUTOCATALYST_SDK_DEBUG=1` produces debug output in `~/.claude/debug/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)