### PR TITLE
fix: ignore :ac-set-status: emoji reactions outside known run thread context

### DIFF
--- a/src/adapters/slack/classifier.ts
+++ b/src/adapters/slack/classifier.ts
@@ -45,6 +45,13 @@ export function classifyMessage(
     const emojiKey = `ac-${commandMatch[1]}`;
     const commandName = EMOJI_COMMAND_TABLE[emojiKey];
     if (commandName) {
+      // MESSAGE_ONLY_COMMANDS require a registered run thread — reject root and unregistered messages
+      if (MESSAGE_ONLY_COMMANDS.has(commandName)) {
+        const isReply = message.thread_ts !== undefined && message.thread_ts !== message.ts;
+        if (!isReply || registry.resolve(message.thread_ts!) === undefined) {
+          return { intent: 'ignore' };
+        }
+      }
       const stripped = (message.text ?? '').replace(/:ac-[a-z0-9_-]+:/, '').trim();
       const args = stripped ? stripped.split(/\s+/) : [];
       return { intent: 'command', command: commandName, args };

--- a/src/adapters/slack/classifier.ts
+++ b/src/adapters/slack/classifier.ts
@@ -24,6 +24,13 @@ export const EMOJI_COMMAND_TABLE: Record<string, string> = {
   'ac-set-status': 'run.set-status',
 };
 
+/**
+ * Commands that may only be dispatched via a Slack message, never via an emoji reaction.
+ * The reaction_added handler checks this set and discards the event before fetching
+ * message history or emitting a CommandEvent.
+ */
+export const MESSAGE_ONLY_COMMANDS = new Set<string>(['run.set-status']);
+
 export function classifyMessage(
   message: MessageInput,
   botUserId: string,

--- a/src/adapters/slack/slack-adapter.ts
+++ b/src/adapters/slack/slack-adapter.ts
@@ -6,8 +6,7 @@ import { createLogger } from '../../core/logger.js';
 import type { ChannelAdapter } from '../channel-adapter.js';
 import type { ChannelRegistry, ConversationRef, MessageRef } from '../../types/channel.js';
 import type { InboundEvent, Request, ThreadMessage } from '../../types/events.js';
-import { classifyMessage } from './classifier.js';
-import { EMOJI_COMMAND_TABLE } from './classifier.js';
+import { classifyMessage, EMOJI_COMMAND_TABLE, MESSAGE_ONLY_COMMANDS } from './classifier.js';
 import type { CommandEvent } from '../../types/commands.js';
 import { ThreadRegistry } from './thread-registry.js';
 import type { RepoEntry, ChannelRepoMap, PreRepoEntry } from '../../types/config.js';
@@ -293,6 +292,13 @@ export class SlackAdapter implements ChannelAdapter {
       const commandName = EMOJI_COMMAND_TABLE[reaction.reaction];
       if (!commandName) {
         this.logger.debug({ event: 'slack.reaction.ignored', emoji: reaction.reaction }, 'Reaction ignored');
+        return;
+      }
+      if (MESSAGE_ONLY_COMMANDS.has(commandName)) {
+        this.logger.debug(
+          { event: 'slack.reaction.ignored', emoji: reaction.reaction, reason: 'message_only_command' },
+          'Reaction ignored — command requires explicit thread message',
+        );
         return;
       }
 

--- a/src/core/commands/set-status-command.ts
+++ b/src/core/commands/set-status-command.ts
@@ -13,8 +13,7 @@ const VALID_STAGES_LIST = VALID_RUN_STAGES.join(', ');
 export function createSetStatusHandler(deps: SetStatusCommandDeps): CommandHandler {
   return async (event, reply) => {
     // Read stage from args (text command: :ac-set-status: <stage>)
-    // or messageText (emoji reaction on a message containing the stage name)
-    const stageInput = event.args.length > 0 ? event.args.join(' ') : (event.messageText ?? '');
+    const stageInput = event.args.join(' ');
     const stage = stageInput.trim().toLowerCase();
 
     if (!stage) {

--- a/tests/adapters/slack/classifier.test.ts
+++ b/tests/adapters/slack/classifier.test.ts
@@ -237,6 +237,39 @@ describe('classifyMessage — command detection', () => {
   });
 });
 
+describe('classifyMessage — MESSAGE_ONLY_COMMANDS thread guard (ac-set-status)', () => {
+  it(':ac-set-status: in registered run thread → command run.set-status with stage arg', () => {
+    const result = classifyMessage(
+      { text: ':ac-set-status: reviewing_implementation', user: 'U999', ts: '200.0', thread_ts: '100.0' },
+      BOT_ID,
+      makeRegistry({ '100.0': 'req-001' }),
+    );
+    expect(result.intent).toBe('command');
+    if (result.intent === 'command') {
+      expect(result.command).toBe('run.set-status');
+      expect(result.args).toEqual(['reviewing_implementation']);
+    }
+  });
+
+  it(':ac-set-status: in root message → ignore', () => {
+    const result = classifyMessage(
+      { text: ':ac-set-status: reviewing_implementation', user: 'U999', ts: '100.0' },
+      BOT_ID,
+      makeRegistry(),
+    );
+    expect(result.intent).toBe('ignore');
+  });
+
+  it(':ac-set-status: in unregistered thread → ignore', () => {
+    const result = classifyMessage(
+      { text: ':ac-set-status: reviewing_implementation', user: 'U999', ts: '200.0', thread_ts: '100.0' },
+      BOT_ID,
+      makeRegistry(), // '100.0' not registered
+    );
+    expect(result.intent).toBe('ignore');
+  });
+});
+
 describe('classifyMessage — classify-intent command', () => {
   it(':ac-classify-intent: hello world → command classify-intent with args [hello, world]', () => {
     const result = classifyMessage(

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -698,8 +698,7 @@ describe('SlackAdapter — command events (reaction-based)', () => {
     }
   });
 
-  it('reaction on thread reply when history returns a different message → falls back to conversations.replies to find root ts and message text', async () => {
-    // history returns the root message (ts='100.0'), not the reply (ts='200.0')
+  it('ac-set-status reaction on thread reply → no event emitted, no conversations.history call', async () => {
     const mock = makeMockApp({
       botUserId: BOT_ID,
       historyMessages: [{ ts: '100.0', thread_ts: '100.0', text: 'original request' }],
@@ -707,7 +706,7 @@ describe('SlackAdapter — command events (reaction-based)', () => {
     });
     const { ThreadRegistry } = await import('../../../src/adapters/slack/thread-registry.js');
     const registry = new ThreadRegistry();
-    registry.register('100.0', 'req-001'); // root ts registered as known run
+    registry.register('100.0', 'req-001');
 
     const adapter = new SlackAdapter(
       mock as unknown as App,
@@ -716,8 +715,12 @@ describe('SlackAdapter — command events (reaction-based)', () => {
     );
     await adapter.start();
 
-    const eventPromise = takeOne(adapter.receive());
-    // User reacts to the reply at ts='200.0' (not the root at '100.0')
+    let emitted = false;
+    const racePromise = Promise.race([
+      takeOne(adapter.receive()).then(() => { emitted = true; }),
+      new Promise<void>(res => setTimeout(res, 30)),
+    ]);
+
     await mock._triggerReaction({
       type: 'reaction_added',
       reaction: 'ac-set-status',
@@ -725,25 +728,12 @@ describe('SlackAdapter — command events (reaction-based)', () => {
       item: { type: 'message', channel: CHANNEL_ID, ts: '200.0' },
     });
 
-    const event = await eventPromise;
+    await racePromise;
     await adapter.stop();
 
-    expect(event.type).toBe('command');
-    if (event.type === 'command') {
-      // Thread root (100.0) is used, not the reply ts (200.0)
-      expect(event.payload.conversation.conversation_id).toBe('100.0');
-      expect(event.payload.origin.message_id).toBe('200.0');
-      // Message text comes from the reply, not the root
-      expect(event.payload.messageText).toBe('reviewing_implementation');
-      // request_id resolved from thread root in registry
-      expect(event.payload.inferred_context?.request_id).toBe('req-001');
-    }
-
-    // Should have called history AND replies
-    expect(mock.client.conversations.history).toHaveBeenCalled();
-    expect(mock.client.conversations.replies).toHaveBeenCalledWith(
-      expect.objectContaining({ channel: CHANNEL_ID, ts: '100.0', latest: '200.0', inclusive: true, limit: 1 }),
-    );
+    expect(emitted).toBe(false);
+    expect(mock.client.conversations.history).not.toHaveBeenCalled();
+    expect(mock.client.conversations.replies).not.toHaveBeenCalled();
   });
 
   it('reaction_added with unrecognized emoji → no event emitted', async () => {
@@ -968,7 +958,7 @@ describe('SlackAdapter — ignored message reaction', () => {
 });
 
 describe('SlackAdapter — reaction command messageText', () => {
-  it('populates messageText on CommandEvent from the text of the reacted-to message', async () => {
+  it('ac-set-status reaction on root message → no event emitted, no conversations.history call', async () => {
     const mock = makeMockApp({
       botUserId: 'UBOT',
       channels: [{ name: 'ch', id: 'C1' }],
@@ -981,20 +971,23 @@ describe('SlackAdapter — reaction command messageText', () => {
     );
     await adapter.start();
 
-    const eventPromise = takeOne(adapter.receive());
+    let emitted = false;
+    const racePromise = Promise.race([
+      takeOne(adapter.receive()).then(() => { emitted = true; }),
+      new Promise<void>(res => setTimeout(res, 30)),
+    ]);
+
     await mock._triggerReaction({
       reaction: 'ac-set-status',
       user: 'U1',
       item: { type: 'message', channel: 'C1', ts: '111.0' },
     });
-    const event = await eventPromise;
 
-    expect(event.type).toBe('command');
-    const cmd = event.payload as import('../../../src/types/commands.js').CommandEvent;
-    expect(cmd.command).toBe('run.set-status');
-    expect(cmd.messageText).toBe('reviewing_implementation');
-
+    await racePromise;
     await adapter.stop();
+
+    expect(emitted).toBe(false);
+    expect(mock.client.conversations.history).not.toHaveBeenCalled();
   });
 
   it('sets messageText to undefined when reacted-to message has no text', async () => {

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -613,6 +613,98 @@ describe('SlackAdapter — command events (message-based)', () => {
   });
 });
 
+describe('SlackAdapter — ac-set-status message command thread guard', () => {
+  const BOT_ID = 'UBOT001';
+  const CHANNEL_ID = 'C123';
+  const CHANNEL_NAME = 'my-channel';
+
+  it(':ac-set-status: in root message → no event emitted, ac-message-ignored reaction added', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME }, { logDestination: nullDest });
+    await adapter.start();
+
+    let emitted = false;
+    const racePromise = Promise.race([
+      takeOne(adapter.receive()).then(() => { emitted = true; }),
+      new Promise<void>(res => setTimeout(res, 30)),
+    ]);
+
+    await mock._triggerMessage({
+      text: ':ac-set-status: reviewing_implementation',
+      user: 'U123',
+      ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+
+    await racePromise;
+    await adapter.stop();
+
+    expect(emitted).toBe(false);
+    expect(mock.client.reactions.add).toHaveBeenCalledWith({
+      channel: CHANNEL_ID,
+      timestamp: '100.0',
+      name: 'ac-message-ignored',
+    });
+  });
+
+  it(':ac-set-status: in unregistered thread → no event emitted', async () => {
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(mock as unknown as App, { channelName: CHANNEL_NAME }, { logDestination: nullDest });
+    await adapter.start();
+
+    let emitted = false;
+    const racePromise = Promise.race([
+      takeOne(adapter.receive()).then(() => { emitted = true; }),
+      new Promise<void>(res => setTimeout(res, 30)),
+    ]);
+
+    await mock._triggerMessage({
+      text: ':ac-set-status: reviewing_implementation',
+      user: 'U123',
+      ts: '200.0',
+      thread_ts: '100.0', // not registered
+      channel: CHANNEL_ID,
+    });
+
+    await racePromise;
+    await adapter.stop();
+
+    expect(emitted).toBe(false);
+  });
+
+  it(':ac-set-status: in registered run thread → run.set-status command emitted', async () => {
+    const { ThreadRegistry } = await import('../../../src/adapters/slack/thread-registry.js');
+    const registry = new ThreadRegistry();
+    registry.register('100.0', 'req-001');
+    const mock = makeMockApp({ botUserId: BOT_ID });
+    const adapter = new SlackAdapter(
+      mock as unknown as App,
+      { channelName: CHANNEL_NAME },
+      { logDestination: nullDest, registry },
+    );
+    await adapter.start();
+
+    const eventPromise = takeOne(adapter.receive());
+    await mock._triggerMessage({
+      text: ':ac-set-status: reviewing_implementation',
+      user: 'U123',
+      ts: '200.0',
+      thread_ts: '100.0',
+      channel: CHANNEL_ID,
+    });
+
+    const event = await eventPromise;
+    await adapter.stop();
+
+    expect(event.type).toBe('command');
+    if (event.type === 'command') {
+      expect(event.payload.command).toBe('run.set-status');
+      expect(event.payload.args).toEqual(['reviewing_implementation']);
+      expect(event.payload.inferred_context?.request_id).toBe('req-001');
+    }
+  });
+});
+
 describe('SlackAdapter — command events (reaction-based)', () => {
   const BOT_ID = 'UBOT001';
   const CHANNEL_ID = 'C123';

--- a/tests/adapters/slack/slack-adapter.test.ts
+++ b/tests/adapters/slack/slack-adapter.test.ts
@@ -1103,7 +1103,7 @@ describe('SlackAdapter — reactToMessage', () => {
 });
 
 describe('SlackAdapter — reaction command messageText', () => {
-  it('populates messageText on CommandEvent from the text of the reacted-to message', async () => {
+  it('ac-set-status reaction → no event emitted, no conversations.history call', async () => {
     const mock = makeMockApp({
       botUserId: 'UBOT',
       channels: [{ name: 'ch', id: 'C1' }],
@@ -1116,20 +1116,23 @@ describe('SlackAdapter — reaction command messageText', () => {
     );
     await adapter.start();
 
-    const eventPromise = takeOne(adapter.receive());
+    let emitted = false;
+    const racePromise = Promise.race([
+      takeOne(adapter.receive()).then(() => { emitted = true; }),
+      new Promise<void>(res => setTimeout(res, 30)),
+    ]);
+
     await mock._triggerReaction({
       reaction: 'ac-set-status',
       user: 'U1',
       item: { type: 'message', channel: 'C1', ts: '111.0' },
     });
-    const event = await eventPromise;
 
-    expect(event.type).toBe('command');
-    const cmd = event.payload as import('../../../src/types/commands.js').CommandEvent;
-    expect(cmd.command).toBe('run.set-status');
-    expect(cmd.messageText).toBe('reviewing_implementation');
-
+    await racePromise;
     await adapter.stop();
+
+    expect(emitted).toBe(false);
+    expect(mock.client.conversations.history).not.toHaveBeenCalled();
   });
 
   it('sets messageText to undefined when reacted-to message has no text', async () => {

--- a/tests/core/commands/set-status-command.test.ts
+++ b/tests/core/commands/set-status-command.test.ts
@@ -50,7 +50,7 @@ describe('createSetStatusHandler', () => {
 
     await handler(
       makeEvent({
-        messageText: 'reviewing_implementation',
+        args: ['reviewing_implementation'],
         inferred_context: { request_id: 'req-001' },
       }),
       reply,
@@ -65,7 +65,7 @@ describe('createSetStatusHandler', () => {
     expect(msg).toContain('persisted');
   });
 
-  it('stage text with mixed case and surrounding whitespace is normalized and accepted', async () => {
+  it('stage text with mixed case is normalized and accepted', async () => {
     const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
     const findRunById = vi.fn().mockReturnValue(run);
     const overrideRunStage = vi.fn().mockReturnValue('updated');
@@ -74,7 +74,7 @@ describe('createSetStatusHandler', () => {
 
     await handler(
       makeEvent({
-        messageText: '  Reviewing_Implementation  ',
+        args: ['Reviewing_Implementation'],
         inferred_context: { request_id: 'req-001' },
       }),
       reply,
@@ -156,7 +156,7 @@ describe('createSetStatusHandler', () => {
 
     await handler(
       makeEvent({
-        messageText: 'implementing',
+        args: ['implementing'],
         inferred_context: { request_id: 'req-001' },
       }),
       reply,
@@ -189,25 +189,6 @@ describe('createSetStatusHandler', () => {
     const msg = reply.mock.calls[0][0] as string;
     expect(msg).toContain('failed');
     expect(msg).toContain('reviewing_implementation');
-  });
-
-  it('args take precedence over messageText', async () => {
-    const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
-    const findRunById = vi.fn().mockReturnValue(run);
-    const overrideRunStage = vi.fn().mockReturnValue('updated');
-    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
-    const reply = vi.fn().mockResolvedValue(undefined);
-
-    await handler(
-      makeEvent({
-        args: ['reviewing_implementation'],
-        messageText: 'speccing',
-        inferred_context: { request_id: 'req-001' },
-      }),
-      reply,
-    );
-
-    expect(overrideRunStage).toHaveBeenCalledWith('req-001', 'reviewing_implementation');
   });
 
   it('empty args and empty messageText → replies with usage error and valid stage list', async () => {
@@ -248,5 +229,27 @@ describe('createSetStatusHandler', () => {
     expect(overrideRunStage).not.toHaveBeenCalled();
     const msg = reply.mock.calls[0][0] as string;
     expect(msg).toContain('ac-set-status:');
+  });
+
+  it('empty args with messageText only → does not update run (messageText fallback removed)', async () => {
+    const run = makeRun({ stage: 'implementing', request_id: 'req-001' });
+    const findRunById = vi.fn().mockReturnValue(run);
+    const overrideRunStage = vi.fn();
+    const handler = createSetStatusHandler({ findRunById, overrideRunStage });
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(
+      makeEvent({
+        args: [],
+        messageText: 'reviewing_implementation',
+        inferred_context: { request_id: 'req-001' },
+      }),
+      reply,
+    );
+
+    expect(overrideRunStage).not.toHaveBeenCalled();
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('ac-set-status:');
+    expect(msg).toContain('Valid stages');
   });
 });

--- a/tests/core/commands/set-status-command.test.ts
+++ b/tests/core/commands/set-status-command.test.ts
@@ -92,7 +92,7 @@ describe('createSetStatusHandler', () => {
 
     await handler(
       makeEvent({
-        messageText: 'implemneting',
+        args: ['implemneting'],
         inferred_context: { request_id: 'req-001' },
       }),
       reply,
@@ -115,7 +115,7 @@ describe('createSetStatusHandler', () => {
 
     await handler(
       makeEvent({
-        messageText: 'reviewing_implementation',
+        args: ['reviewing_implementation'],
         inferred_context: undefined,
       }),
       reply,


### PR DESCRIPTION
## Summary

- Add adapter-level thread guard for `run.set-status` command
- `classifyMessage` now returns "ignore" for `:ac-set-status:` in root messages or unregistered threads
- Prevents `CommandEvent` dispatch outside known run contexts
- Remove `messageText` fallback from set-status handler (args only)

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] React with `:ac-set-status:` in a non-run thread and verify it is ignored
- [ ] React with `:ac-set-status:` in a run thread and verify it still works