### PR TITLE
feat: add response logging to proxy with stream state and backpressure handling

### DIFF
--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -33,6 +33,13 @@ const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
 
 const CREDENTIAL_HEADERS = new Set(['x-api-key', 'api-key', 'authorization']);
 
+const CREDENTIAL_RESPONSE_HEADERS = new Set([
+  'set-cookie',
+  'authorization',
+  'www-authenticate',
+  'proxy-authenticate',
+]);
+
 export interface RequestLogOptions {
   logDir: string;
 }
@@ -250,6 +257,34 @@ function redactHeaders(headers: Record<string, string>): Record<string, string> 
 function redactCredentialValue(value: string): string {
   if (value.length <= 8) return '[redacted]';
   return `${value.slice(0, 4)}redacted${value.slice(-4)}`;
+}
+
+export function redactResponseHeadersForDump(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    result[name] = CREDENTIAL_RESPONSE_HEADERS.has(name.toLowerCase()) ? '[redacted]' : value;
+  }
+  return result;
+}
+
+export function extractOutputTokens(
+  chunks: Buffer[],
+  truncated: boolean,
+): { tokens: number | null; source: string } {
+  if (truncated) return { tokens: null, source: 'capture_truncated' };
+  if (chunks.length === 0) return { tokens: null, source: 'json_parse_failed' };
+  const text = Buffer.concat(chunks).toString('utf8');
+  try {
+    const json = JSON.parse(text) as Record<string, unknown>;
+    const usage = json['usage'] as Record<string, unknown> | undefined;
+    if (usage) {
+      if (typeof usage['output_tokens'] === 'number') return { tokens: usage['output_tokens'], source: 'json' };
+      if (typeof usage['completion_tokens'] === 'number') return { tokens: usage['completion_tokens'], source: 'json' };
+    }
+    return { tokens: null, source: 'json_no_usage' };
+  } catch {
+    return { tokens: null, source: 'json_parse_failed' };
+  }
 }
 
 function targetUrlForRequest(targetBase: URL, requestUrl: string | undefined): URL {

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -138,8 +138,10 @@ async function handleProxyRequest(
   const headers = requestHeaders(req.headers, stripBetaValues);
   const body = await requestBody(req);
 
+  let dumpId: string | undefined;
   if (requestLog) {
-    await dumpRequest(targetUrl, req.method ?? 'GET', headers, body, requestLog, logger);
+    dumpId = generateDumpId();
+    await dumpRequest(targetUrl, req.method ?? 'GET', headers, body, requestLog, logger, dumpId);
   }
 
   const response = await fetch(targetUrl, {
@@ -167,6 +169,13 @@ async function handleProxyRequest(
   });
 }
 
+function generateDumpId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[:.]/g, '-');
+  const suffix = randomBytes(4).toString('hex');
+  return `${ts}-${suffix}`;
+}
+
 async function dumpRequest(
   targetUrl: URL,
   method: string,
@@ -174,6 +183,7 @@ async function dumpRequest(
   body: ArrayBuffer | undefined,
   requestLog: RequestLogOptions,
   logger: pino.Logger,
+  dumpId: string,
 ): Promise<void> {
   const start = Date.now();
   try {
@@ -195,6 +205,7 @@ async function dumpRequest(
     const now = new Date();
     const record: Record<string, unknown> = {
       timestamp: now.toISOString(),
+      dump_id: dumpId,
       method,
       url: targetUrl.toString(),
       headers: redactedHeaders,
@@ -202,9 +213,7 @@ async function dumpRequest(
     if (parsedBody !== undefined) record['body'] = parsedBody;
     if (bodyRaw !== undefined) record['body_raw'] = bodyRaw;
 
-    const ts = now.toISOString().replace(/[:.]/g, '-');
-    const suffix = randomBytes(4).toString('hex');
-    const filename = `${ts}-${suffix}.json`;
+    const filename = `${dumpId}.request.json`;
     const filePath = join(requestLog.logDir, filename);
     await writeFile(filePath, JSON.stringify(record, null, 2), { mode: 0o600 });
 

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -204,11 +204,18 @@ async function handleProxyRequest(
 
   try {
     await new Promise<void>((resolve, reject) => {
-      Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0])
+      let settled = false;
+      const settleResolve = () => { if (!settled) { settled = true; resolve(); } };
+      const settleReject = (err: Error) => { if (!settled) { settled = true; reject(err); } };
+
+      let finishFired = false;
+      const readable = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+
+      readable
         .on('error', (err: Error) => {
           streamState = 'interrupted';
           streamError = String(err);
-          reject(err);
+          settleReject(err);
         })
         .on('data', (chunk: Buffer) => {
           if (firstByteTime === null) firstByteTime = Date.now() - fetchStart;
@@ -221,16 +228,32 @@ async function handleProxyRequest(
               if (captureSize >= captureLimit) captureTruncated = true;
             }
           }
-          res.write(chunk);
+          const ok = res.write(chunk);
+          if (!ok) {
+            readable.pause();
+            res.once('drain', () => readable.resume());
+          }
         })
         .on('end', () => {
           res.end();
-          resolve();
         });
+
+      res.on('finish', () => {
+        finishFired = true;
+        settleResolve();
+      });
+      res.on('close', () => {
+        if (!finishFired) {
+          streamState = 'interrupted';
+          streamError = 'client disconnected before response finish';
+          readable.destroy();
+        }
+        settleResolve();
+      });
       res.on('error', (err: Error) => {
         streamState = 'interrupted';
         streamError = String(err);
-        reject(err);
+        settleReject(err);
       });
     });
   } catch (err) {

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -151,11 +151,22 @@ async function handleProxyRequest(
     await dumpRequest(targetUrl, req.method ?? 'GET', headers, body, requestLog, logger, dumpId);
   }
 
-  const response = await fetch(targetUrl, {
-    method: req.method,
-    headers,
-    body,
-  });
+  const fetchStart = Date.now();
+  let response: Response;
+  try {
+    response = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body,
+    });
+  } catch (fetchErr) {
+    if (requestLog && dumpId) {
+      await dumpResponseError(targetUrl, req.method ?? 'GET', dumpId, fetchStart, fetchErr, requestLog, logger);
+    }
+    throw fetchErr;
+  }
+
+  const headersTime = Date.now() - fetchStart;
 
   logger.debug(
     { event: 'proxy.request_proxied', method: req.method, upstream_status: response.status },
@@ -163,17 +174,97 @@ async function handleProxyRequest(
   );
 
   res.writeHead(response.status, response.statusText, responseHeaders(response.headers));
+
   if (!response.body) {
+    if (requestLog && dumpId) {
+      await dumpResponse(targetUrl, response, {
+        dumpId,
+        method: req.method ?? 'GET',
+        fetchStart,
+        headersTime,
+        firstByteTime: null,
+        bodyBytes: 0,
+        streamState: 'no_body',
+        captureChunks: [],
+        captureTruncated: false,
+      }, requestLog, logger);
+    }
     res.end();
     return;
   }
-  await new Promise<void>((resolve, reject) => {
-    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0])
-      .on('error', reject)
-      .pipe(res)
-      .on('error', reject)
-      .on('finish', resolve);
-  });
+
+  const captureLimit = 64 * 1024;
+  const captureChunks: Buffer[] = [];
+  let captureSize = 0;
+  let captureTruncated = false;
+  let firstByteTime: number | null = null;
+  let bodyBytes = 0;
+  let streamState: 'completed' | 'interrupted' = 'completed';
+  let streamError: string | undefined;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0])
+        .on('error', (err: Error) => {
+          streamState = 'interrupted';
+          streamError = String(err);
+          reject(err);
+        })
+        .on('data', (chunk: Buffer) => {
+          if (firstByteTime === null) firstByteTime = Date.now() - fetchStart;
+          bodyBytes += chunk.byteLength;
+          if (!captureTruncated) {
+            const space = captureLimit - captureSize;
+            if (space > 0) {
+              captureChunks.push(space >= chunk.byteLength ? chunk : chunk.slice(0, space));
+              captureSize += Math.min(chunk.byteLength, space);
+              if (captureSize >= captureLimit) captureTruncated = true;
+            }
+          }
+          res.write(chunk);
+        })
+        .on('end', () => {
+          res.end();
+          resolve();
+        });
+      res.on('error', (err: Error) => {
+        streamState = 'interrupted';
+        streamError = String(err);
+        reject(err);
+      });
+    });
+  } catch (err) {
+    if (requestLog && dumpId) {
+      await dumpResponse(targetUrl, response, {
+        dumpId,
+        method: req.method ?? 'GET',
+        fetchStart,
+        headersTime,
+        firstByteTime,
+        bodyBytes,
+        streamState: 'interrupted',
+        captureChunks,
+        captureTruncated,
+        streamError: String(err),
+      }, requestLog, logger);
+    }
+    throw err;
+  }
+
+  if (requestLog && dumpId) {
+    await dumpResponse(targetUrl, response, {
+      dumpId,
+      method: req.method ?? 'GET',
+      fetchStart,
+      headersTime,
+      firstByteTime,
+      bodyBytes,
+      streamState,
+      captureChunks,
+      captureTruncated,
+      streamError,
+    }, requestLog, logger);
+  }
 }
 
 function generateDumpId(): string {

--- a/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
+++ b/src/adapters/anthropic/anthropic-beta-header-filter-proxy.ts
@@ -244,6 +244,131 @@ async function dumpRequest(
   }
 }
 
+interface ResponseObservation {
+  dumpId: string;
+  method: string;
+  fetchStart: number;
+  headersTime: number;
+  firstByteTime: number | null;
+  bodyBytes: number;
+  streamState: 'completed' | 'interrupted' | 'no_body';
+  captureChunks: Buffer[];
+  captureTruncated: boolean;
+  streamError?: string;
+}
+
+async function dumpResponse(
+  targetUrl: URL,
+  response: Response,
+  obs: ResponseObservation,
+  requestLog: RequestLogOptions,
+  logger: pino.Logger,
+): Promise<void> {
+  const start = Date.now();
+  try {
+    const totalDuration = Date.now() - obs.fetchStart;
+    const filteredHeaders = responseHeaders(response.headers);
+    const redactedHeaders = redactResponseHeadersForDump(filteredHeaders);
+
+    const { tokens: outputTokens, source: tokenCountSource } = obs.streamState === 'completed'
+      ? extractOutputTokens(obs.captureChunks, obs.captureTruncated)
+      : { tokens: null, source: `unavailable_${obs.streamState}` };
+
+    const record: Record<string, unknown> = {
+      timestamp: new Date(obs.fetchStart).toISOString(),
+      request_dump_id: obs.dumpId,
+      request_file: `${obs.dumpId}.request.json`,
+      method: obs.method,
+      url: targetUrl.toString(),
+      status: response.status,
+      status_text: response.statusText,
+      headers: redactedHeaders,
+      timing_ms: {
+        headers: obs.headersTime,
+        first_body_byte: obs.firstByteTime,
+        total: totalDuration,
+      },
+      body_bytes: obs.bodyBytes,
+      body_capture_truncated: obs.captureTruncated,
+      body_parseable_json: tokenCountSource === 'json' || tokenCountSource === 'json_no_usage',
+      output_tokens: outputTokens,
+      token_count_source: tokenCountSource,
+      stream_state: obs.streamState,
+    };
+
+    if (obs.streamError) record['stream_error'] = obs.streamError;
+
+    const filename = `${obs.dumpId}.response.json`;
+    const filePath = join(requestLog.logDir, filename);
+    await writeFile(filePath, JSON.stringify(record, null, 2), { mode: 0o600 });
+
+    logger.debug(
+      {
+        event: 'proxy.response_dumped',
+        path: filePath,
+        method: obs.method,
+        target_host: targetUrl.hostname,
+        status: response.status,
+        duration_ms: totalDuration,
+        body_bytes: obs.bodyBytes,
+        stream_state: obs.streamState,
+        dump_write_ms: Date.now() - start,
+      },
+      'Proxy response dumped',
+    );
+  } catch (err) {
+    logger.warn(
+      { event: 'proxy.response_dump_failed', error: String(err), duration_ms: Date.now() - start },
+      'Proxy response dump failed',
+    );
+  }
+}
+
+async function dumpResponseError(
+  targetUrl: URL,
+  method: string,
+  dumpId: string,
+  fetchStart: number,
+  error: unknown,
+  requestLog: RequestLogOptions,
+  logger: pino.Logger,
+): Promise<void> {
+  const start = Date.now();
+  try {
+    const record: Record<string, unknown> = {
+      timestamp: new Date(fetchStart).toISOString(),
+      request_dump_id: dumpId,
+      request_file: `${dumpId}.request.json`,
+      method,
+      url: targetUrl.toString(),
+      elapsed_ms: Date.now() - fetchStart,
+      error: String(error),
+      stream_state: 'fetch_error',
+    };
+
+    const filename = `${dumpId}.response-error.json`;
+    const filePath = join(requestLog.logDir, filename);
+    await writeFile(filePath, JSON.stringify(record, null, 2), { mode: 0o600 });
+
+    logger.debug(
+      {
+        event: 'proxy.response_fetch_failed',
+        path: filePath,
+        method,
+        target_host: targetUrl.hostname,
+        elapsed_ms: Date.now() - fetchStart,
+        error: String(error),
+      },
+      'Proxy fetch failed before response headers',
+    );
+  } catch (err) {
+    logger.warn(
+      { event: 'proxy.response_dump_failed', error: String(err), duration_ms: Date.now() - start },
+      'Proxy response-error dump failed',
+    );
+  }
+}
+
 function redactHeaders(headers: Record<string, string>): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [name, value] of Object.entries(headers)) {

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -75,7 +75,7 @@ export function printUsage(): void {
 
 Options:
   --repo <path> [<path2>...]   Path(s) to target repository/repositories
-  --log-requests               Dump outbound proxy requests to <workspace root>/request-logs/
+  --log-requests               Dump proxied request and response diagnostics to <workspace root>/request-logs/
   --help                       Show this help message
 `);
 }

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -2,7 +2,7 @@ import { once } from 'node:events';
 import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync, statSync, mkdirSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
+import { createServer, request as httpRequest, type IncomingHttpHeaders, type Server } from 'node:http';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, test } from 'vitest';
 import {
@@ -533,6 +533,111 @@ describe('Anthropic beta header filter proxy', () => {
       expect(dump.output_tokens).toBeNull();
       expect(typeof dump.token_count_source).toBe('string');
       expect(dump.stream_state).toBe('completed');
+    });
+
+    test('client disconnect before upstream stream completes logs stream_state interrupted', async () => {
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.write('partial-data');
+        // Hold the response open — the test destroys the client socket to simulate a disconnect
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const addr = new URL(proxy.baseUrl);
+      await new Promise<void>((resolve) => {
+        const req = httpRequest({
+          hostname: addr.hostname,
+          port: Number(addr.port),
+          path: '/v1/messages',
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+        }, (incomingRes) => {
+          incomingRes.once('data', () => {
+            req.socket?.destroy();
+            resolve();
+          });
+        });
+        req.on('error', () => resolve());
+        req.write('{}');
+        req.end();
+      });
+
+      await new Promise(r => setTimeout(r, 100));
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      const responseFile = files.find(f => f.endsWith('.response.json'));
+      expect(responseFile).toBeDefined();
+      const dump = JSON.parse(readFileSync(join(logDir, responseFile!), 'utf8')) as Record<string, unknown>;
+      expect(dump.stream_state).toBe('interrupted');
+    });
+
+    test('slow-reader streaming: backpressure is respected and all bytes reach the client', async () => {
+      const chunkSize = 64 * 1024;
+      const chunkCount = 8;
+      const chunkData = Buffer.alloc(chunkSize, 0x61);
+
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        let i = 0;
+        const send = () => {
+          if (i < chunkCount) {
+            const ok = res.write(chunkData);
+            i++;
+            if (ok) setImmediate(send);
+            else res.once('drain', send);
+          } else {
+            res.end();
+          }
+        };
+        send();
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const receivedChunks: Buffer[] = [];
+      const addr = new URL(proxy.baseUrl);
+      await new Promise<void>((resolve, reject) => {
+        const req = httpRequest({
+          hostname: addr.hostname,
+          port: Number(addr.port),
+          path: '/v1/messages',
+          method: 'POST',
+        }, (incomingRes) => {
+          incomingRes.pause();
+          setTimeout(() => incomingRes.resume(), 20);
+          incomingRes.on('data', (chunk: Buffer) => receivedChunks.push(chunk));
+          incomingRes.on('end', resolve);
+          incomingRes.on('error', reject);
+        });
+        req.on('error', reject);
+        req.write('{}');
+        req.end();
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      await proxy.close();
+
+      expect(Buffer.concat(receivedChunks).byteLength).toBe(chunkSize * chunkCount);
+
+      const files = readdirSync(logDir);
+      const responseFile = files.find(f => f.endsWith('.response.json'))!;
+      const dump = JSON.parse(readFileSync(join(logDir, responseFile), 'utf8')) as Record<string, unknown>;
+      expect(dump.stream_state).toBe('completed');
+      expect(dump.body_bytes).toBe(chunkSize * chunkCount);
     });
 
     test('response dump write failure still forwards the upstream response', async () => {

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -6,6 +6,10 @@ import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, test } from 'vitest';
 import { startAnthropicBetaHeaderFilterProxy } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
+import {
+  redactResponseHeadersForDump,
+  extractOutputTokens,
+} from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
 
 async function listen(server: Server): Promise<number> {
   server.listen(0, '127.0.0.1');
@@ -325,6 +329,84 @@ describe('Anthropic beta header filter proxy', () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({ forwarded: true });
       await proxy.close();
+    });
+  });
+});
+
+describe('response dump helpers', () => {
+  describe('redactResponseHeadersForDump', () => {
+    it('passes through non-sensitive headers', () => {
+      const result = redactResponseHeadersForDump({
+        'content-type': 'application/json',
+        'x-request-id': 'abc123',
+        'x-ratelimit-remaining-requests': '42',
+      });
+      expect(result['content-type']).toBe('application/json');
+      expect(result['x-request-id']).toBe('abc123');
+      expect(result['x-ratelimit-remaining-requests']).toBe('42');
+    });
+
+    it('redacts set-cookie', () => {
+      const result = redactResponseHeadersForDump({ 'set-cookie': 'session=abc123; Path=/' });
+      expect(result['set-cookie']).toBe('[redacted]');
+    });
+
+    it('redacts authorization in response headers', () => {
+      const result = redactResponseHeadersForDump({ 'authorization': 'Bearer tok_xxxx' });
+      expect(result['authorization']).toBe('[redacted]');
+    });
+
+    it('redacts www-authenticate', () => {
+      const result = redactResponseHeadersForDump({ 'www-authenticate': 'Bearer realm="example"' });
+      expect(result['www-authenticate']).toBe('[redacted]');
+    });
+
+    it('redacts proxy-authenticate', () => {
+      const result = redactResponseHeadersForDump({ 'proxy-authenticate': 'Basic realm="corp"' });
+      expect(result['proxy-authenticate']).toBe('[redacted]');
+    });
+  });
+
+  describe('extractOutputTokens', () => {
+    it('extracts usage.output_tokens from Anthropic-style JSON', () => {
+      const body = Buffer.from(JSON.stringify({ usage: { input_tokens: 100, output_tokens: 250 } }));
+      const result = extractOutputTokens([body], false);
+      expect(result.tokens).toBe(250);
+      expect(result.source).toBe('json');
+    });
+
+    it('extracts usage.completion_tokens as OpenAI chat fallback', () => {
+      const body = Buffer.from(JSON.stringify({ usage: { prompt_tokens: 10, completion_tokens: 75 } }));
+      const result = extractOutputTokens([body], false);
+      expect(result.tokens).toBe(75);
+      expect(result.source).toBe('json');
+    });
+
+    it('returns null when JSON has no usage field', () => {
+      const body = Buffer.from(JSON.stringify({ id: 'msg_abc', content: [] }));
+      const result = extractOutputTokens([body], false);
+      expect(result.tokens).toBeNull();
+      expect(result.source).toBe('json_no_usage');
+    });
+
+    it('returns null when capture is truncated', () => {
+      const body = Buffer.from(JSON.stringify({ usage: { output_tokens: 100 } }));
+      const result = extractOutputTokens([body], true);
+      expect(result.tokens).toBeNull();
+      expect(result.source).toBe('capture_truncated');
+    });
+
+    it('returns null when body is not valid JSON', () => {
+      const body = Buffer.from('data: {"type":"content_block_delta"}\n\ndata: [DONE]\n');
+      const result = extractOutputTokens([body], false);
+      expect(result.tokens).toBeNull();
+      expect(result.source).toBe('json_parse_failed');
+    });
+
+    it('returns null when chunks are empty', () => {
+      const result = extractOutputTokens([], false);
+      expect(result.tokens).toBeNull();
+      expect(result.source).toBe('json_parse_failed');
     });
   });
 });

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -5,8 +5,8 @@ import { tmpdir } from 'node:os';
 import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, test } from 'vitest';
-import { startAnthropicBetaHeaderFilterProxy } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';
 import {
+  startAnthropicBetaHeaderFilterProxy,
   redactResponseHeadersForDump,
   extractOutputTokens,
 } from '../../../src/adapters/anthropic/anthropic-beta-header-filter-proxy.js';

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -167,9 +167,15 @@ describe('Anthropic beta header filter proxy', () => {
       });
       await proxy.close();
 
-      const files = readdirSync(logDir);
-      expect(files).toHaveLength(1);
-      const dump = JSON.parse(readFileSync(join(logDir, files[0]!), 'utf8')) as Record<string, unknown>;
+      const files = readdirSync(logDir).sort();
+      expect(files).toHaveLength(2);
+
+      const requestFile = files.find(f => f.endsWith('.request.json'));
+      const responseFile = files.find(f => f.endsWith('.response.json'));
+      expect(requestFile).toBeDefined();
+      expect(responseFile).toBeDefined();
+
+      const dump = JSON.parse(readFileSync(join(logDir, requestFile!), 'utf8')) as Record<string, unknown>;
       expect(dump.method).toBe('POST');
       expect(typeof dump.url).toBe('string');
       expect((dump.url as string)).toContain('/v1/messages');
@@ -203,8 +209,8 @@ describe('Anthropic beta header filter proxy', () => {
       await proxy.close();
 
       const files = readdirSync(logDir);
-      expect(files).toHaveLength(1);
-      const dump = JSON.parse(readFileSync(join(logDir, files[0]!), 'utf8')) as Record<string, unknown>;
+      const requestFile = files.find(f => f.endsWith('.request.json'))!;
+      const dump = JSON.parse(readFileSync(join(logDir, requestFile), 'utf8')) as Record<string, unknown>;
       const headers = dump.headers as Record<string, string>;
       // hop-by-hop stripped (transfer-encoding is a hop-by-hop header)
       expect(headers).not.toHaveProperty('transfer-encoding');
@@ -238,7 +244,8 @@ describe('Anthropic beta header filter proxy', () => {
       await proxy.close();
 
       const files = readdirSync(logDir);
-      const dump = JSON.parse(readFileSync(join(logDir, files[0]!), 'utf8')) as Record<string, unknown>;
+      const requestFile = files.find(f => f.endsWith('.request.json'))!;
+      const dump = JSON.parse(readFileSync(join(logDir, requestFile), 'utf8')) as Record<string, unknown>;
       const headers = dump.headers as Record<string, string>;
       // Must keep first 4 and last 4 chars of the full header value
       const apiKey = headers['x-api-key']!;
@@ -329,6 +336,245 @@ describe('Anthropic beta header filter proxy', () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({ forwarded: true });
       await proxy.close();
+    });
+
+    test('response dump includes status, headers, timing, bytes, stream_state, and output_tokens', async () => {
+      const upstream = createServer((req, res) => {
+        let body = '';
+        req.setEncoding('utf8');
+        req.on('data', (c: string) => { body += c; });
+        req.on('end', () => {
+          res.writeHead(200, { 'content-type': 'application/json', 'x-request-id': 'req-abc123' });
+          res.end(JSON.stringify({ usage: { input_tokens: 10, output_tokens: 42 } }));
+        });
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const r1 = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'claude-3', messages: [] }),
+      });
+      await r1.text();
+      // Give the server-side async dump write time to complete before closing
+      await new Promise(r => setTimeout(r, 50));
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      const responseFile = files.find(f => f.endsWith('.response.json'))!;
+      expect(responseFile).toBeDefined();
+      const dump = JSON.parse(readFileSync(join(logDir, responseFile), 'utf8')) as Record<string, unknown>;
+
+      expect(dump.status).toBe(200);
+      expect(dump.status_text).toBe('OK');
+      expect(dump.stream_state).toBe('completed');
+      expect(typeof dump.body_bytes).toBe('number');
+      expect((dump.body_bytes as number)).toBeGreaterThan(0);
+      expect(dump.output_tokens).toBe(42);
+      expect(dump.token_count_source).toBe('json');
+
+      const timing = dump.timing_ms as Record<string, unknown>;
+      expect(typeof timing.headers).toBe('number');
+      expect(typeof timing.total).toBe('number');
+
+      const headers = dump.headers as Record<string, string>;
+      expect(headers['x-request-id']).toBe('req-abc123');
+      expect(headers['content-type']).toBe('application/json');
+
+      const requestFile = files.find(f => f.endsWith('.request.json'))!;
+      const requestDump = JSON.parse(readFileSync(join(logDir, requestFile), 'utf8')) as Record<string, unknown>;
+      expect(dump.request_dump_id).toBe(requestDump.dump_id);
+      expect(dump.request_file).toBe(requestFile);
+    });
+
+    test('response dump redacts set-cookie and credential response headers', async () => {
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'set-cookie': 'session=secret123; Path=/',
+          'www-authenticate': 'Bearer realm="api"',
+          'x-request-id': 'safe-header',
+        });
+        res.end('{}');
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const r2 = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        body: '{}',
+      });
+      await r2.text();
+      // Give the server-side async dump write time to complete before closing
+      await new Promise(r => setTimeout(r, 50));
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      const responseFile = files.find(f => f.endsWith('.response.json'))!;
+      const dump = JSON.parse(readFileSync(join(logDir, responseFile), 'utf8')) as Record<string, unknown>;
+      const headers = dump.headers as Record<string, string>;
+
+      expect(headers['set-cookie']).toBe('[redacted]');
+      expect(headers['www-authenticate']).toBe('[redacted]');
+      expect(headers['x-request-id']).toBe('safe-header');
+    });
+
+    test('writes response-error.json when fetch fails before HTTP response', async () => {
+      // Port 1 has no listener, so fetch() will throw ECONNREFUSED
+      const proxy = await startAnthropicBetaHeaderFilterProxy('http://127.0.0.1:1', {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(response.status).toBe(502);
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      const requestFile = files.find(f => f.endsWith('.request.json'));
+      const errorFile = files.find(f => f.endsWith('.response-error.json'));
+      expect(requestFile).toBeDefined();
+      expect(errorFile).toBeDefined();
+
+      const dump = JSON.parse(readFileSync(join(logDir, errorFile!), 'utf8')) as Record<string, unknown>;
+      expect(dump.stream_state).toBe('fetch_error');
+      expect(typeof dump.error).toBe('string');
+      expect(typeof dump.elapsed_ms).toBe('number');
+      expect(dump.request_dump_id).toBeDefined();
+    });
+
+    test('streaming response: bytes reach caller in order, response dump records byte count and completed state', async () => {
+      const chunks = ['chunk-one', 'chunk-two', 'chunk-three'];
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        let i = 0;
+        const send = () => {
+          if (i < chunks.length) {
+            res.write(chunks[i++]);
+            setImmediate(send);
+          } else {
+            res.end();
+          }
+        };
+        send();
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, { method: 'POST', body: '{}' });
+      const text = await response.text();
+      // Give the server-side async dump write time to complete before closing
+      await new Promise(r => setTimeout(r, 50));
+      await proxy.close();
+
+      expect(text).toBe(chunks.join(''));
+
+      const files = readdirSync(logDir);
+      const responseFile = files.find(f => f.endsWith('.response.json'))!;
+      const dump = JSON.parse(readFileSync(join(logDir, responseFile), 'utf8')) as Record<string, unknown>;
+
+      const expectedBytes = Buffer.byteLength(chunks.join(''));
+      expect(dump.body_bytes).toBe(expectedBytes);
+      expect(dump.stream_state).toBe('completed');
+      const timing = dump.timing_ms as Record<string, unknown>;
+      expect(typeof timing.first_body_byte).toBe('number');
+      expect(typeof timing.total).toBe('number');
+    });
+
+    test('non-JSON response records output_tokens: null and does not fail the proxy', async () => {
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('data: {"type":"ping"}\n\ndata: [DONE]\n\n');
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir },
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, { method: 'POST', body: '{}' });
+      expect(response.status).toBe(200);
+      await response.text();
+      // Give the server-side async dump write time to complete before closing
+      await new Promise(r => setTimeout(r, 50));
+      await proxy.close();
+
+      const files = readdirSync(logDir);
+      const responseFile = files.find(f => f.endsWith('.response.json'))!;
+      const dump = JSON.parse(readFileSync(join(logDir, responseFile), 'utf8')) as Record<string, unknown>;
+
+      expect(dump.output_tokens).toBeNull();
+      expect(typeof dump.token_count_source).toBe('string');
+      expect(dump.stream_state).toBe('completed');
+    });
+
+    test('response dump write failure still forwards the upstream response', async () => {
+      const upstream = createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+      servers.push(upstream);
+      const upstreamPort = await listen(upstream);
+
+      // Use a file path as logDir so directory mkdir succeeds (we reuse the existing tmpdir logDir)
+      // but individual file writes inside it fail by making a subdirectory path that is a FILE
+      const badLogDir = join(logDir, 'not-a-directory');
+      writeFileSync(badLogDir, 'blocking-file');
+
+      const dest = new PassThrough();
+      const logLines: string[] = [];
+      dest.on('data', (c: Buffer) => c.toString().split('\n').filter(Boolean).forEach(l => logLines.push(l)));
+
+      const proxy = await startAnthropicBetaHeaderFilterProxy(`http://127.0.0.1:${upstreamPort}`, {
+        stripBetaValues: [],
+        requestLog: { logDir: badLogDir },
+        logDestination: dest,
+      });
+      servers.push(proxy.server);
+
+      const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      await proxy.close();
+      dest.end();
+      await new Promise(r => dest.on('finish', r));
+
+      const parsed = logLines.map(l => JSON.parse(l) as Record<string, unknown>);
+      const dumpFailed = parsed.find(l =>
+        l['event'] === 'proxy.response_dump_failed' || l['event'] === 'proxy.request_dump_failed'
+      );
+      expect(dumpFailed).toBeDefined();
     });
   });
 });

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -181,4 +181,12 @@ describe('printUsage', () => {
     spy.mockRestore();
     expect(output).toContain('--log-requests');
   });
+
+  it('describes --log-requests as dumping request and response diagnostics', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    printUsage();
+    const output = spy.mock.calls[0]?.[0] as string;
+    spy.mockRestore();
+    expect(output).toMatch(/response/i);
+  });
 });


### PR DESCRIPTION
## Summary

- Extract dump ID generation from `dumpRequest` for paired request/response file naming
- Add response header redaction and output token extraction helpers
- Add `dumpResponse` and `dumpResponseError` functions for proxy response capture
- Wire response observation and dump calls into `handleProxyRequest`
- `stream_state` accurately reflects client disconnect (interrupted) vs normal completion
- Respect backpressure when downstream is slow
- Update `--log-requests` help text to mention request and response logging

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Start with `--log-requests`, trigger a run, verify `.response.json` files appear paired with `.request.json`
- [ ] Verify response timing fields (`headers`, `first_body_byte`, `total`) are populated
- [ ] Kill a request mid-stream and verify `stream_state` shows "interrupted"