### PR TITLE
feat: add planning stage between spec approval and implementation

### DIFF
--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -82,7 +82,7 @@ ai:
     pr.title_generate: grove-gpt-5.4-nano
     artifact.create: grove-gpt-5.5-high
     artifact.revise: grove-gpt-5.5-high
-    implementation.plan: grove-sonnet-4.6-medium
+    implementation.plan: grove-gpt-5.5-high
     implementation.run: grove-sonnet-4.6-medium
     implementation.review.initial: grove-gpt-5.5-high
     implementation.review.final: grove-gpt-5.5-medium

--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -82,6 +82,7 @@ ai:
     pr.title_generate: grove-gpt-5.4-nano
     artifact.create: grove-gpt-5.5-high
     artifact.revise: grove-gpt-5.5-high
+    implementation.plan: grove-sonnet-4.6-medium
     implementation.run: grove-sonnet-4.6-medium
     implementation.review.initial: grove-gpt-5.5-high
     implementation.review.final: grove-gpt-5.5-medium

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -41,8 +41,11 @@ export interface OpenAIAgentSdkAgentRunnerOptions {
 }
 
 export function skillRefsForRoute(route: AgentRoute): AgentSkillRef[] {
+  if (route.task === 'implementation.plan') {
+    return ['superpowers:writing-plans'];
+  }
   if (route.task === 'implementation.run') {
-    return ['superpowers:writing-plans', 'superpowers:subagent-driven-development'];
+    return ['superpowers:subagent-driven-development'];
   }
   if (route.task === 'issue.triage') {
     return ['mm:issue-triage'];

--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -14,7 +14,7 @@ import { materializeOpenAIRuntimeSkills } from './openai-runtime-skill-materiali
 import { buildSandboxEnvironment } from '../sandbox-environment.js';
 import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy, type RequestLogOptions } from '../anthropic/anthropic-beta-header-filter-proxy.js';
 
-const DEFAULT_OPENAI_AGENT_MAX_TURNS = 50;
+const DEFAULT_OPENAI_AGENT_MAX_TURNS = 250;
 
 interface RunFnOptions {
   maxTurns: number;

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -38,6 +38,7 @@ import { ModelPRTitleGenerator } from '../core/ai/pr-title-generator.js';
 import {
   AgentRunnerArtifactAuthoringAgent,
   AgentRunnerImplementationAgent,
+  AgentRunnerImplementationPlanningAgent,
   AgentRunnerIssueTriageAgent,
   AgentRunnerQuestionAnsweringAgent,
   IssueFilingService,
@@ -153,6 +154,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     },
   });
   const implementer = new AgentRunnerImplementationAgent(agentRunner, aiRoutingPolicy, { loggerProvider: options.loggerProvider });
+  const implementationPlanner = new AgentRunnerImplementationPlanningAgent(agentRunner, aiRoutingPolicy, { loggerProvider: options.loggerProvider });
   const prManager = new GHPRManager();
   const issueManager = new GHIssueManager();
   const issueTriageAgent = new AgentRunnerIssueTriageAgent(agentRunner, aiRoutingPolicy, { loggerProvider: options.loggerProvider });
@@ -191,6 +193,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     intentClassifier,
     questionAnswerer,
     specCommitter: artifactDeps.specCommitter,
+    implementationPlanner,
     implementer,
     implFeedbackPage: artifactDeps.implFeedbackPage,
     prManager,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -89,6 +89,7 @@ ai:
     pr.title_generate: classify-haiku
     artifact.create: artifact-agent
     artifact.revise: artifact-agent
+    implementation.plan: impl-agent
     implementation.run: impl-agent
     implementation.review.initial: review-agent
     implementation.review.final: review-agent

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -18,6 +18,8 @@ import type {
   ArtifactCreateResult,
   ArtifactRevisionResult,
   ImplementationAgent,
+  ImplementationPlanResult,
+  ImplementationPlanningAgent,
   ImplementationResult,
   ImplementationReviewFinding,
   ImplementationReviewResult,
@@ -234,9 +236,10 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
     additional_context?: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: { run_id?: string; request_id?: string },
+    plan_path?: string,
   ): Promise<ImplementationResult> {
     const resultFilePath = join(working_directory, '.autocatalyst', 'impl-result.json');
-    const prompt = buildImplementationPrompt(artifact_path, resultFilePath, additional_context);
+    const prompt = buildImplementationPrompt(artifact_path, resultFilePath, additional_context, plan_path);
     const route = { task: 'implementation.run' as const };
 
     this.logger.debug(
@@ -291,6 +294,78 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
     });
     const result = parseImplementationResult(content, resultFilePath);
     this.logger.debug({ event: 'impl.agent_completed', status: result.status }, 'Agent implementation completed');
+    return result;
+  }
+}
+
+export class AgentRunnerImplementationPlanningAgent implements ImplementationPlanningAgent {
+  private readonly logger: pino.Logger;
+  private readonly readFileFn: ReadFileFn;
+
+  constructor(
+    private readonly runner: AgentRunner,
+    private readonly routingPolicy: AgentRoutingPolicy,
+    options?: AgentServiceOptions,
+  ) {
+    this.logger = createLogger('implementation-planning-agent', { destination: options?.logDestination, loggerProvider: options?.loggerProvider });
+    this.readFileFn = options?.readFile ?? ((path, enc) => _readFile(path, enc));
+  }
+
+  async plan(
+    artifact_path: string,
+    working_directory: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: { run_id?: string; request_id?: string },
+  ): Promise<ImplementationPlanResult> {
+    const resultFilePath = join(working_directory, '.autocatalyst', 'implementation-plan-result.json');
+    const prompt = buildImplementationPlanPrompt(artifact_path, working_directory, resultFilePath);
+    const route = { task: 'implementation.plan' as const, stage: 'planning' as const };
+
+    this.logger.debug(
+      { event: 'planning.agent_invoked', artifact_path, working_directory, ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}), ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}) },
+      'Invoking agent for implementation planning',
+    );
+
+    let drainSummary: AgentDrainSummary | undefined;
+    try {
+      await ensureResultDir(resultFilePath);
+      drainSummary = await drainAgentRunner(
+        this.runner.run({
+          route,
+          profile: this.routingPolicy.resolve(route),
+          working_directory,
+          prompt,
+          telemetry: {
+            phase: 'planning',
+            route_task: route.task,
+            handler: 'AgentRunnerImplementationPlanningAgent',
+            ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}),
+            ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}),
+          },
+        }),
+        onProgress,
+        this.logger,
+        'planning',
+        { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
+      );
+    } catch (err) {
+      this.logger.error({ event: 'planning.agent_failed', error: String(err) }, 'Agent exited with error during implementation planning');
+      throw new Error(`Implementation planning failed: ${String(err)}`);
+    }
+
+    const content = await validateRequiredResultFile({
+      readFileFn: this.readFileFn,
+      path: resultFilePath,
+      label: 'Implementation planning',
+      logger: this.logger,
+      phase: 'planning',
+      route_task: 'implementation.plan',
+      run_id: telemetry?.run_id,
+      request_id: telemetry?.request_id,
+      drainSummary,
+    });
+    const result = parseImplementationPlanResult(content, resultFilePath);
+    this.logger.debug({ event: 'planning.agent_completed', status: result.status }, 'Agent implementation planning completed');
     return result;
   }
 }
@@ -802,6 +877,27 @@ function parseImplementationResult(content: string, path: string): Implementatio
   };
 }
 
+function parseImplementationPlanResult(content: string, path: string): ImplementationPlanResult {
+  const obj = parseJsonObject(content, `Implementation planning: result file at "${path}"`);
+  const rawStatus = obj['status'];
+  const status = typeof rawStatus === 'string'
+    ? (STATUS_SYNONYMS[rawStatus] ?? rawStatus)
+    : rawStatus;
+  if (status !== 'complete' && status !== 'needs_input' && status !== 'failed') {
+    throw new Error(`Implementation planning: invalid STATUS value "${String(rawStatus)}" in result file`);
+  }
+  const planPath = typeof obj['plan_path'] === 'string' ? obj['plan_path'] : undefined;
+  if (status === 'complete' && !planPath) {
+    throw new Error(`Implementation planning: result file missing "plan_path" string`);
+  }
+  return {
+    status,
+    plan_path: planPath,
+    question: typeof obj['question'] === 'string' ? obj['question'] : undefined,
+    error: typeof obj['error'] === 'string' ? obj['error'] : undefined,
+  };
+}
+
 function parseQuestionAnswer(content: string): string {
   const obj = parseJsonObject(content, 'Question answering: result file');
   if (typeof obj['answer'] !== 'string') {
@@ -1063,7 +1159,7 @@ function buildArtifactRevisePrompt(
   ].join('\n');
 }
 
-function buildImplementationPrompt(artifact_path: string, result_file_path: string, additionalContext?: string): string {
+function buildImplementationPrompt(artifact_path: string, result_file_path: string, additionalContext?: string, planPath?: string): string {
   const lines: string[] = [];
   lines.push(BRANCH_OWNERSHIP_POLICY);
   lines.push('');
@@ -1091,9 +1187,14 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
   }
 
   lines.push(`Read the approved artifact at: ${artifact_path}`);
+  if (planPath) {
+    lines.push(`Read the existing implementation plan at: ${planPath}`);
+    lines.push('');
+    lines.push('Do not create a new implementation plan. Use the existing plan as the execution checklist.');
+  }
   lines.push('');
 
-  if (!additionalContext) {
+  if (!additionalContext && !planPath) {
     lines.push('Step 1 - Create an implementation plan');
     lines.push('Use the `superpowers:writing-plans` skill.');
     lines.push('');
@@ -1147,6 +1248,36 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
   lines.push(CHECKPOINT_INSTRUCTIONS);
 
   return lines.join('\n');
+}
+
+function buildImplementationPlanPrompt(artifact_path: string, working_directory: string, result_file_path: string): string {
+  const planDir = join(working_directory, 'docs', 'superpowers', 'plans');
+  return [
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    `Read the approved artifact at: ${artifact_path}`,
+    ``,
+    `Create an implementation plan using the \`superpowers:writing-plans\` skill.`,
+    `Use the artifact as the authoritative baseline, especially its task list.`,
+    `Save the plan under: ${planDir}`,
+    ``,
+    `Write the result to: ${result_file_path}`,
+    `Create the directory if it does not exist. The JSON must have this structure:`,
+    `{`,
+    `  "status": "complete" | "needs_input" | "failed",`,
+    `  "plan_path": "<absolute path to the plan file when complete>",`,
+    `  "question": "only when needs_input",`,
+    `  "error": "only when failed"`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Use only the exact canonical status values: "complete", "needs_input", or "failed".`,
+    `- When status is "complete", plan_path must point to the plan file you wrote.`,
+    `- Do not execute the plan in this session; implementation happens in a separate stage.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
 }
 
 function buildQuestionPrompt(question: string, resultPath: string): string {

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -316,9 +316,10 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
     working_directory: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: { run_id?: string; request_id?: string },
+    additional_context?: string,
   ): Promise<ImplementationPlanResult> {
     const resultFilePath = join(working_directory, '.autocatalyst', 'implementation-plan-result.json');
-    const prompt = buildImplementationPlanPrompt(artifact_path, working_directory, resultFilePath);
+    const prompt = buildImplementationPlanPrompt(artifact_path, working_directory, resultFilePath, additional_context);
     const route = { task: 'implementation.plan' as const, stage: 'planning' as const };
 
     this.logger.debug(
@@ -1250,15 +1251,31 @@ function buildImplementationPrompt(artifact_path: string, result_file_path: stri
   return lines.join('\n');
 }
 
-function buildImplementationPlanPrompt(artifact_path: string, working_directory: string, result_file_path: string): string {
+function buildImplementationPlanPrompt(
+  artifact_path: string,
+  working_directory: string,
+  result_file_path: string,
+  additional_context?: string,
+): string {
   const planDir = join(working_directory, 'docs', 'superpowers', 'plans');
-  return [
+  const lines = [
     BRANCH_OWNERSHIP_POLICY,
     ``,
     `Read the approved artifact at: ${artifact_path}`,
     ``,
     `Create an implementation plan using the \`superpowers:writing-plans\` skill.`,
     `Use the artifact as the authoritative baseline, especially its task list.`,
+  ];
+  if (additional_context?.trim()) {
+    lines.push(
+      ``,
+      `Additional planning context from the human:`,
+      additional_context.trim(),
+      ``,
+      `Use this context to answer the previous planning question before writing the plan.`,
+    );
+  }
+  lines.push(
     `Save the plan under: ${planDir}`,
     ``,
     `Write the result to: ${result_file_path}`,
@@ -1277,7 +1294,8 @@ function buildImplementationPlanPrompt(artifact_path: string, working_directory:
     `- Do not signal completion until the result file has been written.`,
     ``,
     CHECKPOINT_INSTRUCTIONS,
-  ].join('\n');
+  );
+  return lines.join('\n');
 }
 
 function buildQuestionPrompt(question: string, resultPath: string): string {

--- a/src/core/ai/route-skills.ts
+++ b/src/core/ai/route-skills.ts
@@ -8,8 +8,10 @@ export function requiredSkillsForRoute(route: AgentRoute): AgentSkillRef[] {
       return [];
     case 'issue.triage':
       return ['mm:issue-triage'];
+    case 'implementation.plan':
+      return ['superpowers:writing-plans'];
     case 'implementation.run':
-      return ['superpowers:writing-plans', 'superpowers:subagent-driven-development'];
+      return ['superpowers:subagent-driven-development'];
     case 'artifact.revise':
     case 'intent.classify':
     case 'pr.title_generate':

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -3,7 +3,7 @@ import type pino from 'pino';
 import type { IssueFiler } from '../types/issue-filing.js';
 import type { IssueManager, PRManager } from '../types/issue-tracker.js';
 import type { PRTitleGenerator } from './ai/pr-title-generator.js';
-import type { ArtifactAuthoringAgent, ImplementationAgent, QuestionAnsweringAgent } from '../types/ai.js';
+import type { ArtifactAuthoringAgent, ImplementationAgent, ImplementationPlanningAgent, QuestionAnsweringAgent } from '../types/ai.js';
 import type { Request, ThreadMessage } from '../types/events.js';
 import type { ConversationRef } from '../types/channel.js';
 import type { FeedbackSource } from '../types/feedback-source.js';
@@ -24,6 +24,7 @@ import { ArtifactFeedbackHandler } from './handlers/artifact-feedback-handler.js
 import { ImplementationStartHandler } from './handlers/implementation-start-handler.js';
 import { ImplementationFeedbackHandler } from './handlers/implementation-feedback-handler.js';
 import { ImplementationApprovalHandler } from './handlers/implementation-approval-handler.js';
+import { PlanningHandler } from './handlers/planning-handler.js';
 import { IssueFilingHandler } from './handlers/issue-filing-handler.js';
 import { PrMergeHandler } from './handlers/pr-merge-handler.js';
 import { QuestionHandler } from './handlers/question-handler.js';
@@ -76,6 +77,7 @@ export interface DefaultHandlerRegistryDeps {
   feedbackSource?: FeedbackSource;
   questionAnswerer?: QuestionAnsweringAgent;
   specCommitter?: Pick<SpecCommitter, 'commit' | 'updateStatus'>;
+  implementationPlanner?: ImplementationPlanningAgent;
   implementer?: ImplementationAgent;
   implFeedbackPage?: ImplementationReviewPublisher;
   prManager?: PRManager;
@@ -141,6 +143,8 @@ export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): H
     const result = await approveArtifact(deps, branchGuard, run, feedback);
     if (result.status === 'failed') return;
     if (!result.implementation_required) return;
+    const planning = await runPlanning(deps, feedback, run);
+    if (planning.status !== 'implementing') return;
     await runImplementation(deps, branchGuard, feedback, run);
   });
   registerThreadMessage('reviewing_implementation', 'approval', 'ImplementationApprovalHandler', (feedback, run) => handleImplementationApproval(deps, branchGuard, feedback, run));
@@ -237,6 +241,26 @@ async function runImplementation(
     reviewCoordinator: deps.reviewCoordinator,
   });
   await handler.handle(run, feedback, additionalContext);
+}
+
+async function runPlanning(
+  deps: DefaultHandlerRegistryDeps,
+  feedback: ThreadMessage,
+  run: Run,
+): Promise<Awaited<ReturnType<PlanningHandler['handle']>>> {
+  if (!deps.implementationPlanner) {
+    await deps.failRun(run, feedback.conversation, new Error('Implementation planner is required for planning'));
+    return { status: 'failed' };
+  }
+  const handler = new PlanningHandler({
+    planner: deps.implementationPlanner,
+    postMessage: deps.postMessage,
+    transition: deps.transition,
+    failRun: deps.failRun,
+    persist: deps.persist,
+    logger: deps.logger,
+  });
+  return handler.handle(run, feedback);
 }
 
 async function handleImplementationFeedback(

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -136,6 +136,11 @@ export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): H
   });
 
   registerThreadMessage('reviewing_spec', 'feedback', 'ArtifactFeedbackHandler', (feedback, run) => handleArtifactFeedback(deps, branchGuard, feedback, run));
+  registerThreadMessage('awaiting_planning_input', 'feedback', 'PlanningHandler.awaiting', async (feedback, run) => {
+    const planning = await runPlanning(deps, feedback, run, feedback.content);
+    if (planning.status !== 'implementing') return;
+    await runImplementation(deps, branchGuard, feedback, run);
+  });
   registerThreadMessage('reviewing_implementation', 'feedback', 'ImplementationFeedbackHandler.reviewing', (feedback, run) => handleImplementationFeedback(deps, branchGuard, feedback, run, 'reviewing_implementation'));
   registerThreadMessage('awaiting_impl_input', 'feedback', 'ImplementationFeedbackHandler.awaiting', (feedback, run) => handleImplementationFeedback(deps, branchGuard, feedback, run, 'awaiting_impl_input'));
   registerThreadMessage('pr_open', 'feedback', 'PrOpenFeedbackHandler', (feedback, run) => handlePrOpenFeedback(deps, feedback, run));
@@ -150,6 +155,11 @@ export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): H
   registerThreadMessage('reviewing_implementation', 'approval', 'ImplementationApprovalHandler', (feedback, run) => handleImplementationApproval(deps, branchGuard, feedback, run));
   registerThreadMessage('pr_open', 'approval', 'PrMergeHandler', (feedback, run) => handlePrMerge(deps, feedback, run));
   registerThreadMessage('reviewing_spec', 'question', 'QuestionHandler.spec', (feedback, run) => answerQuestionAndRestoreStage(deps, feedback, run, 'reviewing_spec'));
+  registerThreadMessage('awaiting_planning_input', 'question', 'PlanningHandler.awaitingQuestion', async (feedback, run) => {
+    const planning = await runPlanning(deps, feedback, run, feedback.content);
+    if (planning.status !== 'implementing') return;
+    await runImplementation(deps, branchGuard, feedback, run);
+  });
   registerThreadMessage('reviewing_implementation', 'question', 'QuestionHandler.impl', (feedback, run) => answerQuestionAndRestoreStage(deps, feedback, run, 'reviewing_implementation'));
   registerThreadMessage('awaiting_impl_input', 'question', 'QuestionHandler.awaiting', (feedback, run) => answerQuestionAndRestoreStage(deps, feedback, run, 'awaiting_impl_input'));
   registerThreadMessage('pr_open', 'question', 'QuestionHandler.pr', (feedback, run) => answerQuestionAndRestoreStage(deps, feedback, run, 'pr_open'));
@@ -247,6 +257,7 @@ async function runPlanning(
   deps: DefaultHandlerRegistryDeps,
   feedback: ThreadMessage,
   run: Run,
+  additionalContext?: string,
 ): Promise<Awaited<ReturnType<PlanningHandler['handle']>>> {
   if (!deps.implementationPlanner) {
     await deps.failRun(run, feedback.conversation, new Error('Implementation planner is required for planning'));
@@ -260,7 +271,7 @@ async function runPlanning(
     persist: deps.persist,
     logger: deps.logger,
   });
-  return handler.handle(run, feedback);
+  return handler.handle(run, feedback, additionalContext);
 }
 
 async function handleImplementationFeedback(

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -95,6 +95,7 @@ export interface DefaultHandlerRegistryDeps {
   logger: Pick<pino.Logger, 'debug' | 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: ImplementationReviewCoordinator;
+  validatePlanPath?: (workspacePath: string, planPath: string) => string;
 }
 
 export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): HandlerRegistry {
@@ -270,6 +271,7 @@ async function runPlanning(
     failRun: deps.failRun,
     persist: deps.persist,
     logger: deps.logger,
+    validatePlanPath: deps.validatePlanPath,
   });
   return handler.handle(run, feedback, additionalContext);
 }

--- a/src/core/extensions/built-ins.ts
+++ b/src/core/extensions/built-ins.ts
@@ -60,6 +60,7 @@ export const BUILT_IN_CLASSIFICATION_CONTEXTS: ClassificationContext[] = [
   'intake',
   'reviewing_spec',
   'reviewing_implementation',
+  'awaiting_planning_input',
   'awaiting_impl_input',
   'planning',
   'speccing',
@@ -116,8 +117,8 @@ export function registerBuiltInIntents(registry: IntentRegistry): void {
   registry.register({
     name: 'feedback',
     description: 'the human is providing feedback or revision requests',
-    valid_contexts: ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing'],
-    fallback_contexts: ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing'],
+    valid_contexts: ['reviewing_spec', 'awaiting_planning_input', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'implementing'],
+    fallback_contexts: ['reviewing_spec', 'awaiting_planning_input', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'implementing'],
   });
   registry.register({
     name: 'approval',
@@ -127,12 +128,12 @@ export function registerBuiltInIntents(registry: IntentRegistry): void {
   registry.register({
     name: 'question',
     description: 'the human is asking a question',
-    valid_contexts: ['new_thread', 'intake', 'existing_issue', 'reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'pr_open'],
+    valid_contexts: ['new_thread', 'intake', 'existing_issue', 'reviewing_spec', 'awaiting_planning_input', 'reviewing_implementation', 'awaiting_impl_input', 'pr_open'],
   });
   registry.register({
     name: 'ignore',
     description: 'the message is not actionable',
-    valid_contexts: ['new_thread', 'intake', 'existing_issue', 'reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing', 'pr_open', 'done', 'failed'],
+    valid_contexts: ['new_thread', 'intake', 'existing_issue', 'reviewing_spec', 'awaiting_planning_input', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing', 'pr_open', 'done', 'failed'],
     fallback_contexts: ['pr_open', 'done', 'failed'],
   });
 }

--- a/src/core/extensions/built-ins.ts
+++ b/src/core/extensions/built-ins.ts
@@ -61,6 +61,7 @@ export const BUILT_IN_CLASSIFICATION_CONTEXTS: ClassificationContext[] = [
   'reviewing_spec',
   'reviewing_implementation',
   'awaiting_impl_input',
+  'planning',
   'speccing',
   'implementing',
   'pr_open',
@@ -115,8 +116,8 @@ export function registerBuiltInIntents(registry: IntentRegistry): void {
   registry.register({
     name: 'feedback',
     description: 'the human is providing feedback or revision requests',
-    valid_contexts: ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'implementing'],
-    fallback_contexts: ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'implementing'],
+    valid_contexts: ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing'],
+    fallback_contexts: ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing'],
   });
   registry.register({
     name: 'approval',
@@ -131,7 +132,7 @@ export function registerBuiltInIntents(registry: IntentRegistry): void {
   registry.register({
     name: 'ignore',
     description: 'the message is not actionable',
-    valid_contexts: ['new_thread', 'intake', 'existing_issue', 'reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'implementing', 'pr_open', 'done', 'failed'],
+    valid_contexts: ['new_thread', 'intake', 'existing_issue', 'reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'speccing', 'planning', 'implementing', 'pr_open', 'done', 'failed'],
     fallback_contexts: ['pr_open', 'done', 'failed'],
   });
 }

--- a/src/core/handlers/artifact-approval-handler.ts
+++ b/src/core/handlers/artifact-approval-handler.ts
@@ -72,7 +72,7 @@ export class ArtifactApprovalHandler {
 
   private async acknowledgeApproval(feedback: ThreadMessage, policy: ArtifactLifecyclePolicy): Promise<void> {
     try {
-      const next = policy.implementation_required ? ' and starting implementation' : '';
+      const next = policy.implementation_required ? ' and starting planning' : '';
       const ackMsg = policy.sync_issue_on_approval
         ? `Approved \u2014 writing triage to issue${next}.`
         : `Approved \u2014 committing spec${next}.`;

--- a/src/core/handlers/artifact-approval-handler.ts
+++ b/src/core/handlers/artifact-approval-handler.ts
@@ -58,8 +58,7 @@ export class ArtifactApprovalHandler {
     if (policy.implementation_required) {
       run.attempt += 1;
       this.deps.persist();
-      this.deps.transition(run, 'implementing');
-      this.deps.logger.info({ event: 'implementation.started', run_id: run.id, request_id: run.request_id }, 'Implementation started');
+      this.deps.transition(run, 'planning');
     } else {
       this.deps.transition(run, 'done');
     }

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -35,6 +35,11 @@ export class ImplementationStartHandler {
       await this.deps.failRun(run, feedback.conversation, new Error('Run missing artifact local path or publisher ref for implementation'));
       return { status: 'failed' };
     }
+    const planPath = additionalContext ? undefined : run.implementation_plan_path;
+    if (!additionalContext && !planPath) {
+      await this.deps.failRun(run, feedback.conversation, new Error('Run missing implementation plan path for implementation'));
+      return { status: 'failed' };
+    }
 
     const onProgress = (message: string): Promise<void> =>
       this.deps.postMessage(feedback.conversation, message).catch(err => {
@@ -61,6 +66,7 @@ export class ImplementationStartHandler {
         additionalContext,
         onProgress,
         { run_id: run.id, request_id: run.request_id },
+        planPath,
       );
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);

--- a/src/core/handlers/planning-handler.ts
+++ b/src/core/handlers/planning-handler.ts
@@ -22,7 +22,7 @@ export type PlanningResult =
 export class PlanningHandler {
   constructor(private readonly deps: PlanningHandlerDeps) {}
 
-  async handle(run: Run, feedback: ThreadMessage): Promise<PlanningResult> {
+  async handle(run: Run, feedback: ThreadMessage, additionalContext?: string): Promise<PlanningResult> {
     const refs = requireArtifactRefs(run);
     if (!refs) {
       await this.deps.failRun(run, feedback.conversation, new Error('Run missing artifact local path or publisher ref for planning'));
@@ -46,6 +46,7 @@ export class PlanningHandler {
         run.workspace_path,
         onProgress,
         { run_id: run.id, request_id: run.request_id },
+        additionalContext,
       );
     } catch (err) {
       this.deps.logger.error({ event: 'planning.failed', run_id: run.id, request_id: run.request_id, error: String(err) }, 'Implementation planning failed');
@@ -60,7 +61,7 @@ export class PlanningHandler {
       } catch (err) {
         this.deps.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post planning question');
       }
-      this.deps.transition(run, 'awaiting_impl_input');
+      this.deps.transition(run, 'awaiting_planning_input');
       return { status: 'needs_input' };
     }
 

--- a/src/core/handlers/planning-handler.ts
+++ b/src/core/handlers/planning-handler.ts
@@ -1,0 +1,90 @@
+import type pino from 'pino';
+import type { ImplementationPlanningAgent } from '../../types/ai.js';
+import type { ThreadMessage } from '../../types/events.js';
+import type { ConversationRef } from '../../types/channel.js';
+import type { Run, RunStage } from '../../types/runs.js';
+import { requireArtifactRefs } from '../run-refs.js';
+
+export interface PlanningHandlerDeps {
+  planner: Pick<ImplementationPlanningAgent, 'plan'>;
+  postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
+  transition: (run: Run, stage: RunStage) => void;
+  failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
+  persist: () => void;
+  logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
+}
+
+export type PlanningResult =
+  | { status: 'implementing'; plan_path: string }
+  | { status: 'needs_input' }
+  | { status: 'failed' };
+
+export class PlanningHandler {
+  constructor(private readonly deps: PlanningHandlerDeps) {}
+
+  async handle(run: Run, feedback: ThreadMessage): Promise<PlanningResult> {
+    const refs = requireArtifactRefs(run);
+    if (!refs) {
+      await this.deps.failRun(run, feedback.conversation, new Error('Run missing artifact local path or publisher ref for planning'));
+      return { status: 'failed' };
+    }
+
+    const onProgress = (message: string): Promise<void> =>
+      this.deps.postMessage(feedback.conversation, message).catch(err => {
+        this.deps.logger.warn(
+          { event: 'progress_failed', phase: 'planning', run_id: run.id, error: String(err) },
+          'Failed to post planning progress update',
+        );
+      });
+
+    this.deps.logger.info({ event: 'planning.started', run_id: run.id, request_id: run.request_id }, 'Implementation planning started');
+
+    let result;
+    try {
+      result = await this.deps.planner.plan(
+        refs.local_path,
+        run.workspace_path,
+        onProgress,
+        { run_id: run.id, request_id: run.request_id },
+      );
+    } catch (err) {
+      this.deps.logger.error({ event: 'planning.failed', run_id: run.id, request_id: run.request_id, error: String(err) }, 'Implementation planning failed');
+      await this.deps.failRun(run, feedback.conversation, err);
+      return { status: 'failed' };
+    }
+
+    if (result.status === 'needs_input') {
+      this.deps.logger.info({ event: 'planning.needs_input', run_id: run.id, request_id: run.request_id }, 'Implementation planning needs input');
+      try {
+        await this.deps.postMessage(feedback.conversation, `I need input before planning implementation — ${result.question ?? 'please provide more context'}`);
+      } catch (err) {
+        this.deps.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post planning question');
+      }
+      this.deps.transition(run, 'awaiting_impl_input');
+      return { status: 'needs_input' };
+    }
+
+    if (result.status === 'failed') {
+      const err = new Error(result.error ?? 'Implementation planning failed');
+      this.deps.logger.error({ event: 'planning.failed', run_id: run.id, request_id: run.request_id, error: err.message }, 'Implementation planning failed');
+      await this.deps.failRun(run, feedback.conversation, err);
+      return { status: 'failed' };
+    }
+
+    if (!result.plan_path) {
+      const err = new Error('Implementation planning completed without a plan_path');
+      this.deps.logger.error({ event: 'planning.failed', run_id: run.id, request_id: run.request_id, error: err.message }, 'Implementation planning returned malformed result');
+      await this.deps.failRun(run, feedback.conversation, err);
+      return { status: 'failed' };
+    }
+
+    run.implementation_plan_path = result.plan_path;
+    this.deps.persist();
+    this.deps.transition(run, 'implementing');
+    this.deps.logger.info(
+      { event: 'planning.completed', run_id: run.id, request_id: run.request_id, plan_path: result.plan_path },
+      'Implementation planning completed',
+    );
+    return { status: 'implementing', plan_path: result.plan_path };
+  }
+}

--- a/src/core/handlers/planning-handler.ts
+++ b/src/core/handlers/planning-handler.ts
@@ -4,6 +4,7 @@ import type { ThreadMessage } from '../../types/events.js';
 import type { ConversationRef } from '../../types/channel.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import { requireArtifactRefs } from '../run-refs.js';
+import { validateImplementationPlanPath } from '../plan-path-validator.js';
 
 export interface PlanningHandlerDeps {
   planner: Pick<ImplementationPlanningAgent, 'plan'>;
@@ -12,6 +13,7 @@ export interface PlanningHandlerDeps {
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
+  validatePlanPath?: (workspacePath: string, planPath: string) => string;
 }
 
 export type PlanningResult =
@@ -79,13 +81,22 @@ export class PlanningHandler {
       return { status: 'failed' };
     }
 
-    run.implementation_plan_path = result.plan_path;
+    let planPath;
+    try {
+      planPath = (this.deps.validatePlanPath ?? validateImplementationPlanPath)(run.workspace_path, result.plan_path);
+    } catch (err) {
+      this.deps.logger.error({ event: 'planning.failed', run_id: run.id, request_id: run.request_id, error: String(err) }, 'Implementation planning returned invalid plan path');
+      await this.deps.failRun(run, feedback.conversation, err);
+      return { status: 'failed' };
+    }
+
+    run.implementation_plan_path = planPath;
     this.deps.persist();
     this.deps.transition(run, 'implementing');
     this.deps.logger.info(
-      { event: 'planning.completed', run_id: run.id, request_id: run.request_id, plan_path: result.plan_path },
+      { event: 'planning.completed', run_id: run.id, request_id: run.request_id, plan_path: planPath },
       'Implementation planning completed',
     );
-    return { status: 'implementing', plan_path: result.plan_path };
+    return { status: 'implementing', plan_path: planPath };
   }
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -81,6 +81,7 @@ export interface OrchestratorDeps {
   handlerRegistry?: HandlerRegistry;
   branchGuard?: BranchGuard;
   reviewCoordinator?: ImplementationReviewCoordinator;
+  validatePlanPath?: (workspacePath: string, planPath: string) => string;
 }
 
 interface OrchestratorOptions {
@@ -531,8 +532,10 @@ export class OrchestratorImpl implements Orchestrator {
       });
       if (handler) {
         await handler(event, run);
+        return;
       }
       // 'ignore' and unregistered intents: silently discard
+      this.restoreStageAfterUnroutedThreadMessage(run, routingStage, intent);
     }
   }
 
@@ -564,6 +567,7 @@ export class OrchestratorImpl implements Orchestrator {
       logger: this.logger,
       branchGuard: this.deps.branchGuard,
       reviewCoordinator: this.deps.reviewCoordinator,
+      validatePlanPath: this.deps.validatePlanPath,
     });
   }
 
@@ -613,6 +617,18 @@ export class OrchestratorImpl implements Orchestrator {
     this.logger.error(
       { event: 'intent_classification.failed', run_id: run.id, request_id: run.request_id, from_stage: from, restored_stage: stage, error: String(error) },
       'Intent classification failed',
+    );
+  }
+
+  private restoreStageAfterUnroutedThreadMessage(run: Run, stage: RunStage, intent: Intent): void {
+    const from = run.stage;
+    run.stage = stage;
+    run.updated_at = new Date().toISOString();
+    this._pendingStage.delete(run.request_id);
+    this._persistRuns();
+    this.logger.debug(
+      { event: 'intent_classification.unrouted', run_id: run.id, request_id: run.request_id, intent, from_stage: from, restored_stage: stage },
+      'Intent had no handler; restored stage after discard',
     );
   }
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -33,6 +33,7 @@ import { extractIssueReference, buildEnrichedClassificationMessage } from './iss
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
 function stageAfterApproval(stage: RunStage): RunStage {
   if (stage === 'reviewing_spec') return 'planning';
+  if (stage === 'awaiting_planning_input') return 'planning';
   if (stage === 'reviewing_implementation') return 'implementing';
   if (stage === 'awaiting_impl_input') return 'implementing';
   return stage;
@@ -208,7 +209,7 @@ export class OrchestratorImpl implements Orchestrator {
       this.logger.debug({ event: 'classify.run_not_found', request_id: event.payload.request_id }, 'No run found; discarding');
       return 'discard';
     }
-    const actionableStages: RunStage[] = ['reviewing_spec', 'reviewing_implementation', 'awaiting_impl_input', 'pr_open'];
+    const actionableStages: RunStage[] = ['reviewing_spec', 'awaiting_planning_input', 'reviewing_implementation', 'awaiting_impl_input', 'pr_open'];
     if (!actionableStages.includes(run.stage)) {
       this.logger.debug({ event: 'classify.stage_blocked', stage: run.stage }, 'Stage blocked: discarding thread_message');
       this.deps.adapter.react?.(event.payload.origin, 'ac-message-discarded').catch((err: unknown) => {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -8,7 +8,7 @@ import { createLogger } from './logger.js';
 import type { ChannelAdapter } from '../adapters/channel-adapter.js';
 import { channelKey, type ConversationRef, type MessageRef } from '../types/channel.js';
 import type { WorkspaceManager } from './workspace-manager.js';
-import type { ArtifactAuthoringAgent, ImplementationAgent, QuestionAnsweringAgent } from '../types/ai.js';
+import type { ArtifactAuthoringAgent, ImplementationAgent, ImplementationPlanningAgent, QuestionAnsweringAgent } from '../types/ai.js';
 import type { ArtifactContentSource, ArtifactPublisher } from '../types/publisher.js';
 import type { Run, RunStage, RequestIntent } from '../types/runs.js';
 import { VALID_RUN_STAGES } from '../types/runs.js';
@@ -32,7 +32,7 @@ import { extractIssueReference, buildEnrichedClassificationMessage } from './iss
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
 function stageAfterApproval(stage: RunStage): RunStage {
-  if (stage === 'reviewing_spec') return 'implementing';
+  if (stage === 'reviewing_spec') return 'planning';
   if (stage === 'reviewing_implementation') return 'implementing';
   if (stage === 'awaiting_impl_input') return 'implementing';
   return stage;
@@ -64,6 +64,7 @@ export interface OrchestratorDeps {
   intentClassifier?: IntentClassifier;
   questionAnswerer?: QuestionAnsweringAgent;
   specCommitter?: SpecCommitter;
+  implementationPlanner?: ImplementationPlanningAgent;
   implementer?: ImplementationAgent;
   implFeedbackPage?: ImplementationReviewPublisher;
   prManager?: PRManager;
@@ -544,6 +545,7 @@ export class OrchestratorImpl implements Orchestrator {
       feedbackSource: this.deps.feedbackSource,
       questionAnswerer: this.deps.questionAnswerer,
       specCommitter: this.deps.specCommitter,
+      implementationPlanner: this.deps.implementationPlanner,
       implementer: this.deps.implementer,
       implFeedbackPage: this.deps.implFeedbackPage,
       prManager: this.deps.prManager,

--- a/src/core/plan-path-validator.ts
+++ b/src/core/plan-path-validator.ts
@@ -1,0 +1,33 @@
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+
+/** Resolve and validate an implementation plan path under the workspace plans directory.
+ * @param workspacePath Current run workspace root.
+ * @param planPath Path returned by the planning agent.
+ * @returns Canonical absolute plan path.
+ */
+export function validateImplementationPlanPath(workspacePath: string, planPath: string): string {
+  const candidate = isAbsolute(planPath) ? planPath : resolve(workspacePath, planPath);
+  const plansDir = join(workspacePath, 'docs', 'superpowers', 'plans');
+
+  if (!existsSync(plansDir)) {
+    throw new Error(`Implementation planning returned plan_path before plans directory exists: ${plansDir}`);
+  }
+  if (!existsSync(candidate)) {
+    throw new Error(`Implementation planning returned non-existent plan_path: ${planPath}`);
+  }
+
+  const realPlansDir = realpathSync(plansDir);
+  const realPlanPath = realpathSync(candidate);
+  const stat = statSync(realPlanPath);
+  if (!stat.isFile()) {
+    throw new Error(`Implementation planning returned plan_path that is not a file: ${planPath}`);
+  }
+
+  const contained = relative(realPlansDir, realPlanPath);
+  if (contained === '' || contained.startsWith('..') || isAbsolute(contained)) {
+    throw new Error(`Implementation planning returned plan_path outside docs/superpowers/plans: ${planPath}`);
+  }
+
+  return realPlanPath;
+}

--- a/src/core/run-store.ts
+++ b/src/core/run-store.ts
@@ -12,7 +12,7 @@ export interface RunStore {
   save(runs: Map<string, Run>): void;
 }
 
-const STALE_STAGES = new Set(['intake', 'speccing', 'implementing']);
+const STALE_STAGES = new Set(['intake', 'speccing', 'planning', 'implementing']);
 const TERMINAL_STAGES = new Set(['done', 'failed']);
 
 interface FileRunStoreOptions {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -8,6 +8,7 @@ export type AgentTaskKind =
   | 'intent.classify'
   | 'artifact.create'
   | 'artifact.revise'
+  | 'implementation.plan'
   | 'implementation.run'
   | 'implementation.review.initial'
   | 'implementation.review.final'
@@ -215,6 +216,22 @@ export interface ArtifactAuthoringAgent {
 
 export type ImplementationStatus = 'complete' | 'needs_input' | 'failed';
 
+export interface ImplementationPlanResult {
+  status: ImplementationStatus;
+  plan_path?: string;
+  question?: string;
+  error?: string;
+}
+
+export interface ImplementationPlanningAgent {
+  plan(
+    artifact_path: string,
+    working_directory: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: { run_id?: string; request_id?: string },
+  ): Promise<ImplementationPlanResult>;
+}
+
 export interface ImplementationResult {
   status: ImplementationStatus;
   summary?: string;
@@ -238,6 +255,7 @@ export interface ImplementationAgent {
     additional_context?: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: { run_id?: string; request_id?: string },
+    plan_path?: string,
   ): Promise<ImplementationResult>;
 }
 

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -229,6 +229,7 @@ export interface ImplementationPlanningAgent {
     working_directory: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: { run_id?: string; request_id?: string },
+    additional_context?: string,
   ): Promise<ImplementationPlanResult>;
 }
 

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -8,6 +8,7 @@ export type RunStage =
   | 'speccing'
   | 'reviewing_spec'
   | 'planning'
+  | 'awaiting_planning_input'
   | 'implementing'
   | 'awaiting_impl_input'
   | 'reviewing_implementation'
@@ -20,6 +21,7 @@ export const VALID_RUN_STAGES: RunStage[] = [
   'speccing',
   'reviewing_spec',
   'planning',
+  'awaiting_planning_input',
   'implementing',
   'awaiting_impl_input',
   'reviewing_implementation',

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -7,6 +7,7 @@ export type RunStage =
   | 'intake'
   | 'speccing'
   | 'reviewing_spec'
+  | 'planning'
   | 'implementing'
   | 'awaiting_impl_input'
   | 'reviewing_implementation'
@@ -18,6 +19,7 @@ export const VALID_RUN_STAGES: RunStage[] = [
   'intake',
   'speccing',
   'reviewing_spec',
+  'planning',
   'implementing',
   'awaiting_impl_input',
   'reviewing_implementation',
@@ -41,6 +43,7 @@ export interface Run {
   workspace_path: string;
   branch: string;
   artifact?: Artifact;
+  implementation_plan_path?: string;
   impl_feedback_ref: string | undefined;
   issue: number | undefined;
   attempt: number;

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -49,9 +49,9 @@ describe('skillRefsForRoute', () => {
       .toEqual(['mm:issue-triage']);
   });
 
-  test('implementation.run → writing-plans + subagent-driven-development', () => {
-    expect(skillRefsForRoute({ task: 'implementation.run' }))
-      .toEqual(['superpowers:writing-plans', 'superpowers:subagent-driven-development']);
+  test('implementation.plan → writing-plans and implementation.run → subagent-driven-development', () => {
+    expect(skillRefsForRoute({ task: 'implementation.plan' })).toEqual(['superpowers:writing-plans']);
+    expect(skillRefsForRoute({ task: 'implementation.run' })).toEqual(['superpowers:subagent-driven-development']);
   });
 
   test('question.answer → no skills', () => {
@@ -175,7 +175,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
     }));
 
     expect(materializeSkills).toHaveBeenCalledWith(
-      ['superpowers:writing-plans', 'superpowers:subagent-driven-development'],
+      ['superpowers:subagent-driven-development'],
     );
   });
 

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -252,7 +252,7 @@ describe('OpenAIAgentSdkAgentRunner', () => {
     }));
 
     expect(vi.mocked(sdkRun).mock.calls[0][2]).toMatchObject({
-      maxTurns: 50,
+      maxTurns: 250,
     });
   });
 

--- a/tests/adapters/runtime-composition-ai-policy.test.ts
+++ b/tests/adapters/runtime-composition-ai-policy.test.ts
@@ -84,7 +84,7 @@ describe('runtime AI routing policy', () => {
     expect(policy.resolve({ task: 'implementation.run' })).toMatchObject({
       id: 'implementation',
       provider: 'claude_agent_sdk',
-      required_skills: ['superpowers:writing-plans', 'superpowers:subagent-driven-development'],
+      required_skills: ['superpowers:subagent-driven-development'],
       plugins: undefined,
     });
   });

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, test, vi } from 'vitest';
 import {
   AgentRunnerArtifactAuthoringAgent,
   AgentRunnerImplementationAgent,
+  AgentRunnerImplementationPlanningAgent,
   AgentRunnerIssueTriageAgent,
   AgentRunnerQuestionAnsweringAgent,
   IssueFilingService,
@@ -68,6 +69,7 @@ function makePolicy(): DefaultAgentRoutingPolicy {
       'artifact.create': 'agent',
       'artifact.revise': 'agent',
       'question.answer': 'agent',
+      'implementation.plan': 'agent',
       'implementation.run': 'agent',
       'issue.triage': 'agent',
     },
@@ -234,6 +236,67 @@ describe('AgentRunner-backed core AI services', () => {
 
       expect(calls[0].prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
       expect(calls[0].prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+
+  test('runs implementation planning through AgentRunner and parses plan_path', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-plan-'));
+    try {
+      const specPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      const planPath = join(workspace, 'docs', 'superpowers', 'plans', '2026-05-23-feature-test.md');
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', plan_path: planPath }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationPlanningAgent(runner, makePolicy());
+      const progress = vi.fn();
+
+      await expect(service.plan(specPath, workspace, progress, { run_id: 'run-1', request_id: 'req-1' })).resolves.toEqual({
+        status: 'complete',
+        plan_path: planPath,
+        question: undefined,
+        error: undefined,
+      });
+
+      expect(calls[0].route).toEqual({ task: 'implementation.plan', stage: 'planning' });
+      expect(calls[0].telemetry).toMatchObject({ phase: 'planning', route_task: 'implementation.plan', run_id: 'run-1', request_id: 'req-1' });
+      expect(calls[0].prompt).toContain('superpowers:writing-plans');
+      expect(calls[0].prompt).toContain('Do not execute the plan in this session');
+      expect(progress).toHaveBeenCalledWith('working');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation prompt with a plan path skips writing-plans and reads the saved plan', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-existing-plan-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const planPath = join(workspace, 'docs', 'superpowers', 'plans', 'implementation-plan.md');
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'Done', testing_instructions: 'Run tests' }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+
+      await service.implement('/tmp/spec.md', workspace, undefined, undefined, undefined, planPath);
+
+      expect(calls[0].prompt).toContain(`Read the existing implementation plan at: ${planPath}`);
+      expect(calls[0].prompt).toContain('Do not create a new implementation plan');
+      expect(calls[0].prompt).not.toContain('superpowers:writing-plans');
+      expect(calls[0].prompt).toContain('superpowers:subagent-driven-development');
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -276,6 +276,32 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('implementation planning prompt includes follow-up context when planning is resumed', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-plan-context-'));
+    try {
+      const specPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      const planPath = join(workspace, 'docs', 'superpowers', 'plans', '2026-05-23-feature-test.md');
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', plan_path: planPath }), 'utf8');
+      });
+      const service = new AgentRunnerImplementationPlanningAgent(runner, makePolicy());
+
+      await service.plan(specPath, workspace, undefined, { run_id: 'run-1', request_id: 'req-1' }, 'Limit scope to the adapter path.');
+
+      expect(calls[0].prompt).toContain('Additional planning context from the human:');
+      expect(calls[0].prompt).toContain('Limit scope to the adapter path.');
+      expect(calls[0].prompt).toContain('Use this context to answer the previous planning question before writing the plan.');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('implementation prompt with a plan path skips writing-plans and reads the saved plan', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-existing-plan-'));
     try {

--- a/tests/core/ai/route-skills.test.ts
+++ b/tests/core/ai/route-skills.test.ts
@@ -10,10 +10,8 @@ describe('requiredSkillsForRoute', () => {
 
   test('maps implementation and issue triage routes to their required skills', () => {
     expect(requiredSkillsForRoute({ task: 'issue.triage' })).toEqual(['mm:issue-triage']);
-    expect(requiredSkillsForRoute({ task: 'implementation.run' })).toEqual([
-      'superpowers:writing-plans',
-      'superpowers:subagent-driven-development',
-    ]);
+    expect(requiredSkillsForRoute({ task: 'implementation.plan' })).toEqual(['superpowers:writing-plans']);
+    expect(requiredSkillsForRoute({ task: 'implementation.run' })).toEqual(['superpowers:subagent-driven-development']);
   });
 
   test('leaves direct and non-skill routes empty', () => {

--- a/tests/core/ai/routing-policy.test.ts
+++ b/tests/core/ai/routing-policy.test.ts
@@ -105,7 +105,7 @@ describe('DefaultAgentRoutingPolicy', () => {
       required_skills: ['mm:issue-triage'],
     });
     expect(policy.resolve({ task: 'implementation.run' })).toMatchObject({
-      required_skills: ['superpowers:writing-plans', 'superpowers:subagent-driven-development'],
+      required_skills: ['superpowers:subagent-driven-development'],
     });
     expect(policy.resolve({ task: 'question.answer' })).toMatchObject({
       required_skills: [],

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -113,6 +113,7 @@ function makeDeps() {
       error: vi.fn(),
     },
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
+    validatePlanPath: vi.fn((_workspacePath: string, planPath: string) => planPath),
   };
 }
 

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -69,6 +69,9 @@ function makeDeps() {
       commit: vi.fn().mockResolvedValue(undefined),
       updateStatus: vi.fn().mockResolvedValue(undefined),
     },
+    implementationPlanner: {
+      plan: vi.fn().mockResolvedValue({ status: 'complete', plan_path: '/ws/request-001/docs/superpowers/plans/implementation-plan.md' }),
+    },
     implementer: {
       implement: vi.fn().mockResolvedValue({
         status: 'complete',
@@ -137,6 +140,7 @@ describe('buildDefaultHandlerRegistry', () => {
       undefined,
       expect.any(Function),
       { run_id: 'run-001', request_id: 'request-001' },
+      '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(run.stage).toBe('reviewing_implementation');
   });
@@ -344,6 +348,7 @@ describe('buildDefaultHandlerRegistry', () => {
       undefined,
       expect.any(Function),
       { run_id: 'run-001', request_id: 'request-001' },
+      '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(run.stage).toBe('reviewing_implementation');
   });

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -183,6 +183,34 @@ describe('buildDefaultHandlerRegistry', () => {
     expect(run.stage).toBe('done');
   });
 
+  it('re-enters planning with human context when planning previously needed input', async () => {
+    const deps = makeDeps();
+    const registry = buildDefaultHandlerRegistry(deps);
+    const run = makeRun({ stage: 'awaiting_planning_input' });
+    const feedback = makeFeedback({ content: 'Use the adapter composition path.' });
+    const event: InboundEvent = { type: 'thread_message', payload: feedback };
+
+    const handler = registry.resolve({
+      event_type: 'thread_message',
+      stage: 'awaiting_planning_input',
+      intent: 'feedback',
+    });
+
+    expect(handler).toBeDefined();
+    await handler?.(event, run);
+
+    expect(deps.implementationPlanner.plan).toHaveBeenCalledWith(
+      '/ws/request-001/context-human/specs/typed-feature.md',
+      '/ws/request-001',
+      expect.any(Function),
+      { run_id: 'run-001', request_id: 'request-001' },
+      'Use the adapter composition path.',
+    );
+    expect(deps.implementer.implement).toHaveBeenCalled();
+    expect(run.implementation_plan_path).toBe('/ws/request-001/docs/superpowers/plans/implementation-plan.md');
+    expect(run.stage).toBe('reviewing_implementation');
+  });
+
   it('does not mutate or persist pr_open runs when handling non-actionable feedback', async () => {
     const deps = makeDeps();
     const registry = buildDefaultHandlerRegistry(deps);

--- a/tests/core/extensions/built-ins.test.ts
+++ b/tests/core/extensions/built-ins.test.ts
@@ -23,6 +23,14 @@ describe('registerBuiltInIntents', () => {
       'question',
       'ignore',
     ]);
+    expect(registry.validIntentsForContext('planning')).toEqual([
+      'ignore',
+    ]);
+    expect(registry.validIntentsForContext('awaiting_planning_input')).toEqual([
+      'feedback',
+      'question',
+      'ignore',
+    ]);
   });
 
   it('registers existing_issue context with idea, bug, chore, question, ignore — not file_issues or work_on_issue', () => {

--- a/tests/core/handlers/artifact-approval-handler.test.ts
+++ b/tests/core/handlers/artifact-approval-handler.test.ts
@@ -115,7 +115,7 @@ describe('ArtifactApprovalHandler', () => {
     expect(deps.issueManager.create).not.toHaveBeenCalled();
     expect(deps.artifactPublisher.setIssueLink).not.toHaveBeenCalled();
     expect(run.attempt).toBe(1);
-    expect(run.stage).toBe('implementing');
+    expect(run.stage).toBe('planning');
     expect(run.artifact?.status).toBe('approved');
   });
 

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -51,6 +51,7 @@ function makeRun(overrides: Partial<Run> = {}): Run {
       published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
       status: 'approved',
     },
+    implementation_plan_path: '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     impl_feedback_ref: undefined,
     issue: undefined,
     attempt: 1,
@@ -122,6 +123,7 @@ describe('ImplementationStartHandler', () => {
       undefined,
       expect.any(Function),
       { run_id: 'run-001', request_id: 'request-001' },
+      '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith({
       artifact_ref: 'CANVAS-TYPED',
@@ -154,6 +156,7 @@ describe('ImplementationStartHandler', () => {
       undefined,
       expect.any(Function),
       { run_id: 'run-001', request_id: 'request-001' },
+      '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith({
       artifact_ref: 'CANVAS001',

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -101,6 +101,21 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
 }
 
 describe('ImplementationStartHandler', () => {
+  it('fails the run when starting initial implementation without a plan path', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ implementation_plan_path: undefined });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(
+      run,
+      TEST_CONVERSATION,
+      expect.objectContaining({ message: 'Run missing implementation plan path for implementation' }),
+    );
+    expect(deps.implementer.implement).not.toHaveBeenCalled();
+  });
+
   it('starts implementation from typed artifact refs when legacy spec fields are absent', async () => {
     const { handler, deps } = makeHandler();
     const run = makeRun({

--- a/tests/core/handlers/planning-handler.test.ts
+++ b/tests/core/handlers/planning-handler.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PlanningHandler } from '../../../src/core/handlers/planning-handler.js';
 import type { ThreadMessage } from '../../../src/types/events.js';
 import type { Run } from '../../../src/types/runs.js';
@@ -55,9 +58,19 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof PlanningHan
     failRun: vi.fn().mockResolvedValue(undefined),
     persist: vi.fn(),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    validatePlanPath: vi.fn((_workspacePath: string, planPath: string) => planPath),
     ...overrides,
   };
   return { handler: new PlanningHandler(deps), deps };
+}
+
+function makeWorkspaceWithPlan(): { workspace: string; planPath: string } {
+  const workspace = mkdtempSync(join(tmpdir(), 'ac-planning-handler-'));
+  const plansDir = join(workspace, 'docs', 'superpowers', 'plans');
+  mkdirSync(plansDir, { recursive: true });
+  const planPath = join(plansDir, 'implementation-plan.md');
+  writeFileSync(planPath, '# Implementation plan\n', 'utf8');
+  return { workspace: realpathSync(workspace), planPath: realpathSync(planPath) };
 }
 
 describe('PlanningHandler', () => {
@@ -125,6 +138,45 @@ describe('PlanningHandler', () => {
     expect(result).toEqual({ status: 'failed' });
     expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.any(Error));
     expect(run.stage).toBe('planning');
+  });
+
+  it('canonicalizes an existing plan path under docs/superpowers/plans before storing it', async () => {
+    const { workspace, planPath } = makeWorkspaceWithPlan();
+    const { handler } = makeHandler({
+      planner: { plan: vi.fn().mockResolvedValue({ status: 'complete', plan_path: 'docs/superpowers/plans/implementation-plan.md' }) },
+      validatePlanPath: undefined,
+    });
+    const run = makeRun({
+      workspace_path: workspace,
+      artifact: {
+        kind: 'feature_spec',
+        local_path: join(workspace, 'context-human', 'specs', 'feature-test.md'),
+        published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
+        status: 'approved',
+      },
+    });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'implementing', plan_path: planPath });
+    expect(run.implementation_plan_path).toBe(planPath);
+  });
+
+  it('fails the run when plan_path is outside workspace docs/superpowers/plans', async () => {
+    const { workspace } = makeWorkspaceWithPlan();
+    const outsidePlan = join(workspace, 'outside-plan.md');
+    writeFileSync(outsidePlan, '# Outside plan\n', 'utf8');
+    const { handler, deps } = makeHandler({
+      planner: { plan: vi.fn().mockResolvedValue({ status: 'complete', plan_path: outsidePlan }) },
+      validatePlanPath: undefined,
+    });
+    const run = makeRun({ workspace_path: workspace });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.any(Error));
+    expect(run.implementation_plan_path).toBeUndefined();
   });
 
   it('fails the run when planning agent returns failed status', async () => {

--- a/tests/core/handlers/planning-handler.test.ts
+++ b/tests/core/handlers/planning-handler.test.ts
@@ -73,6 +73,7 @@ describe('PlanningHandler', () => {
       '/ws/request-001',
       expect.any(Function),
       { run_id: 'run-001', request_id: 'request-001' },
+      undefined,
     );
     expect(run.implementation_plan_path).toBe('/ws/request-001/docs/superpowers/plans/implementation-plan.md');
     expect(deps.persist).toHaveBeenCalled();
@@ -90,8 +91,27 @@ describe('PlanningHandler', () => {
 
     expect(result).toEqual({ status: 'needs_input' });
     expect(deps.postMessage).toHaveBeenCalledWith(TEST_CONVERSATION, expect.stringContaining('Which scope?'));
-    expect(run.stage).toBe('awaiting_impl_input');
+    expect(run.stage).toBe('awaiting_planning_input');
     expect(run.implementation_plan_path).toBeUndefined();
+  });
+
+  it('passes human follow-up context when re-running planning', async () => {
+    const planner = {
+      plan: vi.fn().mockResolvedValue({ status: 'complete', plan_path: '/ws/request-001/docs/superpowers/plans/implementation-plan.md' }),
+    };
+    const { handler } = makeHandler({ planner });
+    const run = makeRun({ stage: 'awaiting_planning_input' });
+
+    const result = await handler.handle(run, makeFeedback({ content: 'Use the adapter composition path.' }), 'Use the adapter composition path.');
+
+    expect(result).toEqual({ status: 'implementing', plan_path: '/ws/request-001/docs/superpowers/plans/implementation-plan.md' });
+    expect(planner.plan).toHaveBeenCalledWith(
+      '/ws/request-001/context-human/specs/feature-test.md',
+      '/ws/request-001',
+      expect.any(Function),
+      { run_id: 'run-001', request_id: 'request-001' },
+      'Use the adapter composition path.',
+    );
   });
 
   it('fails the run when planning returns malformed complete output', async () => {
@@ -104,6 +124,19 @@ describe('PlanningHandler', () => {
 
     expect(result).toEqual({ status: 'failed' });
     expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.any(Error));
+    expect(run.stage).toBe('planning');
+  });
+
+  it('fails the run when planning agent returns failed status', async () => {
+    const { handler, deps } = makeHandler({
+      planner: { plan: vi.fn().mockResolvedValue({ status: 'failed', error: 'agent timed out' }) },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.objectContaining({ message: 'agent timed out' }));
     expect(run.stage).toBe('planning');
   });
 });

--- a/tests/core/handlers/planning-handler.test.ts
+++ b/tests/core/handlers/planning-handler.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PlanningHandler } from '../../../src/core/handlers/planning-handler.js';
+import type { ThreadMessage } from '../../../src/types/events.js';
+import type { Run } from '../../../src/types/runs.js';
+import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
+
+function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    request_id: 'request-001',
+    channel: TEST_CHANNEL,
+    conversation: TEST_CONVERSATION,
+    origin: TEST_ORIGIN,
+    content: 'approved',
+    author: 'U123',
+    received_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-001',
+    request_id: 'request-001',
+    intent: 'idea',
+    stage: 'planning',
+    workspace_path: '/ws/request-001',
+    branch: 'spec/request-001',
+    artifact: {
+      kind: 'feature_spec',
+      local_path: '/ws/request-001/context-human/specs/feature-test.md',
+      published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
+      status: 'approved',
+    },
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 1,
+    channel: TEST_CHANNEL,
+    conversation: TEST_CONVERSATION,
+    origin: TEST_ORIGIN,
+    pr_url: undefined,
+    last_impl_result: undefined,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeHandler(overrides: Partial<ConstructorParameters<typeof PlanningHandler>[0]> = {}) {
+  const deps = {
+    planner: {
+      plan: vi.fn().mockResolvedValue({ status: 'complete', plan_path: '/ws/request-001/docs/superpowers/plans/implementation-plan.md' }),
+    },
+    postMessage: vi.fn().mockResolvedValue(undefined),
+    transition: vi.fn((run: Run, stage: Run['stage']) => { run.stage = stage; }),
+    failRun: vi.fn().mockResolvedValue(undefined),
+    persist: vi.fn(),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    ...overrides,
+  };
+  return { handler: new PlanningHandler(deps), deps };
+}
+
+describe('PlanningHandler', () => {
+  it('stores the plan path, persists, and transitions to implementing on success', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'implementing', plan_path: '/ws/request-001/docs/superpowers/plans/implementation-plan.md' });
+    expect(deps.planner.plan).toHaveBeenCalledWith(
+      '/ws/request-001/context-human/specs/feature-test.md',
+      '/ws/request-001',
+      expect.any(Function),
+      { run_id: 'run-001', request_id: 'request-001' },
+    );
+    expect(run.implementation_plan_path).toBe('/ws/request-001/docs/superpowers/plans/implementation-plan.md');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(run.stage).toBe('implementing');
+    expect(deps.failRun).not.toHaveBeenCalled();
+  });
+
+  it('asks for input and does not start implementation when planning needs input', async () => {
+    const { handler, deps } = makeHandler({
+      planner: { plan: vi.fn().mockResolvedValue({ status: 'needs_input', question: 'Which scope?' }) },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'needs_input' });
+    expect(deps.postMessage).toHaveBeenCalledWith(TEST_CONVERSATION, expect.stringContaining('Which scope?'));
+    expect(run.stage).toBe('awaiting_impl_input');
+    expect(run.implementation_plan_path).toBeUndefined();
+  });
+
+  it('fails the run when planning returns malformed complete output', async () => {
+    const { handler, deps } = makeHandler({
+      planner: { plan: vi.fn().mockResolvedValue({ status: 'complete' }) },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.any(Error));
+    expect(run.stage).toBe('planning');
+  });
+});

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -1366,7 +1366,6 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     });
     const sc = makeSpecCommitter({ commit: commitFn });
     const orch = makeApprovalOrch({ adapter, specCommitter: sc });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1383,7 +1382,6 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const commitFn = vi.fn().mockImplementation(async () => { callOrder.push('commit'); });
     const sc = makeSpecCommitter({ commit: commitFn });
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, postMessage });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1399,7 +1397,6 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const adapter = makeMockAdapter();
     const sc = makeSpecCommitter();
     const orch = makeApprovalOrch({ adapter, specCommitter: sc });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1423,7 +1420,6 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const sc = makeSpecCommitter({ commit: commitFn });
     const impl = { implement: implementFn };
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, implementer: impl as ImplementationAgent });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1610,7 +1606,6 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     const sc = makeSpecCommitter({ commit: vi.fn().mockRejectedValue(new Error('commit failed')) });
     const impl = makeImplementationAgent();
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, implementer: impl, postError });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
@@ -1690,7 +1685,6 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
       .mockRejectedValueOnce(new Error('Slack error'))  // approval ack fails
       .mockResolvedValue(undefined);                    // completion message succeeds
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, postMessage });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
@@ -2099,7 +2093,6 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
       createPR: vi.fn().mockImplementation(async () => { callOrder.push('createPR'); return 'https://github.com/org/repo/pull/1'; }),
     });
     const orch = makeApprovalOrch2({ adapter, prManager, specCommitter: sc });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await sendImplApproval(orch, adapter);
     await orch.stop();
@@ -2119,7 +2112,6 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
     });
     const prManager = makePRManager();
     const orch = makeApprovalOrch2({ adapter, prManager, specCommitter: sc });
-    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await sendImplApproval(orch, adapter);
     await orch.stop();

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -16,6 +16,7 @@ import type {
   ArtifactComment as NotionComment,
   ArtifactCommentResponse as NotionCommentResponse,
   ImplementationAgent,
+  ImplementationPlanningAgent,
   ImplementationResult,
   QuestionAnsweringAgent,
 } from '../../src/types/ai.js';
@@ -350,6 +351,13 @@ function makeIssueFiler(resultOverrides: Partial<FilingResult> = {}): IssueFiler
   };
   return {
     file: vi.fn().mockResolvedValue(defaultResult),
+  };
+}
+
+
+function makeImplementationPlanningAgent(planPath = '/ws/request-001/docs/superpowers/plans/implementation-plan.md'): ImplementationPlanningAgent {
+  return {
+    plan: vi.fn().mockResolvedValue({ status: 'complete', plan_path: planPath }),
   };
 }
 
@@ -1306,6 +1314,7 @@ describe('Orchestrator — done stage guard', () => {
 function makeApprovalOrch(opts: {
   specCommitter?: SpecCommitter;
   implementer?: ImplementationAgent;
+  implementationPlanner?: ImplementationPlanningAgent;
   implFeedbackPage?: ImplementationReviewPublisher;
   postMessage?: ReturnType<typeof vi.fn>;
   postError?: ReturnType<typeof vi.fn>;
@@ -1320,6 +1329,7 @@ function makeApprovalOrch(opts: {
       intentClassifier: makeIntentClassifier('approval'),
       specCommitter: opts.specCommitter ?? makeSpecCommitter(),
       implementer: opts.implementer ?? makeImplementationAgent(),
+      implementationPlanner: opts.implementationPlanner ?? makeImplementationPlanningAgent(),
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
@@ -1340,14 +1350,14 @@ async function approveSpec(
   await vi.waitUntil(
     () => {
       const r = runs.get('request-001');
-      return r?.stage !== 'reviewing_spec' && r?.stage !== 'implementing';
+      return r?.stage !== 'reviewing_spec' && r?.stage !== 'planning' && r?.stage !== 'implementing';
     },
     { timeout: 3000 },
   );
 }
 
 describe('Orchestrator — _handleSpecApproval happy path', () => {
-  it('run transitions to implementing before any component is called', async () => {
+  it('run transitions to planning before any component is called', async () => {
     const adapter = makeMockAdapter();
     const stages: string[] = [];
     const commitFn = vi.fn().mockImplementation(async () => {
@@ -1356,11 +1366,12 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     });
     const sc = makeSpecCommitter({ commit: commitFn });
     const orch = makeApprovalOrch({ adapter, specCommitter: sc });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
 
-    expect(stages[0]).toBe('implementing');
+    expect(stages[0]).toBe('planning');
   });
 
   it('posts approval acknowledgement to Slack before committing', async () => {
@@ -1372,6 +1383,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const commitFn = vi.fn().mockImplementation(async () => { callOrder.push('commit'); });
     const sc = makeSpecCommitter({ commit: commitFn });
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, postMessage });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1387,6 +1399,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const adapter = makeMockAdapter();
     const sc = makeSpecCommitter();
     const orch = makeApprovalOrch({ adapter, specCommitter: sc });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1410,6 +1423,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
     const sc = makeSpecCommitter({ commit: commitFn });
     const impl = { implement: implementFn };
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, implementer: impl as ImplementationAgent });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await approveSpec(orch, adapter);
     await orch.stop();
@@ -1421,6 +1435,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
       undefined,
       expect.any(Function),
       { run_id: 'run-001', request_id: 'request-001' },
+      '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
   });
 
@@ -1564,6 +1579,7 @@ describe('Orchestrator — _runImplementation onProgress wiring', () => {
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
         implementer: impl as ImplementationAgent,
+        implementationPlanner: makeImplementationPlanningAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
@@ -1594,6 +1610,7 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
     const sc = makeSpecCommitter({ commit: vi.fn().mockRejectedValue(new Error('commit failed')) });
     const impl = makeImplementationAgent();
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, implementer: impl, postError });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
@@ -1673,6 +1690,7 @@ describe('Orchestrator — _handleSpecApproval failure paths', () => {
       .mockRejectedValueOnce(new Error('Slack error'))  // approval ack fails
       .mockResolvedValue(undefined);                    // completion message succeeds
     const orch = makeApprovalOrch({ adapter, specCommitter: sc, postMessage });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
 
     const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
@@ -1706,6 +1724,7 @@ function makeImplFeedbackOrch(opts: {
       artifactPublisher: makeArtifactPublisher(),
       intentClassifier: makeIntentClassifier(opts.intentOverride ?? 'feedback'),
       specCommitter: makeSpecCommitter(),
+      implementationPlanner: makeImplementationPlanningAgent(),
       implementer: opts.implementer ?? makeImplementationAgent(),
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
@@ -1965,6 +1984,7 @@ function makeApprovalOrch2(opts: {
       artifactPublisher: makeArtifactPublisher(),
       intentClassifier: makeIntentClassifier('approval'),
       specCommitter: opts.specCommitter ?? makeSpecCommitter(),
+      implementationPlanner: makeImplementationPlanningAgent(),
       implementer: makeImplementationAgent(),
       implFeedbackPage: makeImplFeedbackPage(),
       prManager: opts.prManager ?? makePRManager(),
@@ -2079,6 +2099,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
       createPR: vi.fn().mockImplementation(async () => { callOrder.push('createPR'); return 'https://github.com/org/repo/pull/1'; }),
     });
     const orch = makeApprovalOrch2({ adapter, prManager, specCommitter: sc });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await sendImplApproval(orch, adapter);
     await orch.stop();
@@ -2098,6 +2119,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
     });
     const prManager = makePRManager();
     const orch = makeApprovalOrch2({ adapter, prManager, specCommitter: sc });
+    implementationPlanner: makeImplementationPlanningAgent(),
     await orch.start();
     await sendImplApproval(orch, adapter);
     await orch.stop();
@@ -2120,6 +2142,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
         artifactPublisher,
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
@@ -2206,6 +2229,7 @@ function makeApprovalOrch3(opts: {
       artifactPublisher: makeArtifactPublisher(),
       intentClassifier: makeIntentClassifier('approval'),
       specCommitter: makeSpecCommitter(),
+      implementationPlanner: makeImplementationPlanningAgent(),
       implementer: makeImplementationAgent(),
       implFeedbackPage: makeImplFeedbackPage(),
       prManager: opts.prManager ?? makePRManager(),
@@ -2304,6 +2328,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         intentClassifier: ic,
         questionAnswerer: qa,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
@@ -2337,6 +2362,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         artifactPublisher: makeArtifactPublisher(),
         intentClassifier: ic,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
@@ -2372,6 +2398,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         artifactPublisher: makeArtifactPublisher(),
         intentClassifier: ic,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager,
@@ -2541,6 +2568,7 @@ describe('Orchestrator — run persistence', () => {
         artifactPublisher: makeArtifactPublisher(),
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
@@ -2581,6 +2609,7 @@ describe('Orchestrator — run persistence', () => {
         artifactPublisher: makeArtifactPublisher(),
         intentClassifier: makeIntentClassifier('feedback'),
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
@@ -2622,6 +2651,7 @@ describe('Orchestrator — run persistence', () => {
         artifactPublisher: makeArtifactPublisher(),
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage,
         postError: vi.fn().mockResolvedValue(undefined),
@@ -2994,7 +3024,7 @@ describe('_classify — serial classification gate', () => {
     await orch.stop();
   });
 
-  it('thread_message in reviewing_spec advances stage to implementing and returns dispatch', async () => {
+  it('thread_message in reviewing_spec advances stage to planning and returns dispatch', async () => {
     const { records, destination } = makeLogCapture();
     const adapter = makeMockAdapter();
     const orch = new OrchestratorImpl({
@@ -3021,13 +3051,13 @@ describe('_classify — serial classification gate', () => {
     const action = await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify(event);
     expect(action).toBe('dispatch');
     // Stage must be advanced before _classify returns
-    expect(run.stage).toBe('implementing');
+    expect(run.stage).toBe('planning');
     expect(records.find(r => r['event'] === 'classify.dispatched')).toBeDefined();
 
     await orch.stop();
   });
 
-  it('duplicate approval: first returns dispatch advancing stage; second sees implementing and returns discard', async () => {
+  it('duplicate approval: first returns dispatch advancing stage; second sees planning and returns discard', async () => {
     const adapter = makeMockAdapter();
     const orch = new OrchestratorImpl({
       adapter,
@@ -3055,7 +3085,7 @@ describe('_classify — serial classification gate', () => {
 
     const action1 = await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify(approval1);
     expect(action1).toBe('dispatch');
-    expect(run.stage).toBe('implementing');
+    expect(run.stage).toBe('planning');
 
     const action2 = await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify(approval2);
     expect(action2).toBe('discard');
@@ -3566,13 +3596,13 @@ describe('concurrent dispatch — additional coverage', () => {
 
     await vi.waitUntil(() => callCount === 2, { timeout: 300 });
 
-    // Both runs advanced to implementing by _classify
-    expect(runA.stage).toBe('implementing');
-    expect(runB.stage).toBe('implementing');
+    // Both runs advanced to planning by _classify
+    expect(runA.stage).toBe('planning');
+    expect(runB.stage).toBe('planning');
 
     // Mutating runA's stage should not affect runB
     runA.stage = 'done';
-    expect(runB.stage).toBe('implementing');
+    expect(runB.stage).toBe('planning');
 
     ctrlA.resolve();
     ctrlB.resolve();
@@ -4043,7 +4073,7 @@ describe('observability — log field correctness', () => {
     const e = makeEventFixture('thread_message', { request_id: 'req-rev' });
     await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify(e);
     const log = records.find(r => r['event'] === 'classify.dispatched');
-    expect(log!['stage']).toBe('implementing');
+    expect(log!['stage']).toBe('planning');
     await orch.stop();
   });
 
@@ -4442,6 +4472,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
@@ -4481,6 +4512,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
@@ -4522,6 +4554,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
       } as never,
@@ -4563,6 +4596,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         channelRepoMap: makeChannelRepoMap(),
         intentClassifier: ic,
         specCommitter: deps.sc,
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
@@ -4852,6 +4886,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -4905,6 +4940,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -4957,6 +4993,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5013,6 +5050,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer,
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5062,6 +5100,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer,
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5108,6 +5147,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer,
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5151,6 +5191,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: sc,
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5205,6 +5246,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactAuthoringAgent: makeArtifactAuthoringAgent(),
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
+        implementationPlanner: makeImplementationPlanningAgent(),
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -1073,6 +1073,45 @@ describe('Orchestrator — intent classification routing', () => {
     expect(run.stage).toBe('reviewing_spec');
   });
 
+  it('ignored message in awaiting_planning_input restores the waiting stage for later replies', async () => {
+    const adapter = makeMockAdapter();
+    const classifier: IntentClassifier = {
+      classify: vi.fn().mockResolvedValue('ignore'),
+    };
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+        artifactPublisher: makeArtifactPublisher(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        channelRepoMap: makeChannelRepoMap(),
+        intentClassifier: classifier,
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    const run = makeRun({ stage: 'awaiting_planning_input' });
+    runs.set('request-001', run);
+    adapter._emit({ type: 'thread_message', payload: makeFeedback({ content: 'thanks' }) });
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(classifier.classify).toHaveBeenCalledWith('thanks', 'awaiting_planning_input');
+    expect(run.stage).toBe('awaiting_planning_input');
+
+    const action = await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify({
+      type: 'thread_message',
+      payload: makeFeedback({ content: 'Use the adapter composition path.' }),
+    });
+    expect(action).toBe('dispatch');
+    expect(run.stage).toBe('planning');
+
+    await orch.stop();
+  });
+
   it('classifier called with feedback content and run stage when in reviewing_spec', async () => {
     const adapter = makeMockAdapter();
     const ic = makeIntentClassifier('idea');
@@ -1334,6 +1373,7 @@ function makeApprovalOrch(opts: {
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
       postMessage: opts.postMessage ?? vi.fn().mockResolvedValue(undefined),
       channelRepoMap: makeChannelRepoMap(),
+      validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
     } as never,
     { logDestination: nullDest },
   );
@@ -1576,6 +1616,7 @@ describe('Orchestrator — _runImplementation onProgress wiring', () => {
         specCommitter: makeSpecCommitter(),
         implementer: impl as ImplementationAgent,
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
         postMessage,
@@ -1719,6 +1760,7 @@ function makeImplFeedbackOrch(opts: {
       intentClassifier: makeIntentClassifier(opts.intentOverride ?? 'feedback'),
       specCommitter: makeSpecCommitter(),
       implementationPlanner: makeImplementationPlanningAgent(),
+      validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
       implementer: opts.implementer ?? makeImplementationAgent(),
       implFeedbackPage: opts.implFeedbackPage ?? makeImplFeedbackPage(),
       postError: opts.postError ?? vi.fn().mockResolvedValue(undefined),
@@ -1979,6 +2021,7 @@ function makeApprovalOrch2(opts: {
       intentClassifier: makeIntentClassifier('approval'),
       specCommitter: opts.specCommitter ?? makeSpecCommitter(),
       implementationPlanner: makeImplementationPlanningAgent(),
+      validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
       implementer: makeImplementationAgent(),
       implFeedbackPage: makeImplFeedbackPage(),
       prManager: opts.prManager ?? makePRManager(),
@@ -2135,6 +2178,7 @@ describe('Orchestrator — _handleImplementationApproval happy path', () => {
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
@@ -2222,6 +2266,7 @@ function makeApprovalOrch3(opts: {
       intentClassifier: makeIntentClassifier('approval'),
       specCommitter: makeSpecCommitter(),
       implementationPlanner: makeImplementationPlanningAgent(),
+      validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
       implementer: makeImplementationAgent(),
       implFeedbackPage: makeImplFeedbackPage(),
       prManager: opts.prManager ?? makePRManager(),
@@ -2321,6 +2366,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         questionAnswerer: qa,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
@@ -2355,6 +2401,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         intentClassifier: ic,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager: makePRManager(),
@@ -2391,6 +2438,7 @@ describe('Orchestrator — pr_open routing guards', () => {
         intentClassifier: ic,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         prManager,
@@ -2561,6 +2609,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
@@ -2602,6 +2651,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('feedback'),
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         postError: vi.fn().mockResolvedValue(undefined),
@@ -2644,6 +2694,7 @@ describe('Orchestrator — run persistence', () => {
         intentClassifier: makeIntentClassifier('approval'),
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage,
         postError: vi.fn().mockResolvedValue(undefined),
@@ -4465,6 +4516,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
@@ -4505,6 +4557,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
@@ -4547,6 +4600,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
       } as never,
@@ -4589,6 +4643,7 @@ describe('Orchestrator — implementation lifecycle status updates', () => {
         intentClassifier: ic,
         specCommitter: deps.sc,
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: deps.impl,
         implFeedbackPage: deps.implFb,
         prManager: deps.prManager,
@@ -4879,6 +4934,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -4933,6 +4989,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -4986,6 +5043,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5043,6 +5101,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer,
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5093,6 +5152,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer,
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5140,6 +5200,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer,
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5184,6 +5245,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: sc,
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,
@@ -5239,6 +5301,7 @@ describe('Orchestrator — bug/chore approval paths', () => {
         artifactPublisher: cp,
         specCommitter: makeSpecCommitter(),
         implementationPlanner: makeImplementationPlanningAgent(),
+        validatePlanPath: (_workspacePath: string, planPath: string) => planPath,
         implementer: makeImplementationAgent(),
         implFeedbackPage: makeImplFeedbackPage(),
         issueManager: im,

--- a/tests/core/run-store.test.ts
+++ b/tests/core/run-store.test.ts
@@ -336,6 +336,7 @@ describe('FileRunStore.load — stale stage demotion', () => {
 describe('FileRunStore.load — stable stages unchanged', () => {
   const stableStages = [
     'reviewing_spec',
+    'awaiting_planning_input',
     'awaiting_impl_input',
     'reviewing_implementation',
     'done',


### PR DESCRIPTION
## Summary

Adds a `planning` pipeline stage that runs between spec approval and implementation. The planning agent reads the approved spec, explores the codebase, and produces an implementation plan in a separate short-lived session — avoiding the pathological hang that occurs when plan generation happens inside the implementation session's accumulated context (#166, #179).

## Changes

- New `planning` stage in the orchestrator state machine (between `speccing` and `implementing`)
- New `PlanningHandler` that invokes the Claude Agent SDK to generate the plan
- Implementation stage now receives the pre-written plan instead of invoking `writing-plans` itself
- No human feedback required between planning and implementation — autocatalyst transitions automatically
- Route `planning.run` added to the routing policy
- Updated handler registry, extensions, and run store to support the new stage

## Test plan

- [ ] New unit tests for `PlanningHandler` (194 lines)
- [ ] Updated orchestrator tests cover the planning → implementing transition
- [ ] Existing implementation handler tests still pass
- [ ] End-to-end: trigger a feature run and verify it goes through intake → speccing → planning → implementing → reviewing

Closes #179