### PR TITLE
feat: block spec publication until author responses validate in spec review pass

### DIFF
--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -82,6 +82,7 @@ ai:
     pr.title_generate: grove-gpt-5.4-nano
     artifact.create: grove-gpt-5.5-high
     artifact.revise: grove-gpt-5.5-high
+    spec.review: grove-gpt-5.5-high
     implementation.plan: grove-gpt-5.5-high
     implementation.run: grove-sonnet-4.6-medium
     implementation.review.initial: grove-gpt-5.5-high
@@ -92,6 +93,10 @@ implementation_review:
   max_initial_rounds: 1
   max_final_rounds: 1
   on_review_failure: warn
+spec_review:
+  max_rounds: 1
+  on_review_failure: warn
+  template_conformance: true
 telemetry:
   metrics_endpoint: http://localhost:8428/opentelemetry/v1/metrics
   logs_endpoint: http://localhost:9428/insert/opentelemetry/v1/logs

--- a/context-human/specs/enhancement-spec-ai-review-pass.md
+++ b/context-human/specs/enhancement-spec-ai-review-pass.md
@@ -1,0 +1,453 @@
+---
+created: 2026-06-04
+last_updated: 2026-06-04
+status: implementing
+issue: 164
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Spec AI review pass
+
+## Parent features
+
+- `feature-idea-to-spec.md` — provides artifact generation, human spec review, and feedback-driven spec revision.
+- `enhancement-notion-publisher.md` — provides artifact publication and in-place spec updates before human review.
+- `enhancement-two-part-implementation-review.md` — provides the AI review coordinator pattern this enhancement mirrors for spec quality review.
+- `enhancement-run-status-workspace-ai-context.md` — provides run AI-context reporting that should include spec review agent invocations.
+## What
+
+Autocatalyst runs an AI review pass on specs before publishing them for human review. The review pass runs after the spec author creates or revises the local artifact and after the branch guard confirms the workspace is still on the expected branch. It runs before Notion publication and before the run transitions to `reviewing_spec`.
+The review model checks the spec for completeness, clarity, testability, feasibility, and `mm:planning` template conformance. If the review returns no findings, Autocatalyst publishes the spec as it does today. If the review returns findings, Autocatalyst sends them back to the spec author agent, requires a structured response for each finding, and only then publishes the updated spec.
+The pass applies to both initial artifact creation and every feedback-driven revision. Review failures follow a configurable policy; the default is `warn`, which records and logs the degraded review but does not block the spec from reaching the human.
+## Why
+
+The implementation lifecycle already uses a separate AI review pass to catch code and test issues before humans spend time on implementation review. The spec lifecycle has no equivalent. A spec can move directly from authoring to human review even when it has vague acceptance criteria, missing testing guidance, contradictory requirements, or the wrong template structure.
+That gap is costly because weak specs compound into weak implementations. A spec review pass catches problems while the authoring agent still has the full context and can revise the artifact before publication. It also creates a second line of defense against spec format drift, especially when generated specs stop matching `mm:planning` frontmatter, section order, or staged artifact structure.
+## Goals
+
+- Run a configurable AI review pass before initial specs are published to Notion or any artifact publisher.
+- Run the same review pass before revised specs are republished after human feedback.
+- Check generated specs for completeness, clarity, measurable acceptance criteria, implementation feasibility, specific testing guidance, and absence of contradictions.
+- Add a template conformance gate that checks canonical frontmatter fields, required section presence, section ordering, and staged `mm:planning` structure.
+- Return actionable findings to the spec author agent and require a structured `fixed`, `declined`, or `needs_input` response for each finding.
+- Instruct the author agent to fully rewrite structurally non-conformant specs from a clean `mm:planning` template instead of patching them in place.
+- Publish only the reviewed local artifact content to the human-facing artifact publisher.
+- Preserve the existing branch guard behavior and run stage lifecycle.
+- Make the review route and failure policy configurable, with safe defaults for new configurations.
+- Add unit coverage for no-findings, findings-with-author-response, structural-rewrite, and degraded-review paths.
+## Non-goals
+
+- Replacing human spec approval.
+- Giving the review model final authority over product decisions.
+- Letting the review model edit the spec directly; it reports findings, and the authoring agent revises.
+- Adding a new human UI for review findings in this enhancement.
+- Running unbounded review/fix loops. This enhancement runs one reviewer pass and, when needed, one author response pass.
+- Guaranteeing true read-only filesystem enforcement for every provider. Autocatalyst should prompt and configure the reviewer as read-only, but hard enforcement depends on the runner/provider.
+- Changing the implementation review lifecycle.
+## Personas
+
+- **Phoebe: Product manager** — wants specs to reach her with clear scope, concrete acceptance criteria, and no obvious template or requirements gaps.
+- **Enzo: Engineer** — wants AI-authored specs to include enough technical and testing detail for an implementation agent to build and verify the work without guessing.
+- **Autocatalyst operator** — configures which AI profile reviews specs and chooses whether review failures warn or block.
+## User stories
+
+- As Phoebe, I receive a spec for review only after a critic model has checked it for ambiguous requirements and missing acceptance criteria.
+- As Phoebe, I can leave feedback on a spec and know the revised spec receives the same quality check before it comes back to me.
+- As Enzo, I can rely on specs to include measurable acceptance criteria and testing expectations before they enter implementation approval.
+- As Enzo, I can see that structurally invalid specs are rewritten from the correct `mm:planning` template rather than patched into a hybrid format.
+- As an operator, I can configure `spec.review` to use a different profile from `artifact.create` and `artifact.revise`.
+- As an operator, I can set spec review failures to warn so a temporary review model problem does not block human review.
+- As an operator, I can inspect logs and run AI context to see when the spec review model was invoked and whether it produced findings.
+- As a spec author agent, I receive stable finding IDs and respond to each with `fixed`, `declined`, or `needs_input` before publication proceeds.
+## Design changes
+
+This is a backend lifecycle enhancement. The human-facing flow stays the same: the Slack thread still receives progress updates and a link to the published artifact when the spec is ready. The difference is that Autocatalyst performs an internal AI quality gate before that link appears.
+### Lifecycle placement
+
+Initial artifact creation becomes:
+```mermaid
+flowchart TD
+  Request[User asks Autocatalyst to work] --> Speccing[Transition to speccing]
+  Speccing --> Author[Spec author creates local artifact]
+  Author --> BranchGuard[Branch guard]
+  BranchGuard --> Review[Spec review pass]
+  Review -->|No findings| Publish[Publish artifact]
+  Review -->|Findings| AuthorResponse[Spec author responds and revises]
+  AuthorResponse --> Publish
+  Review -->|Failure + warn| Publish
+  Review -->|Failure + block| Failed[Fail or ask for input]
+  Publish --> ReviewingSpec[Transition to reviewing_spec]
+```
+Feedback-driven revision becomes:
+```mermaid
+flowchart TD
+  Feedback[Human feedback] --> Speccing[Transition to speccing]
+  Speccing --> Revise[Spec author revises local artifact]
+  Revise --> BranchGuard[Branch guard]
+  BranchGuard --> Review[Spec review pass]
+  Review -->|No findings| Update[Update published artifact]
+  Review -->|Findings| AuthorResponse[Spec author responds and revises]
+  AuthorResponse --> Update
+  Review -->|Failure + warn| Update
+  Review -->|Failure + block| Failed[Fail or ask for input]
+  Update --> ReviewingSpec[Transition to reviewing_spec]
+```
+The branch guard remains before review. If the authoring agent changed branches, Autocatalyst fails before invoking the reviewer. The reviewer should therefore inspect the correct branch and workspace.
+### Review dimensions
+
+The review prompt must ask the reviewer to evaluate these dimensions:
+1. **Completeness** — required sections are present for the artifact type, and each section contains substantive content.
+2. **Clarity** — requirements are specific enough that an implementation agent does not need to infer core behavior.
+3. **Testability** — acceptance criteria and testing guidance are measurable and runnable by an agent.
+4. **Implementation feasibility** — proposed behavior has enough edge-case detail to implement safely.
+5. **Consistency** — the spec has no contradictory requirements, mismatched scope, or stale copied content.
+6. **Template conformance** — frontmatter, section order, and staged structure match `mm:planning` expectations.
+### Template conformance gate
+
+The reviewer must treat structural template drift as a distinct category. It checks:
+- Frontmatter includes the canonical fields `created`, `last_updated`, `status`, `issue`, `specced_by`, `implemented_by`, and `superseded_by`.
+- Frontmatter omits non-standard fields such as `type`, `source_issue`, `related_specs`, and `related_adrs`.
+- The top-level heading follows the artifact type, such as `# Feature: ...` or `# Enhancement: ...`.
+- The section order follows the canonical feature or enhancement template used by `mm:planning`.
+- The spec does not collapse product requirements, design spec, tech spec, and task decomposition into one unreviewed monolithic pass when the staged workflow calls for separate sections.
+When the reviewer detects structural non-conformance, it should return one high-severity finding with category `template_conformance` and `requires_full_rewrite: true`. The author response prompt must not ask the author to patch individual section or frontmatter items. It must instruct the author to:
+1. Walk through `mm:planning` from first principles.
+2. Write a clean replacement file at `-new.md`.
+3. Use only the original draft's content to answer questions that would normally require human input.
+4. Let the `mm:planning` template, not the original malformed structure, determine the new file structure.
+5. Delete the malformed original after the replacement is complete.
+6. Rename the replacement file to the original path.
+This rewrite behavior avoids hybrid specs that keep parts of the wrong structure.
+### Progress updates
+
+Autocatalyst should post best-effort progress updates while the internal review runs:
+```plain text
+Spec draft complete — starting AI spec review with 
+Spec review found no findings — publishing for review
+Spec review returned 3 findings — asking the spec author to revise
+Spec author addressed review feedback — publishing for review
+Spec review failed; continuing because on_review_failure is warn
+```
+Progress update failures are non-blocking and logged with `event: 'progress_failed'` and `phase: 'spec_review'`.
+### Review authority
+
+The reviewer returns findings only. The authoring agent decides how to respond:
+- `fixed` — the author changed the spec and explains what changed.
+- `declined` — the author leaves the spec unchanged and gives a concrete reason.
+- `needs_input` — the author cannot resolve the issue without a human decision.
+A declined finding without a concrete reason is invalid. A `needs_input` response should keep the run out of `reviewing_spec` and surface the question to the human through the existing failure/input path selected by the handler implementation.
+## Technical changes
+
+### Affected files
+
+- `src/types/ai.ts` — add `'spec.review'` to `AgentTaskKind`; add spec review result, finding, response, and exchange types.
+- `src/types/config.ts` — add `SpecReviewPolicy` and optional `spec_review` config block, analogous to `ImplementationReviewPolicy`.
+- `src/config/defaults.ts` — add a default spec review profile or route entry for `spec.review`.
+- `autocatalyst.yaml` — add the repository's `spec.review` route key.
+- `src/core/ai/agent-services.ts` — add `buildSpecReviewPrompt()`, `buildSpecAuthorResponsePrompt()`, and `parseSpecReviewResult()`.
+- `src/core/ai/spec-review-coordinator.ts` — add `SpecReviewCoordinator` with `runSpecReview()`.
+- `src/core/handlers/artifact-creation-handler.ts` — run spec review after branch guard and before `createArtifact()` / `reviewing_spec` transition.
+- `src/core/handlers/artifact-feedback-handler.ts` — run spec review after branch guard and before `updateArtifact()` / `reviewing_spec` transition.
+- `src/core/default-handler-registry.ts` and dependency wiring modules — construct and inject `SpecReviewCoordinator` where artifact handlers are assembled.
+- `tests/core/ai/agent-services.test.ts` — cover spec review prompts, author response prompts, and review result parsing.
+- `tests/core/ai/spec-review-coordinator.test.ts` — cover review flow behavior.
+- `tests/core/handlers/artifact-creation-handler.test.ts` — cover review placement before first publication.
+- `tests/core/handlers/artifact-feedback-handler.test.ts` — cover review placement before republishing revisions.
+- `tests/core/config.test.ts` or routing policy tests — cover `spec.review` config and defaults.
+### 1. Prerequisites and assumptions
+
+- The existing artifact authoring agent writes local spec files and returns `artifact_path` for creation and revision workflows.
+- The existing branch guard already runs after authoring and before publication in both artifact handlers.
+- The implementation review coordinator proves the project accepts a reviewer/coordinator pattern that runs an agent, parses a JSON result file, and sends findings back to the authoring/implementation agent.
+- The spec reviewer needs repository and workspace context, so `spec.review` should resolve to an agent-runner profile, not a direct chat-only profile.
+- The author response pass can reuse `ArtifactAuthoringAgent.revise()` only if it can provide a synthetic feedback payload with review findings. If that creates awkward coupling to human comments, add a dedicated author response method instead.
+- No new external dependency is required.
+### 2. Config and routing
+
+Add one AI route key:
+```typescript
+export type AgentTaskKind =
+  | 'intent.classify'
+  | 'artifact.create'
+  | 'artifact.revise'
+  | 'spec.review'
+  | 'implementation.plan'
+  | 'implementation.run'
+  | 'implementation.review.initial'
+  | 'implementation.review.final'
+  | 'question.answer'
+  | 'issue.triage'
+  | 'pr.title_generate';
+```
+Example config:
+```yaml
+ai:
+  routing:
+    artifact.create: artifact-agent
+    artifact.revise: artifact-agent
+    spec.review: review-agent
+
+spec_review:
+  max_rounds: 1
+  on_review_failure: warn # warn | block
+  template_conformance: true
+```
+`SpecReviewPolicy`:
+```typescript
+export interface SpecReviewPolicy {
+  max_rounds?: number;
+  on_review_failure?: 'warn' | 'block';
+  template_conformance?: boolean;
+}
+```
+Defaults:
+- `max_rounds: 1`
+- `on_review_failure: warn`
+- `template_conformance: true`
+Compatibility rules:
+- If `spec.review` is configured, Autocatalyst runs spec review for specs and spec revisions.
+- If `spec.review` is absent, existing repositories preserve current behavior. Autocatalyst logs `spec.review.skipped` at warn level and publishes the spec without review.
+- Generated default config includes `spec.review: review-agent` so new repositories receive the feature by default.
+- If `spec_review.on_review_failure` is omitted, failures warn and publication proceeds.
+### 3. Review result contract
+
+The reviewer writes JSON to `.autocatalyst/spec-review-result.json` in the run workspace:
+```typescript
+export type SpecReviewFindingSeverity = 'blocker' | 'warning' | 'info';
+export type SpecReviewFindingCategory =
+  | 'completeness'
+  | 'clarity'
+  | 'testability'
+  | 'feasibility'
+  | 'consistency'
+  | 'template_conformance';
+
+export interface SpecReviewFinding {
+  id: string;
+  severity: SpecReviewFindingSeverity;
+  category: SpecReviewFindingCategory;
+  finding: string;
+  suggested_action?: string;
+  requires_full_rewrite?: boolean;
+}
+
+export interface SpecReviewResult {
+  status: 'no_findings' | 'findings' | 'failed';
+  summary: string;
+  findings: SpecReviewFinding[];
+  error?: string;
+}
+```
+Rules:
+- `status: 'no_findings'` must include an empty `findings` array.
+- `status: 'findings'` must include at least one finding.
+- Each finding must have a stable ID such as `SPEC-1`.
+- `requires_full_rewrite` may be true only for `template_conformance` findings.
+- `status: 'failed'` must include an `error` string.
+- Parser validation should degrade invalid JSON to `status: 'failed'` with a clear error, matching `parseImplementationReviewResult()` behavior.
+### 4. Author response contract
+
+When findings exist, the authoring agent writes or updates the artifact and returns structured responses:
+```typescript
+export interface SpecReviewResponseItem {
+  id: string;
+  disposition: 'fixed' | 'declined' | 'needs_input';
+  response: string;
+}
+
+export interface SpecReviewAuthorResponseResult {
+  status: 'complete' | 'needs_input' | 'failed';
+  responses: SpecReviewResponseItem[];
+  question?: string;
+  error?: string;
+}
+```
+The response prompt must require one response for every finding ID. The coordinator validates that all IDs are present and that each response has a non-empty explanation. Missing or invalid responses are treated as `failed` or `needs_input`, depending on whether the author can still ask the human a concrete question.
+For non-structural findings, the author may edit the original artifact in place. For `requires_full_rewrite` findings, the author must use the replacement-file flow described in the template conformance gate.
+### 5. Coordinator design
+
+Add `SpecReviewCoordinator`:
+```typescript
+export interface SpecReviewCoordinatorDeps {
+  runner: AgentRunner;
+  artifactAuthoringAgent: Pick;
+  routingPolicy: AgentRoutingPolicy;
+  policy: Required;
+  logger: Pick;
+  readFile?: (path: string, encoding: 'utf-8') => Promise;
+}
+
+export interface SpecReviewRunParams {
+  run: Run;
+  artifact_path: string;
+  working_directory: string;
+  artifact_kind: ArtifactKind;
+  current_page_markdown?: string;
+  onProgress?: (message: string) => Promise;
+  onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+}
+
+export interface SpecReviewRunResult {
+  status: 'complete' | 'needs_input' | 'failed';
+  artifact_path: string;
+  page_content?: string;
+  summary?: string;
+  question?: string;
+  error?: string;
+}
+```
+`runSpecReview()` flow:
+1. Resolve `spec.review` through `routingPolicy.resolveOptional({ task: 'spec.review', artifact_kind })`.
+2. If no profile exists, log `spec.review.skipped` and return `complete`.
+3. Record agent request metadata with route `spec.review` and the resolved model.
+4. Build a prompt that includes artifact path, artifact kind, workspace path, relevant `mm:planning` template rules, and explicit JSON output instructions.
+5. Run the reviewer using `AgentRunner` and drain output with the same helper used by implementation review.
+6. Read `.autocatalyst/spec-review-result.json` and parse it.
+7. If parsing or runner execution fails, apply `on_review_failure`.
+8. If no findings exist, log `spec.review.completed` and return `complete`.
+9. If findings exist, post progress, build the author response prompt, and run the spec author response pass.
+10. Validate author responses and branch state if the handler performs another guard after revision.
+11. Return `complete`, `needs_input`, or `failed` to the handler.
+The coordinator should not publish artifacts or transition run stages. Handlers keep lifecycle authority.
+### 6. Handler integration
+
+`ArtifactCreationHandler.handle()` changes after branch guard:
+1. Author creates the local artifact.
+2. Handler sets `run.artifact` to `drafting` as today.
+3. Branch guard checks the workspace branch.
+4. Handler invokes `specReviewCoordinator.runSpecReview()` when the dependency is configured and the artifact kind is spec-like.
+5. If review returns `complete`, handler proceeds to `artifactPublisher.createArtifact()`.
+6. If review returns `needs_input`, handler posts the question or fails through the existing run failure/input mechanism selected for spec authoring.
+7. If review returns `failed`, handler fails the run when policy blocks; with `warn`, the coordinator returns `complete` and the handler proceeds.
+`ArtifactFeedbackHandler.handle()` changes after branch guard and before `updateArtifact()`:
+1. Author revises the local artifact using human feedback.
+2. Branch guard checks the workspace branch.
+3. Handler invokes `specReviewCoordinator.runSpecReview()` with `current_page_markdown` when available.
+4. Handler uses returned `page_content` if the author response pass produced span-preserving content for Notion.
+5. Handler updates the published artifact and comment replies only after the reviewed local artifact is ready.
+6. Handler transitions to `reviewing_spec` after publication as today.
+If the author response pass changes files, either the coordinator or handler must run branch guard again before publication. The preferred design is for the handler to run the existing guard after `runSpecReview()` returns `complete`, because handlers own branch safety today.
+### 7. Prompt requirements
+
+`buildSpecReviewPrompt()` must instruct the reviewer to:
+- Read the artifact from `artifact_path`.
+- Inspect nearby repository context only as needed.
+- Treat `context-human/specs` and `mm:planning` structure as the source of template expectations.
+- Check frontmatter fields and reject non-standard frontmatter fields.
+- Check section order for feature versus enhancement specs.
+- Check for measurable acceptance criteria and specific testing requirements.
+- Return only structured JSON in `.autocatalyst/spec-review-result.json`.
+- Avoid secrets and do not include environment values, tokens, or credentials.
+`buildSpecAuthorResponsePrompt()` must instruct the author to:
+- Address every finding ID.
+- Preserve user-approved product intent.
+- Make the smallest safe content changes unless a full rewrite is required.
+- Use the full replacement-file flow for `requires_full_rewrite` findings.
+- Return structured response JSON or a clearly delimited response block that the coordinator can parse.
+- Never remove human comments or Notion comment spans from `page_content` when span-preserving markdown is supplied.
+### 8. Logging and telemetry
+
+Add structured logs:
+- `spec.review.started` — review begins, including run ID and profile.
+- `spec.review.round_started` — reviewer pass begins.
+- `spec.review.round_completed` — reviewer pass completes, including finding counts by severity and category.
+- `spec.review.completed` — no findings or addressed findings.
+- `spec.review.findings_returned` — findings are sent to the author.
+- `spec.review.author_response_completed` — author response pass completes.
+- `spec.review.skipped` — route is missing.
+- `spec.review.degraded` — reviewer failed and policy is `warn`.
+- `spec.review.failed` — reviewer or author response failure blocks the run.
+The coordinator must call `onAgentRequest` for the review agent so `ac-run-status` can show spec review model activity during `speccing` or `reviewing_spec` lifecycle windows.
+### 9. Testing requirements
+
+- Spec review runs after initial artifact creation branch guard and before `artifactPublisher.createArtifact()`.
+- Spec review runs after every artifact revision branch guard and before `artifactPublisher.updateArtifact()`.
+- When the review result is `no_findings`, publication proceeds without invoking the author response pass.
+- When findings exist, the author response pass receives every finding and publication waits for the response.
+- When a finding has `requires_full_rewrite: true`, the author prompt contains the full replacement-file instructions.
+- When the reviewer writes invalid JSON, `parseSpecReviewResult()` returns `failed` with a useful error.
+- When the reviewer errors and `spec_review.on_review_failure` is `warn`, the spec is still published and a degraded review is logged.
+- When the reviewer errors and `spec_review.on_review_failure` is `block`, publication does not occur and the run fails or asks for input.
+- When `spec.review` is missing from routing, existing publication behavior is preserved with a warning log.
+- `spec.review` appears in generated default config and this repository's `autocatalyst.yaml`.
+- Agent request metadata is recorded for review invocations.
+- Branch guard still prevents publication if the author changed branches before review, and runs again after review-driven edits before publication.
+## Implementation tasks
+
+### Story 1: Configure spec review routing
+
+**Description:** Add configuration and type support for routing a spec review agent.
+**Tasks:**
+- Add `'spec.review'` to `AgentTaskKind`.
+- Add `SpecReviewPolicy` and `spec_review?: SpecReviewPolicy` to config types.
+- Add default policy resolution where workflow config is loaded.
+- Add `spec.review` to generated default config and `autocatalyst.yaml`.
+- Add routing/default tests for configured and missing `spec.review` routes.
+**Acceptance criteria:**
+- TypeScript accepts `spec.review` anywhere an agent route is resolved.
+- New generated configs include a review route by default.
+- Existing configs without `spec.review` still load.
+**Dependencies:** None.
+### Story 2: Add spec review prompt builders and parser
+
+**Description:** Teach agent services how to instruct the reviewer, instruct the author response pass, and parse review JSON.
+**Tasks:**
+- Add spec review finding/result/response types.
+- Implement `buildSpecReviewPrompt()` with quality and template conformance dimensions.
+- Implement `buildSpecAuthorResponsePrompt()` with normal-fix and full-rewrite instructions.
+- Implement `parseSpecReviewResult()` with validation behavior matching implementation review parsing.
+- Add unit tests for prompt content and parser edge cases.
+**Acceptance criteria:**
+- The review prompt requires JSON output at `.autocatalyst/spec-review-result.json`.
+- The author response prompt includes the full rewrite flow when needed.
+- Invalid JSON and invalid statuses produce `failed` results with useful errors.
+**Dependencies:** Story 1.
+### Story 3: Implement `SpecReviewCoordinator`
+
+**Description:** Add the coordinator that runs the reviewer and, when needed, sends findings back to the spec author.
+**Tasks:**
+- Create `src/core/ai/spec-review-coordinator.ts`.
+- Resolve the optional `spec.review` profile and skip safely when missing.
+- Drain the review agent and parse `.autocatalyst/spec-review-result.json`.
+- Apply `on_review_failure` policy.
+- Invoke the author response pass when findings exist.
+- Validate author responses and return `complete`, `needs_input`, or `failed`.
+- Emit structured logs and progress updates.
+- Record agent request metadata for run AI context.
+**Acceptance criteria:**
+- No-findings review returns `complete` without author response.
+- Findings review invokes author response exactly once and requires all finding IDs to be addressed.
+- Warn-mode reviewer failure returns `complete` and logs a degraded event.
+- Block-mode reviewer failure returns `failed`.
+**Dependencies:** Stories 1 and 2.
+### Story 4: Integrate review into artifact creation and revision
+
+**Description:** Run spec review in both spec lifecycle paths before human-facing publication.
+**Tasks:**
+- Inject `SpecReviewCoordinator` into `ArtifactCreationHandler` and `ArtifactFeedbackHandler` dependency wiring.
+- Call `runSpecReview()` after branch guard in initial creation.
+- Call `runSpecReview()` after branch guard in feedback revision.
+- Run branch guard again after review-driven author edits before publication.
+- Preserve existing publication, comment response, and status-transition behavior after successful review.
+- Handle `needs_input` and `failed` coordinator results without publishing stale artifacts.
+**Acceptance criteria:**
+- Initial specs are reviewed before `createArtifact()`.
+- Revised specs are reviewed before `updateArtifact()`.
+- Publication still occurs for no-findings and warn-mode degraded review paths.
+- Publication does not occur for blocking review failures or unresolved author responses.
+**Dependencies:** Story 3.
+### Story 5: Cover lifecycle behavior with tests
+
+**Description:** Add targeted tests that prove review ordering, policy behavior, and branch safety.
+**Tasks:**
+- Add coordinator unit tests for no findings, findings, full rewrite prompt, warn failure, block failure, and missing route.
+- Add creation handler tests that assert review runs after branch guard and before publication.
+- Add feedback handler tests that assert review runs before republishing and preserves comment response flow.
+- Add branch guard tests for review-driven edits before publication.
+- Add config tests for defaults and backwards compatibility.
+**Acceptance criteria:**
+- Test failures clearly identify ordering regressions.
+- The suite proves existing no-review config behavior still works.
+- The suite proves `on_review_failure: warn` does not block publication.
+**Dependencies:** Stories 1 through 4.

--- a/context-human/specs/enhancement-spec-ai-review-pass.md
+++ b/context-human/specs/enhancement-spec-ai-review-pass.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-04
-last_updated: 2026-06-04
-status: implementing
+last_updated: 2026-06-06
+status: complete
 issue: 164
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -8,7 +8,7 @@ import { App } from '@slack/bolt';
 import Anthropic from '@anthropic-ai/sdk';
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { loadConfigFromPath, repoNameFromUrl, resolveEnvVars, resolveAiConfig, getImplementationReviewPolicy, type ResolvedAiConfig } from '../core/config.js';
+import { loadConfigFromPath, repoNameFromUrl, resolveEnvVars, resolveAiConfig, getImplementationReviewPolicy, getSpecReviewPolicy, type ResolvedAiConfig } from '../core/config.js';
 import { bootstrapWorkflowRuntime } from '../core/bootstrap.js';
 import { normalizeWorkflowConfig } from '../core/config-normalizer.js';
 import { configExists, runInit } from '../core/init.js';
@@ -50,6 +50,7 @@ import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner, Ag
 import { ClaudeAgentSdkAgentRunner } from './anthropic/claude-agent-sdk-agent-runner.js';
 import { OpenAIAgentSdkAgentRunner } from './openai/agent-sdk-agent-runner.js';
 import { ImplementationReviewCoordinator } from '../core/ai/implementation-review-coordinator.js';
+import { SpecReviewCoordinator } from '../core/ai/spec-review-coordinator.js';
 import { createLogger } from '../core/logger.js';
 import { WorkspacePruner } from '../core/workspace-pruner.js';
 import { CommandConfirmationRegistryImpl } from '../core/command-confirmations.js';
@@ -187,6 +188,14 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     logger,
   });
 
+  const specReviewCoordinator = new SpecReviewCoordinator({
+    runner: agentRunner,
+    artifactAuthoringAgent,
+    routingPolicy: aiRoutingPolicy,
+    policy: getSpecReviewPolicy(currentConfig.config),
+    logger,
+  });
+
   const threadPruner = new SlackThreadPruner(boltApp);
   const workspacePruner = new WorkspacePruner();
   const pruneLogger = createLogger('prune-commands');
@@ -213,6 +222,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     channelRepoMap,
     reacjiComplete,
     reviewCoordinator,
+    specReviewCoordinator,
     threadPruner,
     workspacePruner,
     confirmationRegistry,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -91,12 +91,18 @@ ai:
     pr.title_generate: classify-haiku
     artifact.create: artifact-agent
     artifact.revise: artifact-agent
+    spec.review: review-agent
     implementation.plan: impl-agent
     implementation.run: impl-agent
     implementation.review.initial: review-agent
     implementation.review.final: review-agent
     question.answer: question-agent
     issue.triage: triage-agent
+
+spec_review:
+  max_rounds: 1
+  on_review_failure: warn
+  template_conformance: true
 
 sandbox:
   env_tokens:

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -269,7 +269,10 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
   ): Promise<SpecReviewAuthorResponseResult> {
-    void current_page_markdown;
+    const originalAnchors = current_page_markdown && this.commentAnchorCodec
+      ? this.commentAnchorCodec.extract(current_page_markdown)
+      : [];
+    const hasAnchors = originalAnchors.length > 0;
     const resultPath = join(workspace_path, '.autocatalyst', 'spec-review-author-response.json');
     const route = {
       task: 'artifact.revise' as const,
@@ -325,7 +328,16 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
       request_id: telemetry?.request_id,
       drainSummary,
     });
-    return parseSpecAuthorResponseResult(content, resultPath);
+    const parsed = parseSpecAuthorResponseResult(content, resultPath);
+
+    if (hasAnchors && this.commentAnchorCodec && parsed.status === 'complete') {
+      const agentArtifact = readFileSync(artifact_path, 'utf-8');
+      const pageContent = this.commentAnchorCodec.preserve(agentArtifact, originalAnchors);
+      writeFileSync(artifact_path, this.commentAnchorCodec.strip(pageContent), 'utf-8');
+      return { ...parsed, page_content: pageContent };
+    }
+
+    return parsed;
   }
 }
 
@@ -1918,12 +1930,20 @@ export function parseSpecReviewResult(content: string, path: string): SpecReview
     return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}" has invalid status: "${String(rawStatus)}"` };
   }
 
+  const VALID_SEVERITIES = new Set<string>(['blocker', 'warning', 'info']);
+  const VALID_CATEGORIES = new Set<string>(['completeness', 'clarity', 'testability', 'feasibility', 'consistency', 'template_conformance']);
+
   const findings: SpecReviewFinding[] = [];
   if (Array.isArray(obj['findings'])) {
     for (const raw of obj['findings'] as unknown[]) {
       if (typeof raw !== 'object' || raw === null) continue;
       const f = raw as Record<string, unknown>;
-      if (typeof f['id'] === 'string' && typeof f['severity'] === 'string' && typeof f['category'] === 'string' && typeof f['finding'] === 'string') {
+      if (
+        typeof f['id'] === 'string' &&
+        typeof f['severity'] === 'string' && VALID_SEVERITIES.has(f['severity']) &&
+        typeof f['category'] === 'string' && VALID_CATEGORIES.has(f['category']) &&
+        typeof f['finding'] === 'string'
+      ) {
         findings.push({
           id: f['id'],
           severity: f['severity'] as SpecReviewFinding['severity'],
@@ -1939,6 +1959,11 @@ export function parseSpecReviewResult(content: string, path: string): SpecReview
   // Validate: no_findings must have empty findings array
   if (rawStatus === 'no_findings' && findings.length > 0) {
     return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}": no_findings must include an empty findings array` };
+  }
+
+  // Validate: findings status must include at least one valid finding
+  if (rawStatus === 'findings' && findings.length === 0) {
+    return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}": status is 'findings' but no valid findings were parsed` };
   }
 
   // Validate: requires_full_rewrite only for template_conformance

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -32,11 +32,14 @@ import type {
   IssueTriageItem,
   IssueTriageResult,
   QuestionAnsweringAgent,
+  SpecReviewFinding,
+  SpecReviewResult,
 } from '../../types/ai.js';
 import type { Request, ThreadMessage } from '../../types/events.js';
 import type { FilingResult, FiledIssue, IssueFiler } from '../../types/issue-filing.js';
 import type { IssueManager } from '../../types/issue-tracker.js';
 import { artifactKindForIntent } from '../../types/artifact.js';
+import type { ArtifactKind } from '../../types/artifact.js';
 import type { ArtifactCommentAnchorCodec } from '../../types/publisher.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
@@ -1632,6 +1635,214 @@ export function buildImplementerResponsePrompt(
     ``,
     CHECKPOINT_INSTRUCTIONS,
   ].join('\n');
+}
+
+export interface BuildSpecReviewPromptParams {
+  artifact_path: string;
+  artifact_kind: ArtifactKind;
+  working_directory: string;
+  result_path: string;
+  template_conformance: boolean;
+  current_page_markdown?: string;
+}
+
+export interface BuildSpecAuthorResponsePromptParams {
+  artifact_path: string;
+  working_directory: string;
+  result_path: string;
+  findings: SpecReviewFinding[];
+  current_page_markdown?: string;
+}
+
+export function buildSpecReviewPrompt(params: BuildSpecReviewPromptParams): string {
+  const { artifact_path, working_directory, result_path, template_conformance } = params;
+
+  const templateConformanceSection = template_conformance ? [
+    ``,
+    `Template conformance gate:`,
+    `- Frontmatter must include the canonical fields \`created\`, \`last_updated\`, \`status\`, \`issue\`, \`specced_by\`, \`implemented_by\`, and \`superseded_by\`.`,
+    `- Frontmatter must omit non-standard fields such as \`type\`, \`source_issue\`, \`related_specs\`, and \`related_adrs\`.`,
+    `- The top-level heading must follow the artifact type (e.g., \`# Feature: ...\` or \`# Enhancement: ...\`).`,
+    `- Section order must follow the canonical feature or enhancement template used by \`mm:planning\`.`,
+    `- Structural non-conformance: return one high-severity finding with category \`template_conformance\` and \`requires_full_rewrite: true\`.`,
+  ] : [];
+
+  return [
+    `You are an adversarial spec reviewer. Your job is to inspect the spec and find quality issues.`,
+    `Do NOT edit any files. Read only.`,
+    ``,
+    `Spec artifact: ${artifact_path}`,
+    `Working directory: ${working_directory}`,
+    ``,
+    `Inspect nearby repository context (e.g., \`context-human/specs\`) only as needed.`,
+    `Treat \`context-human/specs\` and \`mm:planning\` structure as the source of template expectations.`,
+    ``,
+    `Review dimensions:`,
+    `1. Completeness — required sections are present and contain substantive content.`,
+    `2. Clarity — requirements are specific enough for an implementation agent to act without inferring core behavior.`,
+    `3. Testability — acceptance criteria and testing guidance are measurable and runnable by an agent.`,
+    `4. Implementation feasibility — proposed behavior has enough edge-case detail to implement safely.`,
+    `5. Consistency — no contradictory requirements, mismatched scope, or stale copied content.`,
+    `6. Template conformance — frontmatter, section order, and staged structure match \`mm:planning\` expectations.`,
+    ...templateConformanceSection,
+    ``,
+    `Write your result to: ${result_path}`,
+    `Content must be:`,
+    `{`,
+    `  "status": "no_findings" | "findings" | "failed",`,
+    `  "summary": "1-2 sentence summary of review outcome",`,
+    `  "findings": [`,
+    `    {`,
+    `      "id": "SPEC-1",`,
+    `      "severity": "blocker" | "warning" | "info",`,
+    `      "category": "completeness" | "clarity" | "testability" | "feasibility" | "consistency" | "template_conformance",`,
+    `      "finding": "concise description",`,
+    `      "suggested_action": "optional action",`,
+    `      "requires_full_rewrite": true  // only for template_conformance findings`,
+    `    }`,
+    `  ],`,
+    `  "error": "only when status is failed"`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Do NOT include secrets, API keys, env values, or raw credential values in findings.`,
+    `- Do NOT include your reasoning chain or full prompt in findings.`,
+    `- Do NOT edit any files in the workspace.`,
+    `- Use sequential IDs: SPEC-1, SPEC-2, etc.`,
+    `- If no issues found, use status: "no_findings" with empty findings array.`,
+    `- \`requires_full_rewrite\` may be true only for \`template_conformance\` findings.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildSpecAuthorResponsePrompt(params: BuildSpecAuthorResponsePromptParams): string {
+  const { artifact_path, working_directory, result_path, findings } = params;
+  const hasFullRewrite = findings.some(f => f.requires_full_rewrite);
+
+  // Derive the -new.md path
+  const newArtifactPath = artifact_path.replace(/\.md$/, '-new.md');
+
+  const findingBlocks = findings.map(f => [
+    `[SPEC_REVIEW_ID: ${f.id}]`,
+    `Severity: ${f.severity}`,
+    `Category: ${f.category}`,
+    `Finding: ${f.finding}`,
+    ...(f.suggested_action ? [`Suggested action: ${f.suggested_action}`] : []),
+    ...(f.requires_full_rewrite ? [`Requires full rewrite: true`] : []),
+  ].join('\n'));
+
+  const rewriteInstructions = hasFullRewrite ? [
+    ``,
+    `FULL REWRITE REQUIRED for template_conformance finding(s):`,
+    `1. Walk through \`mm:planning\` from first principles.`,
+    `2. Write a clean replacement file at \`${newArtifactPath}\`.`,
+    `3. Use only the original draft's content to answer questions that would normally require human input.`,
+    `4. Let the \`mm:planning\` template, not the original malformed structure, determine the new file structure.`,
+    `5. Delete the malformed original after the replacement is complete.`,
+    `6. Rename the replacement file to the original path.`,
+  ] : [];
+
+  return [
+    `Spec review findings require your response.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    `Spec artifact: ${artifact_path}`,
+    `Working directory: ${working_directory}`,
+    ``,
+    `Review findings:`,
+    ``,
+    findingBlocks.join('\n\n'),
+    ...rewriteInstructions,
+    ``,
+    `For each [SPEC_REVIEW_ID: ...] finding, respond with one of:`,
+    `- \`fixed\`: You changed the spec and explain what changed.`,
+    `- \`declined\`: You leave the spec unchanged and give a concrete reason (not "no action needed").`,
+    `- \`needs_input\`: You cannot resolve without a human decision — provide a specific question.`,
+    ``,
+    `Do not remove human comments or Notion comment spans from page_content.`,
+    `Preserve user-approved product intent. Make the smallest safe content changes unless a full rewrite is required.`,
+    ``,
+    `Write the result to: ${result_path}`,
+    `Content must be:`,
+    `{`,
+    `  "status": "complete" | "needs_input" | "failed",`,
+    `  "responses": [`,
+    `    {`,
+    `      "id": "<exact SPEC_REVIEW_ID value>",`,
+    `      "disposition": "fixed" | "declined" | "needs_input",`,
+    `      "response": "what changed or concrete reason"`,
+    `    }`,
+    `  ],`,
+    `  "question": "only when needs_input",`,
+    `  "error": "only when failed"`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Include one response entry per [SPEC_REVIEW_ID:] finding.`,
+    `- "declined" responses must include a concrete reason, not just "no action needed".`,
+    `- Use exact ID strings — do not modify or guess IDs.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function parseSpecReviewResult(content: string, path: string): SpecReviewResult {
+  let obj: Record<string, unknown>;
+  try {
+    const data = JSON.parse(content);
+    if (typeof data !== 'object' || data === null) {
+      return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}" is not a JSON object` };
+    }
+    obj = data as Record<string, unknown>;
+  } catch (err) {
+    return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}" is not valid JSON: ${String(err)}` };
+  }
+
+  const rawStatus = obj['status'];
+  if (rawStatus !== 'no_findings' && rawStatus !== 'findings' && rawStatus !== 'failed') {
+    return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}" has invalid status: "${String(rawStatus)}"` };
+  }
+
+  const findings: SpecReviewFinding[] = [];
+  if (Array.isArray(obj['findings'])) {
+    for (const raw of obj['findings'] as unknown[]) {
+      if (typeof raw !== 'object' || raw === null) continue;
+      const f = raw as Record<string, unknown>;
+      if (typeof f['id'] === 'string' && typeof f['severity'] === 'string' && typeof f['category'] === 'string' && typeof f['finding'] === 'string') {
+        findings.push({
+          id: f['id'],
+          severity: f['severity'] as SpecReviewFinding['severity'],
+          category: f['category'] as SpecReviewFinding['category'],
+          finding: f['finding'],
+          ...(typeof f['suggested_action'] === 'string' ? { suggested_action: f['suggested_action'] } : {}),
+          ...(f['requires_full_rewrite'] === true ? { requires_full_rewrite: true } : {}),
+        });
+      }
+    }
+  }
+
+  // Validate: no_findings must have empty findings array
+  if (rawStatus === 'no_findings' && findings.length > 0) {
+    return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}": no_findings must include an empty findings array` };
+  }
+
+  // Validate: requires_full_rewrite only for template_conformance
+  for (const finding of findings) {
+    if (finding.requires_full_rewrite && finding.category !== 'template_conformance') {
+      return { status: 'failed', summary: '', findings: [], error: `Spec review result at "${path}": requires_full_rewrite may only be true for template_conformance findings` };
+    }
+  }
+
+  return {
+    status: rawStatus,
+    summary: typeof obj['summary'] === 'string' ? obj['summary'] : '',
+    findings,
+    ...(typeof obj['error'] === 'string' ? { error: obj['error'] } : {}),
+  };
 }
 
 export function parseImplementationReviewResult(content: string, path: string): ImplementationReviewResult {

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -32,7 +32,9 @@ import type {
   IssueTriageItem,
   IssueTriageResult,
   QuestionAnsweringAgent,
+  SpecReviewAuthorResponseResult,
   SpecReviewFinding,
+  SpecReviewResponseItem,
   SpecReviewResult,
 } from '../../types/ai.js';
 import type { Request, ThreadMessage } from '../../types/events.js';
@@ -258,6 +260,115 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
 
     return { comment_responses: commentResponses };
   }
+
+  async respondToSpecReview(
+    artifact_path: string,
+    workspace_path: string,
+    review_prompt: string,
+    current_page_markdown?: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: AgentServiceTelemetry,
+  ): Promise<SpecReviewAuthorResponseResult> {
+    void current_page_markdown;
+    const resultPath = join(workspace_path, '.autocatalyst', 'spec-review-author-response.json');
+    const route = {
+      task: 'artifact.revise' as const,
+      stage: 'reviewing_spec' as const,
+      intent: 'feedback' as const,
+    };
+
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
+    const progressWithHeartbeat: ((msg: string) => Promise<void>) | undefined =
+      onProgress && telemetry?.onAgentRequest
+        ? async (msg: string) => {
+            notifyAgentRequest(telemetry, profile, route, true);
+            return onProgress(msg);
+          }
+        : onProgress;
+
+    let drainSummary: AgentDrainSummary | undefined;
+    try {
+      await ensureResultDir(resultPath);
+      drainSummary = await drainAgentRunner(
+        this.runner.run({
+          route,
+          profile,
+          working_directory: workspace_path,
+          prompt: review_prompt,
+          telemetry: {
+            phase: 'spec_review_author_response',
+            route_task: route.task,
+            handler: 'AgentRunnerArtifactAuthoringAgent',
+            ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}),
+            ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}),
+          },
+        }),
+        progressWithHeartbeat,
+        this.logger,
+        'spec_review_author_response',
+        { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
+      );
+    } catch (err) {
+      return { status: 'failed', responses: [], error: `Spec review author response failed: ${String(err)}` };
+    }
+
+    const content = await validateRequiredResultFile({
+      readFileFn: this.readFileFn,
+      path: resultPath,
+      label: 'Spec review author response',
+      logger: this.logger,
+      phase: 'spec_review_author_response',
+      route_task: 'artifact.revise',
+      run_id: telemetry?.run_id,
+      request_id: telemetry?.request_id,
+      drainSummary,
+    });
+    return parseSpecAuthorResponseResult(content, resultPath);
+  }
+}
+
+function parseSpecAuthorResponseResult(content: string, path: string): SpecReviewAuthorResponseResult {
+  let obj: Record<string, unknown>;
+  try {
+    const data = JSON.parse(content);
+    if (typeof data !== 'object' || data === null) {
+      return { status: 'failed', responses: [], error: `Spec author response at "${path}" is not a JSON object` };
+    }
+    obj = data as Record<string, unknown>;
+  } catch (err) {
+    return { status: 'failed', responses: [], error: `Spec author response at "${path}" is not valid JSON: ${String(err)}` };
+  }
+
+  const rawStatus = obj['status'];
+  if (rawStatus !== 'complete' && rawStatus !== 'needs_input' && rawStatus !== 'failed') {
+    return { status: 'failed', responses: [], error: `Spec author response at "${path}" has invalid status: "${String(rawStatus)}"` };
+  }
+
+  const responses: SpecReviewResponseItem[] = [];
+  if (Array.isArray(obj['responses'])) {
+    for (const raw of obj['responses'] as unknown[]) {
+      if (typeof raw !== 'object' || raw === null) continue;
+      const r = raw as Record<string, unknown>;
+      if (
+        typeof r['id'] === 'string' && r['id'].trim() !== '' &&
+        typeof r['disposition'] === 'string' &&
+        (r['disposition'] === 'fixed' || r['disposition'] === 'declined' || r['disposition'] === 'needs_input') &&
+        typeof r['response'] === 'string' && r['response'].trim() !== ''
+      ) {
+        responses.push({ id: r['id'], disposition: r['disposition'], response: r['response'] });
+      }
+    }
+  }
+
+  return {
+    status: rawStatus,
+    responses,
+    ...(typeof obj['page_content'] === 'string' ? { page_content: obj['page_content'] } : {}),
+    ...(typeof obj['question'] === 'string' ? { question: obj['question'] } : {}),
+    ...(typeof obj['error'] === 'string' ? { error: obj['error'] } : {}),
+  };
 }
 
 export class AgentRunnerImplementationAgent implements ImplementationAgent {
@@ -1762,7 +1873,7 @@ export function buildSpecAuthorResponsePrompt(params: BuildSpecAuthorResponsePro
     `- \`declined\`: You leave the spec unchanged and give a concrete reason (not "no action needed").`,
     `- \`needs_input\`: You cannot resolve without a human decision — provide a specific question.`,
     ``,
-    `Do not remove human comments or Notion comment spans from page_content.`,
+    `Do not remove human comments or publisher comment spans from page_content.`,
     `Preserve user-approved product intent. Make the smallest safe content changes unless a full rewrite is required.`,
     ``,
     `Write the result to: ${result_path}`,

--- a/src/core/ai/route-skills.ts
+++ b/src/core/ai/route-skills.ts
@@ -12,13 +12,14 @@ export function requiredSkillsForRoute(route: AgentRoute): AgentSkillRef[] {
       return ['superpowers:writing-plans'];
     case 'implementation.run':
       return ['superpowers:subagent-driven-development'];
+    case 'spec.review':
+      return ['mm:planning'];
     case 'artifact.revise':
     case 'intent.classify':
     case 'pr.title_generate':
     case 'question.answer':
     case 'implementation.review.initial':
     case 'implementation.review.final':
-    case 'spec.review':
       return [];
   }
 }

--- a/src/core/ai/route-skills.ts
+++ b/src/core/ai/route-skills.ts
@@ -18,6 +18,7 @@ export function requiredSkillsForRoute(route: AgentRoute): AgentSkillRef[] {
     case 'question.answer':
     case 'implementation.review.initial':
     case 'implementation.review.final':
+    case 'spec.review':
       return [];
   }
 }

--- a/src/core/ai/spec-review-coordinator.ts
+++ b/src/core/ai/spec-review-coordinator.ts
@@ -209,7 +209,14 @@ export class SpecReviewCoordinator {
       return { status: 'failed', artifact_path, error: authorResponse.error ?? 'Author response failed' };
     }
 
-    this.validateAuthorResponses(run, reviewResult.findings, authorResponse.responses ?? []);
+    const validationErrors = this.validateAuthorResponses(run, reviewResult.findings, authorResponse.responses ?? []);
+    if (validationErrors.length > 0) {
+      return {
+        status: 'failed',
+        artifact_path,
+        error: `Author responses failed validation: ${validationErrors.join('; ')}`,
+      };
+    }
 
     this.deps.logger.info(
       { event: 'spec.review.author_response_completed', run_id: run.id, response_count: authorResponse.responses?.length ?? 0 },
@@ -260,24 +267,73 @@ export class SpecReviewCoordinator {
     run: Run,
     findings: SpecReviewFinding[],
     responses: Array<{ id: string; disposition: string; response: string }>,
-  ): void {
-    const responseIds = new Set(responses.map(r => r.id));
+  ): string[] {
+    const errors: string[] = [];
+    const findingIds = new Set(findings.map(f => f.id));
+    const seenResponseIds = new Set<string>();
+    const validDispositions = new Set(['fixed', 'declined', 'needs_input']);
+
     for (const finding of findings) {
-      if (!responseIds.has(finding.id)) {
+      if (!responses.some(r => r.id === finding.id)) {
+        const msg = `No response for finding ID: ${finding.id}`;
+        errors.push(msg);
         this.deps.logger.warn(
           { event: 'spec.review.response_invalid', run_id: run.id, missing_id: finding.id },
-          `Author did not respond to finding ID: ${finding.id}`,
+          msg,
         );
       }
     }
 
     for (const response of responses) {
-      if (response.disposition === 'declined' && response.response.trim().toLowerCase() === 'no action needed') {
+      if (seenResponseIds.has(response.id)) {
+        const msg = `Duplicate response for finding ID: ${response.id}`;
+        errors.push(msg);
+        this.deps.logger.warn(
+          { event: 'spec.review.response_invalid', run_id: run.id, duplicate_id: response.id },
+          msg,
+        );
+      }
+      seenResponseIds.add(response.id);
+
+      if (!findingIds.has(response.id)) {
+        const msg = `Response references unknown finding ID: ${response.id}`;
+        errors.push(msg);
+        this.deps.logger.warn(
+          { event: 'spec.review.response_invalid', run_id: run.id, unknown_id: response.id },
+          msg,
+        );
+      }
+
+      if (!validDispositions.has(response.disposition)) {
+        const msg = `Invalid disposition '${response.disposition}' for finding ${response.id}`;
+        errors.push(msg);
+        this.deps.logger.warn(
+          { event: 'spec.review.response_invalid', run_id: run.id, invalid_disposition: response.disposition, id: response.id },
+          msg,
+        );
+      }
+
+      if (!response.response?.trim()) {
+        const msg = `Empty response explanation for finding ${response.id}`;
+        errors.push(msg);
+        this.deps.logger.warn(
+          { event: 'spec.review.response_invalid', run_id: run.id, empty_response_id: response.id },
+          msg,
+        );
+      }
+
+      if (response.disposition === 'declined' && !response.response?.trim()) {
+        // already caught by empty response check above
+      } else if (response.disposition === 'declined' && response.response.trim().toLowerCase() === 'no action needed') {
+        const msg = `Finding ${response.id} declined without a concrete reason`;
+        errors.push(msg);
         this.deps.logger.warn(
           { event: 'spec.review.response_invalid', run_id: run.id, invalid_id: response.id },
-          `Author declined finding ${response.id} without a concrete reason`,
+          msg,
         );
       }
     }
+
+    return errors;
   }
 }

--- a/src/core/ai/spec-review-coordinator.ts
+++ b/src/core/ai/spec-review-coordinator.ts
@@ -1,0 +1,283 @@
+import { join } from 'node:path';
+import { readFile as _readFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type pino from 'pino';
+import type {
+  AgentInvocationMetadata,
+  AgentRunner,
+  AgentRoutingPolicy,
+  ArtifactAuthoringAgent,
+  SpecReviewAuthorResponseResult,
+  SpecReviewFinding,
+  SpecReviewResult,
+} from '../../types/ai.js';
+import type { ArtifactKind } from '../../types/artifact.js';
+import type { SpecReviewPolicy } from '../../types/config.js';
+import type { Run } from '../../types/runs.js';
+import {
+  buildSpecReviewPrompt,
+  buildSpecAuthorResponsePrompt,
+  parseSpecReviewResult,
+  drainAgentRunner,
+} from './agent-services.js';
+import { agentProfileSummary } from './routing-policy.js';
+
+type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
+
+export interface SpecReviewCoordinatorDeps {
+  runner: AgentRunner;
+  artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'respondToSpecReview'>;
+  routingPolicy: AgentRoutingPolicy;
+  policy: Required<SpecReviewPolicy>;
+  logger: Pick<pino.Logger, 'info' | 'warn' | 'debug' | 'error'>;
+  readFile?: ReadFileFn;
+}
+
+export interface SpecReviewRunParams {
+  run: Run;
+  artifact_path: string;
+  working_directory: string;
+  artifact_kind: ArtifactKind;
+  current_page_markdown?: string;
+  onProgress?: (message: string) => Promise<void>;
+  onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+}
+
+export interface SpecReviewRunResult {
+  status: 'complete' | 'needs_input' | 'failed';
+  artifact_path: string;
+  page_content?: string;
+  summary?: string;
+  question?: string;
+  error?: string;
+}
+
+export class SpecReviewCoordinator {
+  private readonly readFileFn: ReadFileFn;
+
+  constructor(private readonly deps: SpecReviewCoordinatorDeps) {
+    this.readFileFn = deps.readFile ?? ((path, enc) => _readFile(path, enc));
+  }
+
+  async runSpecReview(params: SpecReviewRunParams): Promise<SpecReviewRunResult> {
+    const { run, artifact_path, working_directory, artifact_kind, current_page_markdown, onProgress, onAgentRequest } = params;
+
+    const reviewProfile = this.deps.routingPolicy.resolveOptional({ task: 'spec.review', artifact_kind });
+
+    if (!reviewProfile) {
+      this.deps.logger.warn(
+        { event: 'spec.review.skipped', run_id: run.id },
+        'No spec.review route configured — skipping spec review',
+      );
+      return { status: 'complete', artifact_path };
+    }
+
+    const reviewSummary = agentProfileSummary(reviewProfile);
+
+    this.deps.logger.info(
+      { event: 'spec.review.started', run_id: run.id, review_profile: reviewSummary.profile },
+      'Starting spec review',
+    );
+
+    if (onProgress) {
+      await onProgress(`Spec draft complete — starting AI spec review with ${reviewSummary.profile}`).catch(() => {});
+    }
+
+    if (onAgentRequest) {
+      onAgentRequest({
+        model: reviewProfile.model?.trim() || 'unknown',
+        requested_at: new Date().toISOString(),
+        route: { task: 'spec.review', artifact_kind },
+      });
+    }
+
+    const reviewResultPath = join(working_directory, '.autocatalyst', 'spec-review-result.json');
+    const prompt = buildSpecReviewPrompt({
+      artifact_path,
+      artifact_kind,
+      working_directory,
+      result_path: reviewResultPath,
+      template_conformance: this.deps.policy.template_conformance,
+      current_page_markdown,
+    });
+
+    try {
+      await mkdir(dirname(reviewResultPath), { recursive: true });
+    } catch { /* ignore */ }
+
+    this.deps.logger.info(
+      { event: 'spec.review.round_started', run_id: run.id, review_profile: reviewProfile.id },
+      'Spec review round started',
+    );
+
+    let reviewResultContent: string;
+    let reviewResult: SpecReviewResult;
+    try {
+      await drainAgentRunner(
+        this.deps.runner.run({
+          route: { task: 'spec.review', artifact_kind },
+          profile: reviewProfile,
+          working_directory,
+          prompt,
+          telemetry: {
+            run_id: run.id,
+            request_id: run.request_id,
+            phase: 'spec_review',
+            route_task: 'spec.review',
+            handler: 'SpecReviewCoordinator',
+          },
+        }),
+        onProgress,
+        this.deps.logger,
+        'spec_review',
+        { run_id: run.id, request_id: run.request_id },
+      );
+      reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
+      reviewResult = parseSpecReviewResult(reviewResultContent, reviewResultPath);
+    } catch (err) {
+      return this.handleReviewFailure(run, artifact_path, String(err), onProgress);
+    }
+
+    if (reviewResult.status === 'failed') {
+      return this.handleReviewFailure(run, artifact_path, reviewResult.error ?? 'Review model reported failure', onProgress);
+    }
+
+    const blockerCount = reviewResult.findings.filter(f => f.severity === 'blocker').length;
+    const warningCount = reviewResult.findings.filter(f => f.severity === 'warning').length;
+    const infoCount = reviewResult.findings.filter(f => f.severity === 'info').length;
+    this.deps.logger.info(
+      {
+        event: 'spec.review.round_completed',
+        run_id: run.id,
+        review_profile: reviewProfile.id,
+        blocker_count: blockerCount,
+        warning_count: warningCount,
+        info_count: infoCount,
+      },
+      'Spec review round completed',
+    );
+
+    if (reviewResult.status === 'no_findings') {
+      if (onProgress) {
+        await onProgress('Spec review found no findings — publishing for review').catch(() => {});
+      }
+      this.deps.logger.info(
+        { event: 'spec.review.completed', run_id: run.id, status: 'no_findings' },
+        'Spec review completed with no findings',
+      );
+      return { status: 'complete', artifact_path };
+    }
+
+    if (onProgress) {
+      await onProgress(`Spec review returned ${reviewResult.findings.length} finding(s) — asking the spec author to revise`).catch(() => {});
+    }
+    this.deps.logger.info(
+      { event: 'spec.review.findings_returned', run_id: run.id, finding_count: reviewResult.findings.length },
+      'Spec review findings returned to author',
+    );
+
+    const authorResponseResultPath = join(working_directory, '.autocatalyst', 'spec-review-author-response.json');
+    const authorPrompt = buildSpecAuthorResponsePrompt({
+      artifact_path,
+      working_directory,
+      result_path: authorResponseResultPath,
+      findings: reviewResult.findings,
+      current_page_markdown,
+    });
+
+    let authorResponse: SpecReviewAuthorResponseResult;
+    const progressFn = onProgress ?? ((_msg: string) => Promise.resolve());
+    try {
+      authorResponse = await this.deps.artifactAuthoringAgent.respondToSpecReview(
+        artifact_path,
+        working_directory,
+        authorPrompt,
+        current_page_markdown,
+        progressFn,
+        { run_id: run.id, request_id: run.request_id, onAgentRequest },
+      );
+    } catch (err) {
+      return { status: 'failed', artifact_path, error: `Spec author response failed: ${String(err)}` };
+    }
+
+    if (authorResponse.status === 'needs_input') {
+      return { status: 'needs_input', artifact_path, question: authorResponse.question };
+    }
+
+    if (authorResponse.status === 'failed') {
+      return { status: 'failed', artifact_path, error: authorResponse.error ?? 'Author response failed' };
+    }
+
+    this.validateAuthorResponses(run, reviewResult.findings, authorResponse.responses ?? []);
+
+    this.deps.logger.info(
+      { event: 'spec.review.author_response_completed', run_id: run.id, response_count: authorResponse.responses?.length ?? 0 },
+      'Spec author response completed',
+    );
+
+    if (onProgress) {
+      await onProgress('Spec author addressed review feedback — publishing for review').catch(() => {});
+    }
+
+    this.deps.logger.info(
+      { event: 'spec.review.completed', run_id: run.id, status: 'findings_addressed' },
+      'Spec review completed after author response',
+    );
+
+    return {
+      status: 'complete',
+      artifact_path,
+      page_content: authorResponse.page_content,
+      summary: reviewResult.summary,
+    };
+  }
+
+  private handleReviewFailure(
+    run: Run,
+    artifact_path: string,
+    errorMsg: string,
+    onProgress?: (message: string) => Promise<void>,
+  ): SpecReviewRunResult {
+    this.deps.logger.warn(
+      { event: 'spec.review.degraded', run_id: run.id, error: errorMsg },
+      'Spec review failed',
+    );
+    if (this.deps.policy.on_review_failure === 'block') {
+      this.deps.logger.error(
+        { event: 'spec.review.failed', run_id: run.id, error: errorMsg },
+        'Spec review failed and policy is block',
+      );
+      return { status: 'failed', artifact_path, error: errorMsg };
+    }
+    if (onProgress) {
+      onProgress('Spec review failed; continuing because on_review_failure is warn').catch(() => {});
+    }
+    return { status: 'complete', artifact_path };
+  }
+
+  private validateAuthorResponses(
+    run: Run,
+    findings: SpecReviewFinding[],
+    responses: Array<{ id: string; disposition: string; response: string }>,
+  ): void {
+    const responseIds = new Set(responses.map(r => r.id));
+    for (const finding of findings) {
+      if (!responseIds.has(finding.id)) {
+        this.deps.logger.warn(
+          { event: 'spec.review.response_invalid', run_id: run.id, missing_id: finding.id },
+          `Author did not respond to finding ID: ${finding.id}`,
+        );
+      }
+    }
+
+    for (const response of responses) {
+      if (response.disposition === 'declined' && response.response.trim().toLowerCase() === 'no action needed') {
+        this.deps.logger.warn(
+          { event: 'spec.review.response_invalid', run_id: run.id, invalid_id: response.id },
+          `Author declined finding ${response.id} without a concrete reason`,
+        );
+      }
+    }
+  }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,7 @@
 import { parse as parseYaml } from 'yaml';
 import { existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join, basename, dirname, resolve } from 'node:path';
-import type { WorkflowConfig, LoadedConfig, AiConfig, CredentialConfig, EndpointConfig, ProfileConfig, RoutingConfig } from '../types/config.js';
+import type { WorkflowConfig, LoadedConfig, AiConfig, CredentialConfig, EndpointConfig, ProfileConfig, RoutingConfig, SpecReviewPolicy } from '../types/config.js';
 import { generateDefaultConfig } from '../config/defaults.js';
 
 // ─── Resolved AI config types ─────────────────────────────────────────────────
@@ -182,6 +182,25 @@ export function validateConfig(config: WorkflowConfig): void {
       if (typeof rr['max_final_rounds'] !== 'number' || !Number.isInteger(rr['max_final_rounds']) || (rr['max_final_rounds'] as number) < 1) {
         throw new Error('implementation_review.max_final_rounds must be a positive integer');
       }
+    }
+  }
+
+  const rawSpecReview = (config as Record<string, unknown>)['spec_review'];
+  if (rawSpecReview !== undefined && rawSpecReview !== null) {
+    if (typeof rawSpecReview !== 'object' || Array.isArray(rawSpecReview)) {
+      throw new Error('spec_review must be an object');
+    }
+    const sr = rawSpecReview as Record<string, unknown>;
+    if (sr['on_review_failure'] !== undefined && sr['on_review_failure'] !== 'warn' && sr['on_review_failure'] !== 'block') {
+      throw new Error(`spec_review.on_review_failure must be "warn" or "block", got "${String(sr['on_review_failure'])}"`);
+    }
+    if (sr['max_rounds'] !== undefined) {
+      if (typeof sr['max_rounds'] !== 'number' || !Number.isInteger(sr['max_rounds']) || (sr['max_rounds'] as number) < 1) {
+        throw new Error('spec_review.max_rounds must be a positive integer');
+      }
+    }
+    if (sr['template_conformance'] !== undefined && typeof sr['template_conformance'] !== 'boolean') {
+      throw new Error('spec_review.template_conformance must be a boolean');
     }
   }
 }
@@ -407,5 +426,14 @@ export function getImplementationReviewPolicy(config: WorkflowConfig): {
     max_final_rounds: typeof raw?.['max_final_rounds'] === 'number' ? raw['max_final_rounds'] as number : 1,
     on_review_failure: (raw?.['on_review_failure'] === 'block' ? 'block' : 'warn'),
     retest_on_behavior_change: raw?.['retest_on_behavior_change'] === false ? false : true,
+  };
+}
+
+export function getSpecReviewPolicy(config: WorkflowConfig): Required<SpecReviewPolicy> {
+  const raw = (config as Record<string, unknown>)['spec_review'] as Record<string, unknown> | undefined;
+  return {
+    max_rounds: typeof raw?.['max_rounds'] === 'number' ? raw['max_rounds'] as number : 1,
+    on_review_failure: raw?.['on_review_failure'] === 'block' ? 'block' : 'warn',
+    template_conformance: raw?.['template_conformance'] === false ? false : true,
   };
 }

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -19,6 +19,7 @@ import type { SpecCommitter } from './spec-committer.js';
 import { HandlerRegistryImpl, type HandlerRegistry } from './handler-registry.js';
 import { GitBranchGuard, type BranchGuard } from './git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
+import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
 import { ArtifactCreationHandler } from './handlers/artifact-creation-handler.js';
 import { ArtifactApprovalHandler, type ArtifactApprovalResult } from './handlers/artifact-approval-handler.js';
 import { ArtifactFeedbackHandler } from './handlers/artifact-feedback-handler.js';
@@ -96,6 +97,7 @@ export interface DefaultHandlerRegistryDeps {
   logger: Pick<pino.Logger, 'debug' | 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: ImplementationReviewCoordinator;
+  specReviewCoordinator?: SpecReviewCoordinator;
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   workspacePruner?: Pick<WorkspacePruner, 'prune'>;
   autoPruneWorkspace?: boolean;
@@ -189,6 +191,7 @@ async function startArtifactCreation(
     persist: deps.persist,
     logger: deps.logger,
     branchGuard,
+    specReviewCoordinator: deps.specReviewCoordinator,
   });
   await handler.handle(run, request, intent);
 }
@@ -233,6 +236,7 @@ async function handleArtifactFeedback(
     persist: deps.persist,
     logger: deps.logger,
     branchGuard,
+    specReviewCoordinator: deps.specReviewCoordinator,
   });
   await handler.handle(run, feedback);
 }

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -9,6 +9,7 @@ import type { ChannelRepoMap } from '../../types/config.js';
 import type { WorkspaceManager } from '../workspace-manager.js';
 import { channelKey, type ConversationRef } from '../../types/channel.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import type { SpecReviewCoordinator } from '../ai/spec-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 type ArtifactCreationIntent = Extract<RequestIntent, 'idea' | 'bug' | 'chore'>;
@@ -24,6 +25,7 @@ export interface ArtifactCreationDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'warn' | 'error' | 'info'>;
   branchGuard?: BranchGuard;
+  specReviewCoordinator?: Pick<SpecReviewCoordinator, 'runSpecReview'>;
 }
 
 export class ArtifactCreationHandler {
@@ -87,6 +89,40 @@ export class ArtifactCreationHandler {
         await this.deps.workspaceManager.destroy(workspace_path);
         await this.deps.failRun(run, request.conversation, err);
         return;
+      }
+    }
+
+    // Spec review (idea intent only, after branch guard, before publish)
+    if (intent === 'idea' && this.deps.specReviewCoordinator && run.artifact) {
+      const reviewResult = await this.deps.specReviewCoordinator.runSpecReview({
+        run,
+        artifact_path: local_path,
+        working_directory: workspace_path,
+        artifact_kind: run.artifact.kind,
+        onProgress: (message: string) => this.deps.postMessage(request.conversation, message).catch(err => {
+          this.deps.logger.warn(
+            { event: 'progress_failed', phase: 'spec_review', run_id: run.id, error: String(err) },
+            'Failed to post spec review progress update',
+          );
+        }),
+        onAgentRequest,
+      });
+
+      if (reviewResult.status !== 'complete') {
+        await this.deps.workspaceManager.destroy(workspace_path);
+        await this.deps.failRun(run, request.conversation, new Error(reviewResult.question ?? reviewResult.error ?? 'Spec review did not complete'));
+        return;
+      }
+
+      // Second branch guard after review-driven author edits
+      if (this.deps.branchGuard) {
+        try {
+          await this.deps.branchGuard.check(workspace_path, branch);
+        } catch (err) {
+          await this.deps.workspaceManager.destroy(workspace_path);
+          await this.deps.failRun(run, request.conversation, err);
+          return;
+        }
       }
     }
 

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -7,6 +7,7 @@ import type { Run, RunStage } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { requireArtifactRefs } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import type { SpecReviewCoordinator } from '../ai/spec-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 
 export interface ArtifactFeedbackDeps {
@@ -20,6 +21,7 @@ export interface ArtifactFeedbackDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'debug' | 'warn' | 'error' | 'info'>;
   branchGuard?: BranchGuard;
+  specReviewCoordinator?: Pick<SpecReviewCoordinator, 'runSpecReview'>;
 }
 
 export type ArtifactFeedbackResult = { status: 'revised' } | { status: 'failed' };
@@ -96,8 +98,43 @@ export class ArtifactFeedbackHandler {
       'Comment responses returned from revise()',
     );
 
+    // Spec review (feature_spec only, after branch guard, before publish)
+    let reviewedPageContent = page_content;
+    if (refs.artifact.kind === 'feature_spec' && this.deps.specReviewCoordinator) {
+      const reviewResult = await this.deps.specReviewCoordinator.runSpecReview({
+        run,
+        artifact_path: refs.local_path,
+        working_directory: run.workspace_path,
+        artifact_kind: refs.artifact.kind,
+        current_page_markdown: pageMarkdown,
+        onProgress: (message: string) => this.deps.postMessage(feedback.conversation, message).catch(err => {
+          this.deps.logger.warn(
+            { event: 'progress_failed', phase: 'spec_review', run_id: run.id, error: String(err) },
+            'Failed to post spec review progress update',
+          );
+        }),
+        onAgentRequest,
+      });
+
+      if (reviewResult.status !== 'complete') {
+        await this.deps.failRun(run, feedback.conversation, new Error(reviewResult.question ?? reviewResult.error ?? 'Spec review did not complete'));
+        return { status: 'failed' };
+      }
+      if (reviewResult.page_content) reviewedPageContent = reviewResult.page_content;
+
+      // Second branch guard after review-driven edits
+      if (this.deps.branchGuard) {
+        try {
+          await this.deps.branchGuard.check(run.workspace_path, run.branch);
+        } catch (err) {
+          await this.deps.failRun(run, feedback.conversation, err);
+          return { status: 'failed' };
+        }
+      }
+    }
+
     try {
-      await this.deps.artifactPublisher.updateArtifact(refs.publication_ref, refs.artifact, page_content);
+      await this.deps.artifactPublisher.updateArtifact(refs.publication_ref, refs.artifact, reviewedPageContent);
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -28,6 +28,7 @@ import type { HandlerRegistry } from './handler-registry.js';
 import { buildDefaultHandlerRegistry as buildDefaultHandlers } from './default-handler-registry.js';
 import type { BranchGuard } from './git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
+import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
 import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
 
@@ -82,6 +83,7 @@ export interface OrchestratorDeps {
   handlerRegistry?: HandlerRegistry;
   branchGuard?: BranchGuard;
   reviewCoordinator?: ImplementationReviewCoordinator;
+  specReviewCoordinator?: SpecReviewCoordinator;
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   autoPruneWorkspace?: boolean;
   workspacePruner?: import('./workspace-pruner.js').WorkspacePruner;
@@ -570,6 +572,7 @@ export class OrchestratorImpl implements Orchestrator {
       logger: this.logger,
       branchGuard: this.deps.branchGuard,
       reviewCoordinator: this.deps.reviewCoordinator,
+      specReviewCoordinator: this.deps.specReviewCoordinator,
       validatePlanPath: this.deps.validatePlanPath,
       autoPruneWorkspace: this.deps.autoPruneWorkspace,
       workspacePruner: this.deps.workspacePruner,

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -8,6 +8,7 @@ export type AgentTaskKind =
   | 'intent.classify'
   | 'artifact.create'
   | 'artifact.revise'
+  | 'spec.review'
   | 'implementation.plan'
   | 'implementation.run'
   | 'implementation.review.initial'

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -226,6 +226,14 @@ export interface ArtifactAuthoringAgent {
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
   ): Promise<ArtifactRevisionResult>;
+  respondToSpecReview(
+    artifact_path: string,
+    workspace_path: string,
+    review_prompt: string,
+    current_page_markdown?: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: AgentServiceTelemetry,
+  ): Promise<SpecReviewAuthorResponseResult>;
 }
 
 export type ImplementationStatus = 'complete' | 'needs_input' | 'failed';

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -305,4 +305,43 @@ export interface IssueTriageResult {
   error?: string;
 }
 
+export type SpecReviewFindingSeverity = 'blocker' | 'warning' | 'info';
+export type SpecReviewFindingCategory =
+  | 'completeness'
+  | 'clarity'
+  | 'testability'
+  | 'feasibility'
+  | 'consistency'
+  | 'template_conformance';
+
+export interface SpecReviewFinding {
+  id: string;
+  severity: SpecReviewFindingSeverity;
+  category: SpecReviewFindingCategory;
+  finding: string;
+  suggested_action?: string;
+  requires_full_rewrite?: boolean;
+}
+
+export interface SpecReviewResult {
+  status: 'no_findings' | 'findings' | 'failed';
+  summary: string;
+  findings: SpecReviewFinding[];
+  error?: string;
+}
+
+export interface SpecReviewResponseItem {
+  id: string;
+  disposition: 'fixed' | 'declined' | 'needs_input';
+  response: string;
+}
+
+export interface SpecReviewAuthorResponseResult {
+  status: 'complete' | 'needs_input' | 'failed';
+  responses: SpecReviewResponseItem[];
+  page_content?: string;
+  question?: string;
+  error?: string;
+}
+
 export type { ClassificationContext, Intent, IntentClassifier };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -59,6 +59,12 @@ export interface ProfileConfig {
 /** Maps AgentTaskKind string keys to ProfileConfig.name values. */
 export type RoutingConfig = Record<string, string>;
 
+export interface SpecReviewPolicy {
+  max_rounds?: number;
+  on_review_failure?: 'warn' | 'block';
+  template_conformance?: boolean;
+}
+
 export interface ImplementationReviewPolicy {
   max_initial_rounds?: number;
   max_final_rounds?: number;
@@ -113,6 +119,7 @@ export interface WorkflowConfig {
   /** Required — declares all AI provider configuration. */
   ai: AiConfig;
   implementation_review?: ImplementationReviewPolicy;
+  spec_review?: SpecReviewPolicy;
   sandbox?: SandboxConfig;
   [key: string]: unknown;
 }

--- a/tests/adapters/runtime-composition.test.ts
+++ b/tests/adapters/runtime-composition.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, test } from 'vitest';
 import { resolveAiConfig } from '../../src/core/config.js';
+import { OrchestratorImpl } from '../../src/core/orchestrator.js';
+import type { OrchestratorDeps } from '../../src/core/orchestrator.js';
 import type { WorkflowConfig, AiConfig } from '../../src/types/config.js';
 import { buildDirectModelRunner, buildAgentRunner, RoutingAwareDirectModelRunner, RoutingAwareAgentRunner } from '../../src/adapters/runtime-composition.js';
 import { OpenAIDirectModelRunner } from '../../src/adapters/openai/direct-model-runner.js';
@@ -384,5 +386,27 @@ describe('buildAgentRunner — requestLogDir threading', () => {
     expect(runner).toBeInstanceOf(OpenAIAgentSdkAgentRunner);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((runner as any).requestLog).toBeUndefined();
+  });
+});
+
+describe('runtime wiring: specReviewCoordinator flows through OrchestratorDeps', () => {
+  it('OrchestratorDeps accepts specReviewCoordinator and OrchestratorImpl forwards it to the handler registry', () => {
+    // Verify that specReviewCoordinator is accepted by OrchestratorDeps at the type level
+    // and that the orchestrator passes it through to buildDefaultHandlerRegistry.
+    const runSpecReview = vi.fn().mockResolvedValue({ status: 'complete', artifact_path: '/ws/spec.md' });
+    const specReviewCoordinator = { runSpecReview };
+
+    const minimalDeps: OrchestratorDeps = {
+      adapter: { on: vi.fn(), resolveChannels: vi.fn(), isConnected: vi.fn() } as unknown as OrchestratorDeps['adapter'],
+      workspaceManager: { create: vi.fn(), findExisting: vi.fn(), cleanup: vi.fn() } as unknown as OrchestratorDeps['workspaceManager'],
+      artifactAuthoringAgent: { create: vi.fn(), revise: vi.fn(), respondToSpecReview: vi.fn() } as unknown as OrchestratorDeps['artifactAuthoringAgent'],
+      artifactPublisher: { createArtifact: vi.fn(), updateArtifact: vi.fn() } as unknown as OrchestratorDeps['artifactPublisher'],
+      channelRepoMap: {},
+      specReviewCoordinator,
+    };
+
+    // OrchestratorImpl should construct without throwing when specReviewCoordinator is provided
+    const orchestrator = new OrchestratorImpl(minimalDeps);
+    expect(orchestrator).toBeDefined();
   });
 });

--- a/tests/config/defaults.test.ts
+++ b/tests/config/defaults.test.ts
@@ -50,4 +50,15 @@ describe('generateDefaultConfig', () => {
     const result = parseAutocatalystConfig(content);
     expect(result.workspace?.auto_prune).toBe(true);
   });
+
+  it('includes spec.review route and spec_review policy', () => {
+    const content = generateDefaultConfig('my-repo');
+    const result = parseAutocatalystConfig(content);
+    expect(result.ai.routing['spec.review']).toBe('review-agent');
+    expect(result.spec_review).toEqual({
+      max_rounds: 1,
+      on_review_failure: 'warn',
+      template_conformance: true,
+    });
+  });
 });

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -419,6 +419,79 @@ describe('AgentRunner-backed core AI services', () => {
     }
   });
 
+  test('respondToSpecReview preserves comment anchors when current_page_markdown has anchors', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-spec-review-author-'));
+    try {
+      const artifactPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      // respondToSpecReview always writes to this known path
+      const resultPath = join(workspace, '.autocatalyst', 'spec-review-author-response.json');
+      const codec: ArtifactCommentAnchorCodec = {
+        extract: vi.fn().mockReturnValue([{ id: 'anchor-1', text: 'anchored text' }]),
+        promptInstructions: vi.fn().mockReturnValue([]),
+        preserve: vi.fn().mockReturnValue('REVIEWED CONTENT WITH ANCHOR'),
+        strip: vi.fn().mockReturnValue('LOCAL CONTENT WITHOUT ANCHOR'),
+      };
+      const runner = fakeAgentRunner(async () => {
+        await mkdir(dirname(resultPath), { recursive: true });
+        await mkdir(dirname(artifactPath), { recursive: true });
+        await writeFile(artifactPath, 'author-edited spec content', 'utf8');
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          responses: [{ id: 'SPEC-1', disposition: 'fixed', response: 'Clarified.' }],
+        }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy(), { commentAnchorCodec: codec });
+
+      const result = await service.respondToSpecReview(
+        artifactPath,
+        workspace,
+        'Address these spec review findings...',
+        'published content with <span data-id="anchor-1">anchored text</span>',
+      );
+
+      expect(codec.extract).toHaveBeenCalledWith('published content with <span data-id="anchor-1">anchored text</span>');
+      expect(codec.preserve).toHaveBeenCalledWith('author-edited spec content', [{ id: 'anchor-1', text: 'anchored text' }]);
+      expect(result.status).toBe('complete');
+      expect(result.page_content).toBe('REVIEWED CONTENT WITH ANCHOR');
+      await expect(readFile(artifactPath, 'utf8')).resolves.toBe('LOCAL CONTENT WITHOUT ANCHOR');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('respondToSpecReview skips anchor preservation when no anchors in current_page_markdown', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-spec-review-author-noanchor-'));
+    try {
+      const artifactPath = join(workspace, 'context-human', 'specs', 'feature-test.md');
+      const resultPath = join(workspace, '.autocatalyst', 'spec-review-author-response.json');
+      const codec: ArtifactCommentAnchorCodec = {
+        extract: vi.fn().mockReturnValue([]),
+        promptInstructions: vi.fn().mockReturnValue([]),
+        preserve: vi.fn(),
+        strip: vi.fn(),
+      };
+      const runner = fakeAgentRunner(async () => {
+        await mkdir(dirname(resultPath), { recursive: true });
+        await mkdir(dirname(artifactPath), { recursive: true });
+        await writeFile(artifactPath, 'author-edited content', 'utf8');
+        await writeFile(resultPath, JSON.stringify({
+          status: 'complete',
+          responses: [{ id: 'SPEC-1', disposition: 'fixed', response: 'Fixed it.' }],
+        }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy(), { commentAnchorCodec: codec });
+
+      const result = await service.respondToSpecReview(artifactPath, workspace, 'Address findings...', 'plain page content');
+
+      expect(codec.extract).toHaveBeenCalled();
+      expect(codec.preserve).not.toHaveBeenCalled();
+      expect(result.status).toBe('complete');
+      expect(result.page_content).toBeUndefined();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('requires question answering to write the result file', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'ac-question-'));
     try {
@@ -1035,6 +1108,57 @@ describe('spec review prompts and parser', () => {
     }), '/ws/.autocatalyst/spec-review-result.json');
     expect(result.status).toBe('failed');
     expect(result.error).toContain('requires_full_rewrite may only be true for template_conformance findings');
+  });
+
+  it('parseSpecReviewResult silently drops findings with invalid severity', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'findings',
+      summary: 'Mixed bag.',
+      findings: [
+        { id: 'SPEC-1', severity: 'critical', category: 'clarity', finding: 'invalid severity' },
+        { id: 'SPEC-2', severity: 'blocker', category: 'clarity', finding: 'valid' },
+      ],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('findings');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].id).toBe('SPEC-2');
+  });
+
+  it('parseSpecReviewResult returns failed when status is findings but all findings have invalid severity', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'findings',
+      summary: 'Bad output.',
+      findings: [
+        { id: 'SPEC-1', severity: 'critical', category: 'clarity', finding: 'bad severity' },
+        { id: 'SPEC-2', severity: 'high', category: 'testability', finding: 'also bad' },
+      ],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain("status is 'findings' but no valid findings were parsed");
+  });
+
+  it('parseSpecReviewResult silently drops findings with invalid category', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'findings',
+      summary: 'Mixed categories.',
+      findings: [
+        { id: 'SPEC-1', severity: 'blocker', category: 'unknown_category', finding: 'invalid category' },
+        { id: 'SPEC-2', severity: 'warning', category: 'testability', finding: 'valid category' },
+      ],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('findings');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].id).toBe('SPEC-2');
+  });
+
+  it('parseSpecReviewResult returns failed when status is findings with empty findings array', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'findings',
+      summary: 'Something was found.',
+      findings: [],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain("status is 'findings' but no valid findings were parsed");
   });
 });
 

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -14,6 +14,9 @@ import {
   buildFinalReviewPrompt,
   buildImplementerResponsePrompt,
   parseImplementationReviewResult,
+  buildSpecReviewPrompt,
+  buildSpecAuthorResponsePrompt,
+  parseSpecReviewResult,
   drainAgentRunner,
   validateRequiredResultFile,
 } from '../../../src/core/ai/agent-services.js';
@@ -941,6 +944,97 @@ describe('validateRequiredResultFile', () => {
     expect(missing).toBeDefined();
     // Check stderr excerpt is surfaced
     expect(JSON.stringify(missing)).toContain('auth failed');
+  });
+});
+
+describe('spec review prompts and parser', () => {
+  it('buildSpecReviewPrompt requires read-only review and JSON result file', () => {
+    const prompt = buildSpecReviewPrompt({
+      artifact_path: '/ws/context-human/specs/enhancement-x.md',
+      artifact_kind: 'feature_spec',
+      working_directory: '/ws',
+      result_path: '/ws/.autocatalyst/spec-review-result.json',
+      template_conformance: true,
+      current_page_markdown: '# Published copy',
+    });
+
+    expect(prompt).toContain('Do NOT edit any files');
+    expect(prompt).toContain('/ws/.autocatalyst/spec-review-result.json');
+    expect(prompt).toContain('Completeness');
+    expect(prompt).toContain('Template conformance');
+    expect(prompt).toContain('canonical fields `created`, `last_updated`, `status`, `issue`, `specced_by`, `implemented_by`, and `superseded_by`');
+    expect(prompt).toContain('"status": "no_findings" | "findings" | "failed"');
+  });
+
+  it('buildSpecAuthorResponsePrompt includes every finding and normal response contract', () => {
+    const prompt = buildSpecAuthorResponsePrompt({
+      artifact_path: '/ws/context-human/specs/enhancement-x.md',
+      working_directory: '/ws',
+      result_path: '/ws/.autocatalyst/spec-review-author-response.json',
+      findings: [
+        { id: 'SPEC-1', severity: 'warning', category: 'clarity', finding: 'Acceptance criteria are vague.' },
+      ],
+    });
+
+    expect(prompt).toContain('[SPEC_REVIEW_ID: SPEC-1]');
+    expect(prompt).toContain('"disposition": "fixed" | "declined" | "needs_input"');
+    expect(prompt).toContain('Include one response entry per [SPEC_REVIEW_ID:] finding');
+  });
+
+  it('buildSpecAuthorResponsePrompt includes full rewrite flow for template conformance findings', () => {
+    const prompt = buildSpecAuthorResponsePrompt({
+      artifact_path: '/ws/context-human/specs/enhancement-x.md',
+      working_directory: '/ws',
+      result_path: '/ws/.autocatalyst/spec-review-author-response.json',
+      findings: [
+        { id: 'SPEC-1', severity: 'blocker', category: 'template_conformance', finding: 'Wrong template.', requires_full_rewrite: true },
+      ],
+    });
+
+    expect(prompt).toContain('Write a clean replacement file at `/ws/context-human/specs/enhancement-x-new.md`');
+    expect(prompt).toContain('Delete the malformed original after the replacement is complete');
+    expect(prompt).toContain('Rename the replacement file to the original path');
+    expect(prompt).toContain('Let the `mm:planning` template, not the original malformed structure, determine the new file structure');
+  });
+
+  it('parseSpecReviewResult parses a valid findings result', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'findings',
+      summary: 'Two issues.',
+      findings: [
+        { id: 'SPEC-1', severity: 'blocker', category: 'template_conformance', finding: 'Wrong fields.', requires_full_rewrite: true },
+      ],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+
+    expect(result.status).toBe('findings');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].requires_full_rewrite).toBe(true);
+  });
+
+  it('parseSpecReviewResult degrades invalid JSON to failed', () => {
+    const result = parseSpecReviewResult('{bad json', '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('not valid JSON');
+  });
+
+  it('parseSpecReviewResult rejects no_findings with findings', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'no_findings',
+      summary: 'ok',
+      findings: [{ id: 'SPEC-1', severity: 'info', category: 'clarity', finding: 'x' }],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('no_findings must include an empty findings array');
+  });
+
+  it('parseSpecReviewResult rejects requires_full_rewrite outside template_conformance', () => {
+    const result = parseSpecReviewResult(JSON.stringify({
+      status: 'findings',
+      summary: 'bad',
+      findings: [{ id: 'SPEC-1', severity: 'blocker', category: 'clarity', finding: 'x', requires_full_rewrite: true }],
+    }), '/ws/.autocatalyst/spec-review-result.json');
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('requires_full_rewrite may only be true for template_conformance findings');
   });
 });
 

--- a/tests/core/ai/route-skills.test.ts
+++ b/tests/core/ai/route-skills.test.ts
@@ -14,6 +14,11 @@ describe('requiredSkillsForRoute', () => {
     expect(requiredSkillsForRoute({ task: 'implementation.run' })).toEqual(['superpowers:subagent-driven-development']);
   });
 
+  test('maps spec.review to mm:planning so the reviewer has template context', () => {
+    expect(requiredSkillsForRoute({ task: 'spec.review' })).toEqual(['mm:planning']);
+    expect(requiredSkillsForRoute({ task: 'spec.review', artifact_kind: 'feature_spec' })).toEqual(['mm:planning']);
+  });
+
   test('leaves direct and non-skill routes empty', () => {
     expect(requiredSkillsForRoute({ task: 'intent.classify' })).toEqual([]);
     expect(requiredSkillsForRoute({ task: 'pr.title_generate' })).toEqual([]);

--- a/tests/core/ai/spec-review-coordinator.test.ts
+++ b/tests/core/ai/spec-review-coordinator.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SpecReviewCoordinator } from '../../../src/core/ai/spec-review-coordinator.js';
+import type { AgentProfile, AgentRunner, AgentRoutingPolicy, ArtifactAuthoringAgent, SpecReviewAuthorResponseResult, SpecReviewResult } from '../../../src/types/ai.js';
+import type { Run } from '../../../src/types/runs.js';
+
+const WORKING_DIR = '/ws/test';
+const ARTIFACT_PATH = '/ws/test/context-human/specs/enhancement-x.md';
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-001',
+    request_id: 'req-001',
+    intent: 'idea',
+    stage: 'speccing',
+    workspace_path: WORKING_DIR,
+    branch: 'spec/req-001',
+    artifact: { kind: 'feature_spec', local_path: ARTIFACT_PATH, status: 'drafting' },
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 1,
+    pr_url: undefined,
+    last_impl_result: undefined,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeAgentProfile(name = 'review-agent'): AgentProfile {
+  return { id: name, provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' };
+}
+
+function makeRoutingPolicy(reviewProfile: AgentProfile | null = makeAgentProfile()): AgentRoutingPolicy {
+  return {
+    resolve: vi.fn().mockImplementation((route: { task: string }) => {
+      throw new Error(`No route for ${route.task}`);
+    }),
+    resolveOptional: vi.fn().mockImplementation((route: { task: string }) => {
+      if (route.task === 'spec.review') return reviewProfile;
+      if (route.task === 'artifact.revise') return makeAgentProfile('artifact-agent');
+      return null;
+    }),
+  };
+}
+
+function makeRunner(): AgentRunner {
+  return {
+    run: vi.fn().mockReturnValue((async function* () {})()),
+  };
+}
+
+function makeAuthoringAgent(authorResponse: SpecReviewAuthorResponseResult = {
+  status: 'complete',
+  responses: [{ id: 'SPEC-1', disposition: 'fixed', response: 'Updated acceptance criteria.' }],
+}): Pick<ArtifactAuthoringAgent, 'respondToSpecReview'> {
+  return { respondToSpecReview: vi.fn().mockResolvedValue(authorResponse) };
+}
+
+function makeDeps(
+  reviewResult: SpecReviewResult = { status: 'no_findings', summary: 'Looks good.', findings: [] },
+  overrides: Record<string, unknown> = {},
+) {
+  const reviewJson = JSON.stringify(reviewResult);
+  return {
+    runner: makeRunner(),
+    artifactAuthoringAgent: makeAuthoringAgent(),
+    routingPolicy: makeRoutingPolicy(),
+    policy: { max_rounds: 1, on_review_failure: 'warn' as const, template_conformance: true },
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    readFile: vi.fn().mockResolvedValue(reviewJson),
+    ...overrides,
+  };
+}
+
+describe('SpecReviewCoordinator', () => {
+  describe('runSpecReview — no findings', () => {
+    it('returns complete status without invoking author response pass', async () => {
+      const d = makeDeps();
+      const coordinator = new SpecReviewCoordinator(d);
+      const run = makeRun();
+      const result = await coordinator.runSpecReview({ run, artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('complete');
+      expect(d.artifactAuthoringAgent.respondToSpecReview).not.toHaveBeenCalled();
+    });
+
+    it('logs spec.review.completed', async () => {
+      const d = makeDeps();
+      const coordinator = new SpecReviewCoordinator(d);
+      const run = makeRun();
+      await coordinator.runSpecReview({ run, artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      const infoCalls = (d.logger.info as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[0] as Record<string, unknown>);
+      expect(infoCalls.some(l => l['event'] === 'spec.review.completed')).toBe(true);
+    });
+  });
+
+  describe('runSpecReview — missing route', () => {
+    it('returns complete without invoking runner', async () => {
+      const d = makeDeps({} as SpecReviewResult, { routingPolicy: makeRoutingPolicy(null) });
+      const coordinator = new SpecReviewCoordinator(d);
+      const run = makeRun();
+      const result = await coordinator.runSpecReview({ run, artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('complete');
+      expect(d.runner.run).not.toHaveBeenCalled();
+    });
+
+    it('logs spec.review.skipped at warn level', async () => {
+      const d = makeDeps({} as SpecReviewResult, { routingPolicy: makeRoutingPolicy(null) });
+      const coordinator = new SpecReviewCoordinator(d);
+      const run = makeRun();
+      await coordinator.runSpecReview({ run, artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(d.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'spec.review.skipped' }),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('runSpecReview — findings path', () => {
+    it('calls respondToSpecReview with prompt containing SPEC_REVIEW_ID tags', async () => {
+      const d = makeDeps({
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'SPEC-1', severity: 'warning' as const, category: 'clarity' as const, finding: 'Vague criteria.' }],
+      });
+      const coordinator = new SpecReviewCoordinator(d);
+      const run = makeRun();
+      await coordinator.runSpecReview({ run, artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(d.artifactAuthoringAgent.respondToSpecReview).toHaveBeenCalledWith(
+        ARTIFACT_PATH,
+        WORKING_DIR,
+        expect.stringContaining('[SPEC_REVIEW_ID: SPEC-1]'),
+        undefined,
+        expect.any(Function),
+        expect.anything(),
+      );
+    });
+
+    it('returns complete when author responds successfully', async () => {
+      const d = makeDeps({
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'SPEC-1', severity: 'warning' as const, category: 'clarity' as const, finding: 'Vague.' }],
+      });
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('complete');
+    });
+
+    it('calls respondToSpecReview exactly once', async () => {
+      const d = makeDeps({
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'SPEC-1', severity: 'blocker' as const, category: 'completeness' as const, finding: 'Missing section.' }],
+      });
+      const coordinator = new SpecReviewCoordinator(d);
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(d.artifactAuthoringAgent.respondToSpecReview).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('runSpecReview — author needs_input', () => {
+    it('returns needs_input with question when author cannot resolve a finding', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: [{ id: 'SPEC-1', severity: 'blocker' as const, category: 'feasibility' as const, finding: 'Unclear scope.' }] },
+        { artifactAuthoringAgent: makeAuthoringAgent({ status: 'needs_input', responses: [], question: 'Should the feature include migration?' }) },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('needs_input');
+      expect(result.question).toBe('Should the feature include migration?');
+    });
+  });
+
+  describe('runSpecReview — review model failure', () => {
+    it('warn policy: returns complete and logs spec.review.degraded', async () => {
+      const d = makeDeps(
+        { status: 'failed', summary: '', findings: [], error: 'model unavailable' },
+        { policy: { max_rounds: 1, on_review_failure: 'warn' as const, template_conformance: true } },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('complete');
+      expect(d.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'spec.review.degraded' }),
+        expect.any(String),
+      );
+    });
+
+    it('block policy: returns failed with error', async () => {
+      const d = makeDeps(
+        { status: 'failed', summary: '', findings: [], error: 'model unavailable' },
+        { policy: { max_rounds: 1, on_review_failure: 'block' as const, template_conformance: true } },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('model unavailable');
+    });
+  });
+
+  describe('runSpecReview — full rewrite prompt forwarding', () => {
+    it('author response prompt contains full rewrite instructions when requires_full_rewrite is true', async () => {
+      const d = makeDeps({
+        status: 'findings',
+        summary: 'Template issue.',
+        findings: [{ id: 'SPEC-1', severity: 'blocker' as const, category: 'template_conformance' as const, finding: 'Wrong structure.', requires_full_rewrite: true }],
+      });
+      const coordinator = new SpecReviewCoordinator(d);
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      const call = (d.artifactAuthoringAgent.respondToSpecReview as ReturnType<typeof vi.fn>).mock.calls[0];
+      const prompt = call[2] as string;
+      expect(prompt).toContain('Delete the malformed original after the replacement is complete');
+      expect(prompt).toContain('Rename the replacement file to the original path');
+    });
+  });
+
+  describe('runSpecReview — onAgentRequest callback', () => {
+    it('records agent request metadata with route task spec.review and artifact_kind', async () => {
+      const d = makeDeps();
+      const coordinator = new SpecReviewCoordinator(d);
+      const onAgentRequest = vi.fn();
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec', onAgentRequest });
+      expect(onAgentRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          route: expect.objectContaining({ task: 'spec.review', artifact_kind: 'feature_spec' }),
+        }),
+      );
+    });
+  });
+});

--- a/tests/core/ai/spec-review-coordinator.test.ts
+++ b/tests/core/ai/spec-review-coordinator.test.ts
@@ -227,4 +227,119 @@ describe('SpecReviewCoordinator', () => {
       );
     });
   });
+
+  describe('runSpecReview — author response validation', () => {
+    const findingsWithSpec1 = [
+      { id: 'SPEC-1', severity: 'warning' as const, category: 'clarity' as const, finding: 'Vague.' },
+    ];
+
+    it('returns failed when author response is missing a finding ID', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        { artifactAuthoringAgent: makeAuthoringAgent({ status: 'complete', responses: [] }) },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('SPEC-1');
+    });
+
+    it('returns failed when author response has duplicate finding IDs', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        {
+          artifactAuthoringAgent: makeAuthoringAgent({
+            status: 'complete',
+            responses: [
+              { id: 'SPEC-1', disposition: 'fixed', response: 'Fixed it.' },
+              { id: 'SPEC-1', disposition: 'fixed', response: 'Fixed again.' },
+            ],
+          }),
+        },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Duplicate');
+    });
+
+    it('returns failed when author response references an unknown finding ID', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        {
+          artifactAuthoringAgent: makeAuthoringAgent({
+            status: 'complete',
+            responses: [
+              { id: 'SPEC-1', disposition: 'fixed', response: 'Fixed it.' },
+              { id: 'SPEC-99', disposition: 'fixed', response: 'Extra response.' },
+            ],
+          }),
+        },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('SPEC-99');
+    });
+
+    it('returns failed when a response has an invalid disposition', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        {
+          artifactAuthoringAgent: makeAuthoringAgent({
+            status: 'complete',
+            responses: [{ id: 'SPEC-1', disposition: 'ignored', response: 'Some text.' }],
+          }),
+        },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('disposition');
+    });
+
+    it('returns failed when a response has an empty explanation', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        {
+          artifactAuthoringAgent: makeAuthoringAgent({
+            status: 'complete',
+            responses: [{ id: 'SPEC-1', disposition: 'fixed', response: '   ' }],
+          }),
+        },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Empty');
+    });
+
+    it('returns failed when a declined response says only "no action needed"', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        {
+          artifactAuthoringAgent: makeAuthoringAgent({
+            status: 'complete',
+            responses: [{ id: 'SPEC-1', disposition: 'declined', response: 'no action needed' }],
+          }),
+        },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('concrete reason');
+    });
+
+    it('does not call publication (returns failed) when validation fails — proving publication is blocked', async () => {
+      const d = makeDeps(
+        { status: 'findings', summary: 'Found issue.', findings: findingsWithSpec1 },
+        { artifactAuthoringAgent: makeAuthoringAgent({ status: 'complete', responses: [] }) },
+      );
+      const coordinator = new SpecReviewCoordinator(d);
+      const result = await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec' });
+      // Coordinator returns failed; handler tests verify createArtifact is not called when status is failed
+      expect(result.status).toBe('failed');
+      expect(result.page_content).toBeUndefined();
+    });
+  });
 });

--- a/tests/core/config-types.test.ts
+++ b/tests/core/config-types.test.ts
@@ -2,7 +2,7 @@
  * Type-level tests for AiConfig, CredentialConfig, ProfileConfig, RoutingConfig.
  * Verified at compile time via `tsc --noEmit` — no runtime assertions needed.
  */
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import type { WorkflowConfig, AiConfig, CredentialConfig, EndpointConfig, ProfileConfig, RoutingConfig } from '../../src/types/config.js';
 
 // T1: WorkflowConfig with anthropic api_key credential satisfies the type
@@ -53,5 +53,24 @@ void (null as unknown as RoutingConfig);
 describe('AiConfig and related compile-time types', () => {
   it('type assertions are verified at compile time via tsc --noEmit', () => {
     // All assertions are compile-time only (see module-level constants above).
+  });
+
+  it('accepts spec review route and policy fields', () => {
+    const config: WorkflowConfig = {
+      ai: {
+        credentials: [],
+        endpoints: [],
+        profiles: [],
+        routing: { 'spec.review': 'review-agent' },
+      },
+      spec_review: {
+        max_rounds: 1,
+        on_review_failure: 'warn',
+        template_conformance: true,
+      },
+    };
+
+    expect(config.ai.routing['spec.review']).toBe('review-agent');
+    expect(config.spec_review?.template_conformance).toBe(true);
   });
 });

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -12,6 +12,7 @@ import {
   loadConfig,
   resolveAiConfig,
   getImplementationReviewPolicy,
+  getSpecReviewPolicy,
   isWorkspaceAutoPruneEnabled,
 } from '../../src/core/config.js';
 import type { WorkflowConfig } from '../../src/types/config.js';
@@ -474,6 +475,64 @@ describe('getImplementationReviewPolicy', () => {
   it('defaults on_review_failure to warn when not set', () => {
     const policy = getImplementationReviewPolicy({ implementation_review: { max_initial_rounds: 2 } } as unknown as WorkflowConfig);
     expect(policy.on_review_failure).toBe('warn');
+  });
+});
+
+// ─── validateConfig: spec_review ─────────────────────────────────────────────
+
+describe('validateConfig: spec_review', () => {
+  it('passes when spec_review is absent', () => {
+    expect(() => validateConfig({} as WorkflowConfig)).not.toThrow();
+  });
+
+  it('passes for a valid spec_review block', () => {
+    expect(() =>
+      validateConfig({ spec_review: { on_review_failure: 'block', max_rounds: 1, template_conformance: true } } as unknown as WorkflowConfig),
+    ).not.toThrow();
+  });
+
+  it('throws when spec_review is not an object', () => {
+    expect(() =>
+      validateConfig({ spec_review: 'bad' } as unknown as WorkflowConfig),
+    ).toThrow('spec_review must be an object');
+  });
+
+  it('throws when spec_review.on_review_failure is invalid', () => {
+    expect(() =>
+      validateConfig({ spec_review: { on_review_failure: 'ignore' } } as unknown as WorkflowConfig),
+    ).toThrow('spec_review.on_review_failure must be "warn" or "block"');
+  });
+
+  it('throws when spec_review.max_rounds is zero', () => {
+    expect(() =>
+      validateConfig({ spec_review: { max_rounds: 0 } } as unknown as WorkflowConfig),
+    ).toThrow('spec_review.max_rounds must be a positive integer');
+  });
+
+  it('throws when spec_review.template_conformance is not boolean', () => {
+    expect(() =>
+      validateConfig({ spec_review: { template_conformance: 'yes' } } as unknown as WorkflowConfig),
+    ).toThrow('spec_review.template_conformance must be a boolean');
+  });
+});
+
+// ─── getSpecReviewPolicy ──────────────────────────────────────────────────────
+
+describe('getSpecReviewPolicy', () => {
+  it('returns safe defaults when spec_review is absent', () => {
+    expect(getSpecReviewPolicy({} as WorkflowConfig)).toEqual({
+      max_rounds: 1,
+      on_review_failure: 'warn',
+      template_conformance: true,
+    });
+  });
+
+  it('uses configured values', () => {
+    expect(getSpecReviewPolicy({ spec_review: { max_rounds: 2, on_review_failure: 'block', template_conformance: false } } as unknown as WorkflowConfig)).toEqual({
+      max_rounds: 2,
+      on_review_failure: 'block',
+      template_conformance: false,
+    });
   });
 });
 

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -339,6 +339,54 @@ describe('buildDefaultHandlerRegistry', () => {
     });
   });
 
+  it('passes specReviewCoordinator through to artifact creation handler', async () => {
+    const runSpecReview = vi.fn().mockResolvedValue({ status: 'complete', artifact_path: '/ws/request-001/spec.md' });
+    const deps = {
+      ...makeDeps(),
+      specReviewCoordinator: { runSpecReview },
+    };
+    (deps.workspaceManager.create as ReturnType<typeof vi.fn>).mockResolvedValue({ workspace_path: '/ws/request-001', branch: 'spec/request-001' });
+    (deps.artifactAuthoringAgent.create as ReturnType<typeof vi.fn>).mockResolvedValue({ artifact_path: '/ws/request-001/spec.md' });
+    (deps.artifactPublisher.createArtifact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'CANVAS-X', url: 'https://x' });
+
+    const registry = buildDefaultHandlerRegistry(deps);
+    const run = makeRun({ stage: 'new_thread', intent: 'idea' });
+
+    const handler = registry.resolve({ event_type: 'new_request', stage: 'new_thread', intent: 'idea' });
+    const event: InboundEvent = {
+      type: 'new_request',
+      payload: {
+        request_id: 'request-001',
+        channel: run.channel,
+        conversation: run.conversation,
+        origin: run.origin,
+        author: 'U123',
+        content: 'idea',
+        intent: 'idea',
+        received_at: new Date().toISOString(),
+      },
+    };
+    await handler?.(event, run);
+    expect(runSpecReview).toHaveBeenCalled();
+  });
+
+  it('passes specReviewCoordinator through to artifact feedback handler', async () => {
+    const runSpecReview = vi.fn().mockResolvedValue({ status: 'complete', artifact_path: '/ws/request-001/spec.md' });
+    const deps = {
+      ...makeDeps(),
+      specReviewCoordinator: { runSpecReview },
+    };
+    (deps.artifactAuthoringAgent.revise as ReturnType<typeof vi.fn>).mockResolvedValue({ comment_responses: [], page_content: '# Revised' });
+
+    const registry = buildDefaultHandlerRegistry(deps);
+    const run = makeRun();
+    const event: InboundEvent = { type: 'thread_message', payload: makeFeedback({ content: 'tweak this' }) };
+
+    const handler = registry.resolve({ event_type: 'thread_message', stage: 'reviewing_spec', intent: 'feedback' });
+    await handler?.(event, run);
+    expect(runSpecReview).toHaveBeenCalled();
+  });
+
   it('passes the artifact local_path to the implementer after bug triage approval without deleting it', async () => {
     const bugLocalPath = '/ws/request-001/.autocatalyst/triage/triage-bug-login.md';
     const deps = {

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -68,6 +68,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactCre
     },
     persist: vi.fn(),
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
+    specReviewCoordinator: undefined as undefined | { runSpecReview: ReturnType<typeof vi.fn> },
     ...overrides,
   };
 
@@ -230,6 +231,102 @@ describe('ArtifactCreationHandler', () => {
       expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
       expect.any(String),
     );
+  });
+
+  describe('spec review integration', () => {
+    it('runs spec review after branch guard and before createArtifact for idea intent', async () => {
+      const callOrder: string[] = [];
+      const branchGuardCheck = vi.fn().mockImplementation(async () => { callOrder.push('branchGuard'); });
+      const runSpecReview = vi.fn().mockImplementation(async () => {
+        callOrder.push('specReview');
+        return { status: 'complete', artifact_path: '/ws/request-001/context-human/specs/feature-test.md' };
+      });
+      const createArtifact = vi.fn().mockImplementation(async () => {
+        callOrder.push('publish');
+        return { id: 'CANVAS001', url: 'https://artifact.example.test/CANVAS001' };
+      });
+      const { handler, deps } = makeHandler({
+        branchGuard: { check: branchGuardCheck },
+        specReviewCoordinator: { runSpecReview },
+        artifactPublisher: {
+          createArtifact,
+          updateStatus: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(callOrder).toEqual(['branchGuard', 'specReview', 'branchGuard', 'publish']);
+      expect(runSpecReview).toHaveBeenCalledWith(expect.objectContaining({
+        artifact_kind: 'feature_spec',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        working_directory: '/ws/request-001',
+      }));
+      expect(deps.failRun).not.toHaveBeenCalled();
+    });
+
+    it('does not call specReviewCoordinator for bug or chore intents', async () => {
+      const runSpecReview = vi.fn();
+      const { handler: bugHandler } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+        artifactAuthoringAgent: {
+          create: vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/bug.md' }),
+        },
+      });
+      await bugHandler.handle(makeRun({ intent: 'bug' }), makeRequest(), 'bug');
+      expect(runSpecReview).not.toHaveBeenCalled();
+
+      const { handler: choreHandler } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+        artifactAuthoringAgent: {
+          create: vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/chore.md' }),
+        },
+      });
+      await choreHandler.handle(makeRun({ intent: 'chore' }), makeRequest(), 'chore');
+      expect(runSpecReview).not.toHaveBeenCalled();
+    });
+
+    it('does not publish when spec review returns needs_input', async () => {
+      const runSpecReview = vi.fn().mockResolvedValue({
+        status: 'needs_input',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        question: 'Need more details',
+      });
+      const { handler, deps } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+      });
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(deps.artifactPublisher.createArtifact).not.toHaveBeenCalled();
+      expect(deps.failRun).toHaveBeenCalled();
+      expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
+    });
+
+    it('does not publish when spec review returns failed', async () => {
+      const runSpecReview = vi.fn().mockResolvedValue({
+        status: 'failed',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        error: 'review crashed',
+      });
+      const { handler, deps } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+      });
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(deps.artifactPublisher.createArtifact).not.toHaveBeenCalled();
+      expect(deps.failRun).toHaveBeenCalled();
+    });
+
+    it('skips spec review when specReviewCoordinator is undefined', async () => {
+      const { handler, deps } = makeHandler({ specReviewCoordinator: undefined });
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(deps.artifactPublisher.createArtifact).toHaveBeenCalled();
+      expect(deps.failRun).not.toHaveBeenCalled();
+    });
   });
 
   it('posts no publication link when url is absent', async () => {

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -62,6 +62,7 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactFee
     },
     feedbackSource: undefined,
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
+    specReviewCoordinator: undefined as undefined | { runSpecReview: ReturnType<typeof vi.fn> },
     postMessage: vi.fn().mockResolvedValue(undefined),
     transition: vi.fn((run: Run, stage: Run['stage']) => { run.stage = stage; }),
     failRun: vi.fn().mockResolvedValue(undefined),
@@ -275,6 +276,99 @@ describe('ArtifactFeedbackHandler', () => {
       expect.objectContaining({ event: 'run.agent_request_recorded', run_id: 'run-001' }),
       expect.any(String),
     );
+  });
+
+  describe('spec review integration', () => {
+    it('runs spec review after branch guard and before updateArtifact', async () => {
+      const callOrder: string[] = [];
+      const branchGuardCheck = vi.fn().mockImplementation(async () => { callOrder.push('branchGuard'); });
+      const runSpecReview = vi.fn().mockImplementation(async () => {
+        callOrder.push('specReview');
+        return { status: 'complete', artifact_path: '/ws/request-001/context-human/specs/feature-test.md' };
+      });
+      const updateArtifact = vi.fn().mockImplementation(async () => { callOrder.push('updateArtifact'); });
+      const { handler } = makeHandler({
+        branchGuard: { check: branchGuardCheck },
+        specReviewCoordinator: { runSpecReview },
+        artifactAuthoringAgent: {
+          revise: vi.fn().mockImplementation(async () => { callOrder.push('revise'); return { comment_responses: [], page_content: '# Revised' }; }),
+        },
+        artifactPublisher: {
+          updateArtifact,
+          updateStatus: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      const run = makeRun();
+      const result = await handler.handle(run, makeFeedback());
+      expect(result).toEqual({ status: 'revised' });
+      expect(callOrder).toEqual(['revise', 'branchGuard', 'specReview', 'branchGuard', 'updateArtifact']);
+      expect(runSpecReview).toHaveBeenCalledWith(expect.objectContaining({
+        artifact_kind: 'feature_spec',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        working_directory: '/ws/request-001',
+      }));
+    });
+
+    it('uses page_content from review result in updateArtifact when provided', async () => {
+      const runSpecReview = vi.fn().mockResolvedValue({
+        status: 'complete',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        page_content: '# Reviewed Content',
+      });
+      const updateArtifact = vi.fn().mockResolvedValue(undefined);
+      const { handler } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+        artifactAuthoringAgent: {
+          revise: vi.fn().mockResolvedValue({ comment_responses: [], page_content: '# Original Revised' }),
+        },
+        artifactPublisher: {
+          updateArtifact,
+          updateStatus: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      const run = makeRun();
+      await handler.handle(run, makeFeedback());
+
+      expect(updateArtifact).toHaveBeenCalledWith(
+        'CANVAS001',
+        expect.any(Object),
+        '# Reviewed Content',
+      );
+    });
+
+    it('does not call updateArtifact when review returns needs_input', async () => {
+      const runSpecReview = vi.fn().mockResolvedValue({
+        status: 'needs_input',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        question: 'clarify scope',
+      });
+      const { handler, deps } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+      });
+      const run = makeRun();
+      const result = await handler.handle(run, makeFeedback());
+
+      expect(result).toEqual({ status: 'failed' });
+      expect(deps.artifactPublisher.updateArtifact).not.toHaveBeenCalled();
+      expect(deps.failRun).toHaveBeenCalled();
+    });
+
+    it('does not call updateArtifact when review returns failed', async () => {
+      const runSpecReview = vi.fn().mockResolvedValue({
+        status: 'failed',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        error: 'review error',
+      });
+      const { handler, deps } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+      });
+      const run = makeRun();
+      const result = await handler.handle(run, makeFeedback());
+
+      expect(result).toEqual({ status: 'failed' });
+      expect(deps.artifactPublisher.updateArtifact).not.toHaveBeenCalled();
+      expect(deps.failRun).toHaveBeenCalled();
+    });
   });
 
   it('does not fail the run when replying to a publisher comment or notifying the channel fails', async () => {

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -353,6 +353,39 @@ describe('ArtifactFeedbackHandler', () => {
       expect(deps.failRun).toHaveBeenCalled();
     });
 
+    it('uses reviewed page_content over revise page_content when review finds issues and author responds', async () => {
+      // Scenario: revise() returns page_content (from anchor codec), then spec review finds issues,
+      // respondToSpecReview edits the artifact and returns updated page_content. updateArtifact must
+      // receive the reviewed page_content, not the stale pre-review page_content from revise().
+      const runSpecReview = vi.fn().mockResolvedValue({
+        status: 'complete',
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        page_content: '# Reviewed + Anchors Preserved',
+      });
+      const updateArtifact = vi.fn().mockResolvedValue(undefined);
+      const { handler } = makeHandler({
+        specReviewCoordinator: { runSpecReview },
+        artifactAuthoringAgent: {
+          revise: vi.fn().mockResolvedValue({
+            comment_responses: [],
+            page_content: '# Stale Pre-Review With Anchors',
+          }),
+        },
+        artifactPublisher: {
+          updateArtifact,
+          updateStatus: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      const run = makeRun();
+      await handler.handle(run, makeFeedback());
+
+      expect(updateArtifact).toHaveBeenCalledWith(
+        'CANVAS001',
+        expect.any(Object),
+        '# Reviewed + Anchors Preserved',
+      );
+    });
+
     it('does not call updateArtifact when review returns failed', async () => {
       const runSpecReview = vi.fn().mockResolvedValue({
         status: 'failed',

--- a/tests/core/runtime-composition.test.ts
+++ b/tests/core/runtime-composition.test.ts
@@ -170,6 +170,7 @@ describe('composeWorkflowRuntime', () => {
         channelRepoMap: new Map([
           ['slack:C123', { channel_ref: 'slack:C123', repo_url: 'https://example.test/org/repo.git', workspace_root: '/tmp/ws' }],
         ]),
+        specReviewCoordinator: expect.objectContaining({ runSpecReview: expect.any(Function) }),
       }),
     );
     expect(logger.info).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- validateAuthorResponses now returns string[] errors instead of void, covering: missing IDs, duplicate IDs, unknown IDs, invalid dispositions, empty explanations, and non-concrete declined reasons
- runSpecReview checks the error array after validation and returns { status: 'failed' } when any errors exist, blocking publication
- Added 7 new coordinator tests — one per invalid-response scenario — proving 'failed' is returned (not 'complete') in each case

## Verify

- [ ] spec-review-coordinator.ts: validateAuthorResponses returns string[] and caller returns failed when non-empty
- [ ] 19 coordinator tests pass including all 7 new validation-failure tests
- [ ] Handler tests (27 tests) confirm that a 'failed' result from runSpecReview blocks createArtifact/updateArtifact calls

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/dfedf871-726f-442d-a09a-05327307dc97
2. npx vitest run tests/core/ai/spec-review-coordinator.test.ts
3. npx vitest run tests/core/handlers/artifact-creation-handler.test.ts tests/core/handlers/artifact-feedback-handler.test.ts

---
Spec: `context-human/specs/enhancement-spec-ai-review-pass.md`
Closes #164