### PR TITLE
feat: enhance `ac-run-status` with workspace and conditional ai context blocks

### DIFF
--- a/context-human/specs/enhancement-run-status-workspace-ai-context.md
+++ b/context-human/specs/enhancement-run-status-workspace-ai-context.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-24
-last_updated: 2026-05-24
-status: implementing
+last_updated: 2026-05-27
+status: complete
 issue: 184
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-run-status-workspace-ai-context.md
+++ b/context-human/specs/enhancement-run-status-workspace-ai-context.md
@@ -1,0 +1,453 @@
+---
+created: 2026-05-24
+last_updated: 2026-05-24
+status: implementing
+issue: 184
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Run status workspace and AI context
+
+## Parent features
+
+- `feature-command-mode.md` — provides Slack command parsing and command handler registration
+- `enhancement-agent-progress-updates.md` — establishes human-visible progress during long-running agent work
+- `enhancement-model-provider-config.md` — defines model routing profiles used by agent calls
+- `enhancement-model-runner-telemetry.md` — adds model-level telemetry for agent runner executions
+## What
+
+The `ac-run-status` command shows more operational context for a run. Successful replies use this line order: run ID, workspace, intent, stage, time in stage, then AI context when applicable. The workspace appears immediately after the run ID so operators can jump to disk before reading the rest of the run state. When the run is in an AI-active stage, the reply also includes the model selected for the latest agent invocation and the age of the latest agent request.
+The workspace line is always present. It is populated directly from `run.workspace_path` as soon as that known run information is available; it does not depend on an agent request or AI metadata having been recorded. If a workspace has not been allocated yet, the command says `not yet allocated` instead of showing an empty string. The AI context block is conditional and appears only for the stages where Autocatalyst may be running or surfacing agent work for the loop: `speccing`, `reviewing_spec`, `planning`, `implementing`, and `reviewing_implementation`.
+## Why
+
+Operators use `ac-run-status` while a run is active and need enough context to inspect or recover it without leaving Slack to search logs. Today the command omits the workspace path, even though that path is already stored on the run. This makes it harder to inspect files, run tests, or clean up a stuck run.
+The command also gives no signal about which model is handling current agent work or whether an agent request happened recently. When an implementation or spec run appears quiet, the operator has to check logs to distinguish normal long-running agent work from a stalled process. Showing the selected model and last-request age gives quick confidence that the AI layer is active and using the expected route.
+## User stories
+
+- Enzo can run `:ac-run-status:` in a run thread and see the exact workspace path to inspect on disk.
+- Enzo can run `:ac-run-status: ` outside a thread and get the same workspace and AI context for that run.
+- Phoebe can check an active implementation and see which model Autocatalyst invoked without opening logs.
+- An operator can see that the last AI request was sent a few minutes ago and decide whether the run is still likely progressing.
+- An operator can check a run before workspace allocation and see `Workspace: not yet allocated` instead of a blank or misleading path.
+- An operator can check a run in `awaiting_impl_input`, `done`, or `failed` and see no stale model/request block.
+## Design changes
+
+This is a Slack command output change only. No new UI surface is introduced.
+Current response shape:
+```plain text
+*Run:* `run-abc123`
+*Stage:* `implementing`
+*Intent:* `idea`
+*Time in stage:* 12m
+```
+New response shape for an active implementation with agent metadata:
+```plain text
+*Run:* `run-abc123`
+*Workspace:* `/home/runner/workspaces/run-abc123`
+*Intent:* `idea`
+*Stage:* `implementing`
+*Time in stage:* 12m
+*Model:* `claude-sonnet-4-5`
+*Last request:* 2m ago
+```
+New response shape before workspace allocation:
+```plain text
+*Run:* `run-abc123`
+*Workspace:* not yet allocated
+*Intent:* `idea`
+*Stage:* `intake`
+*Time in stage:* 8s
+```
+If a run is in an AI-active stage but metadata has not been recorded yet, the AI lines are still shown with explicit placeholders:
+```plain text
+*Model:* not yet requested
+*Last request:* not yet requested
+```
+This avoids hiding the block during a stage where AI work is expected and makes startup race conditions visible.
+## Technical changes
+
+### Affected files
+
+- `src/types/runs.ts` — add optional `current_model?: string` and `last_agent_request_at?: string` fields to `Run`.
+- `src/types/ai.ts` — add a shared optional agent invocation metadata callback to agent-service telemetry types, or a small exported type used by agent services and handlers.
+- `src/core/commands/run-commands.ts` — extend `makeRunStatusHandler` output with workspace path and conditional AI context formatting.
+- `src/core/ai/agent-services.ts` — when resolving an agent profile for artifact creation, artifact revision, implementation planning, implementation, and other agent-backed loop work, notify the callback with the resolved model and request timestamp before starting to drain the runner.
+- `src/core/handlers/artifact-creation-handler.ts` — pass an agent metadata callback that updates the current run during initial spec/triage generation.
+- `src/core/handlers/artifact-feedback-handler.ts` — pass the same callback during spec revision.
+- `src/core/handlers/planning-handler.ts` — pass the callback during implementation planning.
+- `src/core/handlers/implementation-start-handler.ts` — pass the callback during implementation and initial implementation review work.
+- `src/core/handlers/implementation-feedback-handler.ts` — pass the callback during implementation feedback runs.
+- `src/core/ai/implementation-review-coordinator.ts` — preserve and forward agent metadata callbacks for initial/final review agents if the coordinator invokes agent-backed review or fix-up work.
+- `src/core/orchestrator.ts` — clear AI metadata when a run transitions out of the AI-active stage set; also clear it on operator stage override when the target stage is not AI-active.
+- `tests/core/commands/run-commands.test.ts` — cover workspace and AI context output.
+- `tests/core/ai/agent-services.test.ts` — cover callback invocation when an agent profile is resolved and a run starts.
+- `tests/core/orchestrator.test.ts` and/or handler tests — cover run metadata updates and clearing on non-AI stages.
+### Changes
+
+#### 1. Prerequisites and assumptions
+
+- Depends on `feature-command-mode.md` and the existing `makeRunStatusHandler` command implementation.
+- Depends on the existing `Run.workspace_path` field. No schema migration is needed for workspace display.
+- Depends on the existing `AgentRoutingPolicy.resolve(route)` call sites in `src/core/ai/agent-services.ts`; these call sites know the exact profile selected for an agent invocation.
+- The low-level `ClaudeAgentSdkAgentRunner` does not own run state and should not mutate `Run` directly. It should continue to emit telemetry and runner events only.
+- The run store persists unknown optional fields as JSON without extra schema code. Existing persisted runs that do not have the new fields remain valid.
+- No new npm packages are required.
+#### 2. Scope
+
+**In scope**
+- Add `Workspace` to every successful `ac-run-status` reply, immediately after the `Run` line.
+- Populate `Workspace` from `run.workspace_path` independently of AI request metadata.
+- Show `not yet allocated` when `run.workspace_path` is empty or whitespace.
+- Add optional `current_model` and `last_agent_request_at` to `Run`.
+- Record `current_model` and `last_agent_request_at` immediately before each agent invocation starts.
+- Update the timestamp on every new agent invocation, not only on stage transition.
+- Show `Model` and `Last request` only when `run.stage` is in the AI-active set.
+- Format `Last request` as a short relative age with an `ago` suffix, for example `42s ago`, `3m ago`, or `1h 12m ago`.
+- Clear AI metadata when a run transitions to a non-AI-active stage so terminal and waiting stages do not show stale model data.
+- Preserve current command lookup behavior by inferred thread request ID, explicit request ID, or explicit run ID.
+**Out of scope**
+- Changing `ac-run-list` output.
+- Adding a new health endpoint or dashboard field.
+- Showing token usage, request IDs, provider base URLs, or profile IDs in Slack.
+- Recording direct model runner calls used outside the run loop, such as intent classification, unless they are already represented as agent-service invocations for a run.
+- Guaranteeing that a provider exposes lower-level HTTP request timing. This enhancement records when Autocatalyst starts an agent invocation, not when the provider receives each internal model request.
+#### 3. Run data model
+
+Extend `Run` in `src/types/runs.ts`:
+```typescript
+export interface Run {
+  id: string;
+  request_id: string;
+  intent: RequestIntent;
+  stage: RunStage;
+  workspace_path: string;
+  branch: string;
+  current_model?: string;
+  last_agent_request_at?: string;
+  // existing fields...
+}
+```
+Field semantics:
+- `current_model` is the model string from the resolved agent profile for the latest agent invocation in the current AI-active stage.
+- `last_agent_request_at` is an ISO timestamp created immediately before invoking `runner.run(...)` or beginning to drain its returned iterable.
+- If the profile does not contain a model, store `'unknown'`. This matches existing runner telemetry behavior.
+- Both fields are optional for compatibility with persisted runs created before this enhancement.
+No migration function is required. `migrateRun()` in `src/core/run-store.ts` can leave missing fields unset.
+#### 4. AI-active stages
+
+Define one shared stage set near the command formatter and use the same set for clearing logic:
+```typescript
+const AI_ACTIVE_STAGES: ReadonlySet = new Set([
+  'speccing',
+  'reviewing_spec',
+  'planning',
+  'implementing',
+  'reviewing_implementation',
+]);
+```
+This set follows issue #184. It includes stages where AI work is either running or recently produced the artifact/status the human is reviewing. Stages that wait for additional human input (`awaiting_planning_input`, `awaiting_impl_input`) and terminal stages (`done`, `failed`) are not active.
+To avoid duplicate constants, place the set in a small module such as `src/core/run-ai-context.ts` if both commands and orchestrator need it:
+```typescript
+import type { Run, RunStage } from '../types/runs.js';
+
+export const AI_ACTIVE_STAGES: ReadonlySet = new Set([...]);
+
+export function isAiActiveStage(stage: RunStage): boolean {
+  return AI_ACTIVE_STAGES.has(stage);
+}
+
+export function recordAgentRequest(run: Run, model: string | undefined, now = new Date()): void {
+  run.current_model = model?.trim() || 'unknown';
+  run.last_agent_request_at = now.toISOString();
+}
+
+export function clearAgentRequestContext(run: Run): void {
+  delete run.current_model;
+  delete run.last_agent_request_at;
+}
+```
+#### 5. Recording model and request time
+
+Prefer recording metadata in the agent-service layer, not in `ClaudeAgentSdkAgentRunner`. The agent-service layer already resolves the `AgentProfile` and receives run telemetry from handlers. The runner only sees an `AgentRunRequest` and should remain reusable outside orchestrator-owned runs.
+Add a small callback type:
+```typescript
+export interface AgentInvocationMetadata {
+  model: string;
+  requested_at: string;
+  route: AgentRoute;
+}
+
+export interface AgentServiceTelemetry {
+  run_id?: string;
+  request_id?: string;
+  onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+}
+```
+Replace repeated inline telemetry types like `{ run_id?: string; request_id?: string }` in agent service interfaces with `AgentServiceTelemetry` where these services already accept telemetry. This preserves backwards compatibility because the new field is optional.
+In each agent-service method, resolve the profile once, record metadata, then pass the same profile into the runner:
+```typescript
+const profile = this.routingPolicy.resolve(route);
+telemetry?.onAgentRequest?.({
+  model: profile.model ?? 'unknown',
+  requested_at: new Date().toISOString(),
+  route,
+});
+
+await drainAgentRunner(
+  this.runner.run({
+    route,
+    profile,
+    working_directory,
+    prompt,
+    telemetry: { ... },
+  }),
+  onProgress,
+  this.logger,
+  'implementation',
+  { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
+);
+```
+This pattern must be applied to:
+- artifact creation (`artifact.create`)
+- artifact revision (`artifact.revise`)
+- implementation planning (`implementation.plan`)
+- implementation run (`implementation.run`)
+- question answering only if the question is part of a run stage that should surface AI context; otherwise leave out of this enhancement
+- issue triage only if it flows through the same agent-service abstraction and has a run
+- implementation review coordinator calls if they invoke agent work during implementation review
+The timestamp is recorded before awaiting the result. This means `ac-run-status` can show a recent request while the agent call is still in progress.
+#### 6. Handler callback wiring
+
+Each handler that starts agent work should pass a callback that mutates the in-memory `Run` and persists it immediately:
+```typescript
+const onAgentRequest = ({ model, requested_at }: AgentInvocationMetadata): void => {
+  run.current_model = model || 'unknown';
+  run.last_agent_request_at = requested_at;
+  this.deps.persist();
+};
+```
+Pass this callback in the existing telemetry argument:
+```typescript
+await this.deps.implementer.implement(
+  refs.local_path,
+  run.workspace_path,
+  additionalContext,
+  onProgress,
+  { run_id: run.id, request_id: run.request_id, onAgentRequest },
+  planPath,
+);
+```
+Handlers should not derive the model themselves. They should trust the agent-service callback because that callback receives the resolved profile used for the actual invocation.
+If a handler transitions into an AI-active stage and the callback has not fired yet, `ac-run-status` may temporarily show `not yet requested`. That is acceptable and makes the short startup window explicit.
+#### 7. Command output formatting
+
+Update `src/core/commands/run-commands.ts` with helper functions:
+```typescript
+function formatWorkspacePath(workspacePath: string): string {
+  const trimmed = workspacePath.trim();
+  return trimmed ? `\`${trimmed}\`` : 'not yet allocated';
+}
+
+function formatLastRequest(isoDate: string | undefined): string {
+  if (!isoDate) return 'not yet requested';
+  return `${formatTimeSince(isoDate)} ago`;
+}
+```
+Build the response as lines instead of a single template string:
+```typescript
+const lines = [
+  `*Run:* \`${run.id}\``,
+  `*Workspace:* ${formatWorkspacePath(run.workspace_path)}`,
+  `*Intent:* \`${run.intent}\``,
+  `*Stage:* \`${run.stage}\`${stageSuffix}`,
+  `*Time in stage:* ${timeInStage}`,
+];
+
+if (isAiActiveStage(run.stage)) {
+  lines.push(`*Model:* ${run.current_model ? `\`${run.current_model}\`` : 'not yet requested'}`);
+  lines.push(`*Last request:* ${formatLastRequest(run.last_agent_request_at)}`);
+}
+
+await reply(lines.join('\n'));
+```
+Keep existing `done` and `failed` stage suffixes. Do not add the AI block to terminal stages even if persisted metadata exists. The final successful reply order is `Run`, `Workspace`, `Intent`, `Stage`, `Time in stage`, then `Model` and `Last request` for AI-active stages.
+#### 8. Clearing stale metadata
+
+Update `transition(run, stage)` in `src/core/orchestrator.ts` after `run.stage` is set:
+```typescript
+run.stage = stage;
+if (!isAiActiveStage(stage)) {
+  clearAgentRequestContext(run);
+}
+run.updated_at = new Date().toISOString();
+```
+Also update `overrideRunStage()` so operator changes to non-AI-active stages clear stale fields. If an operator changes a run into an AI-active stage, do not synthesize metadata; leave fields absent until the next agent request.
+Do not clear metadata on every transition between AI-active stages. For example, `speccing → reviewing_spec` may still usefully show the model that generated the spec while the human reviews it. A later `reviewing_spec → planning` or `planning → implementing` callback updates the fields with the new actual model.
+#### 9. Persistence
+
+The existing orchestrator persistence path should save the new optional fields whenever handlers call `persist()` after recording metadata. Confirm that places which mutate run metadata but do not call `transition()` still call `persist()`.
+No special run-store migration is required. If a persisted run lacks `current_model` and `last_agent_request_at`, command output uses placeholders or omits the AI block depending on stage.
+#### 10. Observability
+
+Add one structured log event where run metadata is recorded. This can live in handler callback code or in a helper used by handlers:
+
+Event
+Level
+Fields
+Condition
+
+`run.agent_request_recorded`
+info
+`run_id`, `request_id`, `model`, `route_task`, `route_stage`, `route_intent`
+Emitted after `current_model` and `last_agent_request_at` are updated
+
+No new metrics are required. Existing `agent.run_started`, `agent.drain_started`, and model runner telemetry remain the detailed diagnostics path.
+#### 11. Testing plan
+
+**Command tests — ****`tests/core/commands/run-commands.test.ts`**
+- `run.status` includes `*Workspace:* \`/ws/req-001\`` when `workspace_path\` is non-empty.
+- `run.status` includes `*Workspace:* not yet allocated` when `workspace_path` is `''` or whitespace.
+- `run.status` orders successful reply lines as `Run`, `Workspace`, `Intent`, `Stage`, `Time in stage`, then optional `Model` and `Last request`.
+- `implementing` run with `current_model` and `last_agent_request_at` includes `Model` and `Last request` lines.
+- `implementing` run without metadata includes `Model: not yet requested` and `Last request: not yet requested`.
+- `awaiting_impl_input` run with stale metadata does not include `Model` or `Last request`.
+- `done` and `failed` runs with stale metadata do not include `Model` or `Last request`.
+- Existing lookup behavior by inferred request ID, explicit request ID, and explicit run ID still passes.
+Use fake timers or a timestamp near `Date.now()` to assert stable last-request formatting.
+**Agent service tests — ****`tests/core/ai/agent-services.test.ts`**
+- `AgentRunnerImplementationAgent.implement()` calls `onAgentRequest` before draining completes and passes the resolved `profile.model`.
+- `AgentRunnerImplementationPlanningAgent.plan()` calls `onAgentRequest` with the planning route and model.
+- `AgentRunnerArtifactAuthoringAgent.create()` and `.revise()` call `onAgentRequest` with the artifact route and model.
+- Missing `profile.model` is reported as `'unknown'`.
+- The same resolved profile object is passed to `runner.run()` after callback invocation.
+**Handler/orchestrator tests**
+- Starting artifact creation records `run.current_model`, sets `run.last_agent_request_at`, and persists.
+- Starting implementation planning updates `last_agent_request_at` again, proving the timestamp changes per invocation.
+- Starting implementation updates `current_model` to the implementation route's model when it differs from the planning model.
+- Transition from an AI-active stage to `awaiting_impl_input` clears both fields.
+- Transition to `done` or `failed` clears both fields.
+- Operator `overrideRunStage()` to `done`, `failed`, `awaiting_impl_input`, or `awaiting_planning_input` clears stale metadata.
+#### 12. Alternatives considered
+
+**Mutate the run from ****`ClaudeAgentSdkAgentRunner`**
+Rejected. The runner does not own orchestrator state, and coupling it to `Run` would make it harder to reuse for non-run tasks. The agent-service layer already resolves the exact profile and receives run telemetry, so it is the right seam for reporting invocation metadata.
+**Resolve the model at command time**
+Rejected. Resolving at command time would show what the routing policy would choose now, not necessarily what was invoked earlier in the run. Storing the model at invocation time records what actually ran.
+**Parse model names from logs**
+Rejected. Logs are diagnostic output, not application state. Parsing them for command output would be slower, more fragile, and harder to test.
+**Show the AI block for every non-terminal stage**
+Rejected. Waiting stages like `awaiting_impl_input` are specifically human-input states. Showing stale model metadata there would imply the AI is still active when it is waiting.
+#### 13. Risks
+
+**The recorded timestamp is an Autocatalyst invocation timestamp, not provider HTTP timing**
+The Claude Agent SDK may make multiple internal model calls during a single agent run. This enhancement records when Autocatalyst started the agent invocation. It does not observe each provider request unless the SDK exposes that later. The Slack label `Last request` should be understood as the latest Autocatalyst agent request.
+**Review stages may show the model from recently completed agent work**
+The issue asks to include `reviewing_spec` and `reviewing_implementation` in the AI-active set. In current orchestration, those stages can also represent human review after agent work completes. The spec keeps metadata visible in those stages because it is useful context for the artifact under review, but it does not claim a provider request is still running.
+**Persist timing depends on handler wiring**
+If a new handler invokes an agent but forgets to pass `onAgentRequest`, `ac-run-status` will show `not yet requested` or stale data for that path. Mitigation: centralize helper types and tests around all current agent-service methods, and document the callback as required for run-scoped agent invocations.
+## Task list
+
+### Story 1 — Extend run state and shared AI context helpers
+
+**Task 1.1 — Add optional AI request fields to ****`Run`**
+- **Description**: Add `current_model?: string` and `last_agent_request_at?: string` to `Run` in `src/types/runs.ts`.
+- **Acceptance criteria**:
+	- `Run` accepts both optional fields.
+	- Existing tests and persisted run fixtures compile without setting the fields.
+	- `npm run typecheck` passes.
+- **Dependencies**: None
+**Task 1.2 — Add shared AI-active stage helper**
+- **Description**: Create `src/core/run-ai-context.ts` with `AI_ACTIVE_STAGES`, `isAiActiveStage()`, `recordAgentRequest()`, and `clearAgentRequestContext()`.
+- **Acceptance criteria**:
+	- The AI-active set contains `speccing`, `reviewing_spec`, `planning`, `implementing`, and `reviewing_implementation`.
+	- `recordAgentRequest()` stores `unknown` for missing/blank model names.
+	- `clearAgentRequestContext()` removes both optional fields.
+	- Unit tests cover helper behavior if helper tests are customary in this repo; otherwise behavior is covered through command/orchestrator tests.
+- **Dependencies**: Task 1.1
+### Story 2 — Update `ac-run-status` output
+
+**Task 2.1 — Add workspace output**
+- **Description**: Update `makeRunStatusHandler` to build response lines and always include `*Workspace:*` with a backticked path or `not yet allocated`.
+- **Acceptance criteria**:
+	- Non-empty workspace paths are shown exactly once, wrapped in backticks, and placed immediately after the `Run` line.
+	- Empty and whitespace workspace paths show `not yet allocated`.
+	- Workspace output does not depend on `current_model`, `last_agent_request_at`, or any agent request being sent.
+	- Existing run ID, stage, intent, time-in-stage, and terminal suffix content is unchanged, aside from the new line order.
+- **Dependencies**: None
+**Task 2.2 — Add conditional AI context output**
+- **Description**: Use `isAiActiveStage()` in `makeRunStatusHandler` to show `Model` and `Last request` lines only for AI-active stages.
+- **Acceptance criteria**:
+	- `implementing` with metadata shows model in backticks and relative request age with `ago`.
+	- AI-active stages without metadata show `not yet requested` placeholders.
+	- `awaiting_impl_input`, `awaiting_planning_input`, `done`, and `failed` do not show AI context lines.
+	- Existing lookup tests by request ID and run ID still pass.
+- **Dependencies**: Task 1.2, Task 2.1
+### Story 3 — Record agent invocation metadata
+
+**Task 3.1 — Add agent invocation metadata telemetry type**
+- **Description**: Add `AgentInvocationMetadata` and `AgentServiceTelemetry` types in `src/types/ai.ts`, then update agent service method signatures to accept `AgentServiceTelemetry` instead of repeated inline telemetry shapes.
+- **Acceptance criteria**:
+	- `onAgentRequest` is optional and backwards compatible.
+	- All existing call sites compile without changes until callbacks are wired.
+	- The metadata includes model, requested timestamp, and route.
+- **Dependencies**: Task 1.1
+**Task 3.2 — Invoke callback from agent services**
+- **Description**: In `src/core/ai/agent-services.ts`, resolve each profile into a local variable, call `telemetry?.onAgentRequest?.(...)`, and pass the same profile to `runner.run()`.
+- **Acceptance criteria**:
+	- Artifact create, artifact revise, implementation planning, and implementation run paths call the callback before awaiting drain completion.
+	- Missing model is reported as `unknown`.
+	- Callback failures do not mask agent execution unless the chosen callback deliberately throws; prefer catching/logging in handlers or make the callback non-throwing.
+	- Existing runner behavior and prompt construction are unchanged.
+- **Dependencies**: Task 3.1
+**Task 3.3 — Wire handler callbacks to update runs**
+- **Description**: In run-scoped handlers, pass an `onAgentRequest` callback that updates the run, persists, and logs `run.agent_request_recorded`.
+- **Acceptance criteria**:
+	- Spec creation and revision update `current_model` and `last_agent_request_at`.
+	- Planning updates both fields.
+	- Implementation and implementation feedback updates both fields.
+	- If implementation review coordinator invokes agent-backed work, metadata is forwarded through that path as well.
+	- Each update calls `persist()` after mutation.
+- **Dependencies**: Task 3.2
+### Story 4 — Clear stale metadata on non-AI stages
+
+**Task 4.1 — Clear fields in normal transitions**
+- **Description**: Update `transition(run, stage)` in `src/core/orchestrator.ts` to call `clearAgentRequestContext(run)` when the target stage is not AI-active.
+- **Acceptance criteria**:
+	- Transition to `awaiting_impl_input` clears metadata.
+	- Transition to `awaiting_planning_input` clears metadata.
+	- Transition to `done` and `failed` clears metadata.
+	- Transition between AI-active stages preserves metadata until a new agent invocation updates it.
+- **Dependencies**: Task 1.2
+**Task 4.2 — Clear fields in operator stage overrides**
+- **Description**: Update `overrideRunStage()` to clear AI metadata when the target stage is not AI-active.
+- **Acceptance criteria**:
+	- Override to a waiting or terminal stage clears stale fields.
+	- Override to an AI-active stage does not synthesize metadata.
+	- Stage override logging remains unchanged except for any added structured field if useful.
+- **Dependencies**: Task 4.1
+### Story 5 — Tests
+
+**Task 5.1 — Add run status command tests**
+- **Description**: Extend `tests/core/commands/run-commands.test.ts` for workspace output and conditional AI context.
+- **Acceptance criteria**:
+	- Tests cover non-empty workspace, unallocated workspace, the required line order, implementing with metadata, implementing without metadata, and non-AI stages with stale metadata.
+	- Tests use stable time control for request-age formatting.
+	- Existing command tests still pass.
+- **Dependencies**: Story 2
+**Task 5.2 — Add agent-service callback tests**
+- **Description**: Extend `tests/core/ai/agent-services.test.ts` to assert `onAgentRequest` callback behavior for each agent service path.
+- **Acceptance criteria**:
+	- Callback receives resolved model and route for artifact create/revise, planning, and implementation.
+	- Callback fires before the service resolves its final result.
+	- Unknown model fallback is covered.
+	- The resolved profile is still passed to `runner.run()`.
+- **Dependencies**: Story 3
+**Task 5.3 — Add run metadata lifecycle tests**
+- **Description**: Extend orchestrator and/or handler tests to cover mutation, persistence, and clearing of run AI metadata.
+- **Acceptance criteria**:
+	- A run records metadata when an agent-backed handler starts.
+	- A second agent invocation updates `last_agent_request_at`.
+	- Normal transitions to waiting/terminal stages clear metadata.
+	- Operator stage overrides to waiting/terminal stages clear metadata.
+- **Dependencies**: Story 3, Story 4

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -8,10 +8,14 @@ import type { LoggerProvider } from '@opentelemetry/api-logs';
 import { createLogger } from '../logger.js';
 import type {
   AgentDrainSummary,
+  AgentInvocationMetadata,
+  AgentProfile,
+  AgentRoute,
   AgentRunContentBlock,
   AgentRunEvent,
   AgentRunner,
   AgentRoutingPolicy,
+  AgentServiceTelemetry,
   ArtifactAuthoringAgent,
   ArtifactComment,
   ArtifactCommentResponse,
@@ -36,6 +40,14 @@ import { artifactKindForIntent } from '../../types/artifact.js';
 import type { ArtifactCommentAnchorCodec } from '../../types/publisher.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
+
+function notifyAgentRequest(telemetry: AgentServiceTelemetry | undefined, profile: AgentProfile, route: AgentRoute): void {
+  telemetry?.onAgentRequest?.({
+    model: profile.model?.trim() || 'unknown',
+    requested_at: new Date().toISOString(),
+    route,
+  } satisfies AgentInvocationMetadata);
+}
 
 interface AgentServiceOptions {
   logDestination?: pino.DestinationStream;
@@ -64,7 +76,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     workspace_path: string,
     onProgress?: (message: string) => Promise<void>,
     intent: 'idea' | 'bug' | 'chore' = 'idea',
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<ArtifactCreateResult> {
     const createResultPath = join(workspace_path, '.autocatalyst', 'spec-create-result.json');
     const artifactDir = (intent === 'bug' || intent === 'chore')
@@ -80,13 +92,16 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
 
     this.logger.debug({ event: 'artifact.agent_invoked', request_id: request.id }, 'Invoking agent for artifact creation');
 
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(createResultPath);
       drainSummary = await drainAgentRunner(
         this.runner.run({
           route,
-          profile: this.routingPolicy.resolve(route),
+          profile,
           working_directory: workspace_path,
           prompt,
           telemetry: {
@@ -136,7 +151,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     workspace_path: string,
     current_page_markdown?: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<ArtifactRevisionResult> {
     const reviseResultPath = join(workspace_path, '.autocatalyst', 'spec-revise-result.json');
     const originalAnchors = current_page_markdown && this.commentAnchorCodec
@@ -163,13 +178,16 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
       'Revise called with publisher comments',
     );
 
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(reviseResultPath);
       drainSummary = await drainAgentRunner(
         this.runner.run({
           route,
-          profile: this.routingPolicy.resolve(route),
+          profile,
           working_directory: workspace_path,
           prompt,
           telemetry: {
@@ -235,7 +253,7 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
     working_directory: string,
     additional_context?: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
     plan_path?: string,
   ): Promise<ImplementationResult> {
     const resultFilePath = join(working_directory, '.autocatalyst', 'impl-result.json');
@@ -247,13 +265,16 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
       'Invoking agent for implementation',
     );
 
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(resultFilePath);
       drainSummary = await drainAgentRunner(
         this.runner.run({
           route,
-          profile: this.routingPolicy.resolve(route),
+          profile,
           working_directory,
           prompt,
           telemetry: {
@@ -315,7 +336,7 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
     artifact_path: string,
     working_directory: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
     additional_context?: string,
   ): Promise<ImplementationPlanResult> {
     const resultFilePath = join(working_directory, '.autocatalyst', 'implementation-plan-result.json');
@@ -327,13 +348,16 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
       'Invoking agent for implementation planning',
     );
 
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(resultFilePath);
       drainSummary = await drainAgentRunner(
         this.runner.run({
           route,
-          profile: this.routingPolicy.resolve(route),
+          profile,
           working_directory,
           prompt,
           telemetry: {

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -530,6 +530,14 @@ export class AgentRunnerIssueTriageAgent implements IssueTriageAgent {
     const profile = this.routingPolicy.resolve(route);
     notifyAgentRequest(telemetry, profile, route);
 
+    const progressWithHeartbeat: ((msg: string) => Promise<void>) | undefined =
+      onProgress && telemetry?.onAgentRequest
+        ? async (msg: string) => {
+            notifyAgentRequest(telemetry, profile, route, true);
+            return onProgress(msg);
+          }
+        : onProgress;
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(resultPath);
@@ -547,7 +555,7 @@ export class AgentRunnerIssueTriageAgent implements IssueTriageAgent {
             ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}),
           },
         }),
-        onProgress,
+        progressWithHeartbeat,
         this.logger,
         'issue_triage',
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -409,12 +409,15 @@ export class AgentRunnerQuestionAnsweringAgent implements QuestionAnsweringAgent
     this.readFileFn = options?.readFile ?? ((path, enc) => _readFile(path, enc));
   }
 
-  async answer(question: string, telemetry?: { run_id?: string; request_id?: string }): Promise<string> {
+  async answer(question: string, telemetry?: AgentServiceTelemetry): Promise<string> {
     const resultPath = join(this.repo_path, '.autocatalyst', `question-${randomUUID()}.json`);
     const prompt = buildQuestionPrompt(question, resultPath);
     const route = { task: 'question.answer' as const };
 
     this.logger.debug({ event: 'question.answering', question_length: question.length, ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}), ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}) }, 'Answering question via agent');
+
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
 
     let drainSummary: AgentDrainSummary | undefined;
     try {
@@ -422,7 +425,7 @@ export class AgentRunnerQuestionAnsweringAgent implements QuestionAnsweringAgent
       drainSummary = await drainAgentRunner(
         this.runner.run({
           route,
-          profile: this.routingPolicy.resolve(route),
+          profile,
           working_directory: this.repo_path,
           prompt,
           telemetry: {
@@ -478,7 +481,7 @@ export class AgentRunnerIssueTriageAgent implements IssueTriageAgent {
     request: Request,
     working_directory: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<IssueTriageResult> {
     const resultPath = join(working_directory, '.autocatalyst', 'enrichment-result.json');
     const prompt = buildIssueTriagePrompt(request, resultPath);
@@ -486,13 +489,16 @@ export class AgentRunnerIssueTriageAgent implements IssueTriageAgent {
 
     this.logger.debug({ event: 'filing.agent_invoked', request_id: request.id }, 'Invoking agent for issue triage');
 
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(resultPath);
       drainSummary = await drainAgentRunner(
         this.runner.run({
           route,
-          profile: this.routingPolicy.resolve(route),
+          profile,
           working_directory,
           prompt,
           telemetry: {
@@ -541,7 +547,7 @@ export class IssueFilingService implements IssueFiler {
     request: Request,
     workspace_path: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<FilingResult> {
     const triageResult = await this.issueTriageAgent.triage(request, workspace_path, onProgress, telemetry);
     if (triageResult.status === 'failed') {

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -41,11 +41,17 @@ import type { ArtifactCommentAnchorCodec } from '../../types/publisher.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
-function notifyAgentRequest(telemetry: AgentServiceTelemetry | undefined, profile: AgentProfile, route: AgentRoute): void {
+function notifyAgentRequest(
+  telemetry: AgentServiceTelemetry | undefined,
+  profile: AgentProfile,
+  route: AgentRoute,
+  is_heartbeat = false,
+): void {
   telemetry?.onAgentRequest?.({
     model: profile.model?.trim() || 'unknown',
     requested_at: new Date().toISOString(),
     route,
+    is_heartbeat,
   } satisfies AgentInvocationMetadata);
 }
 
@@ -95,6 +101,14 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     const profile = this.routingPolicy.resolve(route);
     notifyAgentRequest(telemetry, profile, route);
 
+    const progressWithHeartbeat: ((msg: string) => Promise<void>) | undefined =
+      onProgress && telemetry?.onAgentRequest
+        ? async (msg: string) => {
+            notifyAgentRequest(telemetry, profile, route, true);
+            return onProgress(msg);
+          }
+        : onProgress;
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(createResultPath);
@@ -112,7 +126,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
             ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}),
           },
         }),
-        onProgress,
+        progressWithHeartbeat,
         this.logger,
         'artifact_generation',
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
@@ -181,6 +195,14 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     const profile = this.routingPolicy.resolve(route);
     notifyAgentRequest(telemetry, profile, route);
 
+    const progressWithHeartbeat: ((msg: string) => Promise<void>) | undefined =
+      onProgress && telemetry?.onAgentRequest
+        ? async (msg: string) => {
+            notifyAgentRequest(telemetry, profile, route, true);
+            return onProgress(msg);
+          }
+        : onProgress;
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(reviseResultPath);
@@ -198,7 +220,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
             ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}),
           },
         }),
-        onProgress,
+        progressWithHeartbeat,
         this.logger,
         'artifact_generation',
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
@@ -268,6 +290,14 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
     const profile = this.routingPolicy.resolve(route);
     notifyAgentRequest(telemetry, profile, route);
 
+    const progressWithHeartbeat: ((msg: string) => Promise<void>) | undefined =
+      onProgress && telemetry?.onAgentRequest
+        ? async (msg: string) => {
+            notifyAgentRequest(telemetry, profile, route, true);
+            return onProgress(msg);
+          }
+        : onProgress;
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(resultFilePath);
@@ -285,7 +315,7 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
             ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}),
           },
         }),
-        onProgress,
+        progressWithHeartbeat,
         this.logger,
         'implementation',
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
@@ -351,6 +381,14 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
     const profile = this.routingPolicy.resolve(route);
     notifyAgentRequest(telemetry, profile, route);
 
+    const progressWithHeartbeat: ((msg: string) => Promise<void>) | undefined =
+      onProgress && telemetry?.onAgentRequest
+        ? async (msg: string) => {
+            notifyAgentRequest(telemetry, profile, route, true);
+            return onProgress(msg);
+          }
+        : onProgress;
+
     let drainSummary: AgentDrainSummary | undefined;
     try {
       await ensureResultDir(resultFilePath);
@@ -368,7 +406,7 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
             ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}),
           },
         }),
-        onProgress,
+        progressWithHeartbeat,
         this.logger,
         'planning',
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import type pino from 'pino';
 import type {
+  AgentInvocationMetadata,
   AgentRunner,
   AgentRoutingPolicy,
   ImplementationAgent,
@@ -49,7 +50,7 @@ export interface ReviewRunParams {
   implementation_result: ImplementationResult;
   working_directory: string;
   onProgress?: (message: string) => Promise<void>;
-  onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void;
+  onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
 }
 
 export class ImplementationReviewCoordinator {

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -134,6 +134,20 @@ export class ImplementationReviewCoordinator {
           route: { task: routeTask },
         });
       }
+
+      const progressWithHeartbeat: typeof onProgress =
+        onProgress && onAgentRequest && reviewProfile
+          ? async (msg: string) => {
+              onAgentRequest({
+                model: reviewProfile.model?.trim() || 'unknown',
+                requested_at: new Date().toISOString(),
+                route: { task: routeTask },
+                is_heartbeat: true,
+              });
+              return onProgress(msg);
+            }
+          : onProgress;
+
       await drainAgentRunner(
         this.deps.runner.run({
           route: { task: routeTask },
@@ -148,7 +162,7 @@ export class ImplementationReviewCoordinator {
             handler: 'ImplementationReviewCoordinator',
           },
         }),
-        onProgress,
+        progressWithHeartbeat,
         this.deps.logger,
         `implementation_review_${phase}`,
         { run_id: run.id, request_id: run.request_id },

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -49,6 +49,7 @@ export interface ReviewRunParams {
   implementation_result: ImplementationResult;
   working_directory: string;
   onProgress?: (message: string) => Promise<void>;
+  onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void;
 }
 
 export class ImplementationReviewCoordinator {
@@ -69,7 +70,7 @@ export class ImplementationReviewCoordinator {
   private async runReview(
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
-    { run, artifact_path, implementation_result, working_directory, onProgress }: ReviewRunParams,
+    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest }: ReviewRunParams,
   ): Promise<ImplementationResult> {
     // Resolve review profile — fall back to initial when final is absent
     let reviewProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask });
@@ -125,6 +126,13 @@ export class ImplementationReviewCoordinator {
     let reviewResultContent: string;
     let reviewResult: ReturnType<typeof parseImplementationReviewResult>;
     try {
+      if (onAgentRequest && reviewProfile) {
+        onAgentRequest({
+          model: reviewProfile.model?.trim() || 'unknown',
+          requested_at: new Date().toISOString(),
+          route: { task: routeTask },
+        });
+      }
       await drainAgentRunner(
         this.deps.runner.run({
           route: { task: routeTask },
@@ -233,7 +241,7 @@ export class ImplementationReviewCoordinator {
         working_directory,
         responsePrompt,
         progressFn,
-        { run_id: run.id },
+        { run_id: run.id, onAgentRequest },
       );
     } catch (err) {
       return { status: 'failed', error: `Implementer response to review failed: ${String(err)}` };

--- a/src/core/commands/run-commands.ts
+++ b/src/core/commands/run-commands.ts
@@ -1,5 +1,6 @@
 import type { CommandHandler } from '../../types/commands.js';
 import type { Run } from '../../types/runs.js';
+import { isAiActiveStage } from '../run-ai-context.js';
 
 function findRun(runs: Map<string, Run>, requestId: string | undefined, idArg: string | undefined): Run | undefined {
   if (requestId) {
@@ -24,6 +25,16 @@ function formatTimeSince(isoDate: string): string {
   return `${hours}h ${minutes % 60}m`;
 }
 
+function formatWorkspacePath(workspacePath: string): string {
+  const trimmed = workspacePath.trim();
+  return trimmed ? `\`${trimmed}\`` : 'not yet allocated';
+}
+
+function formatLastRequest(isoDate: string | undefined): string {
+  if (!isoDate) return 'not yet requested';
+  return `${formatTimeSince(isoDate)} ago`;
+}
+
 export function makeRunStatusHandler(runs: Map<string, Run>): CommandHandler {
   return async (event, reply) => {
     const requestId = event.inferred_context?.request_id;
@@ -42,9 +53,21 @@ export function makeRunStatusHandler(runs: Map<string, Run>): CommandHandler {
 
     const timeInStage = formatTimeSince(run.updated_at);
     const stageSuffix = run.stage === 'done' ? ' ✓ (complete)' : run.stage === 'failed' ? ' ✗ (failed)' : '';
-    await reply(
-      `*Run:* \`${run.id}\`\n*Stage:* \`${run.stage}\`${stageSuffix}\n*Intent:* \`${run.intent}\`\n*Time in stage:* ${timeInStage}`,
-    );
+
+    const lines = [
+      `*Run:* \`${run.id}\``,
+      `*Workspace:* ${formatWorkspacePath(run.workspace_path)}`,
+      `*Intent:* \`${run.intent}\``,
+      `*Stage:* \`${run.stage}\`${stageSuffix}`,
+      `*Time in stage:* ${timeInStage}`,
+    ];
+
+    if (isAiActiveStage(run.stage)) {
+      lines.push(`*Model:* ${run.current_model ? `\`${run.current_model}\`` : 'not yet requested'}`);
+      lines.push(`*Last request:* ${formatLastRequest(run.last_agent_request_at)}`);
+    }
+
+    await reply(lines.join('\n'));
   };
 }
 

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -227,6 +227,7 @@ async function handleArtifactFeedback(
     postMessage: deps.postMessage,
     transition: deps.transition,
     failRun: deps.failRun,
+    persist: deps.persist,
     logger: deps.logger,
     branchGuard,
   });

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -342,6 +342,7 @@ async function startFilingPipeline(deps: DefaultHandlerRegistryDeps, run: Run, r
     postMessage: deps.postMessage,
     transition: deps.transition,
     failRun: deps.failRun,
+    persist: deps.persist,
     reactToRunMessage: deps.reactToRunMessage,
     reacjiComplete: deps.reacjiComplete,
     logger: deps.logger,
@@ -359,6 +360,7 @@ async function handleQuestion(
     questionAnswerer: deps.questionAnswerer,
     postMessage: deps.postMessage,
     postError: deps.postError,
+    persist: deps.persist,
     logger: deps.logger,
   });
   return handler.handle(content, conversation, run);

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -9,6 +9,7 @@ import type { ChannelRepoMap } from '../../types/config.js';
 import type { WorkspaceManager } from '../workspace-manager.js';
 import { channelKey, type ConversationRef } from '../../types/channel.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 type ArtifactCreationIntent = Extract<RequestIntent, 'idea' | 'bug' | 'chore'>;
 
@@ -59,11 +60,13 @@ export class ArtifactCreationHandler {
         );
       });
 
+    const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+
     let local_path: string;
     try {
       const result = intent === 'idea'
-        ? await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, { run_id: run.id, request_id: run.request_id })
-        : await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, intent, { run_id: run.id, request_id: run.request_id });
+        ? await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, { run_id: run.id, request_id: run.request_id, onAgentRequest })
+        : await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, intent, { run_id: run.id, request_id: run.request_id, onAgentRequest });
       local_path = result.artifact_path;
       this.setArtifactDraft(run, artifactKindForIntent(intent)!, local_path);
       if (intent !== 'idea' && result.existing_issue !== undefined) {

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -7,6 +7,7 @@ import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { requireArtifactRefs } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface ArtifactFeedbackDeps {
   artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'revise'>;
@@ -16,7 +17,8 @@ export interface ArtifactFeedbackDeps {
   postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
-  logger: Pick<pino.Logger, 'debug' | 'warn' | 'error'>;
+  persist: () => void;
+  logger: Pick<pino.Logger, 'debug' | 'warn' | 'error' | 'info'>;
   branchGuard?: BranchGuard;
 }
 
@@ -62,9 +64,11 @@ export class ArtifactFeedbackHandler {
         );
       });
 
+    const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+
     let result;
     try {
-      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id });
+      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest });
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -12,6 +12,7 @@ import { getArtifactLifecyclePolicy } from '../../types/artifact.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 import type { ImplementationResult } from '../../types/ai.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface ImplementationApprovalDeps {
   specCommitter?: Pick<SpecCommitter, 'updateStatus'>;
@@ -83,6 +84,7 @@ export class ImplementationApprovalHandler {
 
     // Run final review before PR creation
     if (this.deps.reviewCoordinator) {
+      const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
       const currentResult: ImplementationResult = {
         status: 'complete',
         summary: run.last_impl_result?.summary,
@@ -95,6 +97,7 @@ export class ImplementationApprovalHandler {
         artifact_path: localPath ?? '',
         implementation_result: currentResult,
         working_directory: run.workspace_path,
+        onAgentRequest,
       });
 
       if (reviewedResult.status === 'needs_input') {

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -86,6 +86,7 @@ export class ImplementationFeedbackHandler {
         implementation_result: result,
         working_directory: run.workspace_path,
         onProgress,
+        onAgentRequest,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -7,6 +7,7 @@ import type { ConversationRef } from '../../types/channel.js';
 import { artifactPath } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface ImplementationFeedbackDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -50,6 +51,8 @@ export class ImplementationFeedbackHandler {
     run.attempt += 1;
     this.deps.persist();
 
+    const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+
     let result;
     try {
       result = await this.deps.implementer.implement(
@@ -57,7 +60,7 @@ export class ImplementationFeedbackHandler {
         run.workspace_path,
         additionalContext.value,
         onProgress,
-        { run_id: run.id, request_id: run.request_id },
+        { run_id: run.id, request_id: run.request_id, onAgentRequest },
       );
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -8,6 +8,7 @@ import type { ConversationRef } from '../../types/channel.js';
 import { requireArtifactRefs, artifactPublishedUrl } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface ImplementationStartDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -58,6 +59,8 @@ export class ImplementationStartHandler {
       );
     }
 
+    const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+
     let result;
     try {
       result = await this.deps.implementer.implement(
@@ -65,7 +68,7 @@ export class ImplementationStartHandler {
         run.workspace_path,
         additionalContext,
         onProgress,
-        { run_id: run.id, request_id: run.request_id },
+        { run_id: run.id, request_id: run.request_id, onAgentRequest },
         planPath,
       );
     } catch (err) {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -95,6 +95,7 @@ export class ImplementationStartHandler {
         implementation_result: result,
         working_directory: run.workspace_path,
         onProgress,
+        onAgentRequest,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/issue-filing-handler.ts
+++ b/src/core/handlers/issue-filing-handler.ts
@@ -5,6 +5,7 @@ import type { ChannelRepoMap } from '../../types/config.js';
 import type { Request } from '../../types/events.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import { channelKey, type ConversationRef } from '../../types/channel.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface IssueFilingDeps {
   workspaceManager: Pick<WorkspaceManager, 'create' | 'destroy'>;
@@ -13,6 +14,7 @@ export interface IssueFilingDeps {
   postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;
+  persist?: () => void;
   reactToRunMessage?: (run: Run, reaction: string) => Promise<void>;
   reacjiComplete?: string | null;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
@@ -50,9 +52,13 @@ export class IssueFilingHandler {
         );
       });
 
+    const onAgentRequest = this.deps.persist
+      ? makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger)
+      : undefined;
+
     let result: FilingResult;
     try {
-      result = await this.deps.issueFiler.file(request, workspace_path, onProgress, { run_id: run.id, request_id: run.request_id });
+      result = await this.deps.issueFiler.file(request, workspace_path, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest });
     } catch (err) {
       await this.deps.workspaceManager.destroy(workspace_path);
       await this.deps.failRun(run, request.conversation, err);

--- a/src/core/handlers/planning-handler.ts
+++ b/src/core/handlers/planning-handler.ts
@@ -5,6 +5,7 @@ import type { ConversationRef } from '../../types/channel.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import { requireArtifactRefs } from '../run-refs.js';
 import { validateImplementationPlanPath } from '../plan-path-validator.js';
+import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface PlanningHandlerDeps {
   planner: Pick<ImplementationPlanningAgent, 'plan'>;
@@ -41,13 +42,15 @@ export class PlanningHandler {
 
     this.deps.logger.info({ event: 'planning.started', run_id: run.id, request_id: run.request_id }, 'Implementation planning started');
 
+    const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+
     let result;
     try {
       result = await this.deps.planner.plan(
         refs.local_path,
         run.workspace_path,
         onProgress,
-        { run_id: run.id, request_id: run.request_id },
+        { run_id: run.id, request_id: run.request_id, onAgentRequest },
         additionalContext,
       );
     } catch (err) {

--- a/src/core/handlers/question-handler.ts
+++ b/src/core/handlers/question-handler.ts
@@ -2,11 +2,13 @@ import type pino from 'pino';
 import type { QuestionAnsweringAgent } from '../../types/ai.js';
 import type { Run } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
+import { isAiActiveStage, makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface QuestionDeps {
   questionAnswerer?: Pick<QuestionAnsweringAgent, 'answer'>;
   postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
   postError: (conversation: ConversationRef, text: string) => Promise<void>;
+  persist?: () => void;
   logger: Pick<pino.Logger, 'info' | 'error'>;
 }
 
@@ -23,10 +25,14 @@ export class QuestionHandler {
   async handle(content: string, conversation: ConversationRef, run: Run): Promise<QuestionResult> {
     this.deps.logger.info({ event: 'question.received', run_id: run.id, request_id: run.request_id }, 'Question received');
 
+    const onAgentRequest = (this.deps.persist && isAiActiveStage(run.stage))
+      ? makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger)
+      : undefined;
+
     let response: string;
     if (this.deps.questionAnswerer) {
       try {
-        response = await this.deps.questionAnswerer.answer(content, { run_id: run.id, request_id: run.request_id });
+        response = await this.deps.questionAnswerer.answer(content, { run_id: run.id, request_id: run.request_id, onAgentRequest });
       } catch (err) {
         this.deps.logger.error({ event: 'question.answer_failed', run_id: run.id, error: String(err) }, 'Failed to answer question');
         await this.deps.postError(conversation, QUESTION_UNAVAILABLE_MESSAGE);

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -28,6 +28,7 @@ import type { HandlerRegistry } from './handler-registry.js';
 import { buildDefaultHandlerRegistry as buildDefaultHandlers } from './default-handler-registry.js';
 import type { BranchGuard } from './git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
+import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
@@ -584,6 +585,9 @@ export class OrchestratorImpl implements Orchestrator {
     this._stageStartTimes.set(run.id, endMs);
 
     run.stage = stage;
+    if (!isAiActiveStage(stage)) {
+      clearAgentRequestContext(run);
+    }
     run.updated_at = new Date().toISOString();
     this.logger.info({ event: 'run.stage_transition', run_id: run.id, request_id: run.request_id, from_stage: from, to_stage: stage }, 'Stage transition');
     this._appendRunLog(run.request_id, `[${new Date().toISOString()}] Stage: ${from} → ${stage}`);
@@ -726,6 +730,9 @@ export class OrchestratorImpl implements Orchestrator {
     const run = this.runs.get(requestId);
     if (!run) return 'not_found';
     run.stage = stage;
+    if (!isAiActiveStage(stage)) {
+      clearAgentRequestContext(run);
+    }
     run.updated_at = new Date().toISOString();
     this._persistRuns();
     this.logger.info(

--- a/src/core/run-ai-context.ts
+++ b/src/core/run-ai-context.ts
@@ -4,10 +4,8 @@ import type { Run, RunStage } from '../types/runs.js';
 
 export const AI_ACTIVE_STAGES: ReadonlySet<RunStage> = new Set([
   'speccing',
-  'reviewing_spec',
   'planning',
   'implementing',
-  'reviewing_implementation',
 ]);
 
 export function isAiActiveStage(stage: RunStage): boolean {

--- a/src/core/run-ai-context.ts
+++ b/src/core/run-ai-context.ts
@@ -1,0 +1,49 @@
+import type pino from 'pino';
+import type { AgentInvocationMetadata } from '../types/ai.js';
+import type { Run, RunStage } from '../types/runs.js';
+
+export const AI_ACTIVE_STAGES: ReadonlySet<RunStage> = new Set([
+  'speccing',
+  'reviewing_spec',
+  'planning',
+  'implementing',
+  'reviewing_implementation',
+]);
+
+export function isAiActiveStage(stage: RunStage): boolean {
+  return AI_ACTIVE_STAGES.has(stage);
+}
+
+export function recordAgentRequest(run: Run, model: string | undefined, now = new Date()): void {
+  run.current_model = model?.trim() || 'unknown';
+  run.last_agent_request_at = now.toISOString();
+}
+
+export function clearAgentRequestContext(run: Run): void {
+  delete run.current_model;
+  delete run.last_agent_request_at;
+}
+
+export function makeRunAgentRequestRecorder(
+  run: Run,
+  persist: () => void,
+  logger: Pick<pino.Logger, 'info'>,
+): (metadata: AgentInvocationMetadata) => void {
+  return metadata => {
+    run.current_model = metadata.model?.trim() || 'unknown';
+    run.last_agent_request_at = metadata.requested_at;
+    persist();
+    logger.info(
+      {
+        event: 'run.agent_request_recorded',
+        run_id: run.id,
+        request_id: run.request_id,
+        model: run.current_model,
+        route_task: metadata.route.task,
+        ...(metadata.route.stage ? { route_stage: metadata.route.stage } : {}),
+        ...(metadata.route.intent ? { route_intent: metadata.route.intent } : {}),
+      },
+      'Agent request metadata recorded',
+    );
+  };
+}

--- a/src/core/run-ai-context.ts
+++ b/src/core/run-ai-context.ts
@@ -4,8 +4,10 @@ import type { Run, RunStage } from '../types/runs.js';
 
 export const AI_ACTIVE_STAGES: ReadonlySet<RunStage> = new Set([
   'speccing',
+  'reviewing_spec',
   'planning',
   'implementing',
+  'reviewing_implementation',
 ]);
 
 export function isAiActiveStage(stage: RunStage): boolean {

--- a/src/core/run-ai-context.ts
+++ b/src/core/run-ai-context.ts
@@ -31,17 +31,19 @@ export function makeRunAgentRequestRecorder(
     run.current_model = metadata.model?.trim() || 'unknown';
     run.last_agent_request_at = metadata.requested_at;
     persist();
-    logger.info(
-      {
-        event: 'run.agent_request_recorded',
-        run_id: run.id,
-        request_id: run.request_id,
-        model: run.current_model,
-        route_task: metadata.route.task,
-        ...(metadata.route.stage ? { route_stage: metadata.route.stage } : {}),
-        ...(metadata.route.intent ? { route_intent: metadata.route.intent } : {}),
-      },
-      'Agent request metadata recorded',
-    );
+    if (!metadata.is_heartbeat) {
+      logger.info(
+        {
+          event: 'run.agent_request_recorded',
+          run_id: run.id,
+          request_id: run.request_id,
+          model: run.current_model,
+          route_task: metadata.route.task,
+          ...(metadata.route.stage ? { route_stage: metadata.route.stage } : {}),
+          ...(metadata.route.intent ? { route_intent: metadata.route.intent } : {}),
+        },
+        'Agent request metadata recorded',
+      );
+    }
   };
 }

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -23,6 +23,18 @@ export interface AgentRoute {
   artifact_kind?: ArtifactKind;
 }
 
+export interface AgentInvocationMetadata {
+  model: string;
+  requested_at: string;
+  route: AgentRoute;
+}
+
+export interface AgentServiceTelemetry {
+  run_id?: string;
+  request_id?: string;
+  onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+}
+
 export type AgentEffort = 'low' | 'medium' | 'high' | 'max';
 export type AgentSettingSource = 'user' | 'project' | 'local';
 

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -213,7 +213,7 @@ export interface ArtifactAuthoringAgent {
     workspace_path: string,
     onProgress?: (message: string) => Promise<void>,
     intent?: 'idea' | 'bug' | 'chore',
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<ArtifactCreateResult>;
   revise(
     feedback: ThreadMessage,
@@ -222,7 +222,7 @@ export interface ArtifactAuthoringAgent {
     workspace_path: string,
     current_page_markdown?: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<ArtifactRevisionResult>;
 }
 
@@ -240,7 +240,7 @@ export interface ImplementationPlanningAgent {
     artifact_path: string,
     working_directory: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
     additional_context?: string,
   ): Promise<ImplementationPlanResult>;
 }
@@ -267,7 +267,7 @@ export interface ImplementationAgent {
     working_directory: string,
     additional_context?: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
     plan_path?: string,
   ): Promise<ImplementationResult>;
 }

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -27,6 +27,7 @@ export interface AgentInvocationMetadata {
   model: string;
   requested_at: string;
   route: AgentRoute;
+  is_heartbeat?: boolean;
 }
 
 export interface AgentServiceTelemetry {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -273,7 +273,7 @@ export interface ImplementationAgent {
 }
 
 export interface QuestionAnsweringAgent {
-  answer(question: string, telemetry?: { run_id?: string; request_id?: string }): Promise<string>;
+  answer(question: string, telemetry?: AgentServiceTelemetry): Promise<string>;
 }
 
 export interface IssueTriageAgent {
@@ -281,7 +281,7 @@ export interface IssueTriageAgent {
     request: Request,
     working_directory: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<IssueTriageResult>;
 }
 

--- a/src/types/issue-filing.ts
+++ b/src/types/issue-filing.ts
@@ -1,4 +1,5 @@
 import type { Request } from './events.js';
+import type { AgentServiceTelemetry } from './ai.js';
 
 export interface FiledIssue {
   number: number;
@@ -18,6 +19,6 @@ export interface IssueFiler {
     request: Request,
     workspace_path: string,
     onProgress?: (message: string) => Promise<void>,
-    telemetry?: { run_id?: string; request_id?: string },
+    telemetry?: AgentServiceTelemetry,
   ): Promise<FilingResult>;
 }

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -51,6 +51,8 @@ export interface Run {
   stage: RunStage;
   workspace_path: string;
   branch: string;
+  current_model?: string;
+  last_agent_request_at?: string;
   artifact?: Artifact;
   implementation_plan_path?: string;
   impl_feedback_ref: string | undefined;

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -1167,4 +1167,77 @@ describe('AgentServiceTelemetry onAgentRequest callback', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  test('question.answer calls onAgentRequest before drain completes with resolved model', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'ac-callback-question-'));
+    try {
+      const events: string[] = [];
+      const callbacks: Array<{ model: string; route: { task: string } }> = [];
+
+      const runner = fakeAgentRunner(async request => {
+        events.push('runner');
+        const match = request.prompt.match(/write it to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ answer: 'Yes.' }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string; route: { task: string } }) => {
+        events.push('callback');
+        callbacks.push(metadata);
+      });
+
+      const service = new AgentRunnerQuestionAnsweringAgent(runner, makePolicy(), repo);
+      await service.answer('Is it working?', { run_id: 'run-001', request_id: 'req-001', onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledOnce();
+      expect(callbacks[0].model).toBe('claude-sonnet-4-5');
+      expect(callbacks[0].route).toMatchObject({ task: 'question.answer' });
+      expect(events.slice(0, 2)).toEqual(['callback', 'runner']);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('issue.triage calls onAgentRequest before drain completes with resolved model', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-callback-triage-'));
+    try {
+      const events: string[] = [];
+      const callbacks: Array<{ model: string; route: { task: string } }> = [];
+
+      const runner = fakeAgentRunner(async request => {
+        events.push('runner');
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', items: [] }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string; route: { task: string } }) => {
+        events.push('callback');
+        callbacks.push(metadata);
+      });
+
+      const service = new AgentRunnerIssueTriageAgent(runner, makePolicy());
+      const request: Request = {
+        id: 'req-001',
+        channel,
+        conversation,
+        origin,
+        content: 'Bug: login broken',
+        author: 'U123',
+        received_at: new Date().toISOString(),
+      };
+      await service.triage(request, workspace, undefined, { run_id: 'run-001', request_id: 'req-001', onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledOnce();
+      expect(callbacks[0].model).toBe('claude-sonnet-4-5');
+      expect(callbacks[0].route).toMatchObject({ task: 'issue.triage' });
+      expect(events.slice(0, 2)).toEqual(['callback', 'runner']);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -1240,4 +1240,71 @@ describe('AgentServiceTelemetry onAgentRequest callback', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  test('relay progress events trigger heartbeat callbacks with is_heartbeat: true', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-heartbeat-'));
+    try {
+      const callbacks: Array<{ model: string; is_heartbeat?: boolean }> = [];
+
+      const runnerWithRelays: AgentRunner = {
+        async *run(request: AgentRunRequest): AsyncIterable<AgentRunEvent> {
+          const match = request.prompt.match(/write the result to:\s*(.+)/i);
+          const resultPath = match?.[1]?.trim();
+          if (!resultPath) throw new Error('result path not found');
+          await mkdir(dirname(resultPath), { recursive: true });
+          await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+          yield { type: 'assistant', content: [{ type: 'text', text: '[Relay] step one' }] };
+          yield { type: 'assistant', content: [{ type: 'text', text: '[Relay] step two' }] };
+        },
+      };
+
+      const onAgentRequest = vi.fn((metadata: { model: string; is_heartbeat?: boolean }) => {
+        callbacks.push(metadata);
+      });
+      const onProgress = vi.fn();
+      const service = new AgentRunnerArtifactAuthoringAgent(runnerWithRelays, makePolicy());
+      await service.create(makeRequest(), workspace, onProgress, 'idea', { onAgentRequest });
+
+      // Initial call + one heartbeat per relay message
+      expect(callbacks).toHaveLength(3);
+      expect(callbacks[0].is_heartbeat).toBeFalsy();
+      expect(callbacks[1].is_heartbeat).toBe(true);
+      expect(callbacks[2].is_heartbeat).toBe(true);
+      expect(callbacks[1].model).toBe('claude-sonnet-4-5');
+      expect(onProgress).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('no heartbeat callbacks when onProgress is absent', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-no-heartbeat-'));
+    try {
+      const callbacks: Array<{ model: string; is_heartbeat?: boolean }> = [];
+
+      const runnerWithRelays: AgentRunner = {
+        async *run(request: AgentRunRequest): AsyncIterable<AgentRunEvent> {
+          const match = request.prompt.match(/write the result to:\s*(.+)/i);
+          const resultPath = match?.[1]?.trim();
+          if (!resultPath) throw new Error('result path not found');
+          await mkdir(dirname(resultPath), { recursive: true });
+          await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+          yield { type: 'assistant', content: [{ type: 'text', text: '[Relay] step one' }] };
+        },
+      };
+
+      const onAgentRequest = vi.fn((metadata: { model: string; is_heartbeat?: boolean }) => {
+        callbacks.push(metadata);
+      });
+      // No onProgress — heartbeat wrapper should not be installed
+      const service = new AgentRunnerArtifactAuthoringAgent(runnerWithRelays, makePolicy());
+      await service.create(makeRequest(), workspace, undefined, 'idea', { onAgentRequest });
+
+      // Only the initial call, no heartbeat
+      expect(callbacks).toHaveLength(1);
+      expect(callbacks[0].is_heartbeat).toBeFalsy();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -983,3 +983,188 @@ describe('parseImplementationReviewResult', () => {
     expect(result.requires_human_retest).toBe(true);
   });
 });
+
+describe('AgentServiceTelemetry onAgentRequest callback', () => {
+  test('artifact.create calls onAgentRequest before drain completes with resolved model', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-callback-create-'));
+    try {
+      const events: string[] = [];
+      const callbacks: Array<{ model: string; route: { task: string } }> = [];
+      const calls: AgentRunRequest[] = [];
+
+      const runner = fakeAgentRunner(async request => {
+        events.push('runner');
+        calls.push(request);
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string; route: { task: string } }) => {
+        events.push('callback');
+        callbacks.push(metadata);
+      });
+
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+      await service.create(makeRequest(), workspace, undefined, 'idea', { run_id: 'run-001', request_id: 'req-001', onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledOnce();
+      expect(callbacks[0].model).toBe('claude-sonnet-4-5');
+      expect(callbacks[0].route).toMatchObject({ task: 'artifact.create' });
+      expect(events.slice(0, 2)).toEqual(['callback', 'runner']);
+      expect(calls[0].profile?.model).toBe('claude-sonnet-4-5');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('artifact.revise calls onAgentRequest before drain completes with resolved model', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-callback-revise-'));
+    try {
+      const events: string[] = [];
+      const callbacks: Array<{ model: string; route: { task: string } }> = [];
+
+      const artifactFilePath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      await mkdir(dirname(artifactFilePath), { recursive: true });
+      await writeFile(artifactFilePath, 'original content', 'utf8');
+
+      const runner = fakeAgentRunner(async request => {
+        events.push('runner');
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(artifactFilePath, 'revised content', 'utf8');
+        await writeFile(resultPath, JSON.stringify({ comment_responses: [] }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string; route: { task: string } }) => {
+        events.push('callback');
+        callbacks.push(metadata);
+      });
+
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+      await service.revise(makeFeedback(), [], artifactFilePath, workspace, undefined, undefined, { run_id: 'run-001', request_id: 'req-001', onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledOnce();
+      expect(callbacks[0].model).toBe('claude-sonnet-4-5');
+      expect(callbacks[0].route).toMatchObject({ task: 'artifact.revise' });
+      expect(events.slice(0, 2)).toEqual(['callback', 'runner']);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation.plan calls onAgentRequest before drain completes with resolved model', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-callback-plan-'));
+    try {
+      const events: string[] = [];
+      const callbacks: Array<{ model: string; route: { task: string } }> = [];
+      const calls: AgentRunRequest[] = [];
+
+      const specPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      const planPath = join(workspace, 'docs', 'superpowers', 'plans', '2026-05-24-feature-test.md');
+      await mkdir(dirname(specPath), { recursive: true });
+      await writeFile(specPath, '# Feature', 'utf8');
+
+      const runner = fakeAgentRunner(async request => {
+        events.push('runner');
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await mkdir(dirname(planPath), { recursive: true });
+        await writeFile(planPath, '# Plan', 'utf8');
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', plan_path: planPath }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string; route: { task: string } }) => {
+        events.push('callback');
+        callbacks.push(metadata);
+      });
+
+      const service = new AgentRunnerImplementationPlanningAgent(runner, makePolicy());
+      await service.plan(specPath, workspace, undefined, { run_id: 'run-001', request_id: 'req-001', onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledOnce();
+      expect(callbacks[0].model).toBe('claude-sonnet-4-5');
+      expect(callbacks[0].route).toMatchObject({ task: 'implementation.plan' });
+      expect(events.slice(0, 2)).toEqual(['callback', 'runner']);
+      expect(calls[0].profile?.model).toBe('claude-sonnet-4-5');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation.run calls onAgentRequest before drain completes with resolved model', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-callback-impl-'));
+    try {
+      const events: string[] = [];
+      const callbacks: Array<{ model: string; route: { task: string } }> = [];
+      const calls: AgentRunRequest[] = [];
+
+      const specPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      await mkdir(dirname(specPath), { recursive: true });
+      await writeFile(specPath, '# Feature', 'utf8');
+
+      const runner = fakeAgentRunner(async request => {
+        events.push('runner');
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'done' }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string; route: { task: string } }) => {
+        events.push('callback');
+        callbacks.push(metadata);
+      });
+
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+      await service.implement(specPath, workspace, undefined, undefined, { run_id: 'run-001', request_id: 'req-001', onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledOnce();
+      expect(callbacks[0].model).toBe('claude-sonnet-4-5');
+      expect(callbacks[0].route).toMatchObject({ task: 'implementation.run' });
+      expect(events.slice(0, 2)).toEqual(['callback', 'runner']);
+      expect(calls[0].profile?.model).toBe('claude-sonnet-4-5');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('missing profile.model is reported as unknown', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-callback-unknown-'));
+    try {
+      const callbacks: Array<{ model: string }> = [];
+
+      const policyWithoutModel = new DefaultAgentRoutingPolicy({
+        credentials: [{ name: 'api-key', type: 'api_key', value: 'test-key' }],
+        endpoints: [{ name: 'agent-ep', protocol: 'anthropic', credential: 'api-key' }],
+        profiles: [{ name: 'agent', endpoint: 'agent-ep', runner: 'claude_agent_sdk' }],
+        routing: { 'artifact.create': 'agent', 'artifact.revise': 'agent', 'implementation.plan': 'agent', 'implementation.run': 'agent', 'question.answer': 'agent', 'issue.triage': 'agent' },
+      });
+
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+      });
+
+      const onAgentRequest = vi.fn((metadata: { model: string }) => { callbacks.push(metadata); });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, policyWithoutModel);
+      await service.create(makeRequest(), workspace, undefined, 'idea', { onAgentRequest });
+
+      expect(callbacks[0].model).toBe('unknown');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -287,6 +287,34 @@ describe('ImplementationReviewCoordinator', () => {
     });
   });
 
+  describe('onAgentRequest callback', () => {
+    it('calls onAgentRequest with model, requested_at, and route when review profile is resolved', async () => {
+      const deps = makeDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const onAgentRequest = vi.fn();
+
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, onAgentRequest });
+
+      expect(onAgentRequest).toHaveBeenCalledWith(expect.objectContaining({
+        model: expect.any(String),
+        requested_at: expect.any(String),
+        route: expect.objectContaining({ task: 'implementation.review.initial' }),
+      }));
+    });
+
+    it('does not call onAgentRequest when no review profile is configured', async () => {
+      const deps = makeDeps({} as never, { routingPolicy: makeRoutingPolicy(null, null) });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const onAgentRequest = vi.fn();
+
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, onAgentRequest });
+
+      expect(onAgentRequest).not.toHaveBeenCalled();
+    });
+  });
+
   describe('review round telemetry', () => {
     it('logs implementation.review.round_started and round_completed', async () => {
       const deps = makeDeps();

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -373,4 +373,61 @@ describe('ImplementationReviewCoordinator', () => {
       expect(completed!['info_count']).toBe(1);
     });
   });
+
+  describe('runInitialReview — heartbeat callbacks', () => {
+    it('fires onAgentRequest with is_heartbeat: true on relay progress events', async () => {
+      const relayRunner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [{ type: 'text', text: '[Relay] reviewing now' }] };
+        })()),
+      };
+      const deps = makeDeps(undefined, { runner: relayRunner });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const callbacks: Array<{ is_heartbeat?: boolean }> = [];
+      const onAgentRequest = vi.fn((metadata: { is_heartbeat?: boolean }) => callbacks.push(metadata));
+      const onProgress = vi.fn();
+
+      await coordinator.runInitialReview({
+        run,
+        artifact_path: '/ws/spec.md',
+        implementation_result: makeCompleteResult(),
+        working_directory: WORKING_DIR,
+        onProgress,
+        onAgentRequest,
+      });
+
+      // Initial call (not heartbeat) + one heartbeat per relay event
+      expect(callbacks.length).toBeGreaterThanOrEqual(2);
+      expect(callbacks[0].is_heartbeat).toBeFalsy();
+      expect(callbacks.slice(1).every(c => c.is_heartbeat === true)).toBe(true);
+      expect(onProgress).toHaveBeenCalled();
+    });
+
+    it('no heartbeat callbacks when onProgress is absent', async () => {
+      const relayRunner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [{ type: 'text', text: '[Relay] reviewing now' }] };
+        })()),
+      };
+      const deps = makeDeps(undefined, { runner: relayRunner });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const callbacks: Array<{ is_heartbeat?: boolean }> = [];
+      const onAgentRequest = vi.fn((metadata: { is_heartbeat?: boolean }) => callbacks.push(metadata));
+
+      await coordinator.runInitialReview({
+        run,
+        artifact_path: '/ws/spec.md',
+        implementation_result: makeCompleteResult(),
+        working_directory: WORKING_DIR,
+        onAgentRequest,
+        // onProgress intentionally absent
+      });
+
+      // Only the initial call, no heartbeat
+      expect(callbacks).toHaveLength(1);
+      expect(callbacks[0].is_heartbeat).toBeFalsy();
+    });
+  });
 });

--- a/tests/core/commands/run-commands.test.ts
+++ b/tests/core/commands/run-commands.test.ts
@@ -52,6 +52,103 @@ describe('run.status handler', () => {
     expect(msg).toContain('idea');
   });
 
+  it('includes workspace immediately after run ID when workspace is allocated', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T01:12:00.000Z'));
+    try {
+      const runs = new Map<string, Run>();
+      runs.set('req-001', makeRun({ id: 'run-001', request_id: 'req-001', stage: 'intake', workspace_path: '/ws/req-001', updated_at: '2026-05-24T01:11:52.000Z' }));
+      const handler = makeRunStatusHandler(runs);
+      const reply = vi.fn().mockResolvedValue(undefined);
+
+      await handler(makeEvent({ inferred_context: { request_id: 'req-001' } }), reply);
+
+      expect(reply.mock.calls[0][0]).toBe([
+        '*Run:* `run-001`',
+        '*Workspace:* `/ws/req-001`',
+        '*Intent:* `idea`',
+        '*Stage:* `intake`',
+        '*Time in stage:* 8s',
+      ].join('\n'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows not yet allocated for empty or whitespace workspace paths', async () => {
+    const runs = new Map<string, Run>();
+    runs.set('req-001', makeRun({ request_id: 'req-001', workspace_path: '   ', stage: 'intake' }));
+    const handler = makeRunStatusHandler(runs);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ inferred_context: { request_id: 'req-001' } }), reply);
+
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('*Workspace:* not yet allocated');
+    expect(msg).not.toContain('*Workspace:* ``');
+  });
+
+  it('shows model and relative last request for AI-active stages with metadata', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T01:12:00.000Z'));
+    try {
+      const runs = new Map<string, Run>();
+      runs.set('req-001', makeRun({
+        id: 'run-001',
+        request_id: 'req-001',
+        stage: 'implementing',
+        workspace_path: '/ws/req-001',
+        current_model: 'claude-sonnet-4-5',
+        last_agent_request_at: '2026-05-24T01:09:00.000Z',
+        updated_at: '2026-05-24T01:00:48.000Z',
+      }));
+      const handler = makeRunStatusHandler(runs);
+      const reply = vi.fn().mockResolvedValue(undefined);
+
+      await handler(makeEvent({ inferred_context: { request_id: 'req-001' } }), reply);
+
+      expect(reply.mock.calls[0][0]).toBe([
+        '*Run:* `run-001`',
+        '*Workspace:* `/ws/req-001`',
+        '*Intent:* `idea`',
+        '*Stage:* `implementing`',
+        '*Time in stage:* 11m',
+        '*Model:* `claude-sonnet-4-5`',
+        '*Last request:* 3m ago',
+      ].join('\n'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows AI placeholders during AI-active stages before metadata is recorded', async () => {
+    const runs = new Map<string, Run>();
+    runs.set('req-001', makeRun({ request_id: 'req-001', stage: 'planning' }));
+    const handler = makeRunStatusHandler(runs);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    await handler(makeEvent({ inferred_context: { request_id: 'req-001' } }), reply);
+
+    const msg = reply.mock.calls[0][0] as string;
+    expect(msg).toContain('*Model:* not yet requested');
+    expect(msg).toContain('*Last request:* not yet requested');
+  });
+
+  it('omits stale AI metadata for waiting and terminal stages', async () => {
+    for (const stage of ['awaiting_impl_input', 'awaiting_planning_input', 'done', 'failed'] as const) {
+      const runs = new Map<string, Run>();
+      runs.set('req-001', makeRun({ request_id: 'req-001', stage, current_model: 'claude-sonnet-4-5', last_agent_request_at: '2026-05-24T01:09:00.000Z' }));
+      const handler = makeRunStatusHandler(runs);
+      const reply = vi.fn().mockResolvedValue(undefined);
+
+      await handler(makeEvent({ inferred_context: { request_id: 'req-001' } }), reply);
+
+      const msg = reply.mock.calls[0][0] as string;
+      expect(msg).not.toContain('*Model:*');
+      expect(msg).not.toContain('*Last request:*');
+    }
+  });
+
   it('with explicit request_id as first arg → looks up by request_id; replies correctly', async () => {
     const runs = new Map<string, Run>();
     runs.set('req-001', makeRun({ request_id: 'req-001', stage: 'implementing' }));

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -140,7 +140,7 @@ describe('buildDefaultHandlerRegistry', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(run.stage).toBe('reviewing_implementation');
@@ -204,7 +204,7 @@ describe('buildDefaultHandlerRegistry', () => {
       '/ws/request-001/context-human/specs/typed-feature.md',
       '/ws/request-001',
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       'Use the adapter composition path.',
     );
     expect(deps.implementer.implement).toHaveBeenCalled();
@@ -376,7 +376,7 @@ describe('buildDefaultHandlerRegistry', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(run.stage).toBe('reviewing_implementation');

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -83,7 +83,7 @@ describe('ArtifactCreationHandler', () => {
     await handler.handle(run, request, 'idea');
 
     expect(deps.workspaceManager.create).toHaveBeenCalledWith('request-001', 'https://example.test/org/repo.git', '/tmp/workspaces');
-    expect(deps.artifactAuthoringAgent.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), undefined, { run_id: 'run-001', request_id: 'request-001' });
+    expect(deps.artifactAuthoringAgent.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), undefined, expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }));
     expect(deps.artifactPublisher.createArtifact).toHaveBeenCalledWith(
       TEST_CONVERSATION,
       expect.objectContaining({
@@ -116,7 +116,7 @@ describe('ArtifactCreationHandler', () => {
 
     await handler.handle(run, request, 'bug');
 
-    expect(deps.artifactAuthoringAgent.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), 'bug', { run_id: 'run-001', request_id: 'request-001' });
+    expect(deps.artifactAuthoringAgent.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), 'bug', expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }));
     expect(run.issue).toBe(42);
     expect(run.artifact).toMatchObject({
       kind: 'bug_triage',
@@ -209,6 +209,26 @@ describe('ArtifactCreationHandler', () => {
     expect(deps.postMessage).toHaveBeenCalledWith(
       TEST_CONVERSATION,
       'Artifact ready for review: https://artifact.example.test/CANVAS001',
+    );
+  });
+
+  it('onAgentRequest callback updates run fields and persists', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ intent: 'idea' });
+    const request = makeRequest();
+
+    await handler.handle(run, request, 'idea');
+
+    const createCall = (deps.artifactAuthoringAgent.create as ReturnType<typeof vi.fn>).mock.calls[0];
+    const telemetry = createCall[4] as { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void };
+    telemetry.onAgentRequest?.({ model: 'claude-opus-4-5', requested_at: '2026-01-01T00:00:00.000Z', route: { task: 'some.task' } });
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
+      expect.any(String),
     );
   });
 

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -65,8 +65,10 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactFee
     postMessage: vi.fn().mockResolvedValue(undefined),
     transition: vi.fn((run: Run, stage: Run['stage']) => { run.stage = stage; }),
     failRun: vi.fn().mockResolvedValue(undefined),
+    persist: vi.fn(),
     logger: {
       debug: vi.fn(),
+      info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
     },
@@ -102,7 +104,7 @@ describe('ArtifactFeedbackHandler', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
     );
     expect(deps.artifactPublisher.updateArtifact).toHaveBeenCalledWith(
       'CANVAS-TYPED',
@@ -159,7 +161,7 @@ describe('ArtifactFeedbackHandler', () => {
       '/ws/request-001',
       '# Current\n\n<span discussion-urls="discussion://disc-1">text</span>',
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
     );
     expect(deps.artifactPublisher.updateArtifact).toHaveBeenCalledWith(
       'CANVAS001',
@@ -197,7 +199,7 @@ describe('ArtifactFeedbackHandler', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
     );
     expect(deps.failRun).not.toHaveBeenCalled();
     expect(run.stage).toBe('reviewing_spec');
@@ -253,6 +255,26 @@ describe('ArtifactFeedbackHandler', () => {
     expect(result).toEqual({ status: 'failed' });
     expect(deps.failRun).toHaveBeenCalledWith(run, expect.anything(), branchDriftError);
     expect(deps.artifactPublisher.updateArtifact).not.toHaveBeenCalled();
+  });
+
+  it('onAgentRequest callback updates run fields and persists', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+    const feedback = makeFeedback();
+
+    await handler.handle(run, feedback);
+
+    const reviseCall = (deps.artifactAuthoringAgent.revise as ReturnType<typeof vi.fn>).mock.calls[0];
+    const telemetry = reviseCall[6] as { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void };
+    telemetry.onAgentRequest?.({ model: 'claude-opus-4-5', requested_at: '2026-01-01T00:00:00.000Z', route: { task: 'some.task' } });
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
+      expect.any(String),
+    );
   });
 
   it('does not fail the run when replying to a publisher comment or notifying the channel fails', async () => {

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -459,6 +459,30 @@ describe('ImplementationApprovalHandler with reviewCoordinator', () => {
     expect(result).toEqual({ status: 'pr_open' });
   });
 
+  it('onAgentRequest callback passed to runFinalReview updates run fields and persists', async () => {
+    let capturedOnAgentRequest: ((metadata: { model: string; requested_at: string; route: { task: string } }) => void) | undefined;
+    const coord = {
+      runFinalReview: vi.fn().mockImplementation(async (params: { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void }) => {
+        capturedOnAgentRequest = params.onAgentRequest;
+        return { status: 'complete', summary: 'Done.', requires_human_retest: false, testing_steps: ['npm test'], review_summary: { changes: ['A'], confirm: ['B'] } };
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    capturedOnAgentRequest?.({ model: 'claude-opus-4-5', requested_at: '2026-01-01T00:00:00.000Z', route: { task: 'some.task' } });
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
+      expect.any(String),
+    );
+  });
+
   it('passes structured implementation result fields into final review', async () => {
     const coord = makeReviewCoordinator();
     const { handler } = makeHandler({ reviewCoordinator: coord });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -123,7 +123,7 @@ describe('ImplementationFeedbackHandler', () => {
       '/ws/request-001',
       expect.any(String),     // additionalContext
       expect.any(Function),   // onProgress
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
     );
     expect(deps.failRun).not.toHaveBeenCalled();
   });
@@ -150,7 +150,7 @@ describe('ImplementationFeedbackHandler', () => {
       '/ws/request-001',
       expect.stringContaining('Fix the bug'),
       expect.any(Function),   // onProgress
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
     );
     const context = (deps.implementer.implement as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
     expect(context).toContain('Some context');
@@ -182,7 +182,7 @@ describe('ImplementationFeedbackHandler', () => {
       '/ws/request-001',
       'use adapter composition',
       expect.any(Function),   // onProgress
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
     );
   });
 
@@ -302,6 +302,25 @@ describe('ImplementationFeedbackHandler', () => {
     expect(context).toBe('please check the edge case');
     expect(deps.logger.info).toHaveBeenCalledWith(
       expect.objectContaining({ event: 'implementation.feedback_empty', run_id: 'run-001' }),
+      expect.any(String),
+    );
+  });
+
+  it('onAgentRequest callback updates run fields and persists', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    const implementCall = (deps.implementer.implement as ReturnType<typeof vi.fn>).mock.calls[0];
+    const telemetry = implementCall[4] as { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void };
+    telemetry.onAgentRequest?.({ model: 'claude-opus-4-5', requested_at: '2026-01-01T00:00:00.000Z', route: { task: 'some.task' } });
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
       expect.any(String),
     );
   });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -542,4 +542,24 @@ describe('ImplementationFeedbackHandler with reviewCoordinator', () => {
     expect(result).toEqual({ status: 'updated' });
     expect(deps.implFeedbackPage?.update).toHaveBeenCalled();
   });
+
+  it('passes onAgentRequest to runInitialReview so review agent updates run metadata', async () => {
+    let capturedOnAgentRequest: ((metadata: { model: string; requested_at: string; route: { task: string } }) => void) | undefined;
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockImplementation(async (params: { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void }) => {
+        capturedOnAgentRequest = params.onAgentRequest;
+        return { status: 'complete', summary: 'Review ok', testing_instructions: 'npm test' };
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun({ impl_feedback_ref: 'page-id' });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(capturedOnAgentRequest).toBeDefined();
+    capturedOnAgentRequest?.({ model: 'claude-opus-4-7', requested_at: '2026-01-02T00:00:00.000Z', route: { task: 'implementation.review.initial' } });
+    expect(run.current_model).toBe('claude-opus-4-7');
+    expect(run.last_agent_request_at).toBe('2026-01-02T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+  });
 });

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -470,6 +470,26 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     expect(deps.implFeedbackPage?.create).toHaveBeenCalled();
   });
 
+  it('passes onAgentRequest to runInitialReview so review agent updates run metadata', async () => {
+    let capturedOnAgentRequest: ((metadata: { model: string; requested_at: string; route: { task: string } }) => void) | undefined;
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockImplementation(async (params: { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void }) => {
+        capturedOnAgentRequest = params.onAgentRequest;
+        return { status: 'complete', summary: 'Review ok', testing_instructions: 'npm test' };
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(capturedOnAgentRequest).toBeDefined();
+    capturedOnAgentRequest?.({ model: 'claude-opus-4-7', requested_at: '2026-01-02T00:00:00.000Z', route: { task: 'implementation.review.initial' } });
+    expect(run.current_model).toBe('claude-opus-4-7');
+    expect(run.last_agent_request_at).toBe('2026-01-02T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+  });
+
   it('posts a labeled testing-guide link when PublishedImplementationReview includes label and url', async () => {
     const { handler, deps } = makeHandler({
       implFeedbackPage: {

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -137,7 +137,7 @@ describe('ImplementationStartHandler', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith({
@@ -170,7 +170,7 @@ describe('ImplementationStartHandler', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith({
@@ -198,6 +198,25 @@ describe('ImplementationStartHandler', () => {
       testing_steps: ['cd /ws/request-001', 'npm install', 'npm test'],
     });
     expect(run.stage).toBe('reviewing_implementation');
+  });
+
+  it('onAgentRequest callback updates run fields and persists', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    const implementCall = (deps.implementer.implement as ReturnType<typeof vi.fn>).mock.calls[0];
+    const telemetry = implementCall[4] as { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void };
+    telemetry.onAgentRequest?.({ model: 'claude-opus-4-5', requested_at: '2026-01-01T00:00:00.000Z', route: { task: 'some.task' } });
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
+      expect.any(String),
+    );
   });
 
   it('relays implementation progress to the channel without failing on post errors', async () => {

--- a/tests/core/handlers/issue-filing-handler.test.ts
+++ b/tests/core/handlers/issue-filing-handler.test.ts
@@ -64,6 +64,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof IssueFiling
     postMessage: vi.fn().mockResolvedValue(undefined),
     transition: vi.fn((run: Run, stage: Run['stage']) => { run.stage = stage; }),
     failRun: vi.fn().mockResolvedValue(undefined),
+    persist: vi.fn(),
     reactToRunMessage: vi.fn().mockResolvedValue(undefined),
     reacjiComplete: 'white_check_mark',
     logger: {
@@ -89,7 +90,7 @@ describe('IssueFilingHandler', () => {
     expect(deps.workspaceManager.create).toHaveBeenCalledWith('request-001', 'https://example.test/org/repo.git', '/tmp/workspaces');
     expect(run.workspace_path).toBe('/ws/request-001');
     expect(run.branch).toBe('file/request-001');
-    expect(deps.issueFiler.file).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), { run_id: 'run-001', request_id: 'request-001' });
+    expect(deps.issueFiler.file).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }));
     expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
     expect(deps.postMessage).toHaveBeenCalledWith(TEST_CONVERSATION, 'Filed 1 new issue: #10 New issue');
     expect(deps.logger.info).toHaveBeenCalledWith(
@@ -155,6 +156,27 @@ describe('IssueFilingHandler', () => {
     expect(result).toEqual({ status: 'failed' });
     expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
     expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, expect.any(Error));
+  });
+
+  it('passes onAgentRequest to issueFiler.file() and updates run metadata when callback fires', async () => {
+    let capturedOnAgentRequest: ((metadata: { model: string; requested_at: string; route: { task: string } }) => void) | undefined;
+    const { handler, deps } = makeHandler({
+      issueFiler: {
+        file: vi.fn().mockImplementation(async (_req, _ws, _progress, telemetry: { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void }) => {
+          capturedOnAgentRequest = telemetry?.onAgentRequest;
+          return { status: 'complete', summary: 'Filed 1 issue', filed_issues: [] };
+        }),
+      },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeRequest());
+
+    expect(capturedOnAgentRequest).toBeDefined();
+    capturedOnAgentRequest?.({ model: 'claude-sonnet-4-6', requested_at: '2026-01-03T00:00:00.000Z', route: { task: 'issue.triage' } });
+    expect(run.current_model).toBe('claude-sonnet-4-6');
+    expect(run.last_agent_request_at).toBe('2026-01-03T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
   });
 
   it('continues to done when workspace cleanup, summary notification, or completion reaction fail', async () => {

--- a/tests/core/handlers/planning-handler.test.ts
+++ b/tests/core/handlers/planning-handler.test.ts
@@ -85,7 +85,7 @@ describe('PlanningHandler', () => {
       '/ws/request-001/context-human/specs/feature-test.md',
       '/ws/request-001',
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       undefined,
     );
     expect(run.implementation_plan_path).toBe('/ws/request-001/docs/superpowers/plans/implementation-plan.md');
@@ -122,8 +122,27 @@ describe('PlanningHandler', () => {
       '/ws/request-001/context-human/specs/feature-test.md',
       '/ws/request-001',
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       'Use the adapter composition path.',
+    );
+  });
+
+  it('onAgentRequest callback updates run fields and persists', async () => {
+    const { handler, deps } = makeHandler();
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    const planCall = (deps.planner.plan as ReturnType<typeof vi.fn>).mock.calls[0];
+    const telemetry = planCall[3] as { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void };
+    telemetry.onAgentRequest?.({ model: 'claude-opus-4-5', requested_at: '2026-01-01T00:00:00.000Z', route: { task: 'some.task' } });
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
+      expect.any(String),
     );
   });
 

--- a/tests/core/handlers/question-handler.test.ts
+++ b/tests/core/handlers/question-handler.test.ts
@@ -35,6 +35,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof QuestionHan
     },
     postMessage: vi.fn().mockResolvedValue(undefined),
     postError: vi.fn().mockResolvedValue(undefined),
+    persist: vi.fn(),
     logger: {
       info: vi.fn(),
       error: vi.fn(),
@@ -51,7 +52,7 @@ describe('QuestionHandler', () => {
 
     const result = await handler.handle('What changed?', TEST_CONVERSATION, makeRun());
 
-    expect(deps.questionAnswerer?.answer).toHaveBeenCalledWith('What changed?', { run_id: 'run-001', request_id: 'request-001' });
+    expect(deps.questionAnswerer?.answer).toHaveBeenCalledWith('What changed?', expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }));
     expect(deps.postMessage).toHaveBeenCalledWith(TEST_CONVERSATION, 'Here is the answer.');
     expect(result.status).toBe('answered');
   });
@@ -84,6 +85,44 @@ describe('QuestionHandler', () => {
 
     expect(deps.postMessage).toHaveBeenCalledWith(TEST_CONVERSATION, expect.stringContaining('coming soon'));
     expect(result.status).toBe('not_configured');
+  });
+
+  it('passes onAgentRequest in AI-active stages and updates run metadata when callback fires', async () => {
+    let capturedTelemetry: { onAgentRequest?: (metadata: { model: string; requested_at: string; route: { task: string } }) => void } | undefined;
+    const { handler, deps } = makeHandler({
+      questionAnswerer: {
+        answer: vi.fn().mockImplementation(async (_q: string, telemetry: typeof capturedTelemetry) => {
+          capturedTelemetry = telemetry;
+          return 'Answer.';
+        }),
+      },
+    });
+    const run = makeRun({ stage: 'reviewing_spec' });
+
+    await handler.handle('What changed?', TEST_CONVERSATION, run);
+
+    expect(capturedTelemetry?.onAgentRequest).toBeDefined();
+    capturedTelemetry?.onAgentRequest?.({ model: 'claude-sonnet-4-6', requested_at: '2026-01-04T00:00:00.000Z', route: { task: 'question.answer' } });
+    expect(run.current_model).toBe('claude-sonnet-4-6');
+    expect(run.last_agent_request_at).toBe('2026-01-04T00:00:00.000Z');
+    expect(deps.persist).toHaveBeenCalled();
+  });
+
+  it('does not pass onAgentRequest for non-AI-active stages (e.g. new_thread)', async () => {
+    let capturedTelemetry: { onAgentRequest?: unknown } | undefined;
+    const { handler } = makeHandler({
+      questionAnswerer: {
+        answer: vi.fn().mockImplementation(async (_q: string, telemetry: typeof capturedTelemetry) => {
+          capturedTelemetry = telemetry;
+          return 'Answer.';
+        }),
+      },
+    });
+    const run = makeRun({ stage: 'done' });
+
+    await handler.handle('What changed?', TEST_CONVERSATION, run);
+
+    expect(capturedTelemetry?.onAgentRequest).toBeUndefined();
   });
 
   it('does not throw when posting the response fails', async () => {

--- a/tests/core/handlers/question-handler.test.ts
+++ b/tests/core/handlers/question-handler.test.ts
@@ -97,7 +97,7 @@ describe('QuestionHandler', () => {
         }),
       },
     });
-    const run = makeRun({ stage: 'reviewing_spec' });
+    const run = makeRun({ stage: 'speccing' });
 
     await handler.handle('What changed?', TEST_CONVERSATION, run);
 

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -434,7 +434,7 @@ describe('Orchestrator — new_request happy path', () => {
     await orch.stop();
 
     expect(wm.create).toHaveBeenCalledWith('request-001', 'https://github.com/org/repo.git', '~/.autocatalyst/workspaces');
-    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), undefined, { run_id: expect.any(String), request_id: 'request-001' });
+    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), undefined, expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }));
     expect(cp.createArtifact).toHaveBeenCalledWith(
       expect.objectContaining({ provider: 'slack', channel_id: 'C123', conversation_id: '100.0' }),
       expect.objectContaining({ kind: 'feature_spec', local_path: '/ws/request-001/context-human/specs/feature-test.md' }),
@@ -571,7 +571,7 @@ describe('Orchestrator — feedback happy path', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: expect.any(String), request_id: 'request-001' },
+      expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }),
     );
     expect(cp.updateArtifact).toHaveBeenCalledWith(
       'CANVAS001',
@@ -809,7 +809,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
       expect.any(String),
       undefined,
       expect.any(Function),
-      { run_id: expect.any(String), request_id: 'request-001' },
+      expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }),
     );
     expect(fs.reply).toHaveBeenCalledTimes(2);
     expect(fs.reply).toHaveBeenCalledWith('CANVAS001', 'disc-1', 'Updated per Phoebe');
@@ -839,7 +839,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
       expect.any(String),
       undefined,
       expect.any(Function),
-      { run_id: expect.any(String), request_id: 'request-001' },
+      expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }),
     );
     expect(fs.reply).not.toHaveBeenCalled();
   });
@@ -866,7 +866,7 @@ describe('Orchestrator — feedback with feedbackSource', () => {
       expect.any(String),
       undefined,
       expect.any(Function),
-      { run_id: expect.any(String), request_id: 'request-001' },
+      expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }),
     );
   });
 
@@ -1470,7 +1470,7 @@ describe('Orchestrator — _handleSpecApproval happy path', () => {
       '/ws/request-001',
       undefined,
       expect.any(Function),
-      { run_id: 'run-001', request_id: 'request-001' },
+      expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
       '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
   });
@@ -4828,7 +4828,7 @@ describe('Orchestrator — bug and chore routing', () => {
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), 'bug', { run_id: expect.any(String), request_id: 'request-001' });
+    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), 'bug', expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }));
   });
 
   it('chore routing: artifactAuthoringAgent.create called with intent=chore', async () => {
@@ -4845,7 +4845,7 @@ describe('Orchestrator — bug and chore routing', () => {
     await new Promise(r => setTimeout(r, 50));
     await orch.stop();
 
-    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), 'chore', { run_id: expect.any(String), request_id: 'request-001' });
+    expect(sg.create).toHaveBeenCalledWith(request, '/ws/request-001', expect.any(Function), 'chore', expect.objectContaining({ run_id: expect.any(String), request_id: 'request-001' }));
   });
 });
 
@@ -6491,5 +6491,75 @@ describe('OrchestratorImpl — work_on_issue two-stage classification', () => {
     });
     const runs = [...orch.getRuns().values()];
     expect(runs[0].intent).toBe('idea');
+  });
+});
+
+describe('Orchestrator — AI context clearing on stage transition', () => {
+  function makeMinimalOrch() {
+    const adapter = makeMockAdapter();
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+        artifactPublisher: makeArtifactPublisher(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        channelRepoMap: makeChannelRepoMap(),
+        intentClassifier: makeIntentClassifier('feedback'),
+      },
+      { logDestination: nullDest },
+    );
+    return { orch, adapter };
+  }
+
+  it('clears current_model and last_agent_request_at when transitioning to a non-AI-active stage', async () => {
+    const { orch } = makeMinimalOrch();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    const run = makeRun({ stage: 'implementing', current_model: 'claude-opus-4-5', last_agent_request_at: '2026-01-01T00:00:00.000Z' });
+    runs.set('request-001', run);
+
+    const transition = (orch as unknown as { transition: (run: Run, stage: Run['stage']) => void }).transition.bind(orch);
+    transition(run, 'pr_open');
+
+    expect(run.current_model).toBeUndefined();
+    expect(run.last_agent_request_at).toBeUndefined();
+  });
+
+  it('preserves current_model and last_agent_request_at when transitioning to an AI-active stage', async () => {
+    const { orch } = makeMinimalOrch();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    const run = makeRun({ stage: 'speccing', current_model: 'claude-opus-4-5', last_agent_request_at: '2026-01-01T00:00:00.000Z' });
+    runs.set('request-001', run);
+
+    const transition = (orch as unknown as { transition: (run: Run, stage: Run['stage']) => void }).transition.bind(orch);
+    transition(run, 'implementing');
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('overrideRunStage clears context when transitioning to a non-AI-active stage', () => {
+    const { orch } = makeMinimalOrch();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    const run = makeRun({ stage: 'implementing', current_model: 'claude-opus-4-5', last_agent_request_at: '2026-01-01T00:00:00.000Z' });
+    runs.set('request-001', run);
+
+    orch.overrideRunStage('request-001', 'pr_open');
+
+    expect(run.current_model).toBeUndefined();
+    expect(run.last_agent_request_at).toBeUndefined();
+  });
+
+  it('overrideRunStage preserves context when transitioning to an AI-active stage', () => {
+    const { orch } = makeMinimalOrch();
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    const run = makeRun({ stage: 'speccing', current_model: 'claude-opus-4-5', last_agent_request_at: '2026-01-01T00:00:00.000Z' });
+    runs.set('request-001', run);
+
+    orch.overrideRunStage('request-001', 'implementing');
+
+    expect(run.current_model).toBe('claude-opus-4-5');
+    expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
   });
 });

--- a/tests/core/run-ai-context.test.ts
+++ b/tests/core/run-ai-context.test.ts
@@ -33,12 +33,12 @@ function makeRun(overrides: Partial<Run> = {}): Run {
 
 describe('run AI context helpers', () => {
   it('defines the approved AI-active stage set', () => {
-    expect([...AI_ACTIVE_STAGES]).toEqual(['speccing', 'planning', 'implementing']);
+    expect([...AI_ACTIVE_STAGES]).toEqual(['speccing', 'reviewing_spec', 'planning', 'implementing', 'reviewing_implementation']);
     expect(isAiActiveStage('speccing')).toBe(true);
+    expect(isAiActiveStage('reviewing_spec')).toBe(true);
     expect(isAiActiveStage('planning')).toBe(true);
     expect(isAiActiveStage('implementing')).toBe(true);
-    expect(isAiActiveStage('reviewing_spec')).toBe(false);
-    expect(isAiActiveStage('reviewing_implementation')).toBe(false);
+    expect(isAiActiveStage('reviewing_implementation')).toBe(true);
     expect(isAiActiveStage('awaiting_planning_input')).toBe(false);
     expect(isAiActiveStage('awaiting_impl_input')).toBe(false);
     expect(isAiActiveStage('pr_open')).toBe(false);
@@ -97,6 +97,25 @@ describe('run AI context helpers', () => {
       },
       'Agent request metadata recorded',
     );
+  });
+
+  it('recorder does not log for heartbeat calls but still mutates and persists', () => {
+    const run = makeRun();
+    const persist = vi.fn();
+    const logger = { info: vi.fn() };
+    const recorder = makeRunAgentRequestRecorder(run, persist, logger);
+
+    recorder({
+      model: 'claude-sonnet-4-5',
+      requested_at: '2026-05-24T01:05:00.000Z',
+      route: { task: 'implementation.run' },
+      is_heartbeat: true,
+    });
+
+    expect(run.current_model).toBe('claude-sonnet-4-5');
+    expect(run.last_agent_request_at).toBe('2026-05-24T01:05:00.000Z');
+    expect(persist).toHaveBeenCalledOnce();
+    expect(logger.info).not.toHaveBeenCalled();
   });
 
   it('recorder uses unknown for blank model', () => {

--- a/tests/core/run-ai-context.test.ts
+++ b/tests/core/run-ai-context.test.ts
@@ -33,12 +33,12 @@ function makeRun(overrides: Partial<Run> = {}): Run {
 
 describe('run AI context helpers', () => {
   it('defines the approved AI-active stage set', () => {
-    expect([...AI_ACTIVE_STAGES]).toEqual(['speccing', 'reviewing_spec', 'planning', 'implementing', 'reviewing_implementation']);
+    expect([...AI_ACTIVE_STAGES]).toEqual(['speccing', 'planning', 'implementing']);
     expect(isAiActiveStage('speccing')).toBe(true);
-    expect(isAiActiveStage('reviewing_spec')).toBe(true);
     expect(isAiActiveStage('planning')).toBe(true);
     expect(isAiActiveStage('implementing')).toBe(true);
-    expect(isAiActiveStage('reviewing_implementation')).toBe(true);
+    expect(isAiActiveStage('reviewing_spec')).toBe(false);
+    expect(isAiActiveStage('reviewing_implementation')).toBe(false);
     expect(isAiActiveStage('awaiting_planning_input')).toBe(false);
     expect(isAiActiveStage('awaiting_impl_input')).toBe(false);
     expect(isAiActiveStage('pr_open')).toBe(false);

--- a/tests/core/run-ai-context.test.ts
+++ b/tests/core/run-ai-context.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AI_ACTIVE_STAGES,
+  clearAgentRequestContext,
+  isAiActiveStage,
+  makeRunAgentRequestRecorder,
+  recordAgentRequest,
+} from '../../src/core/run-ai-context.js';
+import type { Run } from '../../src/types/runs.js';
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-001',
+    request_id: 'req-001',
+    intent: 'idea',
+    stage: 'speccing',
+    workspace_path: '/ws/req-001',
+    branch: 'feature/req-001',
+    artifact: undefined,
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 0,
+    channel: undefined,
+    conversation: undefined,
+    origin: undefined,
+    pr_url: undefined,
+    last_impl_result: undefined,
+    created_at: '2026-05-24T00:00:00.000Z',
+    updated_at: '2026-05-24T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('run AI context helpers', () => {
+  it('defines the approved AI-active stage set', () => {
+    expect([...AI_ACTIVE_STAGES]).toEqual(['speccing', 'reviewing_spec', 'planning', 'implementing', 'reviewing_implementation']);
+    expect(isAiActiveStage('speccing')).toBe(true);
+    expect(isAiActiveStage('reviewing_spec')).toBe(true);
+    expect(isAiActiveStage('planning')).toBe(true);
+    expect(isAiActiveStage('implementing')).toBe(true);
+    expect(isAiActiveStage('reviewing_implementation')).toBe(true);
+    expect(isAiActiveStage('awaiting_planning_input')).toBe(false);
+    expect(isAiActiveStage('awaiting_impl_input')).toBe(false);
+    expect(isAiActiveStage('pr_open')).toBe(false);
+    expect(isAiActiveStage('done')).toBe(false);
+    expect(isAiActiveStage('failed')).toBe(false);
+  });
+
+  it('records model and timestamp, using unknown for blank model names', () => {
+    const run = makeRun();
+    recordAgentRequest(run, 'claude-sonnet-4-5', new Date('2026-05-24T01:02:03.004Z'));
+    expect(run.current_model).toBe('claude-sonnet-4-5');
+    expect(run.last_agent_request_at).toBe('2026-05-24T01:02:03.004Z');
+
+    recordAgentRequest(run, '   ', new Date('2026-05-24T01:03:00.000Z'));
+    expect(run.current_model).toBe('unknown');
+    expect(run.last_agent_request_at).toBe('2026-05-24T01:03:00.000Z');
+  });
+
+  it('records unknown when model is undefined', () => {
+    const run = makeRun();
+    recordAgentRequest(run, undefined, new Date('2026-05-24T01:02:03.004Z'));
+    expect(run.current_model).toBe('unknown');
+  });
+
+  it('clears both metadata fields', () => {
+    const run = makeRun({ current_model: 'claude-sonnet-4-5', last_agent_request_at: '2026-05-24T01:02:03.004Z' });
+    clearAgentRequestContext(run);
+    expect(run.current_model).toBeUndefined();
+    expect(run.last_agent_request_at).toBeUndefined();
+  });
+
+  it('recorder callback mutates, persists, and logs route fields', () => {
+    const run = makeRun();
+    const persist = vi.fn();
+    const logger = { info: vi.fn() };
+    const recorder = makeRunAgentRequestRecorder(run, persist, logger);
+
+    recorder({
+      model: 'claude-sonnet-4-5',
+      requested_at: '2026-05-24T01:02:03.004Z',
+      route: { task: 'implementation.run', stage: 'implementing', intent: 'idea' },
+    });
+
+    expect(run.current_model).toBe('claude-sonnet-4-5');
+    expect(run.last_agent_request_at).toBe('2026-05-24T01:02:03.004Z');
+    expect(persist).toHaveBeenCalledOnce();
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: 'run.agent_request_recorded',
+        run_id: 'run-001',
+        request_id: 'req-001',
+        model: 'claude-sonnet-4-5',
+        route_task: 'implementation.run',
+        route_stage: 'implementing',
+        route_intent: 'idea',
+      },
+      'Agent request metadata recorded',
+    );
+  });
+
+  it('recorder uses unknown for blank model', () => {
+    const run = makeRun();
+    const persist = vi.fn();
+    const logger = { info: vi.fn() };
+    const recorder = makeRunAgentRequestRecorder(run, persist, logger);
+
+    recorder({
+      model: '  ',
+      requested_at: '2026-05-24T01:02:03.004Z',
+      route: { task: 'artifact.create' },
+    });
+
+    expect(run.current_model).toBe('unknown');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'unknown' }),
+      'Agent request metadata recorded',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- AI_ACTIVE_STAGES now includes reviewing_spec and reviewing_implementation, matching the approved spec
- run-ai-context.test.ts updated to assert all 5 AI-active stages and added test verifying heartbeat calls do not emit log entries
- agent-services.test.ts: two new tests covering relay-triggered heartbeat callbacks (is_heartbeat: true) and the no-heartbeat case when onProgress is absent
- implementation-review-coordinator.test.ts: two new tests verifying coordinator fires is_heartbeat callbacks on relay progress and skips them when onProgress is absent

## Verify

- [ ] ac-run-status shows Model and Last request lines when a run is in reviewing_spec or reviewing_implementation stage
- [ ] Heartbeat callbacks fire once per relay message with is_heartbeat: true alongside the normal onProgress call
- [ ] No structured log entry is emitted for heartbeat-flagged onAgentRequest calls
- [ ] All 1276 tests pass (npm test)

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/6308d9e8-12c0-48e2-9d78-9737a64be72b
2. npm test

---
Spec: `context-human/specs/enhancement-run-status-workspace-ai-context.md`
Closes #184