### PR TITLE
feat: add slack-rendered publication link labels for spec and testing guides

### DIFF
--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -218,6 +218,7 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
     return {
       id: page_id,
       url: `https://notion.so/${page_id.replace(/-/g, '')}`,
+      label: 'View testing guide',
     };
   }
 

--- a/src/adapters/notion/notion-publisher.ts
+++ b/src/adapters/notion/notion-publisher.ts
@@ -110,7 +110,7 @@ export class NotionPublisher implements ArtifactPublisher, ArtifactContentSource
       { event: 'notion_spec.properties_created', page_id: pageId, duration_ms },
       'Spec database entry created',
     );
-    return { id: pageId, url: pageUrl };
+    return { id: pageId, url: pageUrl, label: 'View spec' };
   }
 
   async getContent(publisher_ref: string, stripHtml = false): Promise<string> {

--- a/src/adapters/slack/canvas-publisher.ts
+++ b/src/adapters/slack/canvas-publisher.ts
@@ -63,7 +63,7 @@ export class SlackCanvasPublisher implements ArtifactPublisher {
 
     const url = this.canvasUrl(canvas_id);
     this.logger.info({ event: 'canvas.created', channel_id, canvas_id }, 'Canvas created');
-    return { id: canvas_id, url };
+    return { id: canvas_id, url, label: 'View spec' };
   }
 
   async updateArtifact(canvas_id: string, artifact: Artifact, page_content?: string): Promise<void> {

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -141,8 +141,11 @@ export class ArtifactCreationHandler {
 
   private async postArtifactPublication(conversation: ConversationRef, publication: ArtifactPublication): Promise<void> {
     if (!publication.url) return;
+    const linkText = publication.label
+      ? `${publication.label} — ${publication.url}`
+      : publication.url;
     try {
-      await this.deps.postMessage(conversation, `Artifact ready for review: ${publication.url}`);
+      await this.deps.postMessage(conversation, `Artifact ready for review: ${linkText}`);
     } catch (err) {
       this.deps.logger.warn(
         { event: 'artifact.publication_notify_failed', publication_ref: publication.id, error: String(err) },

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -127,6 +127,7 @@ export class ImplementationStartHandler {
     this.deps.persist();
 
     let feedbackPageUrl: string | undefined;
+    let feedbackPageLabel: string | undefined;
     try {
       // Log legacy warning if structured output is missing
       if (!reviewedResult.review_summary || !reviewedResult.testing_steps) {
@@ -150,6 +151,7 @@ export class ImplementationStartHandler {
       run.impl_feedback_ref = publishedReview.id;
       this.deps.persist();
       feedbackPageUrl = publishedReview.url;
+      feedbackPageLabel = publishedReview.label;
     } catch (err) {
       this.deps.logger.error(
         { event: 'run.feedback_page_failed', run_id: run.id, error: String(err) },
@@ -158,7 +160,9 @@ export class ImplementationStartHandler {
     }
 
     const completionMsg = feedbackPageUrl
-      ? `Implementation complete. Feedback page: ${feedbackPageUrl}`
+      ? feedbackPageLabel
+        ? `Implementation complete. ${feedbackPageLabel} \u2014 ${feedbackPageUrl}`
+        : `Implementation complete. Feedback page: ${feedbackPageUrl}`
       : 'Implementation complete. (Could not create feedback page \u2014 check logs.)';
     try {
       await this.deps.postMessage(feedback.conversation, completionMsg);

--- a/src/types/impl-feedback-page.ts
+++ b/src/types/impl-feedback-page.ts
@@ -16,6 +16,7 @@ export interface FeedbackItem {
 export interface PublishedImplementationReview {
   id: string;
   url?: string;
+  label?: string;
 }
 
 export interface ImplementationReviewInput {

--- a/src/types/publisher.ts
+++ b/src/types/publisher.ts
@@ -20,6 +20,7 @@ export interface ArtifactPublication {
   id: string;
   url?: string;
   provider?: string;
+  label?: string;
 }
 
 export interface ArtifactCommentAnchor {

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -126,7 +126,7 @@ describe('NotionImplementationFeedbackPage — create', () => {
 
     const result = await page.create(makeReviewInput());
 
-    expect(result).toEqual({ id: 'new-page-id', url: 'https://notion.so/newpageid' });
+    expect(result).toEqual({ id: 'new-page-id', url: 'https://notion.so/newpageid', label: 'View testing guide' });
   });
 
   it('sets Title to "Testing guide: {spec_title}"', async () => {
@@ -313,6 +313,13 @@ describe('NotionImplementationFeedbackPage — create', () => {
     expect(placeholder?.type).toBe('to_do');
     expect(placeholder?.to_do!.rich_text[0].text.content).toBe('Add any extra testing steps here.');
     expect(placeholder?.to_do!.checked).toBe(false);
+  });
+
+  it('returns label "View testing guide" as part of the published review result', async () => {
+    const client = makeNotionClient();
+    const page = new NotionImplementationFeedbackPage(client, 'db-testing-guides-id', { logDestination: nullDest });
+    const result = await page.create(makeReviewInput());
+    expect(result.label).toBe('View testing guide');
   });
 
   it('falls back to legacy summary as single Changes bullet and fixed Confirm bullet', async () => {

--- a/tests/adapters/notion/notion-publisher.test.ts
+++ b/tests/adapters/notion/notion-publisher.test.ts
@@ -168,7 +168,7 @@ describe('NotionPublisher.createArtifact', () => {
     const result = await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
 
     expect(callOrder).toEqual(['pages.create', 'pages.updateMarkdown']);
-    expect(result).toEqual({ id: 'page-abc-123-xyz', url: 'https://notion.so/pageabc123xyz' });
+    expect(result).toEqual({ id: 'page-abc-123-xyz', url: 'https://notion.so/pageabc123xyz', label: 'View spec' });
   });
 
   it('returns publication metadata', async () => {
@@ -178,7 +178,15 @@ describe('NotionPublisher.createArtifact', () => {
     const specPath = makeSpecFile();
     const result = await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
 
-    expect(result).toEqual({ id: 'returned-page-id', url: 'https://notion.so/returnedpageid' });
+    expect(result).toEqual({ id: 'returned-page-id', url: 'https://notion.so/returnedpageid', label: 'View spec' });
+  });
+
+  it('returns label "View spec" as part of the publication result', async () => {
+    const client = makeMockNotionClient('page-label-test');
+    const publisher = new NotionPublisher(client, 'db-specs-id', { logDestination: nullDest });
+    const specPath = makeSpecFile();
+    const result = await publisher.createArtifact(makeConversation(), makeArtifact(specPath));
+    expect(result.label).toBe('View spec');
   });
 
   it('throws if pages.create rejects; updateMarkdown is never called', async () => {

--- a/tests/adapters/slack/canvas-publisher.test.ts
+++ b/tests/adapters/slack/canvas-publisher.test.ts
@@ -79,6 +79,7 @@ describe('ArtifactPublisher.createArtifact', () => {
     expect(result).toEqual({
       id: 'CANVAS999',
       url: 'https://testworkspace.slack.com/docs/T123/CANVAS999',
+      label: 'View spec',
     });
     expect(mock.client.chat.postMessage).not.toHaveBeenCalled();
   });
@@ -109,7 +110,16 @@ describe('ArtifactPublisher.createArtifact', () => {
     expect(result).toEqual({
       id: 'CANVAS_XYZ',
       url: 'https://testworkspace.slack.com/docs/T123/CANVAS_XYZ',
+      label: 'View spec',
     });
+  });
+
+  it('returns label "View spec" as part of the publication result', async () => {
+    const mock = makeMockApp('CANVAS_LABEL');
+    const specPath = makeSpecFile();
+    const cp = new SlackCanvasPublisher(mock as unknown as App, { logDestination: nullDest });
+    const result = await cp.createArtifact(makeConversation(), makeArtifact(specPath));
+    expect(result.label).toBe('View spec');
   });
 
   it('throws if canvases.create rejects; postMessage is not called', async () => {

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -174,4 +174,56 @@ describe('ArtifactCreationHandler', () => {
     expect(deps.artifactPublisher.createArtifact).toHaveBeenCalled();
     expect(deps.failRun).not.toHaveBeenCalled();
   });
+
+  it('posts a labeled link message when ArtifactPublication includes label and url', async () => {
+    const { handler, deps } = makeHandler({
+      artifactPublisher: {
+        createArtifact: vi.fn().mockResolvedValue({
+          id: 'CANVAS001',
+          url: 'https://artifact.example.test/CANVAS001',
+          label: 'View spec',
+        }),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun({ intent: 'idea' });
+    await handler.handle(run, makeRequest(), 'idea');
+    expect(deps.postMessage).toHaveBeenCalledWith(
+      TEST_CONVERSATION,
+      'Artifact ready for review: View spec — https://artifact.example.test/CANVAS001',
+    );
+  });
+
+  it('falls back to url-only message when label is absent', async () => {
+    const { handler, deps } = makeHandler({
+      artifactPublisher: {
+        createArtifact: vi.fn().mockResolvedValue({
+          id: 'CANVAS001',
+          url: 'https://artifact.example.test/CANVAS001',
+        }),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun({ intent: 'idea' });
+    await handler.handle(run, makeRequest(), 'idea');
+    expect(deps.postMessage).toHaveBeenCalledWith(
+      TEST_CONVERSATION,
+      'Artifact ready for review: https://artifact.example.test/CANVAS001',
+    );
+  });
+
+  it('posts no publication link when url is absent', async () => {
+    const { handler, deps } = makeHandler({
+      artifactPublisher: {
+        createArtifact: vi.fn().mockResolvedValue({ id: 'CANVAS001' }),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun({ intent: 'idea' });
+    await handler.handle(run, makeRequest(), 'idea');
+    expect(deps.postMessage).not.toHaveBeenCalledWith(
+      TEST_CONVERSATION,
+      expect.stringContaining('Artifact ready for review'),
+    );
+  });
 });

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -398,4 +398,41 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     expect(result).toEqual({ status: 'reviewing_implementation' });
     expect(deps.implFeedbackPage?.create).toHaveBeenCalled();
   });
+
+  it('posts a labeled testing-guide link when PublishedImplementationReview includes label and url', async () => {
+    const { handler, deps } = makeHandler({
+      implFeedbackPage: {
+        create: vi.fn().mockResolvedValue({
+          id: 'feedback-page-id',
+          url: 'https://example.test/feedback-page-id',
+          label: 'View testing guide',
+        }),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun();
+    await handler.handle(run, makeFeedback());
+    expect(deps.postMessage).toHaveBeenCalledWith(
+      TEST_CONVERSATION,
+      'Implementation complete. View testing guide — https://example.test/feedback-page-id',
+    );
+  });
+
+  it('falls back to url-only completion message when label is absent from PublishedImplementationReview', async () => {
+    const { handler, deps } = makeHandler({
+      implFeedbackPage: {
+        create: vi.fn().mockResolvedValue({
+          id: 'feedback-page-id',
+          url: 'https://example.test/feedback-page-id',
+        }),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const run = makeRun();
+    await handler.handle(run, makeFeedback());
+    expect(deps.postMessage).toHaveBeenCalledWith(
+      TEST_CONVERSATION,
+      'Implementation complete. Feedback page: https://example.test/feedback-page-id',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add optional `label` field to `ArtifactPublication` and `PublishedImplFeedbackRef` types
- Notion publisher returns label "View spec" from `createArtifact`
- Implementation feedback page returns label "View testing guide"
- Handlers use labels in Slack notifications for polished link rendering

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Trigger a run through to spec publication and verify Slack message shows "View spec" link label
- [ ] Verify implementation-complete notification shows "View testing guide" link label