### PR TITLE
fix: disable local snapshot persistence in openai agent sdk runner

### DIFF
--- a/src/adapters/openai/agent-sdk-agent-runner.ts
+++ b/src/adapters/openai/agent-sdk-agent-runner.ts
@@ -1,7 +1,7 @@
 import { run as _run, OpenAIResponsesModel, setTracingDisabled, type Agent } from '@openai/agents';
 import { SandboxAgent, type Capability, filesystem, shell, compaction } from '@openai/agents/sandbox';
 import { UnixLocalSandboxClient, type UnixLocalSandboxSessionState } from '@openai/agents/sandbox/local';
-import { Manifest } from '@openai/agents/sandbox';
+import { Manifest, NoopSnapshotSpec } from '@openai/agents/sandbox';
 import OpenAI from 'openai';
 import type pino from 'pino';
 import type { LoggerProvider } from '@opentelemetry/api-logs';
@@ -27,6 +27,10 @@ type RunFn = (
   workingDirectory: string,
   options: RunFnOptions,
 ) => AsyncIterable<unknown> | Promise<AsyncIterable<unknown>>;
+
+type NoopSnapshotSessionState = UnixLocalSandboxSessionState & {
+  snapshotSpec: NoopSnapshotSpec;
+};
 
 export interface OpenAIAgentSdkAgentRunnerOptions {
   runFn?: RunFn;
@@ -299,12 +303,14 @@ async function* defaultRunFn(
   workingDirectory: string,
   options: RunFnOptions,
 ): AsyncIterable<unknown> {
-  const client = new UnixLocalSandboxClient();
-  const state: UnixLocalSandboxSessionState = {
+  const snapshot = new NoopSnapshotSpec();
+  const client = new UnixLocalSandboxClient({ snapshot });
+  const state: NoopSnapshotSessionState = {
     manifest: new Manifest(),
     workspaceRootPath: workingDirectory,
     workspaceRootOwned: false,
     environment: options.environment,
+    snapshotSpec: snapshot,
   };
   const session = await client.resume(state);
   const sandbox = { client, session };

--- a/tests/adapters/openai/agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/openai/agent-sdk-agent-runner.test.ts
@@ -17,13 +17,20 @@ vi.mock('@openai/agents', async importOriginal => {
   };
 });
 
+let capturedClientOptions: unknown;
 let capturedResumeState: unknown;
+let capturedResumedSession: unknown;
 
 vi.mock('@openai/agents/sandbox/local', () => ({
   UnixLocalSandboxClient: class {
+    constructor(options?: unknown) {
+      capturedClientOptions = options;
+    }
+
     resume = vi.fn().mockImplementation((state: unknown) => {
       capturedResumeState = state;
-      return Promise.resolve({});
+      capturedResumedSession = { state };
+      return Promise.resolve(capturedResumedSession);
     });
   },
 }));
@@ -156,6 +163,9 @@ describe('OpenAIAgentSdkAgentRunner', () => {
   beforeEach(() => {
     vi.mocked(sdkRun).mockReset();
     vi.mocked(setTracingDisabled).mockReset();
+    capturedClientOptions = undefined;
+    capturedResumeState = undefined;
+    capturedResumedSession = undefined;
   });
 
   test('run() calls materializeSkills with skill refs matching the route', async () => {
@@ -233,7 +243,33 @@ describe('OpenAIAgentSdkAgentRunner', () => {
     });
   });
 
-  test('default run function passes a larger turn budget to the OpenAI SDK', async () => {
+  test('default run function disables SDK local sandbox snapshot persistence', async () => {
+    const materializeSkills = vi.fn().mockResolvedValue([]);
+    vi.mocked(sdkRun).mockResolvedValue({
+      newItems: [],
+      output: [],
+    } as never);
+
+    const runner = new OpenAIAgentSdkAgentRunner('sk-test', undefined, 'gpt-4o', {
+      materializeSkills,
+      logDestination: nullDest,
+    });
+
+    await collect(runner.run({
+      route: { task: 'question.answer' },
+      working_directory: '/tmp/ws',
+      prompt: 'What changed?',
+    }));
+
+    expect((capturedClientOptions as { snapshot?: { type?: string } })?.snapshot).toMatchObject({
+      type: 'noop',
+    });
+    expect((capturedResumeState as { snapshotSpec?: { type?: string } })?.snapshotSpec).toMatchObject({
+      type: 'noop',
+    });
+  });
+
+  test('default run function passes the resumed sandbox and turn budget to the OpenAI SDK', async () => {
     const materializeSkills = vi.fn().mockResolvedValue([]);
     vi.mocked(sdkRun).mockResolvedValue({
       newItems: [],
@@ -251,9 +287,14 @@ describe('OpenAIAgentSdkAgentRunner', () => {
       prompt: 'triage issue',
     }));
 
-    expect(vi.mocked(sdkRun).mock.calls[0][2]).toMatchObject({
-      maxTurns: 250,
-    });
+    expect(vi.mocked(sdkRun)).toHaveBeenCalledOnce();
+    const runOptions = vi.mocked(sdkRun).mock.calls[0][2] as {
+      maxTurns?: number;
+      sandbox?: { client?: unknown; session?: unknown };
+    };
+    expect(runOptions.maxTurns).toBe(250);
+    expect(runOptions.sandbox?.client).toBeDefined();
+    expect(runOptions.sandbox?.session).toBe(capturedResumedSession);
   });
 
   test('run() logs each SDK tool call and tool response with sanitized metadata', async () => {


### PR DESCRIPTION
## Summary

- Imported `NoopSnapshotSpec` from `@openai/agents/sandbox` in `agent-sdk-agent-runner.ts`
- Added a `NoopSnapshotSessionState` intersection type to keep the `snapshotSpec` field explicit
- Updated `defaultRunFn()` to pass `{ snapshot: new NoopSnapshotSpec() }` to `UnixLocalSandboxClient` and set `snapshotSpec` on the resumed session state
- Extended the sandbox client mock in tests to capture constructor options and the resumed session object
- Added a regression test asserting `snapshot.type === 'noop'` on both client options and session state; strengthened the existing `_run()` assertion to verify the sandbox session is passed through

## Verify

- [ ] Verify that the `UnixLocalSandboxClient` mock in `agent-sdk-agent-runner.test.ts` now has a constructor capturing `capturedClientOptions`
- [ ] Confirm the new test 'default run function disables SDK local sandbox snapshot persistence' passes and asserts `type: 'noop'` on both captured values
- [ ] Confirm the renamed test 'default run function passes the resumed sandbox and turn budget to the OpenAI SDK' asserts `maxTurns: 250` and `sandbox.session === capturedResumedSession`
- [ ] Confirm `npm run lint` exits with code 0 (TypeScript type check passes with the intersection type)
- [ ] Note: existing snapshot directories under `~/Library/Application Support/openai-agents-js/sandbox-snapshots` are NOT deleted by this fix — operators must remove them manually to reclaim disk space

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/f7430df8-b26f-4ad0-9678-6d7994791585
2. npm install
3. npm test -- tests/adapters/openai/agent-sdk-agent-runner.test.ts
4. npm run test:adapters
5. npm run lint

Closes #185