### PR TITLE
feat: add request dump support to beta header filter proxy for upstream replay

### DIFF
--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -1,5 +1,5 @@
 import { once } from 'node:events';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingHttpHeaders, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -101,6 +101,7 @@ export async function startAnthropicBetaHeaderFilterProxy(
   if (requestLog) {
     try {
       await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
+      await chmod(requestLog.logDir, 0o700);
     } catch (err) {
       server.close();
       throw err;

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -98,6 +98,10 @@ export async function startAnthropicBetaHeaderFilterProxy(
     throw new Error('Anthropic beta header filter proxy did not bind to a TCP port');
   }
 
+  if (requestLog) {
+    await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
+  }
+
   const port = address.port;
   logger.info(
     { event: 'proxy.started', port, strip_beta_count: stripBetaValues.size },
@@ -165,8 +169,6 @@ async function dumpRequest(
 ): Promise<void> {
   const start = Date.now();
   try {
-    await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
-
     const rawHeaders: Record<string, string> = {};
     headers.forEach((value, name) => { rawHeaders[name] = value; });
     const redactedHeaders = redactHeaders(rawHeaders);
@@ -182,8 +184,9 @@ async function dumpRequest(
       }
     }
 
+    const now = new Date();
     const record: Record<string, unknown> = {
-      timestamp: new Date().toISOString(),
+      timestamp: now.toISOString(),
       method,
       url: targetUrl.toString(),
       headers: redactedHeaders,
@@ -191,7 +194,7 @@ async function dumpRequest(
     if (parsedBody !== undefined) record['body'] = parsedBody;
     if (bodyRaw !== undefined) record['body_raw'] = bodyRaw;
 
-    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const ts = now.toISOString().replace(/[:.]/g, '-');
     const suffix = randomBytes(4).toString('hex');
     const filename = `${ts}-${suffix}.json`;
     const filePath = join(requestLog.logDir, filename);
@@ -228,7 +231,7 @@ function redactHeaders(headers: Record<string, string>): Record<string, string> 
 }
 
 function redactCredentialValue(value: string): string {
-  if (value.length <= 8) return value;
+  if (value.length <= 8) return '[redacted]';
   return `${value.slice(0, 4)}redacted${value.slice(-4)}`;
 }
 

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -1,5 +1,8 @@
 import { once } from 'node:events';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingHttpHeaders, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
@@ -28,6 +31,12 @@ const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
   'upgrade',
 ]);
 
+const CREDENTIAL_HEADERS = new Set(['x-api-key', 'api-key', 'authorization']);
+
+export interface RequestLogOptions {
+  logDir: string;
+}
+
 export interface AnthropicBetaHeaderFilterProxy {
   baseUrl: string;
   server: Server;
@@ -37,6 +46,7 @@ export interface AnthropicBetaHeaderFilterProxy {
 export interface AnthropicBetaHeaderFilterProxyOptions {
   stripBetaValues: string[];
   logDestination?: pino.DestinationStream;
+  requestLog?: RequestLogOptions;
 }
 
 /**
@@ -53,11 +63,12 @@ export async function startAnthropicBetaHeaderFilterProxy(
   const targetBase = new URL(targetBaseUrl);
   const stripBetaValues = normalizedStripBetaValues(options.stripBetaValues);
   const logger = createLogger('anthropic-beta-header-filter-proxy', { destination: options.logDestination });
+  const { requestLog } = options;
   let totalRequests = 0;
 
   const server = createServer((req, res) => {
     totalRequests++;
-    handleProxyRequest(req, res, targetBase, stripBetaValues, logger).catch(err => {
+    handleProxyRequest(req, res, targetBase, stripBetaValues, logger, requestLog).catch(err => {
       logger.error({ event: 'proxy.request_error', method: req.method, error: String(err) }, 'Proxy request error');
       if (res.headersSent) {
         res.destroy(err);
@@ -109,12 +120,20 @@ async function handleProxyRequest(
   targetBase: URL,
   stripBetaValues: ReadonlySet<string>,
   logger: pino.Logger,
+  requestLog?: RequestLogOptions,
 ): Promise<void> {
   const targetUrl = targetUrlForRequest(targetBase, req.url);
+  const headers = requestHeaders(req.headers, stripBetaValues);
+  const body = await requestBody(req);
+
+  if (requestLog) {
+    await dumpRequest(targetUrl, req.method ?? 'GET', headers, body, requestLog, logger);
+  }
+
   const response = await fetch(targetUrl, {
     method: req.method,
-    headers: requestHeaders(req.headers, stripBetaValues),
-    body: await requestBody(req),
+    headers,
+    body,
   });
 
   logger.debug(
@@ -134,6 +153,83 @@ async function handleProxyRequest(
       .on('error', reject)
       .on('finish', resolve);
   });
+}
+
+async function dumpRequest(
+  targetUrl: URL,
+  method: string,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+  requestLog: RequestLogOptions,
+  logger: pino.Logger,
+): Promise<void> {
+  const start = Date.now();
+  try {
+    await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
+
+    const rawHeaders: Record<string, string> = {};
+    headers.forEach((value, name) => { rawHeaders[name] = value; });
+    const redactedHeaders = redactHeaders(rawHeaders);
+
+    let parsedBody: unknown;
+    let bodyRaw: string | undefined;
+    if (body !== undefined) {
+      const text = Buffer.from(body).toString('utf8');
+      try {
+        parsedBody = JSON.parse(text);
+      } catch {
+        bodyRaw = text;
+      }
+    }
+
+    const record: Record<string, unknown> = {
+      timestamp: new Date().toISOString(),
+      method,
+      url: targetUrl.toString(),
+      headers: redactedHeaders,
+    };
+    if (parsedBody !== undefined) record['body'] = parsedBody;
+    if (bodyRaw !== undefined) record['body_raw'] = bodyRaw;
+
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const suffix = randomBytes(4).toString('hex');
+    const filename = `${ts}-${suffix}.json`;
+    const filePath = join(requestLog.logDir, filename);
+    await writeFile(filePath, JSON.stringify(record, null, 2), { mode: 0o600 });
+
+    logger.debug(
+      {
+        event: 'proxy.request_dumped',
+        path: filePath,
+        method,
+        target_host: targetUrl.hostname,
+        body_bytes: body?.byteLength ?? 0,
+        header_count: Object.keys(rawHeaders).length,
+        duration_ms: Date.now() - start,
+      },
+      'Proxy request dumped',
+    );
+  } catch (err) {
+    logger.warn(
+      { event: 'proxy.request_dump_failed', error: String(err), duration_ms: Date.now() - start },
+      'Proxy request dump failed',
+    );
+  }
+}
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    result[name] = CREDENTIAL_HEADERS.has(name.toLowerCase())
+      ? redactCredentialValue(value)
+      : value;
+  }
+  return result;
+}
+
+function redactCredentialValue(value: string): string {
+  if (value.length <= 8) return value;
+  return `${value.slice(0, 4)}redacted${value.slice(-4)}`;
 }
 
 function targetUrlForRequest(targetBase: URL, requestUrl: string | undefined): URL {

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -99,7 +99,12 @@ export async function startAnthropicBetaHeaderFilterProxy(
   }
 
   if (requestLog) {
-    await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
+    try {
+      await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
+    } catch (err) {
+      server.close();
+      throw err;
+    }
   }
 
   const port = address.port;

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -103,8 +103,10 @@ export async function startAnthropicBetaHeaderFilterProxy(
       await mkdir(requestLog.logDir, { recursive: true, mode: 0o700 });
       await chmod(requestLog.logDir, 0o700);
     } catch (err) {
-      server.close();
-      throw err;
+      logger.warn(
+        { event: 'proxy.request_dump_failed', error: String(err) },
+        'Failed to prepare request-log directory; request dumping disabled',
+      );
     }
   }
 

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -396,8 +396,6 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
     const stripBetaValues = profile.anthropic_beta_header_filter?.strip
       .map(value => value.trim())
       .filter(value => value.length > 0) ?? [];
-    if (stripBetaValues.length === 0) return null;
-
     if (!this._betaFilterProxy) {
       const pending = this.startProxy(profile.base_url, {
         stripBetaValues,

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -29,7 +29,7 @@ import type {
 import { createLogger } from '../../core/logger.js';
 import { materializeClaudeRuntimeSkillPlugins } from './claude-runtime-skill-materializer.js';
 import { buildSandboxEnvironmentWithSummary, buildSandboxEnvironment } from '../sandbox-environment.js';
-import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy } from './anthropic-beta-header-filter-proxy.js';
+import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy, type RequestLogOptions } from './anthropic-beta-header-filter-proxy.js';
 
 type QueryFn = typeof _query;
 
@@ -148,6 +148,8 @@ export interface ClaudeAgentSdkAgentRunnerOptions {
   sandboxEnvTokens?: string[];
   logDestination?: pino.DestinationStream;
   loggerProvider?: LoggerProvider;
+  requestLog?: RequestLogOptions;
+  startProxy?: typeof startAnthropicBetaHeaderFilterProxy;
 }
 
 export class ClaudeAgentSdkAgentRunner implements AgentRunner {
@@ -159,12 +161,16 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
   private readonly _agentTokenUsage: Histogram;
   private readonly sandboxEnvTokens: string[];
   private readonly logger: pino.Logger;
+  private readonly requestLog: RequestLogOptions | undefined;
+  private readonly startProxy: typeof startAnthropicBetaHeaderFilterProxy;
   private _betaFilterProxy: Promise<AnthropicBetaHeaderFilterProxy> | null = null;
 
   constructor(options?: ClaudeAgentSdkAgentRunnerOptions) {
     this.queryFn = options?.queryFn ?? _query;
     this.materializeRuntimeSkills = options?.materializeRuntimeSkills ?? materializeClaudeRuntimeSkillPlugins;
     this.sandboxEnvTokens = options?.sandboxEnvTokens ?? [];
+    this.requestLog = options?.requestLog;
+    this.startProxy = options?.startProxy ?? startAnthropicBetaHeaderFilterProxy;
     this.logger = createLogger('claude-agent-sdk', {
       destination: options?.logDestination,
       loggerProvider: options?.loggerProvider,
@@ -393,7 +399,10 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
     if (stripBetaValues.length === 0) return null;
 
     if (!this._betaFilterProxy) {
-      const pending = startAnthropicBetaHeaderFilterProxy(profile.base_url, { stripBetaValues });
+      const pending = this.startProxy(profile.base_url, {
+        stripBetaValues,
+        ...(this.requestLog ? { requestLog: this.requestLog } : {}),
+      });
       this._betaFilterProxy = pending;
       pending.catch(() => {
         if (this._betaFilterProxy === pending) {

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -12,6 +12,7 @@ import type { AgentRunEvent, AgentRunRequest, AgentRunner, AgentRoute, AgentSkil
 import { createLogger } from '../../core/logger.js';
 import { materializeOpenAIRuntimeSkills } from './openai-runtime-skill-materializer.js';
 import { buildSandboxEnvironment } from '../sandbox-environment.js';
+import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy, type RequestLogOptions } from '../anthropic/anthropic-beta-header-filter-proxy.js';
 
 const DEFAULT_OPENAI_AGENT_MAX_TURNS = 50;
 
@@ -35,6 +36,8 @@ export interface OpenAIAgentSdkAgentRunnerOptions {
   loggerProvider?: LoggerProvider;
   maxTurns?: number;
   sandboxEnvTokens?: string[];
+  requestLog?: RequestLogOptions;
+  startProxy?: typeof startAnthropicBetaHeaderFilterProxy;
 }
 
 export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
@@ -60,6 +63,9 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
   private readonly logger: pino.Logger;
   private readonly maxTurns: number;
   private readonly sandboxEnvTokens: string[];
+  private readonly requestLog: RequestLogOptions | undefined;
+  private readonly startProxy: typeof startAnthropicBetaHeaderFilterProxy;
+  private _proxy: Promise<AnthropicBetaHeaderFilterProxy> | null = null;
 
   constructor(
     private readonly apiKey: string,
@@ -76,6 +82,8 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
     });
     this.maxTurns = options?.maxTurns ?? DEFAULT_OPENAI_AGENT_MAX_TURNS;
     this.sandboxEnvTokens = options?.sandboxEnvTokens ?? [];
+    this.requestLog = options?.requestLog;
+    this.startProxy = options?.startProxy ?? startAnthropicBetaHeaderFilterProxy;
     const meter = options?.meter ?? metrics.getMeter('autocatalyst');
     this._agentTurns = meter.createCounter('autocatalyst.agent.turns', {
       unit: '{turn}',
@@ -104,12 +112,14 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
 
     // For Grove/Azure APIM: create a configured OpenAI client with api-key header and wrap it
     // in OpenAIResponsesModel so the custom base URL is applied to every agent HTTP request.
+    // Route through the loopback proxy so all requests can be logged/filtered.
     // For standard OpenAI endpoints: pass the model string and let the SDK use its default client.
     let agentModel: string | OpenAIResponsesModel;
-    if (this.baseUrl) {
+    const proxyUrl = await this.proxyBaseUrl();
+    if (proxyUrl) {
       const client = new OpenAI({
         apiKey: this.apiKey,
-        baseURL: this.baseUrl,
+        baseURL: proxyUrl,
         defaultHeaders: { 'api-key': this.apiKey },
       });
       // Cast required: resolution-mode difference between our OpenAI import and @openai/agents-openai's import
@@ -246,6 +256,36 @@ export class OpenAIAgentSdkAgentRunner implements AgentRunner {
         },
         'OpenAI Agents SDK run completed',
       );
+    }
+  }
+
+  private async proxyBaseUrl(): Promise<string | null> {
+    if (!this.baseUrl) return null;
+    if (!this._proxy) {
+      const pending = this.startProxy(this.baseUrl, {
+        stripBetaValues: [],
+        ...(this.requestLog ? { requestLog: this.requestLog } : {}),
+      });
+      this._proxy = pending;
+      pending.catch(() => {
+        if (this._proxy === pending) {
+          this._proxy = null;
+        }
+      });
+    }
+    const proxy = await this._proxy;
+    return proxy.baseUrl;
+  }
+
+  async close(): Promise<void> {
+    if (this._proxy) {
+      try {
+        const proxy = await this._proxy;
+        await proxy.close();
+      } catch {
+        // proxy never started successfully — nothing to close
+      }
+      this._proxy = null;
     }
   }
 }

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -304,7 +304,12 @@ export function buildAgentRunner(
       credential.resolvedValue!,
       endpoint.base_url,
       openAiAgentProfile.model,
-      { meter, sandboxEnvTokens },
+      {
+        meter,
+        sandboxEnvTokens,
+        loggerProvider,
+        ...(requestLogDir ? { requestLog: { logDir: requestLogDir } } : {}),
+      },
     );
   }
 

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type pino from 'pino';
 import type { Meter } from '@opentelemetry/api';
 import type { LoggerProvider } from '@opentelemetry/api-logs';
@@ -59,6 +60,7 @@ export interface ComposeWorkflowRuntimeOptions {
   logger: RuntimeLogger;
   meter?: Meter;
   loggerProvider?: LoggerProvider;
+  logRequests?: boolean;
 }
 
 export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRuntimeOptions): Promise<ReturnType<typeof bootstrapWorkflowRuntime>> {
@@ -96,6 +98,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
   const repo_name = repoNameFromUrl(repo_url);
   const slackChannelConfig = findConfiguredProvider(normalizedConfig.channels, builtInExtensions, 'channel', 'slack');
   const workspaceRoot = workspaceRootFromConfig(slackChannelConfig?.workspace_root ?? normalizedConfig.workspace_root);
+  const requestLogDir = options.logRequests ? join(workspaceRoot, 'request-logs') : undefined;
 
   const botToken = stringConfig(slackChannelConfig?.config, 'bot_token');
   const appToken = stringConfig(slackChannelConfig?.config, 'app_token');
@@ -119,7 +122,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
 
   const aiRoutingPolicy = buildAgentRoutingPolicy(resolvedAi);
   const directModelRunner = buildDirectModelRunner(resolvedAi, logger, options.loggerProvider);
-  const agentRunner = buildAgentRunner(resolvedAi, logger, options.meter, currentConfig.config.sandbox?.env_tokens, options.loggerProvider);
+  const agentRunner = buildAgentRunner(resolvedAi, logger, options.meter, currentConfig.config.sandbox?.env_tokens, options.loggerProvider, requestLogDir);
   const intentClassifier = new ModelIntentClassifier(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const prTitleGenerator = new ModelPRTitleGenerator(directModelRunner, { routingPolicy: aiRoutingPolicy });
   const questionAnswerer = new AgentRunnerQuestionAnsweringAgent(agentRunner, aiRoutingPolicy, repoPath, { loggerProvider: options.loggerProvider });
@@ -243,6 +246,7 @@ export function buildAgentRunner(
   meter?: Meter,
   sandboxEnvTokens?: string[],
   loggerProvider?: LoggerProvider,
+  requestLogDir?: string,
 ): AgentRunner {
   const claudeProfile = resolvedAi.profiles.find(p => p.runner === 'claude_agent_sdk');
   const openAiAgentProfile = resolvedAi.profiles.find(p => p.runner === 'openai_agent_sdk');
@@ -265,7 +269,12 @@ export function buildAgentRunner(
           },
           'Using Claude Agent SDK',
         );
-        return new ClaudeAgentSdkAgentRunner({ meter, sandboxEnvTokens, loggerProvider });
+        return new ClaudeAgentSdkAgentRunner({
+          meter,
+          sandboxEnvTokens,
+          loggerProvider,
+          ...(requestLogDir ? { requestLog: { logDir: requestLogDir } } : {}),
+        });
       })()
     : null;
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -6,6 +6,7 @@ export interface ParsedArgs {
   repoPath: string;      // first path (backward compat)
   repoPaths: string[];   // all paths; length >= 1 when --repo is provided
   help: boolean;
+  logRequests: boolean;
 }
 
 export function parseArgs(args: string[]): ParsedArgs {
@@ -14,7 +15,7 @@ export function parseArgs(args: string[]): ParsedArgs {
     const remaining = args.slice(1);
 
     if (remaining.includes('--help') || remaining.includes('-h')) {
-      return { command: 'init', repoPath: '', repoPaths: [], help: true };
+      return { command: 'init', repoPath: '', repoPaths: [], help: true, logRequests: false };
     }
 
     const repoIndex = remaining.indexOf('--repo');
@@ -23,13 +24,15 @@ export function parseArgs(args: string[]): ParsedArgs {
         ? remaining[repoIndex + 1]
         : '';
 
-    return { command: 'init', repoPath, repoPaths: repoPath ? [repoPath] : [], help: false };
+    return { command: 'init', repoPath, repoPaths: repoPath ? [repoPath] : [], help: false, logRequests: false };
   }
 
   // --help / -h (run command)
   if (args.includes('--help') || args.includes('-h')) {
-    return { command: 'run', repoPath: '', repoPaths: [], help: true };
+    return { command: 'run', repoPath: '', repoPaths: [], help: true, logRequests: false };
   }
+
+  const logRequests = args.includes('--log-requests');
 
   // run command — --repo is required and validated
   const repoIndex = args.indexOf('--repo');
@@ -60,7 +63,7 @@ export function parseArgs(args: string[]): ParsedArgs {
     return resolved;
   });
 
-  return { command: 'run', repoPath: repoPaths[0], repoPaths, help: false };
+  return { command: 'run', repoPath: repoPaths[0], repoPaths, help: false, logRequests };
 }
 
 export function printUsage(): void {
@@ -72,6 +75,7 @@ export function printUsage(): void {
 
 Options:
   --repo <path> [<path2>...]   Path(s) to target repository/repositories
+  --log-requests               Dump outbound proxy requests to <workspace root>/request-logs/
   --help                       Show this help message
 `);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ try {
     logger,
     meter: telemetry.meter,
     loggerProvider: telemetry.loggerProvider,
+    logRequests: args.logRequests,
   });
 
   const cleanupSignals = registerSignalHandlers(service);

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -298,7 +298,7 @@ describe('Anthropic beta header filter proxy', () => {
       expect(stat.mode & 0o777).toBe(0o700);
     });
 
-    test('throws at startup when logDir cannot be created', async () => {
+    test('starts and forwards requests when logDir cannot be created', async () => {
       const upstream = createServer((req, res) => {
         res.writeHead(200, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ forwarded: true }));
@@ -310,12 +310,21 @@ describe('Anthropic beta header filter proxy', () => {
       rmSync(logDir, { recursive: true });
       writeFileSync(logDir, 'not-a-dir');
 
-      await expect(
-        startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
-          stripBetaValues: [],
-          requestLog: { logDir },
-        }),
-      ).rejects.toThrow();
+      // Startup must succeed — dir setup failure only disables dumping, does not abort the proxy
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ forwarded: true });
+      await proxy.close();
     });
   });
 });

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -1,5 +1,5 @@
 import { once } from 'node:events';
-import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync, statSync, mkdirSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
@@ -272,6 +272,30 @@ describe('Anthropic beta header filter proxy', () => {
       expect(response.status).toBe(200);
       // logDir is a separate temp dir; it should be empty since requestLog was not set
       expect(readdirSync(logDir)).toHaveLength(0);
+    });
+
+    test('chmods pre-existing logDir to 0o700', async () => {
+      // Create the logDir with broad permissions before the proxy starts
+      rmSync(logDir, { recursive: true });
+      mkdirSync(logDir, { mode: 0o755 });
+
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+      await proxy.close();
+
+      const stat = statSync(logDir);
+      // mode & 0o777 gives the permission bits only
+      expect(stat.mode & 0o777).toBe(0o700);
     });
 
     test('throws at startup when logDir cannot be created', async () => {

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -1,7 +1,10 @@
 import { once } from 'node:events';
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
 import { PassThrough } from 'node:stream';
-import { afterEach, describe, expect, it, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test } from 'vitest';
 import { startAnthropicBetaHeaderFilterProxy } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
 
 async function listen(server: Server): Promise<number> {
@@ -121,5 +124,194 @@ describe('Anthropic beta header filter proxy', () => {
     expect(response.status).toBe(200);
     expect(receivedHeaders).toHaveLength(1);
     expect(receivedHeaders[0]).not.toHaveProperty('anthropic-beta');
+  });
+
+  describe('request dump', () => {
+    let logDir: string;
+
+    beforeEach(() => {
+      logDir = mkdtempSync(join(tmpdir(), 'proxy-dump-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(logDir, { recursive: true, force: true });
+    });
+
+    test('writes JSON dump file when requestLog is set', async () => {
+      const upstream = createServer((req, res) => {
+        let body = '';
+        req.setEncoding('utf8');
+        req.on('data', (c: string) => { body += c; });
+        req.on('end', () => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end('{}');
+        });
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'claude-3', messages: [] }),
+      });
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      expect(files).toHaveLength(1);
+      const dump = JSON.parse(readFileSync(join(logDir, files[0]!), 'utf8')) as Record<string, unknown>;
+      expect(dump.method).toBe('POST');
+      expect(typeof dump.url).toBe('string');
+      expect((dump.url as string)).toContain('/v1/messages');
+      expect(typeof dump.timestamp).toBe('string');
+      expect(dump.body).toEqual({ model: 'claude-3', messages: [] });
+      expect(typeof (dump.headers as Record<string, string>)['content-type']).toBe('string');
+    });
+
+    test('dump headers reflect post-filter view: no hop-by-hop, stripped beta', async () => {
+      const upstream = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: ['strip-me-2025-01-01'],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'anthropic-beta': 'keep-me-2025-01-01, strip-me-2025-01-01',
+        },
+        body: '{}',
+      });
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      expect(files).toHaveLength(1);
+      const dump = JSON.parse(readFileSync(join(logDir, files[0]!), 'utf8')) as Record<string, unknown>;
+      const headers = dump.headers as Record<string, string>;
+      // hop-by-hop stripped (transfer-encoding is a hop-by-hop header)
+      expect(headers).not.toHaveProperty('transfer-encoding');
+      // beta filtered
+      expect(headers['anthropic-beta']).toBe('keep-me-2025-01-01');
+    });
+
+    test('credential headers are partially redacted', async () => {
+      const upstream = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'sk-ant-abcdefgh12345678',
+          'authorization': 'Bearer sk-ant-xxxx1111yyyy2222',
+        },
+        body: '{}',
+      });
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      const dump = JSON.parse(readFileSync(join(logDir, files[0]!), 'utf8')) as Record<string, unknown>;
+      const headers = dump.headers as Record<string, string>;
+      // Must keep first 4 and last 4 chars of the full header value
+      const apiKey = headers['x-api-key']!;
+      expect(apiKey).toMatch(/^sk-a/);          // first 4
+      expect(apiKey).toMatch(/5678$/);           // last 4
+      expect(apiKey).toContain('redacted');
+      expect(apiKey).not.toBe('sk-ant-abcdefgh12345678');
+
+      const auth = headers['authorization']!;
+      expect(auth).toMatch(/^Bear/);             // first 4
+      expect(auth).toMatch(/2222$/);             // last 4
+      expect(auth).toContain('redacted');
+    });
+
+    test('no dump files created when requestLog is not set', async () => {
+      const upstream = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      await proxy.close();
+
+      expect(response.status).toBe(200);
+      // logDir is a separate temp dir; it should be empty since requestLog was not set
+      expect(readdirSync(logDir)).toHaveLength(0);
+    });
+
+    test('dump failure logs proxy.request_dump_failed and still forwards request', async () => {
+      const upstream = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ forwarded: true }));
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const dest = new PassThrough();
+      const lines: string[] = [];
+      dest.on('data', (c: Buffer) => c.toString().split('\n').filter(Boolean).forEach(l => lines.push(l)));
+
+      // Create a file at the logDir path so mkdir fails (can't create dir where file exists)
+      rmSync(logDir, { recursive: true });
+      writeFileSync(logDir, 'not-a-dir');
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+        logDestination: dest,
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ forwarded: true });
+
+      await proxy.close();
+      dest.end();
+      await new Promise(r => dest.on('finish', r));
+
+      const parsed = lines.map(l => JSON.parse(l) as Record<string, unknown>);
+      const failEvent = parsed.find(l => l['event'] === 'proxy.request_dump_failed');
+      expect(failEvent).toBeDefined();
+    });
   });
 });

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -274,7 +274,7 @@ describe('Anthropic beta header filter proxy', () => {
       expect(readdirSync(logDir)).toHaveLength(0);
     });
 
-    test('dump failure logs proxy.request_dump_failed and still forwards request', async () => {
+    test('throws at startup when logDir cannot be created', async () => {
       const upstream = createServer((req, res) => {
         res.writeHead(200, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ forwarded: true }));
@@ -282,36 +282,16 @@ describe('Anthropic beta header filter proxy', () => {
       servers.push(upstream);
       const upstreamPort = await listen(upstream);
 
-      const dest = new PassThrough();
-      const lines: string[] = [];
-      dest.on('data', (c: Buffer) => c.toString().split('\n').filter(Boolean).forEach(l => lines.push(l)));
-
       // Create a file at the logDir path so mkdir fails (can't create dir where file exists)
       rmSync(logDir, { recursive: true });
       writeFileSync(logDir, 'not-a-dir');
 
-      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
-        stripBetaValues: [],
-        requestLog: { logDir },
-        logDestination: dest,
-      });
-      servers.push(proxy.server);
-
-      const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: '{}',
-      });
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ forwarded: true });
-
-      await proxy.close();
-      dest.end();
-      await new Promise(r => dest.on('finish', r));
-
-      const parsed = lines.map(l => JSON.parse(l) as Record<string, unknown>);
-      const failEvent = parsed.find(l => l['event'] === 'proxy.request_dump_failed');
-      expect(failEvent).toBeDefined();
+      await expect(
+        startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+          stripBetaValues: [],
+          requestLog: { logDir },
+        }),
+      ).rejects.toThrow();
     });
   });
 });

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -435,7 +435,7 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     expect(call.options.env['ANTHROPIC_CUSTOM_HEADERS']).toBe('api-key: sk-grove-test-key');
   });
 
-  test('passes custom Anthropic base URLs through unchanged without configured beta values to strip', async () => {
+  test('routes custom Anthropic base URLs through a loopback proxy even without configured beta values to strip', async () => {
     const queryFn = vi.fn().mockImplementation(async function* () {
       yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } };
     });
@@ -456,10 +456,12 @@ describe('ClaudeAgentSdkAgentRunner', () => {
       },
     }));
 
+    await runner.close();
+
     const call = queryFn.mock.calls[0][0];
     expect(call.options.env['ANTHROPIC_API_KEY']).toBe('sk-grove-test-key');
     expect(call.options.env['ANTHROPIC_CUSTOM_HEADERS']).toBe('api-key: sk-grove-test-key');
-    expect(call.options.env['ANTHROPIC_BASE_URL']).toBe(groveBaseUrl);
+    expect(call.options.env['ANTHROPIC_BASE_URL']).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
   });
 
   test('routes custom Anthropic base URLs through a loopback beta-header filter when beta values are configured to strip', async () => {
@@ -760,7 +762,7 @@ describe('claudeSdkMessageDiagnostic', () => {
 });
 
 describe('ClaudeAgentSdkAgentRunner — request log options', () => {
-  it('passes requestLog to startProxy when profile has base_url and strip values', async () => {
+  it('passes requestLog to startProxy when profile has base_url', async () => {
     const requestLog: RequestLogOptions = { logDir: '/tmp/test-request-logs' };
     const capturedOptions: unknown[] = [];
 
@@ -836,7 +838,6 @@ describe('ClaudeAgentSdkAgentRunner — request log options', () => {
       id: 'test-profile',
       provider: 'anthropic',
       base_url: 'http://127.0.0.1:9999',
-      anthropic_beta_header_filter: { strip: ['some-beta-2025-01-01'] },
     };
 
     try {

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -2,7 +2,9 @@ import { PassThrough } from 'node:stream';
 import { describe, it, expect, test, vi } from 'vitest';
 import { ClaudeAgentSdkAgentRunner, claudeSdkMessageDiagnostic, redactSecrets } from '../../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
 import type { AgentRunEvent } from '../../../src/types/ai.js';
+import type { AgentProfile } from '../../../src/types/ai.js';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';
+import type { RequestLogOptions, AnthropicBetaHeaderFilterProxy } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
 
 async function collect(events: AsyncIterable<AgentRunEvent>): Promise<AgentRunEvent[]> {
   const collected: AgentRunEvent[] = [];
@@ -754,5 +756,97 @@ describe('claudeSdkMessageDiagnostic', () => {
     expect(redacted).not.toContain('github_pat_11ABCDEF');
     expect(redacted).not.toContain('xapp-1-abc-123');
     expect(redacted).not.toContain('tok123');
+  });
+});
+
+describe('ClaudeAgentSdkAgentRunner — request log options', () => {
+  it('passes requestLog to startProxy when profile has base_url and strip values', async () => {
+    const requestLog: RequestLogOptions = { logDir: '/tmp/test-request-logs' };
+    const capturedOptions: unknown[] = [];
+
+    const mockStartProxy = vi.fn(async (_targetBaseUrl: string, opts: unknown): Promise<AnthropicBetaHeaderFilterProxy> => {
+      capturedOptions.push(opts);
+      const { createServer } = await import('node:http');
+      const server = createServer();
+      server.listen(0, '127.0.0.1');
+      await new Promise<void>(r => server.once('listening', r));
+      const address = server.address() as { port: number };
+      return {
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        server,
+        close: async () => {
+          server.close();
+          await new Promise<void>(r => server.once('close', r));
+        },
+      };
+    });
+
+    const runner = new ClaudeAgentSdkAgentRunner({
+      queryFn: async function* () {},
+      requestLog,
+      startProxy: mockStartProxy,
+    });
+
+    const profile: AgentProfile = {
+      id: 'test-profile',
+      provider: 'anthropic',
+      base_url: 'http://127.0.0.1:9999',
+      anthropic_beta_header_filter: { strip: ['some-beta-2025-01-01'] },
+    };
+
+    try {
+      for await (const _ of runner.run({ route: { task: 'test' }, working_directory: '/tmp', prompt: 'test', profile })) {}
+    } catch {
+      // expected — mock queryFn returns immediately
+    }
+
+    await runner.close();
+
+    expect(mockStartProxy).toHaveBeenCalledOnce();
+    const passedOpts = capturedOptions[0] as { requestLog?: RequestLogOptions };
+    expect(passedOpts.requestLog).toEqual(requestLog);
+  });
+
+  it('does not pass requestLog when runner has no requestLog option', async () => {
+    const capturedOptions: unknown[] = [];
+
+    const mockStartProxy = vi.fn(async (_targetBaseUrl: string, opts: unknown): Promise<AnthropicBetaHeaderFilterProxy> => {
+      capturedOptions.push(opts);
+      const { createServer } = await import('node:http');
+      const server = createServer();
+      server.listen(0, '127.0.0.1');
+      await new Promise<void>(r => server.once('listening', r));
+      const address = server.address() as { port: number };
+      return {
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        server,
+        close: async () => {
+          server.close();
+          await new Promise<void>(r => server.once('close', r));
+        },
+      };
+    });
+
+    const runner = new ClaudeAgentSdkAgentRunner({
+      queryFn: async function* () {},
+      startProxy: mockStartProxy,
+    });
+
+    const profile: AgentProfile = {
+      id: 'test-profile',
+      provider: 'anthropic',
+      base_url: 'http://127.0.0.1:9999',
+      anthropic_beta_header_filter: { strip: ['some-beta-2025-01-01'] },
+    };
+
+    try {
+      for await (const _ of runner.run({ route: { task: 'test' }, working_directory: '/tmp', prompt: 'test', profile })) {}
+    } catch {}
+
+    await runner.close();
+
+    expect(mockStartProxy).toHaveBeenCalledOnce();
+    const passedOpts = capturedOptions[0] as { requestLog?: RequestLogOptions };
+    expect(passedOpts.requestLog).toBeUndefined();
   });
 });

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -4,6 +4,7 @@ import { run as sdkRun, setTracingDisabled } from '@openai/agents';
 import { skillRefsForRoute, OpenAIAgentSdkAgentRunner } from '../../../src/adapters/openai/agent-sdk-agent-runner.js';
 import type { AgentRunEvent } from '../../../src/types/ai.js';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';
+import type { AnthropicBetaHeaderFilterProxy, RequestLogOptions } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
 
 const nullDest = { write: () => {} } as import('pino').DestinationStream;
 
@@ -666,5 +667,241 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       log => log['level'] === 'warn' && log['event'] === 'sandbox.no_github_token',
     );
     expect(warning).toBeUndefined();
+  });
+});
+
+describe('OpenAIAgentSdkAgentRunner — proxy wiring', () => {
+  function makeMockProxy(): {
+    startProxy: typeof startAnthropicBetaHeaderFilterProxy;
+    getCapturedCalls: () => { targetBaseUrl: string; opts: unknown }[];
+  } {
+    const capturedCalls: { targetBaseUrl: string; opts: unknown }[] = [];
+    const startProxy = vi.fn(async (targetBaseUrl: string, opts: unknown): Promise<AnthropicBetaHeaderFilterProxy> => {
+      capturedCalls.push({ targetBaseUrl, opts });
+      const { createServer } = await import('node:http');
+      const server = createServer();
+      server.listen(0, '127.0.0.1');
+      await new Promise<void>(r => server.once('listening', r));
+      const address = server.address() as { port: number };
+      const close = async () => {
+        server.close();
+        await new Promise<void>(r => server.once('close', r));
+      };
+      return {
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        server,
+        close,
+      };
+    });
+    return {
+      startProxy: startProxy as unknown as typeof startAnthropicBetaHeaderFilterProxy,
+      getCapturedCalls: () => capturedCalls,
+    };
+  }
+
+  test('routes Grove base URL through loopback proxy — startProxy called with target URL', async () => {
+    const { startProxy, getCapturedCalls } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    await runner.close();
+
+    expect(getCapturedCalls()).toHaveLength(1);
+    expect(getCapturedCalls()[0].targetBaseUrl).toBe('https://grove.internal/openai');
+  });
+
+  test('does not start proxy when no baseUrl is set', async () => {
+    const { startProxy, getCapturedCalls } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'sk-test',
+      undefined,
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    await runner.close();
+
+    expect(getCapturedCalls()).toHaveLength(0);
+  });
+
+  test('passes requestLog to startProxy when configured', async () => {
+    const requestLog: RequestLogOptions = { logDir: '/tmp/test-request-logs' };
+    const { startProxy, getCapturedCalls } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy, requestLog },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    await runner.close();
+
+    expect(getCapturedCalls()).toHaveLength(1);
+    const passedOpts = getCapturedCalls()[0].opts as { requestLog?: RequestLogOptions };
+    expect(passedOpts.requestLog).toEqual(requestLog);
+  });
+
+  test('does not pass requestLog when not configured', async () => {
+    const { startProxy, getCapturedCalls } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    await runner.close();
+
+    expect(getCapturedCalls()).toHaveLength(1);
+    const passedOpts = getCapturedCalls()[0].opts as { requestLog?: RequestLogOptions };
+    expect(passedOpts.requestLog).toBeUndefined();
+  });
+
+  test('proxy is shared across multiple run() calls', async () => {
+    const { startProxy, getCapturedCalls } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({ route: { task: 'question.answer' }, working_directory: '/tmp/ws', prompt: 'first' }));
+    await collect(runner.run({ route: { task: 'question.answer' }, working_directory: '/tmp/ws', prompt: 'second' }));
+
+    await runner.close();
+
+    expect(getCapturedCalls()).toHaveLength(1);
+  });
+
+  test('close() stops the proxy', async () => {
+    const { startProxy } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    // Get the proxy instance to verify it was closed
+    const proxyPromise = (runner as unknown as { _proxy: Promise<AnthropicBetaHeaderFilterProxy> })._proxy;
+    expect(proxyPromise).not.toBeNull();
+    const proxy = await proxyPromise;
+
+    await runner.close();
+
+    // After close, _proxy should be null
+    expect((runner as unknown as { _proxy: Promise<AnthropicBetaHeaderFilterProxy> | null })._proxy).toBeNull();
+
+    // The server should no longer be listening
+    expect((proxy as unknown as { server: { listening: boolean } }).server.listening).toBe(false);
+  });
+
+  test('OpenAI client is constructed with proxy loopback URL, not the original base URL', async () => {
+    const { startProxy } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    let capturedAgent: unknown;
+    const runFn = vi.fn().mockImplementation(async function* (agent: unknown) {
+      capturedAgent = agent;
+    });
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    await runner.close();
+
+    // The agent's model should be an OpenAIResponsesModel whose internal client
+    // uses the proxy loopback URL, not the original Grove base URL.
+    const clientBaseURL = (capturedAgent as any)?.model?._client?.baseURL as string | undefined;
+    expect(clientBaseURL).toBeDefined();
+    expect(clientBaseURL).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
+    expect(clientBaseURL).not.toBe('https://grove.internal/openai');
+  });
+
+  test('startProxy is called with stripBetaValues: [] for OpenAI traffic', async () => {
+    const { startProxy, getCapturedCalls } = makeMockProxy();
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    const runFn = vi.fn().mockImplementation(async function* () {});
+
+    const runner = new OpenAIAgentSdkAgentRunner(
+      'grove-key-123',
+      'https://grove.internal/openai',
+      'gpt-4o',
+      { runFn, materializeSkills, logDestination: nullDest, startProxy },
+    );
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'test',
+    }));
+
+    await runner.close();
+
+    expect(getCapturedCalls()).toHaveLength(1);
+    const passedOpts = getCapturedCalls()[0].opts as { stripBetaValues?: string[] };
+    expect(passedOpts.stripBetaValues).toEqual([]);
   });
 });

--- a/tests/adapters/runtime-composition.test.ts
+++ b/tests/adapters/runtime-composition.test.ts
@@ -332,3 +332,29 @@ describe('RoutingAwareAgentRunner dispatch', () => {
     expect(openAiRunner.run).not.toHaveBeenCalled();
   });
 });
+
+describe('buildAgentRunner — requestLogDir threading', () => {
+  it('returns ClaudeAgentSdkAgentRunner when requestLogDir is provided', () => {
+    const runner = buildAgentRunner(
+      makeAgentResolvedAi('claude_agent_sdk'),
+      noopLogger,
+      undefined,
+      [],
+      undefined,
+      '/tmp/test-workspace/request-logs',
+    );
+    expect(runner).toBeInstanceOf(ClaudeAgentSdkAgentRunner);
+  });
+
+  it('returns ClaudeAgentSdkAgentRunner when requestLogDir is undefined (backward compat)', () => {
+    const runner = buildAgentRunner(
+      makeAgentResolvedAi('claude_agent_sdk'),
+      noopLogger,
+      undefined,
+      [],
+      undefined,
+      undefined,
+    );
+    expect(runner).toBeInstanceOf(ClaudeAgentSdkAgentRunner);
+  });
+});

--- a/tests/adapters/runtime-composition.test.ts
+++ b/tests/adapters/runtime-composition.test.ts
@@ -357,4 +357,32 @@ describe('buildAgentRunner — requestLogDir threading', () => {
     );
     expect(runner).toBeInstanceOf(ClaudeAgentSdkAgentRunner);
   });
+
+  it('wires requestLog into OpenAIAgentSdkAgentRunner when requestLogDir is provided', () => {
+    const runner = buildAgentRunner(
+      makeAgentResolvedAi('openai_agent_sdk'),
+      noopLogger,
+      undefined,
+      [],
+      undefined,
+      '/tmp/test-workspace/request-logs',
+    );
+    expect(runner).toBeInstanceOf(OpenAIAgentSdkAgentRunner);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((runner as any).requestLog).toEqual({ logDir: '/tmp/test-workspace/request-logs' });
+  });
+
+  it('does not set requestLog on OpenAIAgentSdkAgentRunner when requestLogDir is undefined', () => {
+    const runner = buildAgentRunner(
+      makeAgentResolvedAi('openai_agent_sdk'),
+      noopLogger,
+      undefined,
+      [],
+      undefined,
+      undefined,
+    );
+    expect(runner).toBeInstanceOf(OpenAIAgentSdkAgentRunner);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((runner as any).requestLog).toBeUndefined();
+  });
 });

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -128,6 +128,42 @@ describe('parseArgs — multi-repo', () => {
   });
 });
 
+describe('parseArgs — --log-requests', () => {
+  it('parses --log-requests flag', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    try {
+      const result = parseArgs(['--repo', tempDir, '--log-requests']);
+      expect(result.logRequests).toBe(true);
+      expect(result.repoPaths).toEqual([tempDir]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults logRequests to false when --log-requests is absent', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    try {
+      const result = parseArgs(['--repo', tempDir]);
+      expect(result.logRequests).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--log-requests before --repo paths still collects all paths', () => {
+    const dir1 = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    const dir2 = mkdtempSync(join(tmpdir(), 'cli-test-'));
+    try {
+      const result = parseArgs(['--log-requests', '--repo', dir1, dir2]);
+      expect(result.logRequests).toBe(true);
+      expect(result.repoPaths).toHaveLength(2);
+    } finally {
+      rmSync(dir1, { recursive: true, force: true });
+      rmSync(dir2, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('printUsage', () => {
   it('documents both command forms', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -136,5 +172,13 @@ describe('printUsage', () => {
     spy.mockRestore();
     expect(output).toContain('autocatalyst --repo');
     expect(output).toContain('autocatalyst init');
+  });
+
+  it('documents --log-requests option', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    printUsage();
+    const output = spy.mock.calls[0]?.[0] as string;
+    spy.mockRestore();
+    expect(output).toContain('--log-requests');
   });
 });


### PR DESCRIPTION
## Summary

- Add `--log-requests` CLI flag that enables request/response logging on all proxied requests
- Proxy always starts when `base_url` is configured (not just when beta header stripping is needed)
- Wire both Claude and OpenAI adapters to route through the proxy unconditionally
- Credential redaction in logged headers (first 4 + last 4 chars preserved)
- Timestamped JSON files written to `<workspace root>/request-logs/` with 0o600 permissions
- Treat log-dir setup failure as warn-and-continue rather than abort

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Start with `--log-requests`, trigger a run, verify `.request.json` files appear in the logs directory
- [ ] Verify credential values are redacted in logged headers
- [ ] Verify requests still work correctly (proxy is transparent)