### PR TITLE
fix: use structured impl_result fields for PR body and normalize spec footer

### DIFF
--- a/src/adapters/github/pr-manager.ts
+++ b/src/adapters/github/pr-manager.ts
@@ -1,6 +1,7 @@
 import { promisify } from 'node:util';
 import { execFile as _execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { isAbsolute, relative, sep } from 'node:path';
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
 import type { PRManager, PRManagerOptions } from '../../types/issue-tracker.js';
@@ -56,22 +57,62 @@ function derivePrTitle(runIntent: RequestIntent | undefined, specTitle: string):
   return `feat: ${lowerTitle}`;
 }
 
-function buildPrBody(specPath: string, issueNumber: number | null, options?: PRManagerOptions): string {
-  const summary = options?.impl_result?.summary ?? 'No implementation summary provided.';
-  const testingInstructions = options?.impl_result?.testing_instructions ?? 'No testing instructions provided.';
+function nonEmptyStrings(values: string[] | undefined): string[] {
+  return values?.map(value => value.trim()).filter(Boolean) ?? [];
+}
 
-  const lines: string[] = [
-    summary,
-    '',
-    '## Testing',
-    '',
-    testingInstructions,
-    '',
-    '---',
-    `Spec: \`${specPath}\``,
-  ];
+function specFooterLines(workspacePath: string, specPath: string): string[] {
+  if (!workspacePath || !specPath) return [];
+
+  const relativeSpecPath = relative(workspacePath, specPath);
+  const isOutsideWorkspace = relativeSpecPath === '..'
+    || relativeSpecPath.startsWith(`..${sep}`)
+    || isAbsolute(relativeSpecPath);
+  if (!relativeSpecPath || isOutsideWorkspace) return [];
+
+  const repositoryRelativePath = relativeSpecPath.split(sep).join('/');
+  if (repositoryRelativePath.startsWith('.autocatalyst/triage/')) return [];
+
+  return ['---', `Spec: \`${repositoryRelativePath}\``];
+}
+
+function buildPrBody(
+  workspacePath: string,
+  specPath: string,
+  issueNumber: number | null,
+  options?: PRManagerOptions,
+): string {
+  const implResult = options?.impl_result;
+  const changes = nonEmptyStrings(implResult?.review_summary?.changes);
+  const confirmations = nonEmptyStrings(implResult?.review_summary?.confirm);
+  const testingSteps = nonEmptyStrings(implResult?.testing_steps);
+  const legacySummary = implResult?.summary?.trim() || 'No implementation summary provided.';
+  const legacyTestingInstructions = implResult?.testing_instructions?.trim() || 'No testing instructions provided.';
+
+  const lines: string[] = ['## Summary', ''];
+  if (changes.length > 0) {
+    lines.push(...changes.map(change => `- ${change}`));
+  } else {
+    lines.push(legacySummary);
+  }
+
+  if (confirmations.length > 0) {
+    lines.push('', '## Verify', '', ...confirmations.map(item => `- [ ] ${item}`));
+  }
+
+  if (testingSteps.length > 0) {
+    lines.push('', '## Test steps', '', ...testingSteps.map((step, index) => `${index + 1}. ${step}`));
+  } else {
+    lines.push('', '## Testing', '', legacyTestingInstructions);
+  }
+
+  const footer = specFooterLines(workspacePath, specPath);
+  if (footer.length > 0) {
+    lines.push('', ...footer);
+  }
 
   if (issueNumber !== null && issueNumber > 0) {
+    if (footer.length === 0) lines.push('');
     lines.push(`Closes #${issueNumber}`);
   }
 
@@ -104,7 +145,7 @@ export class GHPRManager implements PRManager {
       ? issueFromOptions
       : (issueFromFrontmatter !== null && !isNaN(issueFromFrontmatter) ? issueFromFrontmatter : null);
 
-    const prBody = buildPrBody(spec_path, issueForBody, options);
+    const prBody = buildPrBody(workspace_path, spec_path, issueForBody, options);
 
     // Push the branch
     try {

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -87,6 +87,8 @@ export class ImplementationApprovalHandler {
         status: 'complete',
         summary: run.last_impl_result?.summary,
         testing_instructions: run.last_impl_result?.testing_instructions,
+        review_summary: run.last_impl_result?.review_summary,
+        testing_steps: run.last_impl_result?.testing_steps,
       };
       const reviewedResult = await this.deps.reviewCoordinator.runFinalReview({
         run,
@@ -133,10 +135,21 @@ export class ImplementationApprovalHandler {
       }
 
       // Update last_impl_result with reviewed result
-      if (reviewedResult.summary !== undefined || reviewedResult.testing_instructions !== undefined) {
+      if (
+        reviewedResult.summary !== undefined
+        || reviewedResult.testing_instructions !== undefined
+        || reviewedResult.review_summary !== undefined
+        || reviewedResult.testing_steps !== undefined
+      ) {
         run.last_impl_result = {
           summary: reviewedResult.summary ?? run.last_impl_result?.summary ?? '',
           testing_instructions: reviewedResult.testing_instructions ?? run.last_impl_result?.testing_instructions ?? '',
+          ...(reviewedResult.review_summary ?? run.last_impl_result?.review_summary
+            ? { review_summary: reviewedResult.review_summary ?? run.last_impl_result?.review_summary }
+            : {}),
+          ...(reviewedResult.testing_steps ?? run.last_impl_result?.testing_steps
+            ? { testing_steps: reviewedResult.testing_steps ?? run.last_impl_result?.testing_steps }
+            : {}),
         };
         this.deps.persist();
       }

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -135,6 +135,8 @@ export class ImplementationFeedbackHandler {
     run.last_impl_result = {
       summary: reviewedResult.summary ?? '',
       testing_instructions: reviewedResult.testing_instructions ?? '',
+      ...(reviewedResult.review_summary ? { review_summary: reviewedResult.review_summary } : {}),
+      ...(reviewedResult.testing_steps ? { testing_steps: reviewedResult.testing_steps } : {}),
     };
     this.deps.persist();
 

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -129,6 +129,8 @@ export class ImplementationStartHandler {
     run.last_impl_result = {
       summary: reviewedResult.summary ?? '',
       testing_instructions: reviewedResult.testing_instructions ?? '',
+      ...(reviewedResult.review_summary ? { review_summary: reviewedResult.review_summary } : {}),
+      ...(reviewedResult.testing_steps ? { testing_steps: reviewedResult.testing_steps } : {}),
     };
     this.deps.persist();
 

--- a/src/types/issue-tracker.ts
+++ b/src/types/issue-tracker.ts
@@ -1,4 +1,4 @@
-import type { RequestIntent } from './runs.js';
+import type { LastImplementationResult, RequestIntent } from './runs.js';
 
 export interface TrackedIssue {
   number: number;
@@ -16,10 +16,7 @@ export interface IssueManager {
 }
 
 export interface PRManagerOptions {
-  impl_result?: {
-    summary: string;
-    testing_instructions: string;
-  };
+  impl_result?: LastImplementationResult;
   run_intent?: RequestIntent;
   issue_number?: number;
   title?: string;

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -32,9 +32,16 @@ export const VALID_RUN_STAGES: RunStage[] = [
 
 export type RequestIntent = 'idea' | 'bug' | 'chore' | 'file_issues' | 'question';
 
+export interface ImplementationReviewSummary {
+  changes: string[];
+  confirm: string[];
+}
+
 export interface LastImplementationResult {
   summary: string;
   testing_instructions: string;
+  review_summary?: ImplementationReviewSummary;
+  testing_steps?: string[];
 }
 
 export interface Run {

--- a/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
+++ b/tests/adapters/anthropic/anthropic-beta-header-filter-proxy.test.ts
@@ -165,6 +165,8 @@ describe('Anthropic beta header filter proxy', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ model: 'claude-3', messages: [] }),
       });
+      // Give the server-side async dump write time to complete before closing
+      await new Promise(r => setTimeout(r, 50));
       await proxy.close();
 
       const files = readdirSync(logDir).sort();

--- a/tests/adapters/github/pr-manager.test.ts
+++ b/tests/adapters/github/pr-manager.test.ts
@@ -108,27 +108,67 @@ describe('GHPRManager — createPR() title derivation', () => {
 // ---- createPR: PR body ----
 
 describe('GHPRManager — createPR() PR body', () => {
-  it('body contains summary and ## Testing section when impl_result provided', async () => {
+  it('body renders structured implementation result fields when provided', async () => {
     const execFn = makeExecFn();
     const manager = new GHPRManager(execFn, { logDestination: nullDest });
     await manager.createPR(tmpDir, 'branch', specPath, {
-      impl_result: { summary: 'Built the thing.', testing_instructions: 'Run npm test.' },
+      issue_number: 182,
+      impl_result: {
+        summary: 'legacy fallback — use review_summary instead',
+        testing_instructions: 'legacy fallback — use testing_steps instead',
+        review_summary: {
+          changes: ['Stored review summary fields', 'Updated GitHub PR body renderer'],
+          confirm: ['PR summary uses review_summary.changes', 'PR verify uses review_summary.confirm'],
+        },
+        testing_steps: ['cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/4ec756c1-2385-45c2-ac96-48ba64d6be8a', 'npm test -- tests/adapters/github/pr-manager.test.ts'],
+      },
     });
     const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
     const body = prArgs[prArgs.indexOf('--body') + 1] as string;
-    expect(body).toContain('Built the thing.');
-    expect(body).toContain('## Testing');
-    expect(body).toContain('Run npm test.');
+    expect(body).toContain('## Summary');
+    expect(body).toContain('- Stored review summary fields');
+    expect(body).toContain('- Updated GitHub PR body renderer');
+    expect(body).toContain('## Verify');
+    expect(body).toContain('- [ ] PR summary uses review_summary.changes');
+    expect(body).toContain('- [ ] PR verify uses review_summary.confirm');
+    expect(body).toContain('## Test steps');
+    expect(body).toContain('1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/4ec756c1-2385-45c2-ac96-48ba64d6be8a');
+    expect(body).toContain('2. npm test -- tests/adapters/github/pr-manager.test.ts');
+    expect(body).toContain('Closes #182');
+    expect(body).not.toContain('legacy fallback — use review_summary instead');
+    expect(body).not.toContain('legacy fallback — use testing_steps instead');
+    expect(body).not.toContain('## Testing');
   });
 
-  it('body contains placeholder text when impl_result not provided', async () => {
+  it('body falls back to legacy summary and testing instructions when structured fields are absent', async () => {
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+    await manager.createPR(tmpDir, 'branch', specPath, {
+      impl_result: {
+        summary: 'Built the legacy-only thing.',
+        testing_instructions: 'Run npm test for the legacy-only thing.',
+      },
+    });
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    const body = prArgs[prArgs.indexOf('--body') + 1] as string;
+    expect(body).toContain('## Summary');
+    expect(body).toContain('Built the legacy-only thing.');
+    expect(body).toContain('## Testing');
+    expect(body).toContain('Run npm test for the legacy-only thing.');
+    expect(body).not.toContain('## Verify');
+    expect(body).not.toContain('## Test steps');
+  });
+
+  it('body renders safe defaults when impl_result is not provided', async () => {
     const execFn = makeExecFn();
     const manager = new GHPRManager(execFn, { logDestination: nullDest });
     await manager.createPR(tmpDir, 'branch', specPath);
     const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
     const body = prArgs[prArgs.indexOf('--body') + 1] as string;
-    expect(body.length).toBeGreaterThan(0);
+    expect(body).toContain('## Summary');
+    expect(body).toContain('No implementation summary provided.');
     expect(body).toContain('## Testing');
+    expect(body).toContain('No testing instructions provided.');
   });
 
   it('body contains "Closes #42" when spec frontmatter issue is 42', async () => {
@@ -150,14 +190,49 @@ describe('GHPRManager — createPR() PR body', () => {
     expect(body).not.toContain('Closes #');
   });
 
-  it('body contains spec path in footer', async () => {
+  it('body renders repository-relative spec path when artifact is inside the workspace', async () => {
     const execFn = makeExecFn();
     const manager = new GHPRManager(execFn, { logDestination: nullDest });
     await manager.createPR(tmpDir, 'branch', specPath);
     const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
     const body = prArgs[prArgs.indexOf('--body') + 1] as string;
-    expect(body).toContain('Spec:');
-    expect(body).toContain(specPath);
+    expect(body).toContain('Spec: `context-human/specs/feature-my-feature.md`');
+    expect(body).not.toContain(specPath);
+  });
+
+  it('body omits Spec footer for internal triage artifacts', async () => {
+    mkdirSync(join(tmpDir, '.autocatalyst', 'triage'), { recursive: true });
+    const triagePath = join(tmpDir, '.autocatalyst', 'triage', 'triage-bug-182.md');
+    writeFileSync(triagePath, TRIAGE_DOC_NO_H1, 'utf-8');
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+
+    await manager.createPR(tmpDir, 'branch', triagePath, { issue_number: 182 });
+
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    const body = prArgs[prArgs.indexOf('--body') + 1] as string;
+    expect(body).not.toContain('Spec:');
+    expect(body).not.toContain(triagePath);
+    expect(body).toContain('Closes #182');
+  });
+
+  it('body omits Spec footer when artifact path is outside the workspace', async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), 'pr-manager-outside-'));
+    const outsidePath = join(outsideDir, 'external-spec.md');
+    writeFileSync(outsidePath, SPEC_NO_ISSUE, 'utf-8');
+    const execFn = makeExecFn();
+    const manager = new GHPRManager(execFn, { logDestination: nullDest });
+
+    try {
+      await manager.createPR(tmpDir, 'branch', outsidePath);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+
+    const prArgs = (execFn.mock.calls[1] as [string, string[], unknown])[1];
+    const body = prArgs[prArgs.indexOf('--body') + 1] as string;
+    expect(body).not.toContain('Spec:');
+    expect(body).not.toContain(outsidePath);
   });
 });
 

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -42,6 +42,11 @@ function makeRun(overrides: Partial<Run> = {}): Run {
     last_impl_result: {
       summary: 'Implemented it.',
       testing_instructions: 'npm test',
+      review_summary: {
+        changes: ['Added approval path data', 'Kept PR body fields'],
+        confirm: ['Approval creates PR', 'PR body has review checklist'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm test'],
     },
     channel: TEST_CHANNEL,
     conversation: TEST_CONVERSATION,
@@ -150,7 +155,15 @@ describe('ImplementationApprovalHandler', () => {
       'spec/request-001',
       '/ws/request-001/context-human/specs/feature-test.md',
       {
-        impl_result: { summary: 'Implemented it.', testing_instructions: 'npm test' },
+        impl_result: {
+          summary: 'Implemented it.',
+          testing_instructions: 'npm test',
+          review_summary: {
+            changes: ['Added approval path data', 'Kept PR body fields'],
+            confirm: ['Approval creates PR', 'PR body has review checklist'],
+          },
+          testing_steps: ['cd /ws/request-001', 'npm test'],
+        },
         run_intent: 'idea',
         title: 'generated title',
       },
@@ -444,5 +457,59 @@ describe('ImplementationApprovalHandler with reviewCoordinator', () => {
     const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
     const result = await handler.handle(makeRun(), makeFeedback());
     expect(result).toEqual({ status: 'pr_open' });
+  });
+
+  it('passes structured implementation result fields into final review', async () => {
+    const coord = makeReviewCoordinator();
+    const { handler } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(coord.runFinalReview).toHaveBeenCalledWith(expect.objectContaining({
+      implementation_result: {
+        status: 'complete',
+        summary: 'Implemented it.',
+        testing_instructions: 'npm test',
+        review_summary: {
+          changes: ['Added approval path data', 'Kept PR body fields'],
+          confirm: ['Approval creates PR', 'PR body has review checklist'],
+        },
+        testing_steps: ['cd /ws/request-001', 'npm test'],
+      },
+    }));
+  });
+
+  it('stores structured fields returned by final review before creating the PR', async () => {
+    const coord = makeReviewCoordinator({
+      summary: 'Final reviewed summary.',
+      testing_instructions: 'Final reviewed tests.',
+      review_summary: {
+        changes: ['Final review kept summary bullets', 'Final review kept verification items'],
+        confirm: ['Summary bullets render', 'Verification checklist renders'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm test -- implementation-approval-handler'],
+    });
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    const expectedImplResult = {
+      summary: 'Final reviewed summary.',
+      testing_instructions: 'Final reviewed tests.',
+      review_summary: {
+        changes: ['Final review kept summary bullets', 'Final review kept verification items'],
+        confirm: ['Summary bullets render', 'Verification checklist renders'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm test -- implementation-approval-handler'],
+    };
+    expect(run.last_impl_result).toEqual(expectedImplResult);
+    expect(deps.prManager.createPR).toHaveBeenCalledWith(
+      '/ws/request-001',
+      'spec/request-001',
+      '/ws/request-001/context-human/specs/feature-test.md',
+      expect.objectContaining({ impl_result: expectedImplResult }),
+    );
   });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -73,6 +73,11 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof Implementat
         status: 'complete',
         summary: 'Fixed it',
         testing_instructions: 'npm test',
+        review_summary: {
+          changes: ['Resolved feedback item', 'Updated regression coverage'],
+          confirm: ['Feedback no longer reproduces', 'Regression test passes'],
+        },
+        testing_steps: ['cd /ws/request-001', 'npm test'],
       }),
     },
     implFeedbackPage: {
@@ -151,7 +156,15 @@ describe('ImplementationFeedbackHandler', () => {
     expect(context).toContain('Some context');
     expect(context).not.toContain('Already done');
     expect(run.attempt).toBe(1);
-    expect(run.last_impl_result).toEqual({ summary: 'Fixed it', testing_instructions: 'npm test' });
+    expect(run.last_impl_result).toEqual({
+      summary: 'Fixed it',
+      testing_instructions: 'npm test',
+      review_summary: {
+        changes: ['Resolved feedback item', 'Updated regression coverage'],
+        confirm: ['Feedback no longer reproduces', 'Regression test passes'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm test'],
+    });
     expect(run.stage).toBe('reviewing_implementation');
   });
 
@@ -472,6 +485,35 @@ describe('ImplementationFeedbackHandler with reviewCoordinator', () => {
       'page-id',
       expect.objectContaining({ review_exchanges: [exchange] }),
     );
+  });
+
+  it('stores structured fields from the reviewed feedback implementation result', async () => {
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockResolvedValue({
+        status: 'complete',
+        summary: 'Reviewed feedback pass.',
+        testing_instructions: 'Reviewed feedback tests.',
+        review_summary: {
+          changes: ['Updated persisted result', 'Kept feedback checklist'],
+          confirm: ['PR options contain changes', 'PR options contain test steps'],
+        },
+        testing_steps: ['cd /ws/request-001', 'npm test -- implementation-feedback-handler'],
+      }),
+    };
+    const { handler } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun({ impl_feedback_ref: 'page-id' });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(run.last_impl_result).toEqual({
+      summary: 'Reviewed feedback pass.',
+      testing_instructions: 'Reviewed feedback tests.',
+      review_summary: {
+        changes: ['Updated persisted result', 'Kept feedback checklist'],
+        confirm: ['PR options contain changes', 'PR options contain test steps'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm test -- implementation-feedback-handler'],
+    });
   });
 
   it('proceeds normally without coordinator when not configured', async () => {

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -191,6 +191,11 @@ describe('ImplementationStartHandler', () => {
     expect(run.last_impl_result).toEqual({
       summary: 'Implemented the feature successfully.',
       testing_instructions: 'npm test',
+      review_summary: {
+        changes: ['Added feature X', 'Wired config loader'],
+        confirm: ['Feature X works', 'Config loads correctly'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
     });
     expect(run.stage).toBe('reviewing_implementation');
   });
@@ -385,6 +390,35 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith(
       expect.objectContaining({ review_exchanges: [exchange] }),
     );
+  });
+
+  it('stores structured fields from the reviewed implementation result', async () => {
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockResolvedValue({
+        status: 'complete',
+        summary: 'Reviewed summary.',
+        testing_instructions: 'Reviewed legacy instructions.',
+        review_summary: {
+          changes: ['Kept generated PR data', 'Stored review checklist'],
+          confirm: ['PR body has summary bullets', 'PR body has verification checklist'],
+        },
+        testing_steps: ['cd /ws/request-001', 'npm test -- pr-manager'],
+      }),
+    };
+    const { handler } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(run.last_impl_result).toEqual({
+      summary: 'Reviewed summary.',
+      testing_instructions: 'Reviewed legacy instructions.',
+      review_summary: {
+        changes: ['Kept generated PR data', 'Stored review checklist'],
+        confirm: ['PR body has summary bullets', 'PR body has verification checklist'],
+      },
+      testing_steps: ['cd /ws/request-001', 'npm test -- pr-manager'],
+    });
   });
 
   it('transitions to awaiting_impl_input when coordinator returns needs_input', async () => {


### PR DESCRIPTION
## Summary

- Extend implementation result contract to include `review_summary` and `testing_steps`
- Persist structured implementation result from both initial and feedback runs
- Forward structured result to PR creation
- Render `review_summary.changes` as summary bullets, `review_summary.confirm` as verification checklist, `testing_steps` as ordered test instructions in PR body
- Normalize spec footer paths (remove absolute local workspace paths)
- Stabilize flaky proxy request-dump test with missing async settle delay

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Trigger a full run through to PR creation and verify the PR body uses the new structured format
- [ ] Verify spec path in PR footer is relative, not absolute

Closes #182