### PR TITLE
feat: add append-only autocatalyst jsonl journaling with run event and session records

### DIFF
--- a/context-human/specs/enhancement-append-only-backfill-journal.md
+++ b/context-human/specs/enhancement-append-only-backfill-journal.md
@@ -1,0 +1,681 @@
+---
+created: 2026-06-07
+last_updated: 2026-06-07
+status: implementing
+issue: 192
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Append-only backfill journal
+
+## Parent feature
+
+- `feature-run-persistence.md` — persists the current run registry in per-repo `.autocatalyst/runs.json`.
+- `feature-approval-to-implementation.md` — defines the request-to-spec-to-implementation run lifecycle and thread-message routing.
+- `enhancement-comprehensive-telemetry-instrumentation.md` — establishes structured logging, redaction expectations, and AI runner diagnostics.
+- `enhancement-model-runner-telemetry.md` — adds model-run telemetry that this enhancement turns into durable per-session journal records.
+- `enhancement-two-part-implementation-review.md` — provides `run.review_exchanges`, which is one source of AI-authored feedback records.
+- `enhancement-run-status-workspace-ai-context.md` — adds current model and latest agent request metadata to active runs.
+- `enhancement-existing-issue-work-routing.md` — introduces the existing-issue flow that may later let multiple runs coalesce under one topic.
+## What
+
+Autocatalyst adds a capture layer that writes an append-only JSONL journal under the per-repo `.autocatalyst/journal/` directory. The journal records the history needed to replay v0 runs into the future Autocatalyst data model: `Conversation`, `Topic`, `Run`, `Message`, `Feedback`, `RunStep`, `RunStepRole`, `Session`, and `Cost`.
+The journal has four streams:
+1. `messages.jsonl` records every run-associated inbound and outbound human-interface message.
+2. `sessions.jsonl` records one model invocation session for every direct-model and agent-runner call that belongs to a run.
+3. `feedback.jsonl` records human feedback and AI review findings with attribution and lifecycle fields.
+4. `run-events.jsonl` records run creation and every run stage transition.
+The capture layer is additive and config-gated by `journal.enabled`, which defaults to `true`. When disabled, Autocatalyst writes no journal files and preserves today's behavior. Journal write failures never fail a run; they are logged and swallowed.
+This enhancement does not import the journal into the future schema. It captures a raw, redacted superset so a later importer can map the data after the new schema settles.
+### Goals
+
+- Create four append-only JSONL streams under per-repo `.autocatalyst/journal/`: `messages.jsonl`, `sessions.jsonl`, `feedback.jsonl`, and `run-events.jsonl`.
+- Keep the journal independent of `runs.json` pruning, demotion, and rewriting.
+- Record every run-associated inbound `new_request` and `thread_message` payload with redacted content and classified intent when classification is available; if a known-run inbound message cannot be classified, record `intent: null` with a classification status instead of inventing an intent.
+- Record every outbound `postMessage()` reply from a single choke point instead of instrumenting each call site.
+- Record one `sessions.jsonl` line for each model invocation associated with a run across Anthropic direct, OpenAI direct, Claude Agent SDK, and OpenAI Agent SDK runners.
+- Include orchestrator-owned direct model calls such as `intent.classify` and `pr.title_generate` when they have run context.
+- Normalize token counts to `{ input, output, cache_read, cache_write }` in adapter code where provider data is available.
+- Record `tokens: null` when provider token data is unavailable.
+- Record `inference.effort` and `inference.thinking` for every session from the resolved profile.
+- Record `assistant_turns`, `tool_calls`, `tool_results`, and elapsed timing for agent sessions.
+- Capture human feedback messages and AI review findings in `feedback.jsonl` with attribution, timestamp, target, category, severity, and disposition.
+- Record run creation and every stage transition in `run-events.jsonl`, including stage loops.
+- Write run event records before any path can prune or demote the run from `runs.json`.
+- Redact captured message and feedback text with the shared secret-redaction implementation.
+- Make journaling config-gated by `journal.enabled`, defaulting to enabled.
+- Add structured logs for journal writer initialization, append counts, disabled state, and write failures.
+### Non-goals
+
+- Building the importer from journal JSONL into the future Autocatalyst data model.
+- Adding pricing, `usd`, rate tables, cost rollups, or aggregation.
+- Adding a query API, dashboard, or user-facing journal UI.
+- Changing existing structured logs or OpenTelemetry-style metric emission except to add journal lifecycle logs.
+- Replacing `runs.json` as the current run store.
+- Guaranteeing token usage for providers that do not expose it.
+- Capturing unredacted secrets for perfect replay.
+- Moving journal files into `~/.autocatalyst/`; the streams live under the per-repo workspace root's `.autocatalyst/journal/` directory.
+## Why
+
+v0 is the tool building the next Autocatalyst. The team wants the full history of how v0 was built to be replayable into the new data model. Today that history is incomplete and sometimes actively destroyed.
+Inbound `Request` and `ThreadMessage` content is transient. Outbound replies pass through `postMessage()` and are not persisted. Only `run.origin.message_id` survives in the run record.
+Model usage is computed at runner boundaries and logged, but it is not connected to durable run state. Direct runners log token counts and drop them. The Claude agent runner reads terminal usage and logs it. `AgentDrainSummary` reports turns, tool calls, tool results, and elapsed time to agent services, then disappears.
+Feedback lacks provenance. Current feedback items and review exchanges do not form a durable record with author, timestamp, target, category, severity, and lifecycle. This makes it hard to reconstruct what a human asked for, what an AI reviewer found, and how the run addressed those items.
+`FileRunStore.load()` can drop active runs whose workspace is missing and demote stale runs to `failed`. Because `runs.json` is rewritten later, a run's history can vanish before anything imports it. The journal must survive this pruning and demotion path.
+### Personas
+
+- **Enzo: Engineer/operator** — needs to reconstruct run history after workspace cleanup, restarts, failed runs, or importer bugs.
+- **Phoebe: Product manager** — wants future Autocatalyst to preserve the product conversation that led to each spec and implementation.
+- **Autocatalyst analytics agent** — needs raw messages, sessions, feedback, and run timelines to build cost, quality, and process analytics later.
+- **Importer implementer** — needs stable JSONL records with enough raw detail to map v0 history into the new data model without scraping logs.
+### Narratives
+
+#### Enzo recovers a pruned active run
+
+An implementation run is active when its workspace directory is accidentally deleted. On restart, `FileRunStore.load()` drops or demotes the run because the workspace path is missing. Before this enhancement, the original conversation, intermediate stages, and model sessions would be gone unless Enzo could find logs.
+With the journal enabled, `run-events.jsonl` still contains the run creation, every stage transition written before the prune path, and the load-time prune or demotion event written before `runs.json` is rewritten. `messages.jsonl` contains the original request and replies. `sessions.jsonl` contains each model invocation that reached the runner boundary. Enzo can inspect the journal or feed it to a later importer without depending on the surviving `runs.json` entry.
+#### Phoebe reviews product history in the next Autocatalyst
+
+Phoebe asks why a feature was built in a particular way. Future Autocatalyst imports the v0 journal and shows the original Slack request, the follow-up feedback, the spec approval, and the implementation review thread as `Message` and `Feedback` records.
+The importer can attach the records to the correct `Conversation`, `Topic`, and `Run` because each journal line carries `conversation_id`, `topic_id`, `run_id`, and `request_id`. The imported history shows what happened, not only the final code and spec.
+#### An analytics agent estimates historical cost
+
+An analytics agent wants to compare model usage across v0 runs. The journal stores raw token counts, cache-read/cache-write counts where providers expose them, inference settings, runner type, turn counts, and tool counts. It does not store dollars.
+The later importer applies a rate table to the raw token records. If a provider did not expose token counts, such as the OpenAI agent SDK path, the journal records `tokens: null`. The importer treats unknown cost as unknown, not zero.
+## User stories
+
+- As Enzo, I can inspect `.autocatalyst/journal/run-events.jsonl` after a `runs.json` prune or demotion and reconstruct the run timeline.
+- As Enzo, I can inspect `messages.jsonl` and see every run-associated inbound request, follow-up, and outbound Autocatalyst reply with secrets redacted.
+- As Enzo, I can disable journaling with `journal.enabled: false` and verify no journal streams are written.
+- As Phoebe, I can later import v0 conversations and see the human messages that shaped a spec and implementation.
+- As Phoebe, I can later distinguish human feedback from AI review findings because each feedback record has an author principal and source target.
+- As an analytics agent, I can read one `sessions.jsonl` record per model invocation and calculate historical cost from raw tokens later.
+- As an analytics agent, I can tell the difference between zero tokens and unknown token usage because unsupported providers write `tokens: null`.
+- As an importer implementer, I can map `conversation_id`, `topic_id`, `run_id`, and `request_id`, then reconstruct per-run session order from `sessions.jsonl` file order without relying on wall-clock ordering alone.
+- As an operator, I can trust journal write failures to be visible in logs but non-fatal to the active run.
+## Design changes
+
+This is a backend capture enhancement. There is no new human-facing UI.
+### Journal location
+
+The runtime writes streams under the same per-repo `.autocatalyst/` root used by `FileRunStore`:
+```plain text
+/.autocatalyst/
+  runs.json
+  journal/
+    messages.jsonl
+    sessions.jsonl
+    feedback.jsonl
+    run-events.jsonl
+```
+`workspace_root` is the configured repository workspace root passed to runtime composition. The journal is not stored inside each per-run cloned workspace. It must survive per-run workspace deletion.
+### Stream format
+
+Each stream is line-delimited JSON. Each line is one complete record with a process-local stream sequence field and a writer boot identifier. Implementations never rewrite or compact a stream.
+`seq` is not durable across process restarts. A file-backed writer generates a `writer_id` when it initializes and starts `seq` at `1` for each stream within that writer process. After a restart, the next writer may append records with a new `writer_id` and `seq: 1` to an existing stream. Importers must use JSONL file order as the primary stream order and use `(writer_id, seq)` only to order records produced by the same writer instance. Cross-process or cross-restart global sequence ordering is not required for v0.
+For `sessions.jsonl`, file append order is also the canonical per-run session order. A process restart can resume an existing run whose `runs.json` entry survived, and v0 writers do not scan existing journal files or persist a per-run counter. Therefore `session_seq` is a best-effort convenience field that is monotonic only while a writer process has an in-memory counter for that run. Importers that need deterministic within-run ordering must filter `sessions.jsonl` to the target `run_id` in file order; they must not use `session_seq` or `ts_start` as the primary order key across restarts.
+Writers append one UTF-8 line ending in `\n`. If the process crashes while writing, the only expected damage is a torn final line. The future importer must tolerate a trailing partial line.
+### Identity mapping
+
+The journal uses explicit IDs so import does not rely on channel-specific fields.
+- `conversation_id` comes from `run.conversation`, serialized as a stable channel-independent conversation reference.
+- `topic_id` is the run ID for v0 because v0 increments `attempt` in place instead of starting a new run for each retry.
+- `run_id` is `run.id`.
+- `request_id` is `run.request_id`.
+- `origin_message_id` is the inbound or outbound message's channel message ref when available.
+The existing-issue and future intent-upgrade flows may create a new run that belongs to the same human topic. The importer can later coalesce those runs into one `Topic` when it sees shared issue references or explicit topic metadata. This enhancement records enough raw identifiers to make that possible, but it does not implement coalescing.
+### Configuration
+
+Add a top-level config block:
+```yaml
+journal:
+  enabled: true
+```
+Rules:
+- Missing `journal` means journaling is enabled.
+- `journal.enabled: true` writes all configured streams.
+- `journal.enabled: false` creates no writer, writes no streams, and preserves existing behavior.
+- Invalid non-boolean `journal.enabled` fails config validation with a clear error.
+This is a deliberate journal-scoped exception to the no-content-at-info-log rule. The journal is durable capture, not routine logs. Captured free text must be redacted before it reaches disk.
+### Message capture
+
+`messages.jsonl` captures inbound and outbound messages that can be associated with a run. Unrouteable inbound messages that cannot be tied to a run are out of scope for this journal. Known-run inbound messages whose intent classification fails are still captured with `intent: null` and `classification_status: "failed"`.
+Inbound hooks:
+- `new_request` after run creation and after Stage 1 classification succeeds or defaults.
+- `thread_message` after the orchestrator identifies the run. If classification succeeds, include the raw v0 intent. If classification fails after the run is known, write the message with `intent: null` and `classification_status: "failed"`.
+- Unknown-thread or otherwise unrouteable inbound messages are not journaled because the v0 journal requires run context.
+Outbound hook:
+- Wrap `OrchestratorImpl.postMessage()` so every successful outbound reply writes one record through a single choke point.
+- If the human-interface adapter returns a message reference, include it as `origin_message_id`. If it does not, write `origin_message_id: null`.
+- Do not instrument every call site individually.
+`messages.jsonl` record shape:
+```json
+{
+  "seq": 1,
+  "writer_id": "journal-writer-uuid",
+  "ts": "2026-06-07T12:00:00.000Z",
+  "conversation_id": "slack:C123:1717600000.000",
+  "topic_id": "run-uuid",
+  "run_id": "run-uuid",
+  "request_id": "request-001",
+  "direction": "in",
+  "author_principal": "slack:U123",
+  "content": "please work on issue 192",
+  "intent": "work_on_issue",
+  "classification_status": "classified",
+  "origin_message_id": "slack:C123:1717600000.000:1717600000.000"
+}
+```
+Field rules:
+- `seq` is monotonic per stream only within one writer process identified by `writer_id`.
+- `writer_id` identifies the writer process boot that assigned `seq`.
+- `ts` uses `received_at` for inbound messages and current time for outbound messages.
+- `direction` is `in` or `out`.
+- `author_principal` is the inbound author for human messages and a service principal such as `autocatalyst` for outbound replies.
+- `content` is redacted before write.
+- `intent` stores the raw v0 `Intent` when available. For outbound messages and classification failures with no classified intent, use `null`.
+- `classification_status` is `classified`, `defaulted`, `failed`, or `not_applicable`. Outbound messages use `not_applicable`.
+### Session capture
+
+`sessions.jsonl` captures one record per model invocation associated with a run. The record must be emitted at the runner boundary, agent-service boundary, or orchestrator direct-call boundary where the resolved route, profile, timing, outcome, and usage are all visible.
+Record shape:
+```json
+{
+  "seq": 1,
+  "writer_id": "journal-writer-uuid",
+  "session_seq": 1,
+  "ts_start": "2026-06-07T12:00:00.000Z",
+  "ts_end": "2026-06-07T12:00:09.200Z",
+  "conversation_id": "slack:C123:1717600000.000",
+  "topic_id": "run-uuid",
+  "run_id": "run-uuid",
+  "request_id": "request-001",
+  "phase": "speccing",
+  "step": "artifact.create",
+  "role": null,
+  "round": 1,
+  "gate": null,
+  "model": { "provider": "anthropic", "name": "claude-sonnet-4-6" },
+  "inference": { "effort": "medium", "thinking": { "type": "enabled", "budget_tokens": 8000 } },
+  "tokens": { "input": 1000, "output": 200, "cache_read": 50, "cache_write": 25 },
+  "assistant_turns": 3,
+  "tool_calls": 4,
+  "tool_results": 4,
+  "outcome": "ok",
+  "runner": "anthropic_agent"
+}
+```
+Field rules:
+- `session_seq` is a best-effort convenience counter. It is monotonic per run only within one writer process and is ordered by capture, not wall-clock time. It may reset or collide after a process restart; importers must use `sessions.jsonl` append order, filtered to the run, as the canonical per-run order.
+- `conversation_id` and `topic_id` use the same identity mapping as message and run-event records.
+- `phase` is the active run stage at invocation time.
+- `step` is `route.task`, such as `intent.classify`, `artifact.create`, `spec.review`, `implementation.plan`, `implementation.run`, or `implementation.review.initial`.
+- `role` is `null` until the convergence role work lands. Later values may include `proposer`, `critic`, `implementer`, `reviewer`, `author`, and `planner`.
+- `round` is `1` for non-loop work until convergence rounds are available.
+- `gate` is `null` until layered convergence lands. Later values may include `layout`, `public_api`, `private_api`, and `build`.
+- `model.provider` comes from the resolved profile provider. `model.name` comes from the resolved profile model.
+- `inference.effort` and `inference.thinking` come from the resolved profile and may be `null` if not configured.
+- `tokens` is normalized raw counts or `null` if unavailable.
+- `assistant_turns`, `tool_calls`, and `tool_results` are `null` for direct calls.
+- `outcome` is `ok`, `failed`, or `incomplete` as appropriate for the runner result.
+- `runner` identifies the runner implementation: `anthropic_direct`, `openai_direct`, `anthropic_agent`, or `openai_agent`.
+Ordering rule:
+- Within a run, `sessions.jsonl` file order is the canonical order for replay and convergence analysis, including future within-round role order such as proposer before critic. `ts_start` is observability data and is not a reliable ordering key. `session_seq` helps humans inspect records from one process boot but is not durable enough to drive import ordering.
+Token normalization rules:
+- Anthropic direct maps `usage.input_tokens` and `usage.output_tokens` to `input` and `output`.
+- Anthropic direct and Claude Agent SDK also map cache fields when exposed: `cache_read_input_tokens` to `cache_read`, and `cache_creation_input_tokens` to `cache_write`.
+- OpenAI direct maps `usage.prompt_tokens` to `input` and `usage.completion_tokens` to `output`.
+- OpenAI direct maps prompt-cache details to `cache_read` when the response exposes cached prompt token data.
+- OpenAI Agent SDK records `tokens: null` unless provider event data later exposes a reliable token breakdown.
+- Missing usage means `tokens: null`, never a zero-filled object.
+- The journal stores raw token counts only. It never stores dollars.
+### Feedback capture
+
+`feedback.jsonl` captures both human-authored feedback and AI-authored review findings.
+Record shape:
+```json
+{
+  "seq": 1,
+  "writer_id": "journal-writer-uuid",
+  "id": "feedback-uuid-or-source-id",
+  "ts_created": "2026-06-07T12:03:00.000Z",
+  "conversation_id": "slack:C123:1717600000.000",
+  "topic_id": "run-uuid",
+  "run_id": "run-uuid",
+  "request_id": "request-001",
+  "target": "artifact",
+  "gate": null,
+  "author_principal": "slack:U123",
+  "text": "Please add a config flag.",
+  "anchor": null,
+  "severity": "info",
+  "category": "human_feedback",
+  "disposition": "open",
+  "thread": []
+}
+```
+Sources:
+- Human `thread_message` events classified as feedback, approval with comments, implementation feedback, or implementation input.
+- Artifact publisher comments and anchors when those are available through `FeedbackSource` or `ArtifactComment`.
+- AI review exchanges at the moment the implementation review coordinator appends each exchange to `run.review_exchanges`.
+- Future `gate_exchanges` if layered convergence work adds that field.
+AI findings must be captured exactly once. The preferred hook is the append point where the coordinator adds an exchange or finding to `run.review_exchanges`, because that hook sees only new source data. If an implementation instead observes `run.review_exchanges` from a transition or persistence hook that can run repeatedly, the feedback writer must dedupe on the stable finding/exchange `id` before appending to `feedback.jsonl`. Importer-side dedupe is allowed as a safety net but is not the primary design.
+Field rules:
+- `conversation_id` and `topic_id` use the same identity mapping as message and run-event records.
+- `id` is stable when source data has an ID. Otherwise generate a deterministic ID from stream source, run ID, source timestamp, and text hash.
+- `target` is `artifact` for spec/triage/chore-plan feedback and `implementation` for implementation review feedback.
+- `gate` is `null` until layered gates exist.
+- `author_principal` is the human author for inbound feedback and the reviewer model profile principal for AI findings.
+- `text` is redacted before write.
+- `anchor` stores comment anchor data when available.
+- `severity` uses source severity for AI findings and defaults to `info` for human feedback unless a source field says otherwise.
+- `category` uses source category for AI findings and `human_feedback` for human messages.
+- `disposition` maps lifecycle states to `open`, `addressed`, `resolved`, or `wont_fix`.
+- `thread` stores redacted follow-up comments when available.
+### Run event capture
+
+`run-events.jsonl` captures run creation, every stage transition, and load-time prune or stale demotion decisions made by `FileRunStore.load()`.
+Record shape:
+```json
+{
+  "seq": 1,
+  "writer_id": "journal-writer-uuid",
+  "event_type": "transition",
+  "ts": "2026-06-07T12:00:00.000Z",
+  "run_id": "run-uuid",
+  "request_id": "request-001",
+  "conversation_id": "slack:C123:1717600000.000",
+  "topic_id": "run-uuid",
+  "from_stage": "intake",
+  "to_stage": "speccing",
+  "attempt": 0,
+  "intent": "idea",
+  "workspace_path": "/workspace-root/request-001",
+  "branch": "spec/request-001",
+  "artifact_ref": "context-human/specs/feature-example.md",
+  "pr_url": null,
+  "issue": 192
+}
+```
+Rules:
+- Run creation writes a record with `event_type: "created"`, `from_stage: null`, and `to_stage: "intake"`.
+- Every call to `transition()` writes a record with `event_type: "transition"` before persisting the mutated `runs.json` state.
+- `FileRunStore.load()` writes a best-effort run event before it rewrites `runs.json` for any active run it is about to drop because the workspace is missing or demote to `failed` because the run is stale.
+- Prune/drop events use `from_stage` as the stage loaded from `runs.json`, `to_stage: null`, and `event_type: "pruned"`.
+- Stale demotion events use `from_stage` as the stage loaded from `runs.json`, `to_stage: "failed"`, and `event_type: "demoted"`.
+- Self-transitions are recorded because they can represent useful lifecycle loops.
+- The stream must contain enough data to reconstruct `RunStep` occurrences by reading `to_stage` values in order.
+- Write the creation event as soon as `createRun()` constructs the run, before later classification or workspace allocation can fail.
+### Redaction
+
+Captured free text must pass through the shared secret redactor before disk write. This includes:
+- message `content`;
+- feedback `text`;
+- feedback thread text;
+- write-failure error strings if they may include captured content.
+The existing redaction behavior in `implementation-feedback-page.ts` should move to a shared utility, then expand as needed to cover known token forms from the telemetry spec: `sk-...`, `github_pat_...`, `gho_...`, `ghs_...`, Slack `xapp-...`, bearer tokens, Anthropic custom header API keys, generic API-key strings, and password-like values.
+Redaction is not optional when journaling is enabled. If redaction fails unexpectedly, the writer logs a redacted failure and skips the record instead of writing unredacted text.
+### Failure modes
+
+- Journal writer initialization failure disables journal writes for that process and logs `journal.init_failed`.
+- Per-record append failure logs `journal.append_failed` with the stream name and redacted reason, then continues the run.
+- A malformed record produced by a caller logs `journal.record_invalid` and skips only that record.
+- Concurrent runs serialize writes per stream through a shared writer instance.
+- Missing token data writes `tokens: null`.
+- A torn final JSONL line after process crash is acceptable; importer tolerance is deferred to the importer task.
+## Technical changes
+
+### Affected files
+
+Expected implementation touch points:
+- `src/types/config.ts` — add `journal?: { enabled?: boolean }` to `WorkflowConfig`.
+- `src/core/config.ts` — validate `journal.enabled` when present.
+- `src/core/config-normalizer.ts` — expose `journal_enabled`, defaulting to `true`.
+- `src/types/journal.ts` — define journal record types, normalized token usage, stream names, writer interface, and no-op writer.
+- `src/core/journal/redaction.ts` — provide shared `redactSecrets()` and tests.
+- `src/core/journal/jsonl-writer.ts` — implement append-only JSONL writing with per-stream sequencing and serialized appends.
+- `src/core/journal/run-journal.ts` — implement high-level capture helpers for messages, sessions, feedback, and run events.
+- `src/core/orchestrator.ts` — capture inbound messages, outbound messages, run creation, stage transitions, and orchestrator-owned direct model calls such as `intent.classify` and `pr.title_generate` when run context exists.
+- `src/core/run-store.ts` or the current `FileRunStore` implementation file — accept a journal dependency during load and capture prune/drop or stale demotion events before rewriting `runs.json`.
+- `src/core/ai/agent-services.ts` — emit agent-session records with route, profile, timing, drain summary, outcome, and telemetry IDs.
+- `src/types/ai.ts` — add normalized usage fields to `DirectModelRunResult`, extend `AgentDrainSummary` with terminal usage, and carry session/capture metadata where needed.
+- `src/adapters/anthropic/direct-model-runner.ts` — normalize Anthropic direct usage including cache fields when present.
+- `src/adapters/openai/direct-model-runner.ts` — normalize OpenAI direct usage including prompt-cache fields when present.
+- `src/adapters/anthropic/claude-agent-sdk-agent-runner.ts` — expose terminal usage through normalized events or `AgentDrainSummary`.
+- `src/adapters/openai/agent-sdk-agent-runner.ts` — emit session metadata with `tokens: null` and no false zero counts.
+- `src/adapters/runtime-composition.ts` — construct the journal writer from normalized config and pass it to orchestrator and AI services.
+- `src/adapters/notion/implementation-feedback-page.ts` — import the shared redactor instead of keeping a local copy.
+- `tests/core/journal/*.test.ts` — cover writer behavior, sequencing, redaction, config gating, and failure handling.
+- `tests/core/orchestrator.test.ts` — cover message and run-event capture.
+- `tests/core/ai/agent-services.test.ts` — cover session capture and summary usage propagation.
+- `tests/adapters/*/*runner*.test.ts` — cover provider-specific token normalization.
+- `tests/core/run-store.test.ts` — cover journal survival and load-time `pruned`/`demoted` event emission through prune/demote cycles.
+### 1. Journal type model
+
+Create shared types with explicit stream names:
+```typescript
+export type JournalStream = 'messages' | 'sessions' | 'feedback' | 'run-events';
+
+export interface NormalizedTokenUsage {
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_write: number;
+}
+
+export interface JournalWriter {
+  append(stream: JournalStream, record: unknown): Promise;
+  appendSync?(stream: JournalStream, record: unknown): void;
+  close?(): Promise;
+}
+```
+`RunJournal` should own domain-specific methods such as `captureInboundMessage()`, `captureOutboundMessage()`, `captureSession()`, `captureFeedback()`, and `captureRunEvent()`. Callers should not hand-build JSON strings.
+Provide a no-op writer for disabled journaling so call sites do not branch repeatedly.
+### 2. JSONL writer
+
+The writer must:
+- create `.autocatalyst/journal/` lazily or during initialization;
+- generate a `writer_id` for the process boot and include it on every record;
+- keep a monotonic `seq` counter per stream for that writer process;
+- serialize concurrent appends per stream with an internal promise queue;
+- append one JSON object plus `\n` per record;
+- call a flush-equivalent operation where practical after append;
+- catch and log I/O errors without throwing to callers;
+- log `journal.writer_started` with `journal_dir` and enabled streams;
+- log `journal.appended` at debug level with `stream`, `seq`, and `record_type` if available;
+- log aggregate append counts on `close()` if a close path exists.
+A single process-local writer is enough for v0. If two Node processes point at the same workspace root, the implementation should rely on OS append semantics and still avoid partial in-process interleaving. Cross-process global sequence ordering is not required.
+The writer must not scan existing stream tails to initialize `seq`. Restarted processes can append duplicate numeric `seq` values as long as `writer_id` differs; importer code must not treat `seq` alone as globally unique or globally monotonic.
+### 3. Config and runtime wiring
+
+Runtime composition should construct one journal object:
+- If `normalizedConfig.journal_enabled` is false, pass a no-op journal.
+- If true, pass a file-backed journal rooted at `/.autocatalyst/journal`.
+- Construct the journal before loading or normalizing `runs.json` so `FileRunStore.load()` can capture prune/drop and stale demotion events before it rewrites `runs.json`.
+The same journal instance must be available to:
+- the run store for load-time prune/drop and stale demotion capture;
+- the orchestrator for message and run-event capture;
+- agent services for session capture;
+- feedback/review coordinators or handlers for feedback capture.
+The config default is on because the goal is complete history. Tests must prove missing config enables the writer and explicit `false` disables it.
+### 4. Orchestrator hooks
+
+Add journal calls without changing control flow:
+- `createRun(request)` captures a `run-events` creation record after the run object is created and before it is persisted.
+- The `new_request` path captures the inbound message after classification succeeds. If no classifier is configured, capture the default intent used by the path.
+- The `thread_message` path captures the inbound message after the orchestrator identifies the run. If classification succeeds, include the raw v0 intent. If classification fails after run identification, capture the message with `intent: null` and `classification_status: "failed"`; do not capture a misleading intent. If the thread cannot be associated with a run, do not write a message record.
+- `transition(run, stage)` captures a `run-events` stage record before `_persistRuns()`.
+- Private `postMessage(conversation, text)` captures outbound content after the adapter call succeeds. If the adapter call fails, do not record a delivered outbound message.
+All hooks are best-effort. A journal rejection must not change current handler behavior.
+### 4a. Run-store prune and demotion hooks
+
+`FileRunStore.load()` is the path that can remove or demote runs before the orchestrator sees them. Runtime composition must pass the already-constructed journal into the run store before `load()` executes.
+During `load()`, before writing a normalized `runs.json` that drops an active run with a missing workspace, append a `run-events` record with `event_type: "pruned"`, `from_stage` set to the loaded stage, and `to_stage: null`. Before writing a stale active run back as `failed`, append a `run-events` record with `event_type: "demoted"`, `from_stage` set to the loaded stage, and `to_stage: "failed"`.
+These load-time records are best-effort and must not prevent current run-store recovery behavior. If journaling is disabled or initialization failed, `FileRunStore.load()` continues exactly as it does today.
+### 5. Session emission boundary
+
+Use the agent-service boundary for run-associated agent sessions because it knows the resolved route, profile, run ID, request ID, stage/phase, and drain summary. Add an `onSession` or `journal` emission hook to the same telemetry object that currently carries `run_id`, `request_id`, and `onAgentRequest`.
+Direct model sessions need equivalent context. For direct calls used by run-owned services, the caller should pass route, run ID, request ID, and phase. If a direct model call is not associated with a run, it can be omitted from this issue or captured with `run_id: null` only if the type model explicitly allows it. The acceptance criteria focus on one session record per model invocation associated with a run.
+The orchestrator has direct model call sites that do not naturally pass through agent services. `intent.classify` and `pr.title_generate` are explicitly in scope when the orchestrator has a run/request context for the call. They should emit `anthropic_direct` or `openai_direct` session records through the same direct-session helper used by other run-owned services. If an `intent.classify` call is truly pre-run and no run ID exists yet, it may be omitted rather than captured with a misleading synthetic run ID.
+Agent-service emission rules:
+1. Record `ts_start` before invoking the runner.
+2. Drain the runner and collect `AgentDrainSummary`.
+3. Capture terminal usage if the runner provides it.
+4. Record `ts_end` and `outcome` in `finally`.
+5. Append the session record in best-effort mode.
+6. Re-throw original runner or drain errors after the journal append attempt so current error handling stays intact.
+### 6. Usage propagation
+
+Extend `DirectModelRunResult`:
+```typescript
+export interface DirectModelRunResult {
+  text: string;
+  raw?: unknown;
+  usage?: NormalizedTokenUsage | null;
+  runner?: 'anthropic_direct' | 'openai_direct';
+}
+```
+Extend `AgentDrainSummary`:
+```typescript
+export interface AgentDrainSummary {
+  event_count: number;
+  assistant_turn_count: number;
+  relay_count: number;
+  tool_call_count: number;
+  tool_result_count: number;
+  elapsed_ms: number;
+  terminal_usage?: NormalizedTokenUsage | null;
+  diagnostics?: {
+    stderr_excerpt_redacted?: string;
+  };
+}
+```
+The Claude Agent SDK runner can surface usage on the normalized terminal result event, and `drainAgentRunner()` can copy it into `terminal_usage`. The OpenAI Agent SDK runner should not invent usage. It reports `terminal_usage: null` or omits the field, and the session record writes `tokens: null`.
+### 7. Feedback capture
+
+Start with three concrete capture paths:
+1. Human `thread_message` events in `reviewing_spec`, `awaiting_planning_input`, `awaiting_impl_input`, `reviewing_implementation`, and `pr_open` when the classified intent is feedback, approval, implementation feedback, or question/input tied to the run.
+2. Artifact comments read through `FeedbackSource` during spec revision when comments have IDs, anchors, and text.
+3. AI review exchanges appended to `run.review_exchanges` by the implementation review coordinator.
+The feedback capture layer should be tolerant of partial source data. For example, a plain Slack feedback message has no anchor and no structured severity, so it writes `anchor: null` and `severity: "info"`.
+AI review exchange capture should happen at append time for each newly created exchange/finding. Re-reading the full `run.review_exchanges` array during repeated transition hooks is not acceptable unless the feedback writer dedupes by stable finding/exchange `id` before writing, because otherwise the same AI finding can be emitted multiple times.
+Feedback capture is in scope for this enhancement and is required for acceptance. If implementation needs sequencing, land feedback capture after message, session, and run-event capture on the same branch; do not mark the enhancement complete while `feedback.jsonl` capture is only a placeholder or follow-up.
+### 8. Telemetry and logs
+
+Add structured logs per `AGENTS.md` and `context-agent/standards/logging.md`:
+- `journal.disabled` when config disables journaling.
+- `journal.writer_started` with `journal_dir`.
+- `journal.appended` at debug level with `stream`, `seq`, and `duration_ms`.
+- `journal.append_failed` at warn level with `stream`, `seq` if assigned, and redacted `error`.
+- `journal.record_invalid` at warn level when validation rejects a caller-provided record.
+- `journal.closed` with per-stream append counts.
+These logs must not include unredacted message or feedback content.
+### Testing plan
+
+#### Unit tests
+
+- Config validation accepts missing `journal`, accepts boolean `journal.enabled`, defaults missing value to true, and rejects non-boolean values.
+- No-op journal accepts append calls and writes no files.
+- JSONL writer creates `.autocatalyst/journal/`, appends valid JSON lines, includes `writer_id`, increments `seq` per stream within the writer process, and preserves existing lines.
+- Concurrent appends to the same stream produce complete, parseable lines with monotonic process-local sequence values for the same `writer_id`.
+- Restarting a writer against existing streams starts new process-local `seq` counters with a new `writer_id`; tests assert importers cannot rely on `seq` alone for global ordering.
+- Restarting the process during a persisted run can reset `session_seq`; tests document that importers must order that run's sessions by `sessions.jsonl` file order, not by `session_seq` or `ts_start`.
+- Writer append failure logs `journal.append_failed` and does not throw to the caller.
+- Shared `redactSecrets()` redacts planted API keys and tokens in message and feedback text.
+- `RunJournal` serializes `ConversationRef`, `MessageRef`, and model profile fields into stable journal IDs.
+#### Orchestrator tests
+
+- `new_request` with classified intent writes one inbound `messages.jsonl` record and one creation `run-events.jsonl` record.
+- `thread_message` for a known run writes one inbound message record with the classified intent.
+- A successful outbound `postMessage()` writes one outbound message record from the private choke point.
+- A failed outbound `postMessage()` does not record a delivered outbound message and preserves current error behavior.
+- Every `transition()` writes a run-event record before run persistence.
+- Stage loops and self-transitions are represented in `run-events.jsonl`.
+- Journal write rejection does not fail the run or change its final stage.
+- `FileRunStore.load()` writes `pruned` and `demoted` run events before rewriting `runs.json`, and disabled/no-op journaling preserves current load behavior.
+#### Runner and session tests
+
+- Anthropic direct returns normalized usage with input/output and cache fields when present.
+- OpenAI direct returns normalized usage with prompt/completion and prompt-cache fields when present.
+- Claude Agent SDK terminal usage reaches `AgentDrainSummary.terminal_usage` and then `sessions.jsonl`.
+- OpenAI Agent SDK produces a session record with `tokens: null`.
+- Direct sessions have `assistant_turns`, `tool_calls`, and `tool_results` set to `null`.
+- Orchestrator-owned direct calls with run context, including `intent.classify` and `pr.title_generate`, produce direct session records instead of being silently missed.
+- Agent sessions include `assistant_turns`, `tool_calls`, `tool_results`, elapsed timing, route task, provider, model, effort, and thinking.
+- A failed runner emits a failed session record when enough context exists and then rethrows the original error.
+#### Feedback tests
+
+- Human feedback messages write feedback records with human `author_principal`, `ts_created`, redacted text, target, and `disposition: "open"`.
+- Artifact comments write feedback records with stable IDs and anchors.
+- AI review exchanges write feedback records once per newly appended finding/exchange with reviewer profile as `author_principal`, finding severity/category, and addressed disposition when the implementer responded.
+- Repeated transition or persistence hooks do not duplicate AI review feedback rows; if capture observes accumulated `run.review_exchanges`, it dedupes by stable finding/exchange `id` before append.
+- Redaction applies to feedback text and nested thread text.
+#### Persistence and recovery tests
+
+- Create an active run, write messages, sessions, feedback, and run events, delete its workspace, then call `FileRunStore.load()`. Assert the run may be dropped or demoted in `runs.json`, the journal lines written before load remain unchanged and parseable, and a best-effort `pruned` or `demoted` run event is appended before the rewrite when journaling is enabled.
+- Disable journaling and repeat a simple run. Assert no `.autocatalyst/journal/` streams are created and existing behavior is unchanged.
+### Acceptance criteria
+
+- [ ] Four append-only streams exist under per-repo `.autocatalyst/journal/`: `messages.jsonl`, `sessions.jsonl`, `feedback.jsonl`, and `run-events.jsonl`.
+- [ ] All run-associated stream schemas carry `conversation_id`, `topic_id`, `run_id`, and `request_id` when those identifiers exist in run context.
+- [ ] Journal streams survive a `FileRunStore.load()` prune or stale-stage demotion cycle unchanged.
+- [ ] `run-events.jsonl` records enabled load-time prune/drop and stale demotion events before `FileRunStore.load()` rewrites `runs.json`.
+- [ ] Run-associated inbound `new_request` and `thread_message` payloads are captured with redacted content and classified intent when available; known-run classification failures write `intent: null` with `classification_status: "failed"`, while unknown-thread and unrouteable messages are explicitly out of scope.
+- [ ] Every successful outbound `postMessage()` reply is captured through one shared outbound hook.
+- [ ] One `sessions.jsonl` record is written for every run-associated model invocation across Anthropic direct, OpenAI direct, Claude Agent SDK, and OpenAI Agent SDK runners, including `conversation_id` and `topic_id` when the run context provides them.
+- [ ] Orchestrator-owned direct model calls with run context, including `intent.classify` and `pr.title_generate`, are captured as direct sessions or are explicitly omitted only when no run ID exists yet.
+- [ ] Within-run session replay order is defined by `sessions.jsonl` file order filtered to `run_id`; `session_seq` is documented and tested as best-effort across process restarts.
+- [ ] Direct and Claude-agent paths record normalized raw token counts, including cache-read/cache-write fields where providers expose them.
+- [ ] OpenAI Agent SDK path records `tokens: null` unless reliable token usage is available.
+- [ ] `inference.effort` and `inference.thinking` are recorded per session from the resolved profile.
+- [ ] Feedback from human messages and AI review exchanges is captured with `conversation_id`, `topic_id`, attribution, `ts_created`, target, severity/category when available, redacted text, and lifecycle disposition.
+- [ ] AI review findings are captured once at source append time or deduped by stable finding/exchange `id` before writing to `feedback.jsonl`.
+- [ ] `run-events.jsonl` records run creation and every stage transition before run persistence can rewrite `runs.json`.
+- [ ] Secret redaction is verified for message content, feedback content, and nested feedback thread text.
+- [ ] Journal write failures are logged and never fail a run.
+- [ ] `journal.enabled` defaults to `true`; when set to `false`, no journal streams are written and runtime behavior matches today.
+- [ ] The journal stores raw tokens only and never stores `usd` or any priced cost field.
+### Risks and mitigations
+
+- **Risk: Captured content may include secrets.** Mitigation: route all free text through a shared redactor, expand token patterns, and skip the record if redaction fails.
+- **Risk: Journal I/O adds latency or fails on disk errors.** Mitigation: keep writes best-effort, serialized, and non-fatal; log failures with enough context to diagnose.
+- **Risk: Provider token fields drift.** Mitigation: normalize only known fields, keep raw response in existing runner result where needed, and use `tokens: null` instead of false zeroes.
+- **Risk: Session context is incomplete for direct calls.** Mitigation: capture run-associated direct calls first and explicitly allow non-run direct calls to be out of scope unless a caller can provide run context.
+- **Risk: Feedback capture expands the issue too much.** Mitigation: sequence feedback implementation after message, session, and run-event capture if needed, but keep it in this enhancement and do not accept the work as complete without `feedback.jsonl`.
+- **Risk: Sequence numbers are process-local.** Mitigation: importer orders streams by file order. For per-run sessions, importer filters `sessions.jsonl` by `run_id` in file order; `session_seq` is best-effort only and cross-process global ordering is not required for v0.
+## Task list
+
+### Story 1 — Add journal configuration and shared types
+
+- [ ] **Task: Add ****`journal.enabled`**** config support**
+	- **Description**: Extend `WorkflowConfig`, config validation, and config normalization with `journal.enabled`, defaulting to `true`. Reject non-boolean values with a clear error.
+	- **Acceptance criteria**:
+		- [ ] Missing `journal` enables journaling.
+		- [ ] `journal.enabled: true` enables journaling.
+		- [ ] `journal.enabled: false` disables journaling.
+		- [ ] Non-boolean `journal.enabled` fails config validation.
+	- **Dependencies**: None.
+- [ ] **Task: Define journal record and writer types**
+	- **Description**: Add `src/types/journal.ts` with stream names, normalized token usage, message/session/feedback/run-event record interfaces, and `JournalWriter`/no-op writer contracts.
+	- **Acceptance criteria**:
+		- [ ] Types cover all four stream schemas in this spec.
+		- [ ] `tokens` can be a normalized object or `null`.
+		- [ ] Direct and agent runner names are represented as a closed union.
+	- **Dependencies**: `journal.enabled` config support.
+### Story 2 — Build the safe append-only writer and redactor
+
+- [ ] **Task: Move and expand secret redaction**
+	- **Description**: Move the local `redactSecrets()` helper from `implementation-feedback-page.ts` into a shared journal-safe redaction utility. Expand patterns for common GitHub, Slack, bearer, Anthropic custom header, API-key, and password-like forms. Update existing imports.
+	- **Acceptance criteria**:
+		- [ ] Existing implementation feedback redaction behavior is preserved.
+		- [ ] Tests cover planted secrets in message and feedback strings.
+		- [ ] Redaction utility has no dependency on Notion-specific code.
+	- **Dependencies**: Journal types.
+- [ ] **Task: Implement the JSONL journal writer**
+	- **Description**: Create a writer that appends one JSON record per line under `.autocatalyst/journal/`, assigns process-local stream sequence numbers, serializes in-process appends per stream, and logs failures without throwing.
+	- **Acceptance criteria**:
+		- [ ] Writer creates the journal directory.
+		- [ ] Appended lines are valid JSON and end in `\n`.
+		- [ ] Every appended record includes the writer process `writer_id`.
+		- [ ] Sequence numbers are monotonic per stream within the process and are not initialized by scanning existing stream tails.
+		- [ ] A restarted writer may reuse numeric `seq` values with a new `writer_id`; tests document that `seq` alone is not globally unique.
+		- [ ] Concurrent appends do not interleave partial JSON lines.
+		- [ ] Write failures log `journal.append_failed` and are non-fatal.
+	- **Dependencies**: Shared redactor and journal types.
+- [ ] **Task: Add the high-level ****`RunJournal`**** facade**
+	- **Description**: Add helper methods that accept domain objects and write stream records. Centralize ID serialization, redaction, default values, and error swallowing in this facade.
+	- **Acceptance criteria**:
+		- [ ] Callers can capture messages, sessions, feedback, and run events without hand-building JSON strings.
+		- [ ] Free-text fields are redacted before append.
+		- [ ] Any `session_seq` assignment is in-memory and process-local; the facade does not scan existing `sessions.jsonl` to resume counters.
+		- [ ] Invalid records are logged and skipped.
+	- **Dependencies**: JSONL writer.
+### Story 3 — Wire run events and message capture
+
+- [ ] **Task: Construct and inject the journal in runtime composition**
+	- **Description**: Build a file-backed journal when enabled and a no-op journal when disabled. Pass it to orchestrator dependencies and AI services.
+	- **Acceptance criteria**:
+		- [ ] Enabled runtime logs `journal.writer_started`.
+		- [ ] Disabled runtime logs `journal.disabled` and writes no stream files.
+		- [ ] The journal is constructed before `FileRunStore.load()` and passed to the run store.
+		- [ ] Tests can inject a fake journal.
+	- **Dependencies**: `RunJournal` facade.
+- [ ] **Task: Capture run creation and transitions**
+	- **Description**: Update `createRun()`, `transition()`, and `FileRunStore.load()` to append `run-events` records. Ensure transition records are written before `_persistRuns()` and load-time prune/demotion records are written before `runs.json` is rewritten.
+	- **Acceptance criteria**:
+		- [ ] Creation records use `from_stage: null`, `to_stage: "intake"`.
+		- [ ] Every transition writes from/to stage, attempt, intent, workspace path, branch, artifact ref, PR URL, and issue.
+		- [ ] `FileRunStore.load()` appends `event_type: "pruned"` before dropping a run whose workspace is missing.
+		- [ ] `FileRunStore.load()` appends `event_type: "demoted"` before writing a stale active run as `failed`.
+		- [ ] Journal failures do not change run stage or persistence behavior.
+	- **Dependencies**: Runtime journal injection.
+- [ ] **Task: Capture inbound and outbound messages**
+	- **Description**: Add inbound capture for `new_request` and `thread_message` after classification context is known. Wrap private `postMessage()` for outbound capture after successful delivery.
+	- **Acceptance criteria**:
+		- [ ] `new_request` records include raw v0 intent.
+		- [ ] `thread_message` records include raw v0 intent when classification succeeds and `intent: null` with `classification_status: "failed"` when classification fails after the run is known.
+		- [ ] Outbound records include service principal and redacted text.
+		- [ ] Failed outbound posts do not record a delivered message.
+	- **Dependencies**: Runtime journal injection.
+### Story 4 — Capture model sessions and token usage
+
+- [ ] **Task: Normalize direct model usage**
+	- **Description**: Extend `DirectModelRunResult` and update Anthropic/OpenAI direct runners to return normalized raw usage. Include cache fields where the provider response exposes them.
+	- **Acceptance criteria**:
+		- [ ] Anthropic direct maps input/output and cache fields.
+		- [ ] OpenAI direct maps prompt/completion and prompt-cache fields.
+		- [ ] Missing usage returns `usage: null` rather than zeroes.
+	- **Dependencies**: Journal types.
+- [ ] **Task: Surface agent terminal usage through drain summaries**
+	- **Description**: Extend normalized agent terminal events and `AgentDrainSummary` so Claude Agent SDK usage reaches agent services. Preserve OpenAI Agent SDK `tokens: null` behavior.
+	- **Acceptance criteria**:
+		- [ ] Claude Agent SDK terminal usage appears in `AgentDrainSummary.terminal_usage`.
+		- [ ] OpenAI Agent SDK does not invent token counts.
+		- [ ] Existing drain telemetry still logs turns, tool calls, tool results, and diagnostics.
+	- **Dependencies**: Journal types.
+- [ ] **Task: Emit session records from the model invocation boundary**
+	- **Description**: Add a session emission hook in agent services and direct-model service call sites with route, phase, profile, timing, outcome, usage, and drain summary fields.
+	- **Acceptance criteria**:
+		- [ ] Every run-associated model invocation writes one `sessions` record.
+		- [ ] `session_seq` increments monotonically per run only within one writer process and is documented as best-effort after restarts.
+		- [ ] Tests and developer comments state that per-run session replay order comes from `sessions.jsonl` file order filtered to `run_id`, not from `session_seq` or `ts_start`.
+		- [ ] Direct sessions have agent turn/tool fields set to `null`.
+		- [ ] Orchestrator-owned direct calls with run context, including `intent.classify` and `pr.title_generate`, emit direct session records through the shared direct-session helper.
+		- [ ] Agent sessions include turn/tool counts and elapsed timing.
+		- [ ] Failed sessions are captured when enough context exists and original errors still propagate.
+	- **Dependencies**: Runtime journal injection; normalized usage propagation.
+### Story 5 — Capture feedback records
+
+- [ ] **Task: Capture human feedback messages**
+	- **Description**: Write `feedback` records for human thread messages that represent spec feedback, implementation feedback, implementation input, approval comments, or PR-stage feedback. Use human author principal and received timestamp.
+	- **Acceptance criteria**:
+		- [ ] Human feedback records include `conversation_id`, `topic_id`, target, author principal, timestamp, redacted text, and `disposition: "open"`.
+		- [ ] Messages without anchors write `anchor: null`.
+		- [ ] Journal failures do not affect feedback handling.
+	- **Dependencies**: Message capture hooks.
+- [ ] **Task: Capture artifact comments and AI review findings**
+	- **Description**: Capture structured artifact comments when available and capture AI findings once as each exchange/finding is appended to `run.review_exchanges`. Map reviewer profiles to author principals and response status to disposition.
+	- **Acceptance criteria**:
+		- [ ] Artifact comments preserve IDs and anchors when present.
+		- [ ] AI findings include severity, category, reviewer principal, and redacted text.
+		- [ ] Repeated stage transitions do not duplicate AI finding rows in `feedback.jsonl`; append-time capture is used, or writes dedupe by stable finding/exchange `id`.
+		- [ ] Addressed/declined responses map to lifecycle disposition.
+	- **Dependencies**: Human feedback capture.
+### Story 6 — Verify durability, gating, and docs
+
+- [ ] **Task: Add recovery and config-gating tests**
+	- **Description**: Add tests that run journal capture, delete a workspace, call `FileRunStore.load()`, and verify journal lines remain. Add disabled-mode tests.
+	- **Acceptance criteria**:
+		- [ ] Journal lines survive active-run drop/demotion.
+		- [ ] Disabled mode writes no stream files.
+		- [ ] Existing run-store behavior remains unchanged.
+	- **Dependencies**: Run-event, message, session, and feedback capture.
+- [ ] **Task: Document provider gaps and importer boundary**
+	- **Description**: Add short developer documentation or comments near journal types describing `tokens: null`, raw-token-only storage, append-order session replay, and the deferred importer.
+	- **Acceptance criteria**:
+		- [ ] Docs state that OpenAI Agent SDK token usage may be unavailable.
+		- [ ] Docs state that pricing and importer work are out of scope.
+		- [ ] Docs state that `sessions.jsonl` file order filtered by `run_id` is the canonical per-run session order and `session_seq` is best-effort across process restarts.
+		- [ ] Docs state that journal write failures are non-fatal.
+	- **Dependencies**: Session capture.

--- a/context-human/specs/enhancement-append-only-backfill-journal.md
+++ b/context-human/specs/enhancement-append-only-backfill-journal.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-07
 last_updated: 2026-06-07
-status: implementing
+status: complete
 issue: 192
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -27,6 +27,8 @@ import type {
   AgentThinking,
 } from '../../types/ai.js';
 import { createLogger } from '../../core/logger.js';
+import { redactSecrets } from '../../core/journal/redaction.js';
+export { redactSecrets } from '../../core/journal/redaction.js';
 import { materializeClaudeRuntimeSkillPlugins } from './claude-runtime-skill-materializer.js';
 import { buildSandboxEnvironmentWithSummary, buildSandboxEnvironment } from '../sandbox-environment.js';
 import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy, type RequestLogOptions } from './anthropic-beta-header-filter-proxy.js';
@@ -34,27 +36,6 @@ import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProx
 type QueryFn = typeof _query;
 
 const MAX_STDERR_LINES = 50;
-
-const SECRET_PATTERNS = [
-  /(?:api[_-]?key|secret|password|credential)\s*[=:]\s*\S+/gi,
-  /ghp_[A-Za-z0-9_]+/g,
-  /github_pat_[A-Za-z0-9_]+/g,
-  /gho_[A-Za-z0-9_]+/g,
-  /ghs_[A-Za-z0-9_]+/g,
-  /sk-[A-Za-z0-9_-]+/g,
-  /xox[bpras]-[A-Za-z0-9-]+/g,
-  /xapp-[A-Za-z0-9-]+/g,
-  /Authorization:\s*Bearer\s+\S+/gi,
-  /ANTHROPIC_CUSTOM_HEADERS[^=]*=\s*api-key:\s*\S+/gi,
-];
-
-export function redactSecrets(text: string): string {
-  let redacted = text;
-  for (const pattern of SECRET_PATTERNS) {
-    redacted = redacted.replace(pattern, '[REDACTED]');
-  }
-  return redacted;
-}
 
 export interface ClaudeSdkMessageDiagnostic {
   sdk_message_type: string;

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -221,7 +221,7 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
     let assistantTurnCount = 0;
     let seenTerminalResult = false;
     let terminalDiagnostics: { stderr_excerpt_redacted?: string } | undefined;
-    let terminalUsage: { input_tokens: number; output_tokens: number } | undefined;
+    let terminalUsage: { input_tokens: number; output_tokens: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number } | undefined;
     let pendingToolResultCount = 0;
 
     const telemetry = request.telemetry ?? {};
@@ -249,7 +249,12 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
         if ((message as SDKMessage).type === 'result') {
           seenTerminalResult = true;
           const result = message as unknown as SDKResultMessage;
-          terminalUsage = { input_tokens: result.usage.input_tokens, output_tokens: result.usage.output_tokens };
+          terminalUsage = {
+            input_tokens: result.usage.input_tokens,
+            output_tokens: result.usage.output_tokens,
+            cache_creation_input_tokens: (result.usage as Record<string, unknown>)['cache_creation_input_tokens'] as number | undefined,
+            cache_read_input_tokens: (result.usage as Record<string, unknown>)['cache_read_input_tokens'] as number | undefined,
+          };
           const sdkOutcome = result.is_error ? 'error' : 'success';
           outcome = sdkOutcome;
           this._agentRunOutcome.add(1, { component: 'claude-agent-sdk', model, outcome: sdkOutcome });
@@ -307,8 +312,20 @@ export class ClaudeAgentSdkAgentRunner implements AgentRunner {
           } else {
             yield event;
           }
-        } else if ((message as SDKMessage).type === 'result' && terminalDiagnostics) {
-          yield { ...event, diagnostics: terminalDiagnostics } as AgentRunEvent;
+        } else if ((message as SDKMessage).type === 'result') {
+          const terminal_usage = terminalUsage
+            ? {
+                input: terminalUsage.input_tokens ?? 0,
+                output: terminalUsage.output_tokens ?? 0,
+                cache_read: terminalUsage.cache_read_input_tokens ?? 0,
+                cache_write: terminalUsage.cache_creation_input_tokens ?? 0,
+              }
+            : null;
+          yield {
+            ...event,
+            ...(terminalDiagnostics ? { diagnostics: terminalDiagnostics } : {}),
+            terminal_usage,
+          } as AgentRunEvent;
         } else {
           yield event;
         }

--- a/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
+++ b/src/adapters/anthropic/claude-agent-sdk-agent-runner.ts
@@ -28,7 +28,6 @@ import type {
 } from '../../types/ai.js';
 import { createLogger } from '../../core/logger.js';
 import { redactSecrets } from '../../core/journal/redaction.js';
-export { redactSecrets } from '../../core/journal/redaction.js';
 import { materializeClaudeRuntimeSkillPlugins } from './claude-runtime-skill-materializer.js';
 import { buildSandboxEnvironmentWithSummary, buildSandboxEnvironment } from '../sandbox-environment.js';
 import { startAnthropicBetaHeaderFilterProxy, type AnthropicBetaHeaderFilterProxy, type RequestLogOptions } from './anthropic-beta-header-filter-proxy.js';

--- a/src/adapters/anthropic/direct-model-runner.ts
+++ b/src/adapters/anthropic/direct-model-runner.ts
@@ -4,12 +4,21 @@ import type { LoggerProvider } from '@opentelemetry/api-logs';
 import { performance } from 'node:perf_hooks';
 import { createLogger } from '../../core/logger.js';
 import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner } from '../../types/ai.js';
+import type { NormalizedTokenUsage } from '../../types/journal.js';
 
 export type AnthropicCreateFn = (params: {
   model: string;
   max_tokens: number;
   messages: Array<{ role: 'user'; content: string }>;
-}) => Promise<{ content: Array<{ type: string; text?: string }>; usage?: { input_tokens?: number; output_tokens?: number } }>;
+}) => Promise<{
+  content: Array<{ type: string; text?: string }>;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+}>;
 
 export interface AnthropicDirectModelRunnerOptions {
   createFn?: AnthropicCreateFn;
@@ -28,7 +37,7 @@ export class AnthropicDirectModelRunner implements DirectModelRunner {
       this.createFn = options.createFn;
     } else {
       const client = new Anthropic({ apiKey });
-      this.createFn = params => client.messages.create(params) as Promise<{ content: Array<{ type: string; text?: string }>; usage?: { input_tokens?: number; output_tokens?: number } }>;
+      this.createFn = params => client.messages.create(params) as Promise<{ content: Array<{ type: string; text?: string }>; usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } }>;
     }
     this.defaultModel = options?.defaultModel;
     this.logger = createLogger('anthropic-direct-model-runner', {
@@ -62,9 +71,19 @@ export class AnthropicDirectModelRunner implements DirectModelRunner {
         },
         'Model run completed',
       );
+      const normalizedUsage: NormalizedTokenUsage | null = raw.usage
+        ? {
+            input: raw.usage.input_tokens ?? 0,
+            output: raw.usage.output_tokens ?? 0,
+            cache_read: raw.usage.cache_read_input_tokens ?? 0,
+            cache_write: raw.usage.cache_creation_input_tokens ?? 0,
+          }
+        : null;
       return {
         text: raw.content.find(block => block.type === 'text')?.text ?? '',
         raw,
+        usage: normalizedUsage,
+        runner: 'anthropic_direct',
       };
     } catch (err) {
       this.logger.error(

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -1,5 +1,6 @@
 import type pino from 'pino';
 import { createLogger } from '../../core/logger.js';
+import { redactSecrets } from '../../core/journal/redaction.js';
 import type { NotionClient } from './notion-client.js';
 import type {
   FeedbackItem,
@@ -16,11 +17,6 @@ export type {
   ImplementationReviewStatus,
   PublishedImplementationReview,
 } from '../../types/impl-feedback-page.js';
-
-function redactSecrets(text: string): string {
-  // Redact common API key patterns starting with sk-
-  return text.replace(/\bsk-[A-Za-z0-9]{8,}\b/g, '[REDACTED]');
-}
 
 function renderAiReviewMarkdown(exchanges: ImplementationReviewExchange[]): string {
   const lines: string[] = [];

--- a/src/adapters/openai/direct-model-runner.ts
+++ b/src/adapters/openai/direct-model-runner.ts
@@ -4,12 +4,20 @@ import type { LoggerProvider } from '@opentelemetry/api-logs';
 import { performance } from 'node:perf_hooks';
 import { createLogger } from '../../core/logger.js';
 import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner } from '../../types/ai.js';
+import type { NormalizedTokenUsage } from '../../types/journal.js';
 
 export type OpenAIChatCompletionFn = (params: {
   model: string;
   max_completion_tokens: number;
   messages: Array<{ role: 'user'; content: string }>;
-}) => Promise<{ choices: Array<{ message: { content: string | null } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } }>;
+}) => Promise<{
+  choices: Array<{ message: { content: string | null } }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+  };
+}>;
 
 export interface OpenAIDirectModelRunnerOptions {
   createFn?: OpenAIChatCompletionFn;
@@ -36,7 +44,7 @@ export class OpenAIDirectModelRunner implements DirectModelRunner {
       }
       const client = new OpenAI(clientOptions);
       this.createFn = params =>
-        client.chat.completions.create(params) as Promise<{ choices: Array<{ message: { content: string | null } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } }>;
+        client.chat.completions.create(params) as Promise<{ choices: Array<{ message: { content: string | null } }>; usage?: { prompt_tokens?: number; completion_tokens?: number; prompt_tokens_details?: { cached_tokens?: number } } }>;
     }
     this.defaultModel = options?.defaultModel;
     this.logger = createLogger('openai-direct-model-runner', {
@@ -70,9 +78,19 @@ export class OpenAIDirectModelRunner implements DirectModelRunner {
         },
         'Model run completed',
       );
+      const normalizedUsage: NormalizedTokenUsage | null = raw.usage
+        ? {
+            input: raw.usage.prompt_tokens ?? 0,
+            output: raw.usage.completion_tokens ?? 0,
+            cache_read: raw.usage.prompt_tokens_details?.cached_tokens ?? 0,
+            cache_write: 0,
+          }
+        : null;
       return {
         text: raw.choices[0]?.message.content ?? '',
         raw,
+        usage: normalizedUsage,
+        runner: 'openai_direct',
       };
     } catch (err) {
       this.logger.error(

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -20,6 +20,9 @@ import { WorkspaceManagerImpl } from '../core/workspace-manager.js';
 import { SlackCanvasPublisher } from './slack/canvas-publisher.js';
 import type { ArtifactCommentAnchorCodec, ArtifactContentSource, ArtifactPublisher } from '../types/publisher.js';
 import { FileRunStore } from '../core/run-store.js';
+import { JsonlJournalWriter } from '../core/journal/jsonl-writer.js';
+import { RunJournal } from '../core/journal/run-journal.js';
+import { NoopJournalWriter } from '../types/journal.js';
 import { NotionClientImpl } from './notion/notion-client.js';
 import { NotionPublisher } from './notion/notion-publisher.js';
 import { NotionCommentAnchorCodec } from './notion/markdown-diff.js';
@@ -152,12 +155,24 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
   const channelRepoMap = channelRegistryToRepoMap(channelRegistry);
 
   const workspaceManager = new WorkspaceManagerImpl();
+
+  let journal: RunJournal;
+  if (normalizedConfig.journal_enabled) {
+    logger.info({ event: 'journal.writer_started' }, 'Journal enabled');
+    const writer = new JsonlJournalWriter(workspaceRoot);
+    journal = new RunJournal(writer);
+  } else {
+    logger.info({ event: 'journal.disabled' }, 'Journal disabled');
+    journal = new RunJournal(new NoopJournalWriter());
+  }
+
   const runStore = new FileRunStore(workspaceRoot, {
     legacyConversationFields: {
       provider: 'slack',
       channelField: 'channel_id',
       conversationField: 'thread_ts',
     },
+    journal,
   });
   const implementer = new AgentRunnerImplementationAgent(agentRunner, aiRoutingPolicy, { loggerProvider: options.loggerProvider });
   const implementationPlanner = new AgentRunnerImplementationPlanningAgent(agentRunner, aiRoutingPolicy, { loggerProvider: options.loggerProvider });
@@ -231,6 +246,7 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     isConnected: () => adapter.isConnected(),
     meter: options.meter,
     onStop: () => agentRunner.close?.() ?? Promise.resolve(),
+    journal,
   });
 }
 

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -768,6 +768,7 @@ export async function drainAgentRunner(
   let tool_call_count = 0;
   let tool_result_count = 0;
   let latestDiagnostics: AgentDrainSummary['diagnostics'];
+  let latestTerminalUsage: AgentDrainSummary['terminal_usage'];
 
   const telCtx = {
     ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}),
@@ -780,9 +781,11 @@ export async function drainAgentRunner(
     for await (const event of events) {
       event_count++;
 
-      // Capture diagnostics propagated from terminal runner events
+      // Capture diagnostics and terminal_usage propagated from terminal runner events
       const eventDiag = (event as { diagnostics?: AgentDrainSummary['diagnostics'] }).diagnostics;
       if (eventDiag) latestDiagnostics = eventDiag;
+      const eventTerminalUsage = (event as { terminal_usage?: AgentDrainSummary['terminal_usage'] }).terminal_usage;
+      if (eventTerminalUsage !== undefined) latestTerminalUsage = eventTerminalUsage;
 
       const content = assistantContent(event);
       if (content) {
@@ -832,6 +835,7 @@ export async function drainAgentRunner(
     tool_call_count,
     tool_result_count,
     elapsed_ms,
+    ...(latestTerminalUsage !== undefined ? { terminal_usage: latestTerminalUsage } : {}),
     ...(latestDiagnostics ? { diagnostics: latestDiagnostics } : {}),
   };
 

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -46,6 +46,32 @@ import type { ArtifactCommentAnchorCodec } from '../../types/publisher.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
+function emitSessionRecord(
+  telemetry: AgentServiceTelemetry | undefined,
+  profile: AgentProfile,
+  route: AgentRoute,
+  ts_start: string,
+  outcome: 'ok' | 'failed' | 'incomplete',
+  drainSummary: AgentDrainSummary | undefined,
+): void {
+  if (!telemetry?.captureSession) return;
+  const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
+  telemetry.captureSession({
+    phase: telemetry.phase ?? null,
+    step: route.task,
+    ts_start,
+    ts_end: new Date().toISOString(),
+    model: { provider: profile.provider, name: profile.model ?? null },
+    inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
+    tokens: drainSummary?.terminal_usage ?? null,
+    assistant_turns: drainSummary?.assistant_turn_count ?? null,
+    tool_calls: drainSummary?.tool_call_count ?? null,
+    tool_results: drainSummary?.tool_result_count ?? null,
+    outcome,
+    runner,
+  });
+}
+
 function notifyAgentRequest(
   telemetry: AgentServiceTelemetry | undefined,
   profile: AgentProfile,
@@ -114,7 +140,9 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
           }
         : onProgress;
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(createResultPath);
       drainSummary = await drainAgentRunner(
@@ -137,12 +165,15 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
       this.logger.error(
         { event: 'artifact.agent_failed', request_id: request.id, error: String(err) },
         'Agent exited with error during artifact creation',
       );
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       throw new Error(`Artifact creation failed: ${String(err)}`);
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,
@@ -208,7 +239,9 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
           }
         : onProgress;
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(reviseResultPath);
       drainSummary = await drainAgentRunner(
@@ -231,12 +264,15 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
       this.logger.error(
         { event: 'artifact.agent_failed', request_id: feedback.request_id, error: String(err) },
         'Agent exited with error during artifact revision',
       );
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       throw new Error(`Artifact revision failed: ${String(err)}`);
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,
@@ -291,7 +327,9 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
           }
         : onProgress;
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(resultPath);
       drainSummary = await drainAgentRunner(
@@ -314,8 +352,11 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       return { status: 'failed', responses: [], error: `Spec review author response failed: ${String(err)}` };
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,
@@ -424,7 +465,9 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
           }
         : onProgress;
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(resultFilePath);
       drainSummary = await drainAgentRunner(
@@ -447,7 +490,9 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
       this.logger.error({ event: 'impl.agent_failed', error: String(err) }, 'Agent exited with error during implementation');
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       const msg = String(err);
       if (msg.includes('exceeded') && msg.includes('output token')) {
         throw new Error(
@@ -457,6 +502,7 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
       }
       throw new Error(`Implementation failed: ${msg}`);
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,
@@ -515,7 +561,9 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
           }
         : onProgress;
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(resultFilePath);
       drainSummary = await drainAgentRunner(
@@ -538,9 +586,12 @@ export class AgentRunnerImplementationPlanningAgent implements ImplementationPla
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
       this.logger.error({ event: 'planning.agent_failed', error: String(err) }, 'Agent exited with error during implementation planning');
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       throw new Error(`Implementation planning failed: ${String(err)}`);
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,
@@ -583,7 +634,9 @@ export class AgentRunnerQuestionAnsweringAgent implements QuestionAnsweringAgent
     const profile = this.routingPolicy.resolve(route);
     notifyAgentRequest(telemetry, profile, route);
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(resultPath);
       drainSummary = await drainAgentRunner(
@@ -606,9 +659,12 @@ export class AgentRunnerQuestionAnsweringAgent implements QuestionAnsweringAgent
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
       this.logger.error({ event: 'question.agent_failed', error: String(err), ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}), ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}) }, 'Agent exited with error during question answering');
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       throw new Error(`Agent question answering failed: ${String(err)}`);
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,
@@ -664,7 +720,9 @@ export class AgentRunnerIssueTriageAgent implements IssueTriageAgent {
           }
         : onProgress;
 
+    const ts_start = new Date().toISOString();
     let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
     try {
       await ensureResultDir(resultPath);
       drainSummary = await drainAgentRunner(
@@ -687,12 +745,15 @@ export class AgentRunnerIssueTriageAgent implements IssueTriageAgent {
         { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
       );
     } catch (err) {
+      sessionOutcome = 'failed';
       this.logger.error(
         { event: 'filing.agent_failed', request_id: request.id, error: String(err) },
         'Agent exited with error during issue triage',
       );
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
       throw new Error(`Issue triage failed: ${String(err)}`);
     }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
 
     const content = await validateRequiredResultFile({
       readFileFn: this.readFileFn,

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -131,6 +131,7 @@ export class ImplementationReviewCoordinator {
 
     let reviewResultContent: string;
     let reviewResult: ReturnType<typeof parseImplementationReviewResult>;
+    let drainSummary: AgentDrainSummary | undefined;
     const ts_start = new Date().toISOString();
     try {
       if (onAgentRequest && reviewProfile) {
@@ -154,7 +155,7 @@ export class ImplementationReviewCoordinator {
             }
           : onProgress;
 
-      const drainSummary = await drainAgentRunner(
+      drainSummary = await drainAgentRunner(
         this.deps.runner.run({
           route: { task: routeTask },
           profile: reviewProfile,
@@ -178,7 +179,7 @@ export class ImplementationReviewCoordinator {
       reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
       this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'ok', drainSummary);
     } catch (err) {
-      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'failed', undefined);
+      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'failed', drainSummary);
       this.deps.logger.error(
         {
           event: 'implementation.review.round_failed',

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../types/ai.js';
 import type { Run } from '../../types/runs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
+import type { AgentDrainSummary } from '../../types/ai.js';
 import {
   buildInitialReviewPrompt,
   buildFinalReviewPrompt,
@@ -153,7 +154,7 @@ export class ImplementationReviewCoordinator {
             }
           : onProgress;
 
-      await drainAgentRunner(
+      const drainSummary = await drainAgentRunner(
         this.deps.runner.run({
           route: { task: routeTask },
           profile: reviewProfile,
@@ -173,11 +174,11 @@ export class ImplementationReviewCoordinator {
         { run_id: run.id, request_id: run.request_id },
       );
 
-      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'ok');
+      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'ok', drainSummary);
       reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
       reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
     } catch (err) {
-      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'failed');
+      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'failed', undefined);
       this.deps.logger.error(
         {
           event: 'implementation.review.round_failed',
@@ -308,6 +309,7 @@ export class ImplementationReviewCoordinator {
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
     ts_start: string,
     outcome: 'ok' | 'failed',
+    drainSummary: AgentDrainSummary | undefined,
   ): void {
     if (!captureSession) return;
     const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
@@ -318,7 +320,7 @@ export class ImplementationReviewCoordinator {
       ts_end: new Date().toISOString(),
       model: { provider: profile.provider, name: profile.model ?? null },
       inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
-      tokens: null,
+      tokens: drainSummary?.terminal_usage ?? null,
       assistant_turns: null,
       tool_calls: null,
       tool_results: null,

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -174,9 +174,9 @@ export class ImplementationReviewCoordinator {
         { run_id: run.id, request_id: run.request_id },
       );
 
-      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'ok', drainSummary);
       reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
       reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
+      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'ok', drainSummary);
     } catch (err) {
       this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'failed', undefined);
       this.deps.logger.error(
@@ -321,9 +321,9 @@ export class ImplementationReviewCoordinator {
       model: { provider: profile.provider, name: profile.model ?? null },
       inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
       tokens: drainSummary?.terminal_usage ?? null,
-      assistant_turns: null,
-      tool_calls: null,
-      tool_results: null,
+      assistant_turns: drainSummary?.assistant_turn_count ?? null,
+      tool_calls: drainSummary?.tool_call_count ?? null,
+      tool_results: drainSummary?.tool_result_count ?? null,
       outcome,
       runner,
     });

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -7,8 +7,10 @@ import { performance } from 'node:perf_hooks';
 import type pino from 'pino';
 import type {
   AgentInvocationMetadata,
+  AgentProfile,
   AgentRunner,
   AgentRoutingPolicy,
+  AgentSessionCaptureFn,
   ImplementationAgent,
   ImplementationResult,
   ImplementationReviewExchange,
@@ -51,6 +53,7 @@ export interface ReviewRunParams {
   working_directory: string;
   onProgress?: (message: string) => Promise<void>;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+  captureSession?: AgentSessionCaptureFn;
 }
 
 export class ImplementationReviewCoordinator {
@@ -71,7 +74,7 @@ export class ImplementationReviewCoordinator {
   private async runReview(
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
-    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest }: ReviewRunParams,
+    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest, captureSession }: ReviewRunParams,
   ): Promise<ImplementationResult> {
     // Resolve review profile — fall back to initial when final is absent
     let reviewProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask });
@@ -126,6 +129,7 @@ export class ImplementationReviewCoordinator {
 
     let reviewResultContent: string;
     let reviewResult: ReturnType<typeof parseImplementationReviewResult>;
+    const ts_start = new Date().toISOString();
     try {
       if (onAgentRequest && reviewProfile) {
         onAgentRequest({
@@ -168,9 +172,11 @@ export class ImplementationReviewCoordinator {
         { run_id: run.id, request_id: run.request_id },
       );
 
+      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'ok');
       reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
       reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
     } catch (err) {
+      this.emitSessionRecord(captureSession, reviewProfile, routeTask, ts_start, 'failed');
       this.deps.logger.error(
         {
           event: 'implementation.review.round_failed',
@@ -293,6 +299,31 @@ export class ImplementationReviewCoordinator {
     });
 
     return implementerResult;
+  }
+
+  private emitSessionRecord(
+    captureSession: AgentSessionCaptureFn | undefined,
+    profile: AgentProfile,
+    routeTask: 'implementation.review.initial' | 'implementation.review.final',
+    ts_start: string,
+    outcome: 'ok' | 'failed',
+  ): void {
+    if (!captureSession) return;
+    const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
+    captureSession({
+      phase: `implementation_review`,
+      step: routeTask,
+      ts_start,
+      ts_end: new Date().toISOString(),
+      model: { provider: profile.provider, name: profile.model ?? null },
+      inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
+      tokens: null,
+      assistant_turns: null,
+      tool_calls: null,
+      tool_results: null,
+      outcome,
+      runner,
+    });
   }
 
   private handleReviewFailure(

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -54,6 +54,7 @@ export interface ReviewRunParams {
   onProgress?: (message: string) => Promise<void>;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
   captureSession?: AgentSessionCaptureFn;
+  captureFeedback?: (exchange: ImplementationReviewExchange, run: Run) => void;
 }
 
 export class ImplementationReviewCoordinator {
@@ -74,7 +75,7 @@ export class ImplementationReviewCoordinator {
   private async runReview(
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
-    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest, captureSession }: ReviewRunParams,
+    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback }: ReviewRunParams,
   ): Promise<ImplementationResult> {
     // Resolve review profile — fall back to initial when final is absent
     let reviewProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask });
@@ -188,7 +189,7 @@ export class ImplementationReviewCoordinator {
         },
         'Review round failed',
       );
-      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, String(err));
+      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, String(err), captureFeedback);
     }
 
     if (reviewResult.status === 'failed') {
@@ -205,7 +206,7 @@ export class ImplementationReviewCoordinator {
         },
         'Review round failed: review agent reported failure',
       );
-      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, reviewResult.error ?? 'Review model reported failure');
+      return this.handleReviewFailure(phase, run, implementation_result, implSummary, reviewSummary, reviewResult.error ?? 'Review model reported failure', captureFeedback);
     }
 
     const duration_ms = Math.round(performance.now() - roundStart);
@@ -244,7 +245,7 @@ export class ImplementationReviewCoordinator {
         findings: [],
         responses: [],
         requires_human_retest: false,
-      });
+      }, captureFeedback);
       return implementation_result;
     }
 
@@ -296,7 +297,7 @@ export class ImplementationReviewCoordinator {
       findings: reviewResult.findings,
       responses,
       requires_human_retest: implementerResult.requires_human_retest ?? false,
-    });
+    }, captureFeedback);
 
     return implementerResult;
   }
@@ -333,6 +334,7 @@ export class ImplementationReviewCoordinator {
     implSummary: ReturnType<typeof agentProfileSummary>,
     reviewSummary: ReturnType<typeof agentProfileSummary>,
     errorMsg: string,
+    captureFeedback?: (exchange: ImplementationReviewExchange, run: Run) => void,
   ): ImplementationResult {
     this.deps.logger.warn(
       { event: 'implementation.review.failed', phase, run_id: run.id, error: errorMsg },
@@ -353,7 +355,7 @@ export class ImplementationReviewCoordinator {
       findings: [],
       responses: [],
       requires_human_retest: false,
-    });
+    }, captureFeedback);
     return original;
   }
 
@@ -369,9 +371,10 @@ export class ImplementationReviewCoordinator {
     }
   }
 
-  private appendExchange(run: Run, exchange: ImplementationReviewExchange): void {
+  private appendExchange(run: Run, exchange: ImplementationReviewExchange, captureFeedback?: (exchange: ImplementationReviewExchange, run: Run) => void): void {
     if (!run.review_exchanges) run.review_exchanges = [];
     run.review_exchanges.push(exchange);
+    captureFeedback?.(exchange, run);
   }
 
   private async getGitDiff(working_directory: string): Promise<string> {

--- a/src/core/ai/spec-review-coordinator.ts
+++ b/src/core/ai/spec-review-coordinator.ts
@@ -4,6 +4,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type pino from 'pino';
 import type {
+  AgentDrainSummary,
   AgentInvocationMetadata,
   AgentProfile,
   AgentRunner,
@@ -118,7 +119,7 @@ export class SpecReviewCoordinator {
     let reviewResult: SpecReviewResult;
     const ts_start = new Date().toISOString();
     try {
-      await drainAgentRunner(
+      const drainSummary = await drainAgentRunner(
         this.deps.runner.run({
           route: { task: 'spec.review', artifact_kind },
           profile: reviewProfile,
@@ -137,11 +138,11 @@ export class SpecReviewCoordinator {
         'spec_review',
         { run_id: run.id, request_id: run.request_id },
       );
-      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'ok');
+      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'ok', drainSummary);
       reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
       reviewResult = parseSpecReviewResult(reviewResultContent, reviewResultPath);
     } catch (err) {
-      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'failed');
+      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'failed', undefined);
       return this.handleReviewFailure(run, artifact_path, String(err), onProgress);
     }
 
@@ -251,6 +252,7 @@ export class SpecReviewCoordinator {
     profile: AgentProfile,
     ts_start: string,
     outcome: 'ok' | 'failed',
+    drainSummary: AgentDrainSummary | undefined,
   ): void {
     if (!captureSession) return;
     const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
@@ -261,7 +263,7 @@ export class SpecReviewCoordinator {
       ts_end: new Date().toISOString(),
       model: { provider: profile.provider, name: profile.model ?? null },
       inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
-      tokens: null,
+      tokens: drainSummary?.terminal_usage ?? null,
       assistant_turns: null,
       tool_calls: null,
       tool_results: null,

--- a/src/core/ai/spec-review-coordinator.ts
+++ b/src/core/ai/spec-review-coordinator.ts
@@ -117,9 +117,10 @@ export class SpecReviewCoordinator {
 
     let reviewResultContent: string;
     let reviewResult: SpecReviewResult;
+    let drainSummary: AgentDrainSummary | undefined;
     const ts_start = new Date().toISOString();
     try {
-      const drainSummary = await drainAgentRunner(
+      drainSummary = await drainAgentRunner(
         this.deps.runner.run({
           route: { task: 'spec.review', artifact_kind },
           profile: reviewProfile,
@@ -142,7 +143,7 @@ export class SpecReviewCoordinator {
       reviewResult = parseSpecReviewResult(reviewResultContent, reviewResultPath);
       this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'ok', drainSummary);
     } catch (err) {
-      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'failed', undefined);
+      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'failed', drainSummary);
       return this.handleReviewFailure(run, artifact_path, String(err), onProgress);
     }
 

--- a/src/core/ai/spec-review-coordinator.ts
+++ b/src/core/ai/spec-review-coordinator.ts
@@ -5,8 +5,10 @@ import { dirname } from 'node:path';
 import type pino from 'pino';
 import type {
   AgentInvocationMetadata,
+  AgentProfile,
   AgentRunner,
   AgentRoutingPolicy,
+  AgentSessionCaptureFn,
   ArtifactAuthoringAgent,
   SpecReviewAuthorResponseResult,
   SpecReviewFinding,
@@ -42,6 +44,7 @@ export interface SpecReviewRunParams {
   current_page_markdown?: string;
   onProgress?: (message: string) => Promise<void>;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+  captureSession?: AgentSessionCaptureFn;
 }
 
 export interface SpecReviewRunResult {
@@ -61,7 +64,7 @@ export class SpecReviewCoordinator {
   }
 
   async runSpecReview(params: SpecReviewRunParams): Promise<SpecReviewRunResult> {
-    const { run, artifact_path, working_directory, artifact_kind, current_page_markdown, onProgress, onAgentRequest } = params;
+    const { run, artifact_path, working_directory, artifact_kind, current_page_markdown, onProgress, onAgentRequest, captureSession } = params;
 
     const reviewProfile = this.deps.routingPolicy.resolveOptional({ task: 'spec.review', artifact_kind });
 
@@ -113,6 +116,7 @@ export class SpecReviewCoordinator {
 
     let reviewResultContent: string;
     let reviewResult: SpecReviewResult;
+    const ts_start = new Date().toISOString();
     try {
       await drainAgentRunner(
         this.deps.runner.run({
@@ -133,9 +137,11 @@ export class SpecReviewCoordinator {
         'spec_review',
         { run_id: run.id, request_id: run.request_id },
       );
+      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'ok');
       reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
       reviewResult = parseSpecReviewResult(reviewResultContent, reviewResultPath);
     } catch (err) {
+      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'failed');
       return this.handleReviewFailure(run, artifact_path, String(err), onProgress);
     }
 
@@ -238,6 +244,30 @@ export class SpecReviewCoordinator {
       page_content: authorResponse.page_content,
       summary: reviewResult.summary,
     };
+  }
+
+  private emitSessionRecord(
+    captureSession: AgentSessionCaptureFn | undefined,
+    profile: AgentProfile,
+    ts_start: string,
+    outcome: 'ok' | 'failed',
+  ): void {
+    if (!captureSession) return;
+    const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
+    captureSession({
+      phase: 'spec_review',
+      step: 'spec.review',
+      ts_start,
+      ts_end: new Date().toISOString(),
+      model: { provider: profile.provider, name: profile.model ?? null },
+      inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
+      tokens: null,
+      assistant_turns: null,
+      tool_calls: null,
+      tool_results: null,
+      outcome,
+      runner,
+    });
   }
 
   private handleReviewFailure(

--- a/src/core/ai/spec-review-coordinator.ts
+++ b/src/core/ai/spec-review-coordinator.ts
@@ -138,9 +138,9 @@ export class SpecReviewCoordinator {
         'spec_review',
         { run_id: run.id, request_id: run.request_id },
       );
-      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'ok', drainSummary);
       reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
       reviewResult = parseSpecReviewResult(reviewResultContent, reviewResultPath);
+      this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'ok', drainSummary);
     } catch (err) {
       this.emitSessionRecord(captureSession, reviewProfile, ts_start, 'failed', undefined);
       return this.handleReviewFailure(run, artifact_path, String(err), onProgress);
@@ -264,9 +264,9 @@ export class SpecReviewCoordinator {
       model: { provider: profile.provider, name: profile.model ?? null },
       inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
       tokens: drainSummary?.terminal_usage ?? null,
-      assistant_turns: null,
-      tool_calls: null,
-      tool_results: null,
+      assistant_turns: drainSummary?.assistant_turn_count ?? null,
+      tool_calls: drainSummary?.tool_call_count ?? null,
+      tool_results: drainSummary?.tool_result_count ?? null,
       outcome,
       runner,
     });

--- a/src/core/config-normalizer.ts
+++ b/src/core/config-normalizer.ts
@@ -24,6 +24,7 @@ export interface NormalizedWorkflowConfig {
   channels: NormalizedChannelConfig[];
   publishers: NormalizedPublisherConfig[];
   artifact_policies: Record<ArtifactKind, ArtifactLifecyclePolicy>;
+  journal_enabled: boolean;
 }
 
 export function normalizeWorkflowConfig(config: WorkflowConfig): NormalizedWorkflowConfig {
@@ -36,6 +37,7 @@ export function normalizeWorkflowConfig(config: WorkflowConfig): NormalizedWorkf
     channels,
     publishers,
     artifact_policies: normalizeArtifactPolicies(config.artifact_policies),
+    journal_enabled: config.journal?.enabled ?? true,
   };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -185,6 +185,17 @@ export function validateConfig(config: WorkflowConfig): void {
     }
   }
 
+  const rawJournal = (config as Record<string, unknown>)['journal'];
+  if (rawJournal !== undefined && rawJournal !== null) {
+    if (typeof rawJournal !== 'object' || Array.isArray(rawJournal)) {
+      throw new Error('journal must be an object');
+    }
+    const journal = rawJournal as Record<string, unknown>;
+    if (journal['enabled'] !== undefined && typeof journal['enabled'] !== 'boolean') {
+      throw new Error('journal.enabled must be a boolean');
+    }
+  }
+
   const rawSpecReview = (config as Record<string, unknown>)['spec_review'];
   if (rawSpecReview !== undefined && rawSpecReview !== null) {
     if (typeof rawSpecReview !== 'object' || Array.isArray(rawSpecReview)) {

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -88,7 +88,7 @@ export interface DefaultHandlerRegistryDeps {
   issueFiler?: IssueFiler;
   channelRepoMap: ChannelRepoMap;
   reacjiComplete?: string | null;
-  postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
+  postMessage: (conversation: ConversationRef, text: string, run?: Run) => Promise<void>;
   postError: (conversation: ConversationRef, text: string) => Promise<void>;
   transition: (run: Run, stage: RunStage) => void;
   failRun: (run: Run, conversation: ConversationRef, error: unknown) => Promise<void>;

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -4,6 +4,7 @@ import type { IssueFiler } from '../types/issue-filing.js';
 import type { IssueManager, PRManager } from '../types/issue-tracker.js';
 import type { PRTitleGenerator } from './ai/pr-title-generator.js';
 import type { ArtifactAuthoringAgent, ImplementationAgent, ImplementationPlanningAgent, QuestionAnsweringAgent } from '../types/ai.js';
+import type { RunJournal } from './journal/run-journal.js';
 import type { Request, ThreadMessage } from '../types/events.js';
 import type { ConversationRef } from '../types/channel.js';
 import type { FeedbackSource } from '../types/feedback-source.js';
@@ -101,6 +102,7 @@ export interface DefaultHandlerRegistryDeps {
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   workspacePruner?: Pick<WorkspacePruner, 'prune'>;
   autoPruneWorkspace?: boolean;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): HandlerRegistry {
@@ -192,6 +194,7 @@ async function startArtifactCreation(
     logger: deps.logger,
     branchGuard,
     specReviewCoordinator: deps.specReviewCoordinator,
+    journal: deps.journal,
   });
   await handler.handle(run, request, intent);
 }
@@ -237,6 +240,7 @@ async function handleArtifactFeedback(
     logger: deps.logger,
     branchGuard,
     specReviewCoordinator: deps.specReviewCoordinator,
+    journal: deps.journal,
   });
   await handler.handle(run, feedback);
 }
@@ -258,6 +262,7 @@ async function runImplementation(
     logger: deps.logger,
     branchGuard,
     reviewCoordinator: deps.reviewCoordinator,
+    journal: deps.journal,
   });
   await handler.handle(run, feedback, additionalContext);
 }
@@ -280,6 +285,7 @@ async function runPlanning(
     persist: deps.persist,
     logger: deps.logger,
     validatePlanPath: deps.validatePlanPath,
+    journal: deps.journal,
   });
   return handler.handle(run, feedback, additionalContext);
 }
@@ -301,6 +307,7 @@ async function handleImplementationFeedback(
     logger: deps.logger,
     branchGuard,
     reviewCoordinator: deps.reviewCoordinator,
+    journal: deps.journal,
   });
   await handler.handle(run, feedback, routingStage);
 }
@@ -361,6 +368,7 @@ async function startFilingPipeline(deps: DefaultHandlerRegistryDeps, run: Run, r
     reactToRunMessage: deps.reactToRunMessage,
     reacjiComplete: deps.reacjiComplete,
     logger: deps.logger,
+    journal: deps.journal,
   });
   await handler.handle(run, request);
 }
@@ -377,6 +385,7 @@ async function handleQuestion(
     postError: deps.postError,
     persist: deps.persist,
     logger: deps.logger,
+    journal: deps.journal,
   });
   return handler.handle(content, conversation, run);
 }

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -102,7 +102,7 @@ export interface DefaultHandlerRegistryDeps {
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   workspacePruner?: Pick<WorkspacePruner, 'prune'>;
   autoPruneWorkspace?: boolean;
-  journal?: Pick<RunJournal, 'captureSession'>;
+  journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
 }
 
 export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): HandlerRegistry {

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -331,6 +331,7 @@ async function handleImplementationApproval(
     logger: deps.logger,
     branchGuard,
     reviewCoordinator: deps.reviewCoordinator,
+    journal: deps.journal,
   });
   await handler.handle(run, feedback);
 }

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -100,6 +100,9 @@ export class ArtifactCreationHandler {
 
     // Spec review (idea intent only, after branch guard, before publish)
     if (intent === 'idea' && this.deps.specReviewCoordinator && run.artifact) {
+      const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       const reviewResult = await this.deps.specReviewCoordinator.runSpecReview({
         run,
         artifact_path: local_path,
@@ -112,6 +115,7 @@ export class ArtifactCreationHandler {
           );
         }),
         onAgentRequest,
+        captureSession: captureSessionForReview,
       });
 
       if (reviewResult.status !== 'complete') {

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -11,6 +11,8 @@ import { channelKey, type ConversationRef } from '../../types/channel.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { SpecReviewCoordinator } from '../ai/spec-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
+import type { AgentSessionCaptureFn } from '../../types/ai.js';
 
 type ArtifactCreationIntent = Extract<RequestIntent, 'idea' | 'bug' | 'chore'>;
 
@@ -26,6 +28,7 @@ export interface ArtifactCreationDeps {
   logger: Pick<pino.Logger, 'warn' | 'error' | 'info'>;
   branchGuard?: BranchGuard;
   specReviewCoordinator?: Pick<SpecReviewCoordinator, 'runSpecReview'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export class ArtifactCreationHandler {
@@ -66,9 +69,12 @@ export class ArtifactCreationHandler {
 
     let local_path: string;
     try {
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       const result = intent === 'idea'
-        ? await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, { run_id: run.id, request_id: run.request_id, onAgentRequest })
-        : await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, intent, { run_id: run.id, request_id: run.request_id, onAgentRequest });
+        ? await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession })
+        : await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, intent, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
       local_path = result.artifact_path;
       this.setArtifactDraft(run, artifactKindForIntent(intent)!, local_path);
       if (intent !== 'idea' && result.existing_issue !== undefined) {

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -106,6 +106,9 @@ export class ArtifactFeedbackHandler {
     // Spec review (feature_spec only, after branch guard, before publish)
     let reviewedPageContent = page_content;
     if (refs.artifact.kind === 'feature_spec' && this.deps.specReviewCoordinator) {
+      const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       const reviewResult = await this.deps.specReviewCoordinator.runSpecReview({
         run,
         artifact_path: refs.local_path,
@@ -119,6 +122,7 @@ export class ArtifactFeedbackHandler {
           );
         }),
         onAgentRequest,
+        captureSession: captureSessionForReview,
       });
 
       if (reviewResult.status !== 'complete') {

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ArtifactAuthoringAgent } from '../../types/ai.js';
+import type { ArtifactAuthoringAgent, AgentSessionCaptureFn } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { FeedbackSource } from '../../types/feedback-source.js';
 import type { ArtifactContentSource, ArtifactPublisher } from '../../types/publisher.js';
@@ -9,6 +9,7 @@ import { requireArtifactRefs } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { SpecReviewCoordinator } from '../ai/spec-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface ArtifactFeedbackDeps {
   artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'revise'>;
@@ -22,6 +23,7 @@ export interface ArtifactFeedbackDeps {
   logger: Pick<pino.Logger, 'debug' | 'warn' | 'error' | 'info'>;
   branchGuard?: BranchGuard;
   specReviewCoordinator?: Pick<SpecReviewCoordinator, 'runSpecReview'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export type ArtifactFeedbackResult = { status: 'revised' } | { status: 'failed' };
@@ -70,7 +72,10 @@ export class ArtifactFeedbackHandler {
 
     let result;
     try {
-      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest });
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
+      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -11,8 +11,9 @@ import { markArtifactStatus, artifactPath, artifactPublisherId } from '../run-re
 import { getArtifactLifecyclePolicy } from '../../types/artifact.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
-import type { ImplementationResult } from '../../types/ai.js';
+import type { AgentSessionCaptureFn, ImplementationResult } from '../../types/ai.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface ImplementationApprovalDeps {
   specCommitter?: Pick<SpecCommitter, 'updateStatus'>;
@@ -28,6 +29,7 @@ export interface ImplementationApprovalDeps {
   now?: () => Date;
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runFinalReview'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export type ImplementationApprovalResult =
@@ -85,6 +87,9 @@ export class ImplementationApprovalHandler {
     // Run final review before PR creation
     if (this.deps.reviewCoordinator) {
       const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+      const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       const currentResult: ImplementationResult = {
         status: 'complete',
         summary: run.last_impl_result?.summary,
@@ -98,6 +103,7 @@ export class ImplementationApprovalHandler {
         implementation_result: currentResult,
         working_directory: run.workspace_path,
         onAgentRequest,
+        captureSession: captureSessionForReview,
       });
 
       if (reviewedResult.status === 'needs_input') {
@@ -160,11 +166,37 @@ export class ImplementationApprovalHandler {
 
     this.markArtifactComplete(run);
 
-    const generatedTitle = await this.deps.prTitleGenerator.generate({
-      intent: run.intent,
-      spec_path: localPath ?? '',
-      impl_summary: run.last_impl_result?.summary,
-    });
+    const prTitleTs = new Date().toISOString();
+    let generatedTitle: string | null;
+    let prTitleOutcome: 'ok' | 'failed' = 'ok';
+    try {
+      generatedTitle = await this.deps.prTitleGenerator.generate({
+        intent: run.intent,
+        spec_path: localPath ?? '',
+        impl_summary: run.last_impl_result?.summary,
+      });
+    } catch (err) {
+      prTitleOutcome = 'failed';
+      generatedTitle = null;
+    }
+    if (this.deps.journal) {
+      void this.deps.journal.captureSession({
+        run,
+        ts_start: prTitleTs,
+        ts_end: new Date().toISOString(),
+        phase: run.stage,
+        step: 'pr.title_generate',
+        round: 1,
+        model: { provider: 'anthropic_direct', name: null },
+        inference: { effort: null, thinking: null },
+        tokens: null,
+        assistant_turns: null,
+        tool_calls: null,
+        tool_results: null,
+        outcome: prTitleOutcome,
+        runner: 'anthropic_direct',
+      }).catch(() => {});
+    }
 
     const prOptions: PRManagerOptions = {
       impl_result: run.last_impl_result,

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ImplementationAgent, AgentSessionCaptureFn } from '../../types/ai.js';
+import type { ImplementationAgent, AgentSessionCaptureFn, ImplementationReviewExchange } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { FeedbackItem, ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
 import type { Run, RunStage } from '../../types/runs.js';
@@ -20,7 +20,7 @@ export interface ImplementationFeedbackDeps {
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error' | 'debug'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
-  journal?: Pick<RunJournal, 'captureSession'>;
+  journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
 }
 
 export type ImplementationFeedbackResult =
@@ -88,6 +88,22 @@ export class ImplementationFeedbackHandler {
       const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
         ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
         : undefined;
+      const captureFeedback = this.deps.journal
+        ? (exchange: ImplementationReviewExchange, captureRun: Run) => {
+            for (const finding of exchange.findings) {
+              void this.deps.journal!.captureFeedback({
+                id: finding.id,
+                run: captureRun,
+                target: 'implementation',
+                author_principal: `review:${exchange.review_profile.provider}:${exchange.review_profile.profile}`,
+                text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
+                severity: finding.severity,
+                category: finding.category,
+                disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
+              }).catch(() => {});
+            }
+          }
+        : undefined;
       reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
         run,
         artifact_path: localPath,
@@ -96,6 +112,7 @@ export class ImplementationFeedbackHandler {
         onProgress,
         onAgentRequest,
         captureSession: captureSessionForReview,
+        captureFeedback,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ImplementationAgent } from '../../types/ai.js';
+import type { ImplementationAgent, AgentSessionCaptureFn } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { FeedbackItem, ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
 import type { Run, RunStage } from '../../types/runs.js';
@@ -8,6 +8,7 @@ import { artifactPath } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface ImplementationFeedbackDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -19,6 +20,7 @@ export interface ImplementationFeedbackDeps {
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error' | 'debug'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export type ImplementationFeedbackResult =
@@ -55,12 +57,15 @@ export class ImplementationFeedbackHandler {
 
     let result;
     try {
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       result = await this.deps.implementer.implement(
         localPath,
         run.workspace_path,
         additionalContext.value,
         onProgress,
-        { run_id: run.id, request_id: run.request_id, onAgentRequest },
+        { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession },
       );
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -85,6 +85,9 @@ export class ImplementationFeedbackHandler {
     // Run initial review if coordinator is configured
     let reviewedResult = result;
     if (this.deps.reviewCoordinator) {
+      const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
         run,
         artifact_path: localPath,
@@ -92,6 +95,7 @@ export class ImplementationFeedbackHandler {
         working_directory: run.workspace_path,
         onProgress,
         onAgentRequest,
+        captureSession: captureSessionForReview,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ImplementationAgent } from '../../types/ai.js';
+import type { ImplementationAgent, AgentSessionCaptureFn } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
 import { titleFromArtifactPath } from '../../types/publisher.js';
@@ -9,6 +9,7 @@ import { requireArtifactRefs, artifactPublishedUrl } from '../run-refs.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface ImplementationStartDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -20,6 +21,7 @@ export interface ImplementationStartDeps {
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export type ImplementationStartResult =
@@ -63,12 +65,15 @@ export class ImplementationStartHandler {
 
     let result;
     try {
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       result = await this.deps.implementer.implement(
         refs.local_path,
         run.workspace_path,
         additionalContext,
         onProgress,
-        { run_id: run.id, request_id: run.request_id, onAgentRequest },
+        { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession },
         planPath,
       );
     } catch (err) {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -94,6 +94,9 @@ export class ImplementationStartHandler {
     // Run initial review if coordinator is configured
     let reviewedResult = result;
     if (this.deps.reviewCoordinator) {
+      const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
         run,
         artifact_path: refs.local_path,
@@ -101,6 +104,7 @@ export class ImplementationStartHandler {
         working_directory: run.workspace_path,
         onProgress,
         onAgentRequest,
+        captureSession: captureSessionForReview,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -62,12 +62,12 @@ export class ImplementationStartHandler {
     }
 
     const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
+    const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+      ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+      : undefined;
 
     let result;
     try {
-      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
-        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
-        : undefined;
       result = await this.deps.implementer.implement(
         refs.local_path,
         run.workspace_path,
@@ -94,9 +94,6 @@ export class ImplementationStartHandler {
     // Run initial review if coordinator is configured
     let reviewedResult = result;
     if (this.deps.reviewCoordinator) {
-      const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
-        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
-        : undefined;
       reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
         run,
         artifact_path: refs.local_path,
@@ -104,7 +101,7 @@ export class ImplementationStartHandler {
         working_directory: run.workspace_path,
         onProgress,
         onAgentRequest,
-        captureSession: captureSessionForReview,
+        captureSession,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ImplementationAgent, AgentSessionCaptureFn } from '../../types/ai.js';
+import type { ImplementationAgent, AgentSessionCaptureFn, ImplementationReviewExchange } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
 import { titleFromArtifactPath } from '../../types/publisher.js';
@@ -21,7 +21,7 @@ export interface ImplementationStartDeps {
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
-  journal?: Pick<RunJournal, 'captureSession'>;
+  journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
 }
 
 export type ImplementationStartResult =
@@ -94,6 +94,22 @@ export class ImplementationStartHandler {
     // Run initial review if coordinator is configured
     let reviewedResult = result;
     if (this.deps.reviewCoordinator) {
+      const captureFeedback = this.deps.journal
+        ? (exchange: ImplementationReviewExchange, captureRun: Run) => {
+            for (const finding of exchange.findings) {
+              void this.deps.journal!.captureFeedback({
+                id: finding.id,
+                run: captureRun,
+                target: 'implementation',
+                author_principal: `review:${exchange.review_profile.provider}:${exchange.review_profile.profile}`,
+                text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
+                severity: finding.severity,
+                category: finding.category,
+                disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
+              }).catch(() => {});
+            }
+          }
+        : undefined;
       reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
         run,
         artifact_path: refs.local_path,
@@ -102,6 +118,7 @@ export class ImplementationStartHandler {
         onProgress,
         onAgentRequest,
         captureSession,
+        captureFeedback,
       });
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');

--- a/src/core/handlers/issue-filing-handler.ts
+++ b/src/core/handlers/issue-filing-handler.ts
@@ -6,6 +6,8 @@ import type { Request } from '../../types/events.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import { channelKey, type ConversationRef } from '../../types/channel.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { AgentSessionCaptureFn } from '../../types/ai.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface IssueFilingDeps {
   workspaceManager: Pick<WorkspaceManager, 'create' | 'destroy'>;
@@ -18,6 +20,7 @@ export interface IssueFilingDeps {
   reactToRunMessage?: (run: Run, reaction: string) => Promise<void>;
   reacjiComplete?: string | null;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export type IssueFilingResult = { status: 'done' } | { status: 'failed' };
@@ -58,7 +61,10 @@ export class IssueFilingHandler {
 
     let result: FilingResult;
     try {
-      result = await this.deps.issueFiler.file(request, workspace_path, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest });
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
+      result = await this.deps.issueFiler.file(request, workspace_path, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
     } catch (err) {
       await this.deps.workspaceManager.destroy(workspace_path);
       await this.deps.failRun(run, request.conversation, err);

--- a/src/core/handlers/planning-handler.ts
+++ b/src/core/handlers/planning-handler.ts
@@ -1,11 +1,12 @@
 import type pino from 'pino';
-import type { ImplementationPlanningAgent } from '../../types/ai.js';
+import type { ImplementationPlanningAgent, AgentSessionCaptureFn } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { ConversationRef } from '../../types/channel.js';
 import type { Run, RunStage } from '../../types/runs.js';
 import { requireArtifactRefs } from '../run-refs.js';
 import { validateImplementationPlanPath } from '../plan-path-validator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface PlanningHandlerDeps {
   planner: Pick<ImplementationPlanningAgent, 'plan'>;
@@ -15,6 +16,7 @@ export interface PlanningHandlerDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export type PlanningResult =
@@ -46,11 +48,14 @@ export class PlanningHandler {
 
     let result;
     try {
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       result = await this.deps.planner.plan(
         refs.local_path,
         run.workspace_path,
         onProgress,
-        { run_id: run.id, request_id: run.request_id, onAgentRequest },
+        { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession },
         additionalContext,
       );
     } catch (err) {

--- a/src/core/handlers/question-handler.ts
+++ b/src/core/handlers/question-handler.ts
@@ -1,8 +1,9 @@
 import type pino from 'pino';
-import type { QuestionAnsweringAgent } from '../../types/ai.js';
+import type { QuestionAnsweringAgent, AgentSessionCaptureFn } from '../../types/ai.js';
 import type { Run } from '../../types/runs.js';
 import type { ConversationRef } from '../../types/channel.js';
 import { isAiActiveStage, makeRunAgentRequestRecorder } from '../run-ai-context.js';
+import type { RunJournal } from '../journal/run-journal.js';
 
 export interface QuestionDeps {
   questionAnswerer?: Pick<QuestionAnsweringAgent, 'answer'>;
@@ -10,6 +11,7 @@ export interface QuestionDeps {
   postError: (conversation: ConversationRef, text: string) => Promise<void>;
   persist?: () => void;
   logger: Pick<pino.Logger, 'info' | 'error'>;
+  journal?: Pick<RunJournal, 'captureSession'>;
 }
 
 export interface QuestionResult {
@@ -31,8 +33,11 @@ export class QuestionHandler {
 
     let response: string;
     if (this.deps.questionAnswerer) {
+      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        : undefined;
       try {
-        response = await this.deps.questionAnswerer.answer(content, { run_id: run.id, request_id: run.request_id, onAgentRequest });
+        response = await this.deps.questionAnswerer.answer(content, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
       } catch (err) {
         this.deps.logger.error({ event: 'question.answer_failed', run_id: run.id, error: String(err) }, 'Failed to answer question');
         await this.deps.postError(conversation, QUESTION_UNAVAILABLE_MESSAGE);

--- a/src/core/journal/jsonl-writer.ts
+++ b/src/core/journal/jsonl-writer.ts
@@ -16,6 +16,14 @@ export interface JsonlJournalWriterOptions {
   writerId?: string;
 }
 
+/**
+ * Append-only JSONL journal writer.
+ *
+ * - A new writer_id is generated on each process boot (randomUUID at construction time).
+ * - seq resets to 0 on restart; importers must use physical file order, not seq alone,
+ *   for global ordering across process restarts.
+ * - Cross-process global sequence ordering is not required for v0.
+ */
 export class JsonlJournalWriter implements JournalWriter {
   private readonly journalDir: string;
   private readonly writer_id: string;

--- a/src/core/journal/jsonl-writer.ts
+++ b/src/core/journal/jsonl-writer.ts
@@ -1,0 +1,89 @@
+import { mkdir, appendFile as fsAppendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import type pino from 'pino';
+import { createLogger } from '../logger.js';
+import type { JournalStream, JournalWriter } from '../../types/journal.js';
+import { JOURNAL_STREAMS } from '../../types/journal.js';
+import { redactSecrets } from './redaction.js';
+
+type AppendFileFn = (path: string, data: string, encoding: string) => Promise<void>;
+
+export interface JsonlJournalWriterOptions {
+  logger?: pino.Logger;
+  appendFile?: AppendFileFn;
+  writerId?: string;
+}
+
+export class JsonlJournalWriter implements JournalWriter {
+  private readonly journalDir: string;
+  private readonly writer_id: string;
+  private readonly logger: pino.Logger;
+  private readonly appendFileFn: AppendFileFn;
+  private readonly seq = new Map<JournalStream, number>();
+  private readonly counts = new Map<JournalStream, number>();
+  private readonly queues = new Map<JournalStream, Promise<void>>();
+
+  constructor(workspaceRoot: string, options?: JsonlJournalWriterOptions) {
+    this.journalDir = join(workspaceRoot, '.autocatalyst', 'journal');
+    this.writer_id = options?.writerId ?? randomUUID();
+    this.logger = options?.logger ?? createLogger('journal-writer');
+    this.appendFileFn = options?.appendFile ?? ((path, data, enc) => fsAppendFile(path, data, enc as 'utf-8'));
+
+    for (const stream of JOURNAL_STREAMS) {
+      this.seq.set(stream, 0);
+      this.counts.set(stream, 0);
+      this.queues.set(stream, Promise.resolve());
+    }
+
+    this.logger.info({ event: 'journal.writer_started', journal_dir: this.journalDir }, 'Journal writer started');
+  }
+
+  async append(stream: JournalStream, record: unknown): Promise<void> {
+    const enqueue = this.queues.get(stream)!.then(() => this.appendNow(stream, record));
+    this.queues.set(stream, enqueue.catch(() => {}));
+    return enqueue.catch(() => {});
+  }
+
+  private async appendNow(stream: JournalStream, record: unknown): Promise<void> {
+    const seq = (this.seq.get(stream) ?? 0) + 1;
+    this.seq.set(stream, seq);
+
+    let payload: string;
+    try {
+      payload = JSON.stringify({ seq, writer_id: this.writer_id, ...(record as Record<string, unknown>) }) + '\n';
+    } catch (err) {
+      this.logger.warn(
+        { event: 'journal.record_invalid', stream, seq, error: redactSecrets(String(err)) },
+        'Journal record serialization failed',
+      );
+      return;
+    }
+
+    const tsStart = performance.now();
+    try {
+      await mkdir(this.journalDir, { recursive: true });
+      await this.appendFileFn(join(this.journalDir, `${stream}.jsonl`), payload, 'utf-8');
+      const duration_ms = Math.round(performance.now() - tsStart);
+      this.counts.set(stream, (this.counts.get(stream) ?? 0) + 1);
+      this.logger.debug({ event: 'journal.appended', stream, seq, duration_ms }, 'Journal record appended');
+    } catch (err) {
+      this.logger.warn(
+        { event: 'journal.append_failed', stream, seq, error: redactSecrets(String(err)) },
+        'Journal append failed',
+      );
+    }
+  }
+
+  appendSync(_stream: JournalStream, _record: unknown): void {
+    // Sync file I/O would block the event loop; callers should use append() instead
+  }
+
+  async close(): Promise<void> {
+    // Drain all per-stream queues before reporting counts
+    await Promise.allSettled([...this.queues.values()]);
+    const countSummary = Object.fromEntries(this.counts.entries());
+    this.logger.info({ event: 'journal.closed', counts: countSummary }, 'Journal writer closed');
+  }
+}

--- a/src/core/journal/redaction.ts
+++ b/src/core/journal/redaction.ts
@@ -11,7 +11,6 @@ const SECRET_REPLACEMENTS: Array<{ pattern: RegExp; replacement: string }> = [
   { pattern: /\b(password|passwd|pwd)\s*[:=]\s*\S+/gi, replacement: '$1=[REDACTED]' },
 ];
 
-/** Redacts common API keys, bearer tokens, Slack tokens, GitHub tokens, and password-like values. */
 export function redactSecrets(text: string): string {
   let redacted = text;
   for (const { pattern, replacement } of SECRET_REPLACEMENTS) redacted = redacted.replace(pattern, replacement);

--- a/src/core/journal/redaction.ts
+++ b/src/core/journal/redaction.ts
@@ -1,0 +1,19 @@
+const SECRET_REPLACEMENTS: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /\bsk-[A-Za-z0-9_-]{8,}\b/g, replacement: '[REDACTED]' },
+  { pattern: /\bgithub_pat_[A-Za-z0-9_]{4,}\b/g, replacement: '[REDACTED]' },
+  { pattern: /\bgh[opsu]_[A-Za-z0-9_]{4,}\b/g, replacement: '[REDACTED]' },
+  { pattern: /\bghs_[A-Za-z0-9_]{4,}\b/g, replacement: '[REDACTED]' },
+  { pattern: /\bxapp-[A-Za-z0-9-]{5,}\b/g, replacement: '[REDACTED]' },
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{5,}\b/g, replacement: '[REDACTED]' },
+  { pattern: /(Authorization:\s*Bearer\s+)\S+/gi, replacement: '$1[REDACTED]' },
+  { pattern: /(ANTHROPIC_CUSTOM_HEADERS[^=]*=\s*api-key:)\S+/gi, replacement: '$1[REDACTED]' },
+  { pattern: /\b(api[_-]?key|secret|credential)\s*[:=]\s*\S+/gi, replacement: '$1=[REDACTED]' },
+  { pattern: /\b(password|passwd|pwd)\s*[:=]\s*\S+/gi, replacement: '$1=[REDACTED]' },
+];
+
+/** Redacts common API keys, bearer tokens, Slack tokens, GitHub tokens, and password-like values. */
+export function redactSecrets(text: string): string {
+  let redacted = text;
+  for (const { pattern, replacement } of SECRET_REPLACEMENTS) redacted = redacted.replace(pattern, replacement);
+  return redacted;
+}

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -51,13 +51,6 @@ export interface CaptureFeedbackParams {
   thread?: Array<{ author_principal: string | null; ts: string | null; text: string }>;
 }
 
-export interface CaptureInboundMessageParams {
-  run: Run;
-  message: { content: string; received_at?: string };
-  intent: Intent | null;
-  classificationStatus: JournalClassificationStatus;
-}
-
 export class RunJournal {
   private readonly writer: JournalWriter;
   private readonly sessionSeq = new Map<string, number>();

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -1,0 +1,246 @@
+import type {
+  JournalWriter,
+  JournalMessageRecord,
+  JournalSessionRecord,
+  JournalFeedbackRecord,
+  JournalRunEventRecord,
+  NormalizedTokenUsage,
+  JournalRunnerName,
+  JournalClassificationStatus,
+  JournalFeedbackTarget,
+  JournalFeedbackCategory,
+  JournalFeedbackDisposition,
+  JournalFeedbackSeverity,
+  JournalSessionOutcome,
+} from '../../types/journal.js';
+import { identityForRun, messageId } from '../../types/journal.js';
+import { redactSecrets } from './redaction.js';
+import type { Run, RunStage } from '../../types/runs.js';
+import type { Intent } from '../../types/intent.js';
+import type { AgentEffort, AgentThinking, AgentTaskKind } from '../../types/ai.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('run-journal');
+
+export interface CaptureSessionParams {
+  run: Run;
+  ts_start: string;
+  ts_end: string;
+  phase?: string | null;
+  step: AgentTaskKind | string;
+  round: number;
+  model: { provider: string; name: string | null };
+  inference: { effort: AgentEffort | null; thinking: AgentThinking | null };
+  tokens?: NormalizedTokenUsage | null;
+  assistant_turns?: number | null;
+  tool_calls?: number | null;
+  tool_results?: number | null;
+  outcome: JournalSessionOutcome;
+  runner: JournalRunnerName;
+}
+
+export interface CaptureFeedbackParams {
+  id: string;
+  run: Run;
+  target: JournalFeedbackTarget;
+  author_principal: string;
+  text: string;
+  severity: JournalFeedbackSeverity;
+  category: JournalFeedbackCategory;
+  disposition?: JournalFeedbackDisposition;
+  thread?: Array<{ author_principal: string | null; ts: string | null; text: string }>;
+}
+
+export interface CaptureInboundMessageParams {
+  run: Run;
+  message: { content: string; received_at?: string };
+  intent: Intent | null;
+  classificationStatus: JournalClassificationStatus;
+}
+
+export class RunJournal {
+  private readonly writer: JournalWriter;
+  private readonly sessionSeq = new Map<string, number>();
+
+  constructor(writer: JournalWriter) {
+    this.writer = writer;
+  }
+
+  async captureInboundMessage(
+    run: Run,
+    message: { content: string; received_at?: string },
+    intent: Intent | null,
+    classificationStatus: JournalClassificationStatus,
+  ): Promise<void> {
+    const identity = identityForRun(run);
+    const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${run.origin?.message_id ?? 'unknown'}`;
+    const ts = message.received_at ?? new Date().toISOString();
+
+    const record: Omit<JournalMessageRecord, 'seq' | 'writer_id'> = {
+      ts,
+      conversation_id: identity.conversation_id,
+      topic_id: identity.topic_id,
+      run_id: identity.run_id,
+      request_id: identity.request_id,
+      direction: 'in',
+      author_principal: authorPrincipal,
+      content: redactSecrets(message.content),
+      intent,
+      classification_status: classificationStatus,
+      origin_message_id: messageId(run.origin),
+    };
+
+    try {
+      await this.writer.append('messages', record);
+    } catch (err) {
+      logger.warn({ event: 'run_journal.capture_failed', stream: 'messages', direction: 'in', error: String(err) }, 'Failed to capture inbound message');
+    }
+  }
+
+  async captureOutboundMessage(run: Run, text: string, originMessageId?: string | null): Promise<void> {
+    const identity = identityForRun(run);
+
+    const record: Omit<JournalMessageRecord, 'seq' | 'writer_id'> = {
+      ts: new Date().toISOString(),
+      conversation_id: identity.conversation_id,
+      topic_id: identity.topic_id,
+      run_id: identity.run_id,
+      request_id: identity.request_id,
+      direction: 'out',
+      author_principal: 'autocatalyst',
+      content: redactSecrets(text),
+      intent: null,
+      classification_status: 'not_applicable',
+      origin_message_id: originMessageId ?? null,
+    };
+
+    try {
+      await this.writer.append('messages', record);
+    } catch (err) {
+      logger.warn({ event: 'run_journal.capture_failed', stream: 'messages', direction: 'out', error: String(err) }, 'Failed to capture outbound message');
+    }
+  }
+
+  async captureSession(params: CaptureSessionParams): Promise<void> {
+    const { run, ts_start, ts_end, phase, step, round, model, inference, tokens, assistant_turns, tool_calls, tool_results, outcome, runner } = params;
+    const identity = identityForRun(run);
+
+    const runId = run.id;
+    const currentSeq = this.sessionSeq.get(runId) ?? 0;
+    const nextSeq = currentSeq + 1;
+    this.sessionSeq.set(runId, nextSeq);
+
+    const record: Omit<JournalSessionRecord, 'seq' | 'writer_id'> = {
+      session_seq: nextSeq,
+      ts_start,
+      ts_end,
+      conversation_id: identity.conversation_id,
+      topic_id: identity.topic_id,
+      run_id: identity.run_id,
+      request_id: identity.request_id,
+      phase: phase ?? null,
+      step,
+      role: null,
+      round,
+      gate: null,
+      model,
+      inference,
+      tokens: tokens ?? null,
+      assistant_turns: assistant_turns ?? null,
+      tool_calls: tool_calls ?? null,
+      tool_results: tool_results ?? null,
+      outcome,
+      runner,
+    };
+
+    try {
+      await this.writer.append('sessions', record);
+    } catch (err) {
+      logger.warn({ event: 'run_journal.capture_failed', stream: 'sessions', run_id: runId, error: String(err) }, 'Failed to capture session');
+    }
+  }
+
+  async captureFeedback(params: CaptureFeedbackParams): Promise<void> {
+    const { id, run, target, author_principal, text, severity, category, disposition = 'open', thread = [] } = params;
+    const identity = identityForRun(run);
+
+    const record: Omit<JournalFeedbackRecord, 'seq' | 'writer_id'> = {
+      id,
+      ts_created: new Date().toISOString(),
+      conversation_id: identity.conversation_id,
+      topic_id: identity.topic_id,
+      run_id: identity.run_id,
+      request_id: identity.request_id,
+      target,
+      gate: null,
+      author_principal,
+      text: redactSecrets(text),
+      anchor: null,
+      severity,
+      category,
+      disposition,
+      thread: thread.map((item) => ({
+        author_principal: item.author_principal,
+        ts: item.ts,
+        text: redactSecrets(item.text),
+      })),
+    };
+
+    try {
+      await this.writer.append('feedback', record);
+    } catch (err) {
+      logger.warn({ event: 'run_journal.capture_failed', stream: 'feedback', id, error: String(err) }, 'Failed to capture feedback');
+    }
+  }
+
+  async captureRunEvent(
+    run: Run,
+    eventType: 'created' | 'transition' | 'pruned' | 'demoted',
+    fromStage?: RunStage | null,
+    toStage?: RunStage | null,
+  ): Promise<void> {
+    const identity = identityForRun(run);
+
+    let resolvedFromStage: RunStage | null;
+    let resolvedToStage: RunStage | null;
+
+    if (eventType === 'created') {
+      resolvedFromStage = null;
+      resolvedToStage = 'intake';
+    } else if (eventType === 'pruned') {
+      resolvedFromStage = fromStage ?? run.stage;
+      resolvedToStage = null;
+    } else if (eventType === 'demoted') {
+      resolvedFromStage = fromStage ?? run.stage;
+      resolvedToStage = 'failed';
+    } else {
+      // transition
+      resolvedFromStage = fromStage ?? null;
+      resolvedToStage = toStage ?? null;
+    }
+
+    const record: Omit<JournalRunEventRecord, 'seq' | 'writer_id'> = {
+      event_type: eventType,
+      ts: new Date().toISOString(),
+      run_id: run.id,
+      request_id: run.request_id,
+      conversation_id: identity.conversation_id,
+      topic_id: identity.topic_id,
+      from_stage: resolvedFromStage,
+      to_stage: resolvedToStage,
+      attempt: run.attempt,
+      intent: run.intent,
+      workspace_path: run.workspace_path,
+      branch: run.branch,
+      artifact_ref: null,
+      pr_url: run.pr_url ?? null,
+      issue: run.issue ?? null,
+    };
+
+    try {
+      await this.writer.append('run-events', record);
+    } catch (err) {
+      logger.warn({ event: 'run_journal.capture_failed', stream: 'run-events', event_type: eventType, run_id: run.id, error: String(err) }, 'Failed to capture run event');
+    }
+  }
+}

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -49,6 +49,7 @@ export interface CaptureFeedbackParams {
   category: JournalFeedbackCategory;
   disposition?: JournalFeedbackDisposition;
   thread?: Array<{ author_principal: string | null; ts: string | null; text: string }>;
+  received_at?: string;
 }
 
 export class RunJournal {
@@ -154,12 +155,12 @@ export class RunJournal {
   }
 
   async captureFeedback(params: CaptureFeedbackParams): Promise<void> {
-    const { id, run, target, author_principal, text, severity, category, disposition = 'open', thread = [] } = params;
+    const { id, run, target, author_principal, text, severity, category, disposition = 'open', thread = [], received_at } = params;
     const identity = identityForRun(run);
 
     const record: Omit<JournalFeedbackRecord, 'seq' | 'writer_id'> = {
       id,
-      ts_created: new Date().toISOString(),
+      ts_created: received_at ?? new Date().toISOString(),
       conversation_id: identity.conversation_id,
       topic_id: identity.topic_id,
       run_id: identity.run_id,

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -54,6 +54,11 @@ export interface CaptureFeedbackParams {
 
 export class RunJournal {
   private readonly writer: JournalWriter;
+  /**
+   * In-memory, process-local counter keyed by run_id.
+   * Resets to 0 on process restart — the Map is not persisted.
+   * Importers must use sessions.jsonl file order filtered by run_id, not session_seq or ts_start.
+   */
   private readonly sessionSeq = new Map<string, number>();
 
   constructor(writer: JournalWriter) {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -360,7 +360,7 @@ export class OrchestratorImpl implements Orchestrator {
 
         // Post interim message immediately
         try {
-          await this.postMessage(request.conversation, `Looking up issue #${ref.number}…`);
+          await this.postMessage(request.conversation, `Looking up issue #${ref.number}…`, run);
         } catch (err) {
           this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post interim issue lookup message');
         }
@@ -686,7 +686,7 @@ export class OrchestratorImpl implements Orchestrator {
     const message = "Server restarted while this was running. The run has been marked as failed. Reply in this thread to try again.";
     for (const run of runs) {
       if (!run.conversation) continue;
-      this.postMessage(run.conversation, message).catch(err => {
+      this.postMessage(run.conversation, message, run).catch(err => {
         this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post restart notification');
       });
     }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -607,6 +607,7 @@ export class OrchestratorImpl implements Orchestrator {
       validatePlanPath: this.deps.validatePlanPath,
       autoPruneWorkspace: this.deps.autoPruneWorkspace,
       workspacePruner: this.deps.workspacePruner,
+      journal: this.deps.journal,
     });
   }
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -32,6 +32,7 @@ import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
 import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
 import type { RunJournal } from './journal/run-journal.js';
+import type { AgentProfile } from '../types/ai.js';
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
 function stageAfterApproval(stage: RunStage): RunStage {
@@ -331,9 +332,12 @@ export class OrchestratorImpl implements Orchestrator {
       // Stage 1: classify raw message in new_thread context
       let stage1Intent: Intent = 'idea';
       if (this.deps.intentClassifier) {
+        const classifyTs = new Date().toISOString();
         try {
           stage1Intent = await this.deps.intentClassifier.classify(request.content, 'new_thread');
+          this.captureDirectSession(run, 'intent.classify', classifyTs, 'ok');
         } catch (err) {
+          this.captureDirectSession(run, 'intent.classify', classifyTs, 'failed');
           await this.handleClassificationUnavailable(run, request.conversation, err);
           return;
         }
@@ -405,9 +409,12 @@ export class OrchestratorImpl implements Orchestrator {
         const enrichedMessage = buildEnrichedClassificationMessage(request.content, issue);
         let intent: Intent = 'idea';
         if (this.deps.intentClassifier) {
+          const classifyTs2 = new Date().toISOString();
           try {
             intent = await this.deps.intentClassifier.classify(enrichedMessage, 'existing_issue');
+            this.captureDirectSession(run, 'intent.classify', classifyTs2, 'ok');
           } catch (err) {
+            this.captureDirectSession(run, 'intent.classify', classifyTs2, 'failed');
             await this.handleClassificationUnavailable(run, request.conversation, err);
             return;
           }
@@ -537,9 +544,12 @@ export class OrchestratorImpl implements Orchestrator {
       let intent: Intent = 'feedback';
       if (this.deps.intentClassifier) {
         const context: ClassificationContext = routingStage as ClassificationContext;
+        const classifyTs3 = new Date().toISOString();
         try {
           intent = await this.deps.intentClassifier.classify(feedback.content, context);
+          this.captureDirectSession(run, 'intent.classify', classifyTs3, 'ok');
         } catch (err) {
+          this.captureDirectSession(run, 'intent.classify', classifyTs3, 'failed');
           void this.deps.journal?.captureInboundMessage(
             run,
             { content: feedback.content },
@@ -784,6 +794,41 @@ export class OrchestratorImpl implements Orchestrator {
       'Run stage overridden via operator command',
     );
     return 'updated';
+  }
+
+  private captureDirectSession(
+    run: Run,
+    task: string,
+    ts_start: string,
+    outcome: 'ok' | 'failed',
+    profile?: AgentProfile | null,
+  ): void {
+    if (!this.deps.journal) return;
+    const ts_end = new Date().toISOString();
+    const providerName = profile?.provider ?? 'anthropic_direct';
+    const runnerName: 'anthropic_direct' | 'openai_direct' = providerName === 'openai_direct' ? 'openai_direct' : 'anthropic_direct';
+    void this.deps.journal.captureSession({
+      run,
+      ts_start,
+      ts_end,
+      phase: run.stage,
+      step: task,
+      round: 1,
+      model: {
+        provider: providerName,
+        name: profile?.model ?? null,
+      },
+      inference: {
+        effort: profile?.effort ?? null,
+        thinking: profile?.thinking ?? null,
+      },
+      tokens: null,
+      assistant_turns: null,
+      tool_calls: null,
+      tool_results: null,
+      outcome,
+      runner: runnerName,
+    }).catch(() => {});
   }
 
   private async reactToRunMessage(run: Run, reaction: string): Promise<void> {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -31,6 +31,7 @@ import type { ImplementationReviewCoordinator } from './ai/implementation-review
 import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
 import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
+import type { RunJournal } from './journal/run-journal.js';
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
 function stageAfterApproval(stage: RunStage): RunStage {
@@ -87,6 +88,7 @@ export interface OrchestratorDeps {
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   autoPruneWorkspace?: boolean;
   workspacePruner?: import('./workspace-pruner.js').WorkspacePruner;
+  journal?: RunJournal;
 }
 
 interface OrchestratorOptions {
@@ -415,6 +417,14 @@ export class OrchestratorImpl implements Orchestrator {
           );
         }
 
+        const stage2ClassificationStatus = this.deps.intentClassifier ? 'classified' : 'defaulted';
+        void this.deps.journal?.captureInboundMessage(
+          run,
+          { content: request.content },
+          intent,
+          stage2ClassificationStatus,
+        ).catch(() => {});
+
         // Post Stage 2 intent-specific acknowledgement (best-effort) — no file_issues ack here
         if (intent !== 'ignore') {
           const intentMessages: Partial<Record<string, string>> = {
@@ -425,7 +435,7 @@ export class OrchestratorImpl implements Orchestrator {
           };
           const intentMessage = intentMessages[intent] ?? "On it — will update here when I'm done.";
           try {
-            await this.postMessage(request.conversation, intentMessage);
+            await this.postMessage(request.conversation, intentMessage, run);
           } catch (err) {
             this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post Stage 2 intent acknowledgement');
           }
@@ -458,6 +468,13 @@ export class OrchestratorImpl implements Orchestrator {
 
       // Single-stage path: all other intents from Stage 1
       const intent = stage1Intent;
+      const stage1ClassificationStatus = this.deps.intentClassifier ? 'classified' : 'defaulted';
+      void this.deps.journal?.captureInboundMessage(
+        run,
+        { content: request.content },
+        intent,
+        stage1ClassificationStatus,
+      ).catch(() => {});
 
       // Post intent-specific acknowledgement (best-effort)
       if (intent !== 'ignore') {
@@ -470,7 +487,7 @@ export class OrchestratorImpl implements Orchestrator {
         };
         const intentMessage = intentMessages[intent] ?? "On it — will update here when I'm done.";
         try {
-          await this.postMessage(request.conversation, intentMessage);
+          await this.postMessage(request.conversation, intentMessage, run);
         } catch (err) {
           this.logger.error({ event: 'run.notify_failed', run_id: run.id, error: String(err) }, 'Failed to post intent acknowledgement');
         }
@@ -523,12 +540,26 @@ export class OrchestratorImpl implements Orchestrator {
         try {
           intent = await this.deps.intentClassifier.classify(feedback.content, context);
         } catch (err) {
+          void this.deps.journal?.captureInboundMessage(
+            run,
+            { content: feedback.content },
+            null,
+            'failed',
+          ).catch(() => {});
           this.restoreStageAfterClassificationFailure(run, routingStage, err);
           await this.postError(feedback.conversation, CLASSIFICATION_UNAVAILABLE_MESSAGE);
           return;
         }
         this.logger.debug({ event: 'intent_classification.result', run_id: run.id, intent, stage: routingStage }, 'Intent classified');
       }
+
+      const threadMsgClassificationStatus = this.deps.intentClassifier ? 'classified' : 'defaulted';
+      void this.deps.journal?.captureInboundMessage(
+        run,
+        { content: feedback.content },
+        intent,
+        threadMsgClassificationStatus,
+      ).catch(() => {});
 
       const handler = this.handlerRegistry.resolve({
         event_type: 'thread_message',
@@ -563,7 +594,7 @@ export class OrchestratorImpl implements Orchestrator {
       issueFiler: this.deps.issueFiler,
       channelRepoMap: this.deps.channelRepoMap,
       reacjiComplete: this.deps.reacjiComplete,
-      postMessage: (conversation, text) => this.postMessage(conversation, text),
+      postMessage: (conversation, text, run) => this.postMessage(conversation, text, run),
       postError: (conversation, text) => this.postError(conversation, text),
       transition: (targetRun, stage) => this.transition(targetRun, stage),
       failRun: (targetRun, conversation, error) => this.failRun(targetRun, conversation, error),
@@ -596,6 +627,7 @@ export class OrchestratorImpl implements Orchestrator {
       clearAgentRequestContext(run);
     }
     run.updated_at = new Date().toISOString();
+    void this.deps.journal?.captureRunEvent(run, 'transition', from, stage).catch(() => {});
     this.logger.info({ event: 'run.stage_transition', run_id: run.id, request_id: run.request_id, from_stage: from, to_stage: stage }, 'Stage transition');
     this._appendRunLog(run.request_id, `[${new Date().toISOString()}] Stage: ${from} → ${stage}`);
     this._persistRuns();
@@ -684,6 +716,7 @@ export class OrchestratorImpl implements Orchestrator {
     // The event loop is sequential, so a second new_request for the same request_id
     // would not arrive until the first is fully processed.
     this.runs.set(request.id, run);
+    void this.deps.journal?.captureRunEvent(run, 'created').catch(() => {});
     this._persistRuns();
     this.logger.info({ event: 'run.created', run_id: run.id, request_id: request.id }, 'Run created');
     return run;
@@ -695,12 +728,15 @@ export class OrchestratorImpl implements Orchestrator {
     await this.postError(conversation, `Sorry, something went wrong: ${String(error)}`);
   }
 
-  private async postMessage(conversation: ConversationRef, text: string): Promise<void> {
+  private async postMessage(conversation: ConversationRef, text: string, run?: Run): Promise<void> {
     if (this.deps.postMessage) {
       await this.deps.postMessage(conversation, text);
-      return;
+    } else {
+      await this.deps.adapter.reply(conversation, text);
     }
-    await this.deps.adapter.reply(conversation, text);
+    if (run && this.deps.journal) {
+      void this.deps.journal.captureOutboundMessage(run, text).catch(() => {});
+    }
   }
 
   private async postError(conversation: ConversationRef, text: string): Promise<void> {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -571,6 +571,24 @@ export class OrchestratorImpl implements Orchestrator {
         threadMsgClassificationStatus,
       ).catch(() => {});
 
+      // Capture feedback record for feedback-type intents
+      const FEEDBACK_INTENTS = new Set(['feedback', 'approval', 'impl_feedback', 'impl_input', 'pr_feedback']);
+      if (FEEDBACK_INTENTS.has(intent) && this.deps.journal) {
+        const feedbackTarget = (routingStage === 'reviewing_spec' || routingStage === 'awaiting_planning_input')
+          ? 'artifact' as const : 'implementation' as const;
+        const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${run.origin?.message_id ?? 'unknown'}`;
+        void this.deps.journal.captureFeedback({
+          id: `${feedback.request_id}:${feedback.received_at ?? new Date().toISOString()}`,
+          run,
+          target: feedbackTarget,
+          author_principal: authorPrincipal,
+          text: feedback.content,
+          severity: 'info',
+          category: 'human_feedback',
+          disposition: 'open',
+        }).catch(() => {});
+      }
+
       const handler = this.handlerRegistry.resolve({
         event_type: 'thread_message',
         stage: routingStage,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -576,7 +576,7 @@ export class OrchestratorImpl implements Orchestrator {
       if (FEEDBACK_INTENTS.has(intent) && this.deps.journal) {
         const feedbackTarget = (routingStage === 'reviewing_spec' || routingStage === 'awaiting_planning_input')
           ? 'artifact' as const : 'implementation' as const;
-        const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${run.origin?.message_id ?? 'unknown'}`;
+        const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${feedback.origin?.message_id ?? 'unknown'}`;
         void this.deps.journal.captureFeedback({
           id: `${feedback.request_id}:${feedback.received_at ?? new Date().toISOString()}`,
           run,
@@ -586,6 +586,7 @@ export class OrchestratorImpl implements Orchestrator {
           severity: 'info',
           category: 'human_feedback',
           disposition: 'open',
+          received_at: feedback.received_at,
         }).catch(() => {});
       }
 

--- a/src/core/run-store.ts
+++ b/src/core/run-store.ts
@@ -6,6 +6,7 @@ import type pino from 'pino';
 import { createLogger } from './logger.js';
 import type { Run } from '../types/runs.js';
 import { artifactKindForIntent } from '../types/artifact.js';
+import type { RunJournal } from './journal/run-journal.js';
 
 export interface RunStore {
   load(): Run[];
@@ -18,6 +19,7 @@ const TERMINAL_STAGES = new Set(['done', 'failed']);
 interface FileRunStoreOptions {
   logDestination?: pino.DestinationStream;
   legacyConversationFields?: LegacyConversationFields | LegacyConversationFields[];
+  journal?: RunJournal;
 }
 
 interface LegacyConversationFields {
@@ -31,6 +33,7 @@ export class FileRunStore implements RunStore {
   private readonly filePath: string;
   private readonly logger: pino.Logger;
   private readonly legacyConversationFields: LegacyConversationFields[];
+  private readonly journal?: RunJournal;
   public demotedIds: Set<string> = new Set();
 
   constructor(workspaceRoot: string, options?: FileRunStoreOptions) {
@@ -41,6 +44,7 @@ export class FileRunStore implements RunStore {
       : options?.legacyConversationFields
         ? [options.legacyConversationFields]
         : [];
+    this.journal = options?.journal;
   }
 
   load(): Run[] {
@@ -77,6 +81,9 @@ export class FileRunStore implements RunStore {
       // 4. Drop runs with missing workspace (terminal runs are exempt — their workspace may be cleaned up)
       if (!TERMINAL_STAGES.has(run.stage) && (!run.workspace_path || !fs.existsSync(run.workspace_path))) {
         this.logger.warn({ event: 'run_store.run_dropped', request_id: run.request_id, workspace_path: run.workspace_path }, 'Dropping run with missing workspace_path');
+        if (this.journal) {
+          void this.journal.captureRunEvent(run, 'pruned', run.stage, null).catch(() => {});
+        }
         droppedCount++;
         continue;
       }
@@ -84,6 +91,9 @@ export class FileRunStore implements RunStore {
       // 5. Demote stale stages
       if (STALE_STAGES.has(run.stage)) {
         const fromStage = run.stage;
+        if (this.journal) {
+          void this.journal.captureRunEvent(run, 'demoted', run.stage, 'failed').catch(() => {});
+        }
         run.stage = 'failed';
         run.updated_at = new Date().toISOString();
         this.demotedIds.add(run.request_id);

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -3,6 +3,7 @@ import type { Request, ThreadMessage } from './events.js';
 import type { ArtifactKind } from './artifact.js';
 import type { RunStage } from './runs.js';
 import type { TelemetryContext } from '../core/ai/telemetry-context.js';
+import type { NormalizedTokenUsage } from './journal.js';
 
 export type AgentTaskKind =
   | 'intent.classify'
@@ -34,6 +35,8 @@ export interface AgentInvocationMetadata {
 export interface AgentServiceTelemetry {
   run_id?: string;
   request_id?: string;
+  phase?: string;
+  captureSession?: unknown;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
 }
 
@@ -148,6 +151,8 @@ export interface DirectModelRunRequest {
 export interface DirectModelRunResult {
   text: string;
   raw?: unknown;
+  usage?: NormalizedTokenUsage | null;
+  runner?: 'anthropic_direct' | 'openai_direct';
 }
 
 export interface DirectModelRunner {
@@ -171,6 +176,7 @@ export interface AgentDrainSummary {
   tool_call_count: number;
   tool_result_count: number;
   elapsed_ms: number;
+  terminal_usage?: NormalizedTokenUsage | null;
   diagnostics?: {
     stderr_excerpt_redacted?: string;
   };

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -5,6 +5,21 @@ import type { RunStage } from './runs.js';
 import type { TelemetryContext } from '../core/ai/telemetry-context.js';
 import type { NormalizedTokenUsage } from './journal.js';
 
+export type AgentSessionCaptureFn = (data: {
+  phase: string | null;
+  step: AgentTaskKind | string;
+  ts_start: string;
+  ts_end: string;
+  model: { provider: string; name: string | null };
+  inference: { effort: AgentEffort | null; thinking: AgentThinking | null };
+  tokens: NormalizedTokenUsage | null;
+  assistant_turns: number | null;
+  tool_calls: number | null;
+  tool_results: number | null;
+  outcome: 'ok' | 'failed' | 'incomplete';
+  runner: 'anthropic_agent' | 'openai_agent';
+}) => void;
+
 export type AgentTaskKind =
   | 'intent.classify'
   | 'artifact.create'
@@ -36,7 +51,7 @@ export interface AgentServiceTelemetry {
   run_id?: string;
   request_id?: string;
   phase?: string;
-  captureSession?: unknown;
+  captureSession?: AgentSessionCaptureFn;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -104,6 +104,10 @@ export interface SandboxConfig {
   env_tokens?: string[];
 }
 
+export interface JournalConfig {
+  enabled?: boolean;
+}
+
 export interface WorkflowConfig {
   polling?: {
     interval_ms?: number;
@@ -121,6 +125,7 @@ export interface WorkflowConfig {
   implementation_review?: ImplementationReviewPolicy;
   spec_review?: SpecReviewPolicy;
   sandbox?: SandboxConfig;
+  journal?: JournalConfig;
   [key: string]: unknown;
 }
 

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -1,0 +1,142 @@
+import type { AgentEffort, AgentThinking, AgentTaskKind, ImplementationReviewExchange, ImplementationReviewFindingCategory, ImplementationReviewFindingSeverity } from './ai.js';
+import type { ConversationRef, MessageRef } from './channel.js';
+import type { Intent } from './intent.js';
+import type { Run, RunStage } from './runs.js';
+
+export type JournalStream = 'messages' | 'sessions' | 'feedback' | 'run-events';
+export const JOURNAL_STREAMS: JournalStream[] = ['messages', 'sessions', 'feedback', 'run-events'];
+
+/** Raw token counts only. Pricing, usd, rate tables, and cost rollups are intentionally out of scope. */
+export interface NormalizedTokenUsage {
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_write: number;
+}
+
+export type JournalRunnerName = 'anthropic_direct' | 'openai_direct' | 'anthropic_agent' | 'openai_agent';
+export type JournalDirection = 'in' | 'out';
+export type JournalClassificationStatus = 'classified' | 'defaulted' | 'failed' | 'not_applicable';
+export type JournalSessionOutcome = 'ok' | 'failed' | 'incomplete';
+export type JournalRunEventType = 'created' | 'transition' | 'pruned' | 'demoted';
+export type JournalFeedbackTarget = 'artifact' | 'implementation';
+export type JournalFeedbackDisposition = 'open' | 'addressed' | 'resolved' | 'wont_fix';
+export type JournalFeedbackSeverity = ImplementationReviewFindingSeverity | 'info';
+export type JournalFeedbackCategory = ImplementationReviewFindingCategory | 'human_feedback' | 'artifact_comment' | 'ai_review';
+
+export interface JournalBaseRecord {
+  seq: number;
+  writer_id: string;
+}
+
+export interface JournalMessageRecord extends JournalBaseRecord {
+  ts: string;
+  conversation_id: string | null;
+  topic_id: string | null;
+  run_id: string | null;
+  request_id: string | null;
+  direction: JournalDirection;
+  author_principal: string;
+  content: string;
+  intent: Intent | null;
+  classification_status: JournalClassificationStatus;
+  origin_message_id: string | null;
+}
+
+/** Session replay order is the physical sessions.jsonl file order filtered by run_id. */
+export interface JournalSessionRecord extends JournalBaseRecord {
+  session_seq: number;
+  ts_start: string;
+  ts_end: string;
+  conversation_id: string | null;
+  topic_id: string | null;
+  run_id: string | null;
+  request_id: string | null;
+  phase: string | null;
+  step: AgentTaskKind | string;
+  role: null;
+  round: number;
+  gate: null;
+  model: { provider: string; name: string | null };
+  inference: { effort: AgentEffort | null; thinking: AgentThinking | null };
+  tokens: NormalizedTokenUsage | null;
+  assistant_turns: number | null;
+  tool_calls: number | null;
+  tool_results: number | null;
+  outcome: JournalSessionOutcome;
+  runner: JournalRunnerName;
+}
+
+export interface JournalFeedbackThreadItem {
+  author_principal: string | null;
+  ts: string | null;
+  text: string;
+}
+
+export interface JournalFeedbackRecord extends JournalBaseRecord {
+  id: string;
+  ts_created: string;
+  conversation_id: string | null;
+  topic_id: string | null;
+  run_id: string | null;
+  request_id: string | null;
+  target: JournalFeedbackTarget;
+  gate: null;
+  author_principal: string;
+  text: string;
+  anchor: unknown | null;
+  severity: JournalFeedbackSeverity;
+  category: JournalFeedbackCategory;
+  disposition: JournalFeedbackDisposition;
+  thread: JournalFeedbackThreadItem[];
+}
+
+export interface JournalRunEventRecord extends JournalBaseRecord {
+  event_type: JournalRunEventType;
+  ts: string;
+  run_id: string;
+  request_id: string;
+  conversation_id: string | null;
+  topic_id: string | null;
+  from_stage: RunStage | null;
+  to_stage: RunStage | null;
+  attempt: number;
+  intent: Run['intent'] | Intent | null;
+  workspace_path: string | null;
+  branch: string | null;
+  artifact_ref: string | null;
+  pr_url: string | null;
+  issue: number | null;
+}
+
+/** Journal writers are best-effort; append failures are logged and must not fail active runs. */
+export interface JournalWriter {
+  append(stream: JournalStream, record: unknown): Promise<void>;
+  appendSync?(stream: JournalStream, record: unknown): void;
+  close?(): Promise<void>;
+}
+
+export class NoopJournalWriter implements JournalWriter {
+  async append(_stream: JournalStream, _record: unknown): Promise<void> {}
+  appendSync(_stream: JournalStream, _record: unknown): void {}
+  async close(): Promise<void> {}
+}
+
+export function conversationId(conversation: ConversationRef | undefined): string | null {
+  if (!conversation) return null;
+  return `${conversation.provider}:${conversation.channel_id}:${conversation.conversation_id}`;
+}
+
+export function messageId(message: MessageRef | undefined): string | null {
+  if (!message) return null;
+  return `${message.provider}:${message.channel_id}:${message.conversation_id}:${message.message_id}`;
+}
+
+export function identityForRun(run: Pick<Run, 'id' | 'request_id' | 'conversation'>) {
+  return { conversation_id: conversationId(run.conversation), topic_id: run.id, run_id: run.id, request_id: run.request_id };
+}
+
+export interface JournalReviewExchangeCapture {
+  run: Run;
+  exchange: ImplementationReviewExchange;
+}

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -1,3 +1,14 @@
+/**
+ * Journal type contracts.
+ *
+ * - tokens: null means token usage was unavailable (not zero); the OpenAI Agent SDK may not
+ *   provide token counts, so callers must treat null as "unknown" rather than "no tokens used".
+ * - Raw counts only — pricing, usd conversion, and rate tables are intentionally out of scope.
+ * - Session replay order: physical sessions.jsonl file order filtered by run_id is canonical.
+ *   session_seq is best-effort and resets on process restart; do not rely on it for global ordering.
+ * - Write failures are logged and must never fail an active run (best-effort writes).
+ * - Schema importer for future versions is deferred; no migration utilities exist in v0.
+ */
 import type { AgentEffort, AgentThinking, AgentTaskKind, ImplementationReviewExchange, ImplementationReviewFindingCategory, ImplementationReviewFindingSeverity } from './ai.js';
 import type { ConversationRef, MessageRef } from './channel.js';
 import type { Intent } from './intent.js';
@@ -43,7 +54,11 @@ export interface JournalMessageRecord extends JournalBaseRecord {
   origin_message_id: string | null;
 }
 
-/** Session replay order is the physical sessions.jsonl file order filtered by run_id. */
+/**
+ * Session replay order is the physical sessions.jsonl file order filtered by run_id.
+ * session_seq is best-effort: it is in-memory and resets on process restart.
+ * Importers must not use session_seq or ts_start for global ordering.
+ */
 export interface JournalSessionRecord extends JournalBaseRecord {
   session_seq: number;
   ts_start: string;
@@ -59,6 +74,7 @@ export interface JournalSessionRecord extends JournalBaseRecord {
   gate: null;
   model: { provider: string; name: string | null };
   inference: { effort: AgentEffort | null; thinking: AgentThinking | null };
+  /** null means token usage was unavailable (e.g. OpenAI Agent SDK did not provide counts), not zero. */
   tokens: NormalizedTokenUsage | null;
   assistant_turns: number | null;
   tool_calls: number | null;

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from 'node:stream';
 import { describe, it, expect, test, vi } from 'vitest';
-import { ClaudeAgentSdkAgentRunner, claudeSdkMessageDiagnostic, redactSecrets } from '../../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
+import { ClaudeAgentSdkAgentRunner, claudeSdkMessageDiagnostic } from '../../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
+import { redactSecrets } from '../../../src/core/journal/redaction.js';
 import type { AgentRunEvent } from '../../../src/types/ai.js';
 import type { AgentProfile } from '../../../src/types/ai.js';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';

--- a/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
+++ b/tests/adapters/anthropic/claude-agent-sdk-agent-runner.test.ts
@@ -630,6 +630,57 @@ describe('ClaudeAgentSdkAgentRunner', () => {
     expect(stderrLog!['stderr_excerpt']).toContain('[REDACTED]');
   });
 
+  test('result event includes terminal_usage normalized from SDK usage with cache fields', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 20, cache_read_input_tokens: 10 },
+      };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    const events = await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6', effort: 'high' },
+    }));
+
+    const resultEvent = events.find(e => e.type === 'result') as Record<string, unknown> | undefined;
+    expect(resultEvent).toBeDefined();
+    expect(resultEvent!['terminal_usage']).toEqual({
+      input: 100,
+      output: 50,
+      cache_read: 10,
+      cache_write: 20,
+    });
+  });
+
+  test('result event includes terminal_usage with zeros when cache fields are absent', async () => {
+    const queryFn = vi.fn().mockImplementation(async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 42, output_tokens: 17 } };
+    });
+    const runner = new ClaudeAgentSdkAgentRunner({ queryFn });
+
+    const events = await collect(runner.run({
+      route: { task: 'implementation.run' },
+      working_directory: '/tmp/workspace',
+      prompt: 'implement',
+      profile: { id: 'impl', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6', effort: 'high' },
+    }));
+
+    const resultEvent = events.find(e => e.type === 'result') as Record<string, unknown> | undefined;
+    expect(resultEvent).toBeDefined();
+    expect(resultEvent!['terminal_usage']).toEqual({
+      input: 42,
+      output: 17,
+      cache_read: 0,
+      cache_write: 0,
+    });
+  });
+
   test('does not log stderr when SDK exits successfully', async () => {
     const { dest, getLogs } = makeLogCapture();
     const queryFn = vi.fn().mockImplementation(function ({ options }: { options: { stderr?: (data: string) => void } }) {

--- a/tests/adapters/anthropic/direct-model-runner.test.ts
+++ b/tests/adapters/anthropic/direct-model-runner.test.ts
@@ -29,7 +29,7 @@ describe('AnthropicDirectModelRunner', () => {
       profile: { id: 'intent', provider: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
       max_tokens: 20,
       messages: [{ role: 'user', content: 'classify this' }],
-    })).resolves.toEqual({ text: 'question', raw: { content: [{ type: 'text', text: 'question' }] } });
+    })).resolves.toEqual({ text: 'question', raw: { content: [{ type: 'text', text: 'question' }] }, usage: null, runner: 'anthropic_direct' });
 
     expect(createFn).toHaveBeenCalledWith({
       model: 'claude-haiku-4-5',
@@ -83,6 +83,60 @@ describe('AnthropicDirectModelRunner', () => {
     expect(failLog!['task']).toBe('intent.classify');
     expect(typeof failLog!['error']).toBe('string');
     expect(failLog!['error'] as string).toContain('API timeout');
+  });
+
+  test('returns normalized usage when provider returns usage data', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'answer' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const runner = new AnthropicDirectModelRunner('test-key', { createFn });
+
+    const result = await runner.run({
+      route: { task: 'intent.classify', stage: 'new_thread' },
+      profile: { id: 'intent', provider: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
+      messages: [{ role: 'user', content: 'classify this' }],
+    });
+
+    expect(result.usage).toEqual({ input: 10, output: 5, cache_read: 0, cache_write: 0 });
+    expect(result.runner).toBe('anthropic_direct');
+  });
+
+  test('returns usage: null when provider returns no usage', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'answer' }],
+    });
+    const runner = new AnthropicDirectModelRunner('test-key', { createFn });
+
+    const result = await runner.run({
+      route: { task: 'intent.classify', stage: 'new_thread' },
+      profile: { id: 'intent', provider: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
+      messages: [{ role: 'user', content: 'classify this' }],
+    });
+
+    expect(result.usage).toBeNull();
+    expect(result.runner).toBe('anthropic_direct');
+  });
+
+  test('maps cache fields correctly from Anthropic usage', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'answer' }],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 80,
+        cache_creation_input_tokens: 20,
+      },
+    });
+    const runner = new AnthropicDirectModelRunner('test-key', { createFn });
+
+    const result = await runner.run({
+      route: { task: 'intent.classify', stage: 'new_thread' },
+      profile: { id: 'intent', provider: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
+      messages: [{ role: 'user', content: 'classify this' }],
+    });
+
+    expect(result.usage).toEqual({ input: 100, output: 50, cache_read: 80, cache_write: 20 });
   });
 
   test('logs null for input_tokens and output_tokens when usage is absent', async () => {

--- a/tests/adapters/openai/direct-model-runner.test.ts
+++ b/tests/adapters/openai/direct-model-runner.test.ts
@@ -34,7 +34,7 @@ describe('OpenAIDirectModelRunner', () => {
       messages: [{ role: 'user', content: 'classify this' }],
     });
 
-    expect(result).toEqual({ text: 'question', raw: makeResponse('question') });
+    expect(result).toEqual({ text: 'question', raw: makeResponse('question'), usage: null, runner: 'openai_direct' });
     expect(createFn).toHaveBeenCalledWith({
       model: 'gpt-4o-mini',
       max_completion_tokens: 20,
@@ -112,6 +112,59 @@ describe('OpenAIDirectModelRunner', () => {
       max_completion_tokens: 1024,
       messages: [{ role: 'user', content: 'classify' }],
     });
+  });
+
+  test('returns normalized usage when provider returns usage data', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: 'answer' } }],
+      usage: { prompt_tokens: 8, completion_tokens: 3 },
+    });
+    const runner = new OpenAIDirectModelRunner('test-key', undefined, { createFn });
+
+    const result = await runner.run({
+      route: { task: 'intent.classify', stage: 'new_thread' },
+      profile: { id: 'gpt', provider: 'openai', model: 'gpt-4o-mini', effort: 'low' },
+      messages: [{ role: 'user', content: 'classify this' }],
+    });
+
+    expect(result.usage).toEqual({ input: 8, output: 3, cache_read: 0, cache_write: 0 });
+    expect(result.runner).toBe('openai_direct');
+  });
+
+  test('returns usage: null when provider returns no usage', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: 'answer' } }],
+    });
+    const runner = new OpenAIDirectModelRunner('test-key', undefined, { createFn });
+
+    const result = await runner.run({
+      route: { task: 'intent.classify', stage: 'new_thread' },
+      profile: { id: 'gpt', provider: 'openai', model: 'gpt-4o-mini', effort: 'low' },
+      messages: [{ role: 'user', content: 'classify this' }],
+    });
+
+    expect(result.usage).toBeNull();
+    expect(result.runner).toBe('openai_direct');
+  });
+
+  test('maps cached_tokens from prompt_tokens_details to cache_read', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: 'answer' } }],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        prompt_tokens_details: { cached_tokens: 60 },
+      },
+    });
+    const runner = new OpenAIDirectModelRunner('test-key', undefined, { createFn });
+
+    const result = await runner.run({
+      route: { task: 'intent.classify', stage: 'new_thread' },
+      profile: { id: 'gpt', provider: 'openai', model: 'gpt-4o-mini', effort: 'low' },
+      messages: [{ role: 'user', content: 'classify this' }],
+    });
+
+    expect(result.usage).toEqual({ input: 100, output: 50, cache_read: 60, cache_write: 0 });
   });
 
   test('emits model.run log event with all fields on success', async () => {

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -950,6 +950,52 @@ describe('drainAgentRunner summary', () => {
     const parsed = lines.map(l => JSON.parse(l));
     expect(parsed.find(l => l.event === 'agent.drain_failed')).toBeDefined();
   });
+
+  it('captures terminal_usage from result event with usage', async () => {
+    const dest = new PassThrough();
+    dest.on('data', () => {});
+
+    async function* eventsWithUsage(): AsyncIterable<AgentRunEvent> {
+      yield { type: 'assistant', content: [{ type: 'text', text: 'done' }] };
+      yield { type: 'result', terminal_usage: { input: 100, output: 50, cache_read: 10, cache_write: 20 } } as AgentRunEvent;
+    }
+
+    const logger = createLogger('test', { destination: dest });
+    const summary = await drainAgentRunner(eventsWithUsage(), undefined, logger, 'test-phase');
+    dest.end();
+
+    expect(summary.terminal_usage).toEqual({ input: 100, output: 50, cache_read: 10, cache_write: 20 });
+  });
+
+  it('sets terminal_usage to null when result event has null terminal_usage', async () => {
+    const dest = new PassThrough();
+    dest.on('data', () => {});
+
+    async function* eventsWithNullUsage(): AsyncIterable<AgentRunEvent> {
+      yield { type: 'result', terminal_usage: null } as AgentRunEvent;
+    }
+
+    const logger = createLogger('test', { destination: dest });
+    const summary = await drainAgentRunner(eventsWithNullUsage(), undefined, logger, 'test-phase');
+    dest.end();
+
+    expect(summary.terminal_usage).toBeNull();
+  });
+
+  it('leaves terminal_usage undefined when no result event is present', async () => {
+    const dest = new PassThrough();
+    dest.on('data', () => {});
+
+    async function* eventsWithoutResult(): AsyncIterable<AgentRunEvent> {
+      yield { type: 'assistant', content: [{ type: 'text', text: 'done' }] };
+    }
+
+    const logger = createLogger('test', { destination: dest });
+    const summary = await drainAgentRunner(eventsWithoutResult(), undefined, logger, 'test-phase');
+    dest.end();
+
+    expect(summary.terminal_usage).toBeUndefined();
+  });
 });
 
 describe('validateRequiredResultFile', () => {

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -1572,3 +1572,95 @@ describe('AgentServiceTelemetry onAgentRequest callback', () => {
     }
   });
 });
+
+describe('AgentServiceTelemetry captureSession callback', () => {
+  test('artifact.create calls captureSession after drain with ok outcome', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-capture-create-'));
+    try {
+      const captures: Array<{ step: string; outcome: string; runner: string }> = [];
+
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-test.md') }), 'utf8');
+      });
+
+      const captureSession = vi.fn((data: { step: string; outcome: string; runner: string }) => {
+        captures.push(data);
+      });
+
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+      await service.create(makeRequest(), workspace, undefined, 'idea', { captureSession });
+
+      expect(captureSession).toHaveBeenCalledOnce();
+      expect(captures[0].step).toBe('artifact.create');
+      expect(captures[0].outcome).toBe('ok');
+      expect(captures[0].runner).toBe('anthropic_agent');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('artifact.create calls captureSession with failed outcome when drain throws', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-capture-fail-'));
+    try {
+      const captures: Array<{ step: string; outcome: string }> = [];
+
+      const runner: import('../../../src/types/ai.js').AgentRunner = {
+        async *run() {
+          throw new Error('agent crashed');
+          // eslint-disable-next-line no-unreachable
+          yield { type: 'assistant', content: [] };
+        },
+      };
+
+      const captureSession = vi.fn((data: { step: string; outcome: string }) => {
+        captures.push(data);
+      });
+
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+      await expect(
+        service.create(makeRequest(), workspace, undefined, 'idea', { captureSession }),
+      ).rejects.toThrow();
+
+      expect(captureSession).toHaveBeenCalledOnce();
+      expect(captures[0].step).toBe('artifact.create');
+      expect(captures[0].outcome).toBe('failed');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation.run calls captureSession with model info', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-capture-impl-'));
+    try {
+      const captures: Array<{ step: string; model: { provider: string; name: string | null } }> = [];
+      const specPath = join(workspace, 'spec.md');
+      await mkdir(workspace, { recursive: true });
+      await writeFile(specPath, '# Spec', 'utf8');
+
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'done', review_summary: { changes: ['c'], confirm: ['v'] }, testing_steps: ['cd /tmp'], resolved_feedback_items: [] }), 'utf8');
+      });
+
+      const captureSession = vi.fn((data: { step: string; model: { provider: string; name: string | null } }) => {
+        captures.push(data);
+      });
+
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+      await service.implement(specPath, workspace, undefined, undefined, { captureSession });
+
+      expect(captureSession).toHaveBeenCalledOnce();
+      expect(captures[0].step).toBe('implementation.run');
+      expect(captures[0].model.name).toBe('claude-sonnet-4-5');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -327,6 +327,32 @@ describe('ImplementationReviewCoordinator', () => {
       expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
     });
 
+    it('failed session after result-file read throws preserves drain counts and token usage', async () => {
+      // drain completes successfully, then readFile throws — the failed session record
+      // must carry the counts and token usage from the completed drain, not null.
+      const runner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [{ type: 'text', text: 'reviewing' }], tool_call_count: 3, tool_result_count: 3 };
+          yield { type: 'assistant', content: [{ type: 'text', text: 'done' }] };
+          yield { type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5 } };
+        })()),
+      };
+      const deps = makeDeps(undefined, {
+        runner,
+        readFile: vi.fn().mockRejectedValue(new Error('ENOENT: no such file')),
+      });
+      const captureSession = vi.fn();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      const record = captureSession.mock.calls[0][0] as Record<string, unknown>;
+      expect(record['outcome']).toBe('failed');
+      expect(record['assistant_turns']).toBe(2);
+      expect(record['tool_calls']).toBe(3);
+      expect(record['tool_results']).toBe(3);
+    });
+
     it('emits one failed session when drainAgentRunner throws — no duplicate', async () => {
       const throwingRunner: AgentRunner = {
         run: vi.fn().mockReturnValue((async function* () {

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -66,7 +66,7 @@ function makeDeps(reviewResult: ImplementationReviewResult = { status: 'no_findi
     routingPolicy: makeRoutingPolicy(),
     policy: { max_initial_rounds: 1, max_final_rounds: 1, on_review_failure: 'warn' as const, retest_on_behavior_change: true },
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
-    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     readFile: vi.fn().mockResolvedValue(reviewJson),
     ...overrides,
   };
@@ -284,6 +284,62 @@ describe('ImplementationReviewCoordinator', () => {
       expect(run.review_exchanges![0].phase).toBe('final');
       const calls = (deps.routingPolicy.resolveOptional as ReturnType<typeof vi.fn>).mock.calls;
       expect(calls.some((c: unknown[]) => (c[0] as { task: string }).task === 'implementation.review.final')).toBe(true);
+    });
+  });
+
+  describe('captureSession', () => {
+    it('emits exactly one ok session with drain counts forwarded from AgentDrainSummary', async () => {
+      // Runner yields assistant events so drainAgentRunner accumulates non-zero counts.
+      const runner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [{ type: 'text', text: 'reviewing' }], tool_call_count: 2, tool_result_count: 2 };
+          yield { type: 'assistant', content: [{ type: 'text', text: 'done' }] };
+        })()),
+      };
+      const deps = makeDeps(undefined, { runner });
+      const captureSession = vi.fn();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({
+        outcome: 'ok',
+        step: 'implementation.review.initial',
+      }));
+      const record = captureSession.mock.calls[0][0] as Record<string, unknown>;
+      // Counts forwarded from drainSummary, not hardcoded null
+      expect(record['assistant_turns']).toBe(2);
+      expect(record['tool_calls']).toBe(2);
+      expect(record['tool_results']).toBe(2);
+    });
+
+    it('emits exactly one failed session and no ok session when result-file read throws', async () => {
+      // The ok emit now lives after readFile inside the try block.
+      // If readFile throws, only the catch-side failed session is emitted.
+      const deps = makeDeps(undefined, {
+        readFile: vi.fn().mockRejectedValue(new Error('ENOENT: no such file')),
+      });
+      const captureSession = vi.fn();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
+    });
+
+    it('emits one failed session when drainAgentRunner throws — no duplicate', async () => {
+      const throwingRunner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          throw new Error('runner exploded');
+        })()),
+      };
+      const deps = makeDeps(undefined, { runner: throwingRunner });
+      const captureSession = vi.fn();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
     });
   });
 

--- a/tests/core/ai/spec-review-coordinator.test.ts
+++ b/tests/core/ai/spec-review-coordinator.test.ts
@@ -214,6 +214,57 @@ describe('SpecReviewCoordinator', () => {
     });
   });
 
+  describe('runSpecReview — captureSession', () => {
+    it('emits exactly one ok session with drain counts forwarded from AgentDrainSummary', async () => {
+      // Runner yields two assistant events with tool activity so drainAgentRunner
+      // can accumulate non-zero counts into the summary.
+      const runner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [{ type: 'text', text: 'analysis' }], tool_call_count: 2, tool_result_count: 2 };
+          yield { type: 'assistant', content: [{ type: 'text', text: 'done' }] };
+        })()),
+      };
+      const d = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] }, { runner });
+      const captureSession = vi.fn();
+      const coordinator = new SpecReviewCoordinator(d);
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec', captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'ok', step: 'spec.review' }));
+      const record = captureSession.mock.calls[0][0] as Record<string, unknown>;
+      // Counts come from drainSummary, not hardcoded null
+      expect(record['assistant_turns']).toBe(2);
+      expect(record['tool_calls']).toBe(2);
+      expect(record['tool_results']).toBe(2);
+    });
+
+    it('emits exactly one failed session and no ok session when result-file read throws', async () => {
+      // The ok emit now lives after readFile inside the try block.
+      // If readFile throws, only the catch-side failed session is emitted.
+      const d = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] }, {
+        readFile: vi.fn().mockRejectedValue(new Error('ENOENT: file not found')),
+      });
+      const captureSession = vi.fn();
+      const coordinator = new SpecReviewCoordinator(d);
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec', captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
+    });
+
+    it('emits one failed session when drainAgentRunner throws — no duplicate', async () => {
+      const throwingRunner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          throw new Error('runner exploded');
+        })()),
+      };
+      const d = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] }, { runner: throwingRunner });
+      const captureSession = vi.fn();
+      const coordinator = new SpecReviewCoordinator(d);
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec', captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
+    });
+  });
+
   describe('runSpecReview — onAgentRequest callback', () => {
     it('records agent request metadata with route task spec.review and artifact_kind', async () => {
       const d = makeDeps();

--- a/tests/core/ai/spec-review-coordinator.test.ts
+++ b/tests/core/ai/spec-review-coordinator.test.ts
@@ -250,6 +250,30 @@ describe('SpecReviewCoordinator', () => {
       expect(captureSession).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
     });
 
+    it('failed session after result-file read throws preserves drain counts from completed drain', async () => {
+      // drain completes successfully, then readFile throws — the failed session record
+      // must carry the counts from the completed drain, not null.
+      const runner: AgentRunner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [{ type: 'text', text: 'reviewing' }], tool_call_count: 3, tool_result_count: 3 };
+          yield { type: 'assistant', content: [{ type: 'text', text: 'done' }] };
+        })()),
+      };
+      const d = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] }, {
+        runner,
+        readFile: vi.fn().mockRejectedValue(new Error('ENOENT: file not found')),
+      });
+      const captureSession = vi.fn();
+      const coordinator = new SpecReviewCoordinator(d);
+      await coordinator.runSpecReview({ run: makeRun(), artifact_path: ARTIFACT_PATH, working_directory: WORKING_DIR, artifact_kind: 'feature_spec', captureSession });
+      expect(captureSession).toHaveBeenCalledTimes(1);
+      const record = captureSession.mock.calls[0][0] as Record<string, unknown>;
+      expect(record['outcome']).toBe('failed');
+      expect(record['assistant_turns']).toBe(2);
+      expect(record['tool_calls']).toBe(3);
+      expect(record['tool_results']).toBe(3);
+    });
+
     it('emits one failed session when drainAgentRunner throws — no duplicate', async () => {
       const throwingRunner: AgentRunner = {
         run: vi.fn().mockReturnValue((async function* () {

--- a/tests/core/config-normalizer.test.ts
+++ b/tests/core/config-normalizer.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { normalizeWorkflowConfig } from '../../src/core/config-normalizer.js';
-import type { WorkflowConfig } from '../../src/types/config.js';
+import type { WorkflowConfig, JournalConfig } from '../../src/types/config.js';
+
+function configWithJournal(journal?: JournalConfig): WorkflowConfig {
+  return journal !== undefined ? { journal } as WorkflowConfig : {} as WorkflowConfig;
+}
+
+describe('normalizeWorkflowConfig journal defaults', () => {
+  it('defaults missing journal to enabled', () => {
+    expect(normalizeWorkflowConfig(configWithJournal()).journal_enabled).toBe(true);
+  });
+
+  it('defaults missing journal.enabled to enabled', () => {
+    expect(normalizeWorkflowConfig(configWithJournal({})).journal_enabled).toBe(true);
+  });
+
+  it('preserves explicit journal.enabled false', () => {
+    expect(normalizeWorkflowConfig(configWithJournal({ enabled: false })).journal_enabled).toBe(false);
+  });
+});
 
 describe('normalizeWorkflowConfig', () => {
   it('does not normalize provider-specific legacy top-level config', () => {

--- a/tests/core/config-types.test.ts
+++ b/tests/core/config-types.test.ts
@@ -3,7 +3,7 @@
  * Verified at compile time via `tsc --noEmit` — no runtime assertions needed.
  */
 import { describe, it, expect } from 'vitest';
-import type { WorkflowConfig, AiConfig, CredentialConfig, EndpointConfig, ProfileConfig, RoutingConfig } from '../../src/types/config.js';
+import type { WorkflowConfig, AiConfig, CredentialConfig, EndpointConfig, ProfileConfig, RoutingConfig, JournalConfig } from '../../src/types/config.js';
 
 // T1: WorkflowConfig with anthropic api_key credential satisfies the type
 const _t1: WorkflowConfig = {
@@ -44,6 +44,22 @@ const _t5: AiConfig = {
   routing: {},
 };
 void _t5;
+
+// T6: WorkflowConfig with journal config satisfies the type
+const _t6: WorkflowConfig = {
+  ai: {
+    credentials: [],
+    endpoints: [],
+    profiles: [],
+    routing: {},
+  },
+  journal: { enabled: false },
+} satisfies WorkflowConfig;
+void _t6;
+
+// T7: JournalConfig with no fields satisfies the type
+const _t7: JournalConfig = {};
+void _t7;
 
 // Suppress unused import warnings
 void (null as unknown as EndpointConfig);

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -536,6 +536,30 @@ describe('getSpecReviewPolicy', () => {
   });
 });
 
+// ─── journal config validation ───────────────────────────────────────────────
+
+function minimalConfig(overrides: Partial<WorkflowConfig> = {}): WorkflowConfig {
+  return { ...overrides } as WorkflowConfig;
+}
+
+describe('journal config validation', () => {
+  it('accepts missing journal config', () => {
+    expect(() => validateConfig(minimalConfig())).not.toThrow();
+  });
+
+  it.each([true, false])('accepts boolean journal.enabled=%s', enabled => {
+    expect(() => validateConfig(minimalConfig({ journal: { enabled } }))).not.toThrow();
+  });
+
+  it('rejects non-object journal config', () => {
+    expect(() => validateConfig({ ...minimalConfig(), journal: 'yes' } as WorkflowConfig)).toThrow('journal must be an object');
+  });
+
+  it('rejects non-boolean journal.enabled with a clear error', () => {
+    expect(() => validateConfig({ ...minimalConfig(), journal: { enabled: 'yes' } } as WorkflowConfig)).toThrow('journal.enabled must be a boolean');
+  });
+});
+
 // ─── isWorkspaceAutoPruneEnabled ─────────────────────────────────────────────
 
 describe('isWorkspaceAutoPruneEnabled', () => {

--- a/tests/core/journal/jsonl-writer.test.ts
+++ b/tests/core/journal/jsonl-writer.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { JsonlJournalWriter } from '../../../src/core/journal/jsonl-writer.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'journal-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('JsonlJournalWriter', () => {
+  it('creates dir and writes valid JSON lines ending in newline', async () => {
+    const writer = new JsonlJournalWriter(tmpDir);
+    await writer.append('messages', { content: 'hello' });
+    await writer.close?.();
+
+    const filePath = path.join(tmpDir, '.autocatalyst', 'journal', 'messages.jsonl');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content.endsWith('\n')).toBe(true);
+
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed).toMatchObject({ content: 'hello' });
+  });
+
+  it('includes writer_id and increments seq for two messages appends', async () => {
+    const writer = new JsonlJournalWriter(tmpDir, { writerId: 'test-writer-id' });
+    await writer.append('messages', { content: 'first' });
+    await writer.append('messages', { content: 'second' });
+    await writer.close?.();
+
+    const filePath = path.join(tmpDir, '.autocatalyst', 'journal', 'messages.jsonl');
+    const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+
+    expect(first.writer_id).toBe('test-writer-id');
+    expect(second.writer_id).toBe('test-writer-id');
+    expect(first.seq).toBe(1);
+    expect(second.seq).toBe(2);
+  });
+
+  it('per-stream seq: sessions append starts at seq 1 independent of messages seq', async () => {
+    const writer = new JsonlJournalWriter(tmpDir, { writerId: 'per-stream-test' });
+    await writer.append('messages', { content: 'msg1' });
+    await writer.append('messages', { content: 'msg2' });
+    await writer.append('sessions', { phase: 'implementation' });
+    await writer.close?.();
+
+    const sessionsPath = path.join(tmpDir, '.autocatalyst', 'journal', 'sessions.jsonl');
+    const sessionLines = fs.readFileSync(sessionsPath, 'utf-8').trim().split('\n');
+    expect(sessionLines).toHaveLength(1);
+
+    const sessionRecord = JSON.parse(sessionLines[0]);
+    expect(sessionRecord.seq).toBe(1);
+  });
+
+  it('second writer preserves existing lines and uses new writer_id, starts seq at 1', async () => {
+    const firstWriter = new JsonlJournalWriter(tmpDir, { writerId: 'writer-one' });
+    await firstWriter.append('messages', { content: 'from first' });
+    await firstWriter.close?.();
+
+    const secondWriter = new JsonlJournalWriter(tmpDir, { writerId: 'writer-two' });
+    await secondWriter.append('messages', { content: 'from second' });
+    await secondWriter.close?.();
+
+    const filePath = path.join(tmpDir, '.autocatalyst', 'journal', 'messages.jsonl');
+    const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+
+    expect(first.writer_id).toBe('writer-one');
+    expect(second.writer_id).toBe('writer-two');
+    expect(first.seq).toBe(1);
+    expect(second.seq).toBe(1);
+  });
+
+  it('concurrent appends produce 25 complete parseable lines with seq 1..25', async () => {
+    const writer = new JsonlJournalWriter(tmpDir);
+    await Promise.all([...Array(25).keys()].map(i => writer.append('feedback', { msg: i })));
+    await writer.close?.();
+
+    const filePath = path.join(tmpDir, '.autocatalyst', 'journal', 'feedback.jsonl');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(25);
+
+    const seqs: number[] = [];
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      expect(typeof parsed.seq).toBe('number');
+      expect(typeof parsed.writer_id).toBe('string');
+      seqs.push(parsed.seq);
+    }
+
+    seqs.sort((a, b) => a - b);
+    expect(seqs).toEqual([...Array(25).keys()].map(i => i + 1));
+  });
+
+  it('write failure is non-fatal: logs journal.append_failed and append resolves', async () => {
+    const warnCalls: Array<{ obj: unknown; msg: string }> = [];
+    const mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn((...args: unknown[]) => {
+        const [obj, msg] = args as [unknown, string];
+        warnCalls.push({ obj, msg });
+      }),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      trace: vi.fn(),
+    } as unknown as import('pino').Logger;
+
+    const failingAppend = vi.fn(async () => {
+      throw new Error('disk full');
+    });
+
+    const writer = new JsonlJournalWriter(tmpDir, {
+      logger: mockLogger,
+      appendFile: failingAppend,
+    });
+
+    // Should resolve without throwing
+    await expect(writer.append('feedback', { msg: 'test' })).resolves.toBeUndefined();
+    await writer.close?.();
+
+    const appendFailedCall = warnCalls.find(
+      c => (c.obj as Record<string, unknown>)?.event === 'journal.append_failed',
+    );
+    expect(appendFailedCall).toBeDefined();
+  });
+
+  it('close() logs journal.closed with per-stream append counts', async () => {
+    const infoCalls: Array<{ obj: unknown; msg: string }> = [];
+    const mockLogger = {
+      info: vi.fn((...args: unknown[]) => {
+        const [obj, msg] = args as [unknown, string];
+        infoCalls.push({ obj, msg: msg ?? '' });
+      }),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      trace: vi.fn(),
+    } as unknown as import('pino').Logger;
+
+    const writer = new JsonlJournalWriter(tmpDir, { logger: mockLogger });
+    await writer.append('messages', { content: 'a' });
+    await writer.append('messages', { content: 'b' });
+    await writer.append('sessions', { phase: 'x' });
+    await writer.close?.();
+
+    const closedCall = infoCalls.find(
+      c => (c.obj as Record<string, unknown>)?.event === 'journal.closed',
+    );
+    expect(closedCall).toBeDefined();
+
+    const counts = (closedCall!.obj as Record<string, unknown>).counts as Record<string, number>;
+    expect(counts['messages']).toBe(2);
+    expect(counts['sessions']).toBe(1);
+  });
+});

--- a/tests/core/journal/redaction.test.ts
+++ b/tests/core/journal/redaction.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { redactSecrets } from '../../../src/core/journal/redaction.js';
+
+describe('redactSecrets', () => {
+  it('redacts sk- API keys', () => {
+    expect(redactSecrets('sk-1234567890abcdef')).toBe('[REDACTED]');
+  });
+
+  it('redacts github_pat_ tokens', () => {
+    expect(redactSecrets('github_pat_1234567890_abcdefghijklmnopqrstuvwxyz')).toBe('[REDACTED]');
+  });
+
+  it('redacts gho_ tokens', () => {
+    expect(redactSecrets('gho_abcdefghijklmnopqrstuvwxyz123456')).toBe('[REDACTED]');
+  });
+
+  it('redacts ghs_ tokens', () => {
+    expect(redactSecrets('ghs_abcdefghijklmnopqrstuvwxyz123456')).toBe('[REDACTED]');
+  });
+
+  it('redacts xapp- tokens', () => {
+    expect(redactSecrets('xapp-1-A0123456789-1234567890-abcdef')).toBe('[REDACTED]');
+  });
+
+  it('redacts xoxb- Slack tokens', () => {
+    expect(redactSecrets('xoxb-1234567890-abcdef')).toBe('[REDACTED]');
+  });
+
+  it('redacts Authorization Bearer token but preserves prefix', () => {
+    expect(redactSecrets('Authorization: Bearer abc.def.ghi')).toBe('Authorization: Bearer [REDACTED]');
+  });
+
+  it('redacts ANTHROPIC_CUSTOM_HEADERS api-key value', () => {
+    const result = redactSecrets('ANTHROPIC_CUSTOM_HEADERS=api-key:secret-value');
+    expect(result).not.toContain('secret-value');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('redacts api_key assignment value', () => {
+    const result = redactSecrets('api_key = secret-value-123');
+    expect(result).not.toContain('secret-value-123');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('redacts password assignment value', () => {
+    const result = redactSecrets('password: hunter2');
+    expect(result).not.toContain('hunter2');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('leaves ordinary text unchanged', () => {
+    expect(redactSecrets('hello world')).toBe('hello world');
+  });
+});

--- a/tests/core/journal/run-journal-facade.test.ts
+++ b/tests/core/journal/run-journal-facade.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RunJournal } from '../../../src/core/journal/run-journal.js';
+import type { JournalStream, JournalWriter } from '../../../src/types/journal.js';
+import type { Run } from '../../../src/types/runs.js';
+
+function makeMockWriter(): { writer: JournalWriter; calls: Array<{ stream: JournalStream; record: unknown }> } {
+  const calls: Array<{ stream: JournalStream; record: unknown }> = [];
+  const writer: JournalWriter = {
+    async append(stream, record) {
+      calls.push({ stream, record });
+    },
+  };
+  return { writer, calls };
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-001',
+    request_id: 'req-001',
+    intent: 'idea',
+    stage: 'intake',
+    workspace_path: '/workspaces/test',
+    branch: 'spec/run-001',
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 0,
+    pr_url: undefined,
+    last_impl_result: undefined,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    conversation: {
+      provider: 'slack',
+      channel_id: 'C123',
+      conversation_id: 'T456',
+    },
+    origin: {
+      provider: 'slack',
+      channel_id: 'C123',
+      conversation_id: 'T456',
+      message_id: 'msg-789',
+    },
+    ...overrides,
+  };
+}
+
+describe('RunJournal facade', () => {
+  it('captureRunEvent writes a run-events record', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureRunEvent(run, 'created');
+
+    expect(calls).toHaveLength(1);
+    const { stream, record } = calls[0];
+    expect(stream).toBe('run-events');
+    const rec = record as Record<string, unknown>;
+    expect(rec.event_type).toBe('created');
+    expect(rec.run_id).toBe('run-001');
+    expect(rec.request_id).toBe('req-001');
+    expect(rec.from_stage).toBeNull();
+    expect(rec.to_stage).toBe('intake');
+    expect(rec.conversation_id).toBe('slack:C123:T456');
+    expect(rec.topic_id).toBe('run-001');
+    expect(rec.intent).toBe('idea');
+    expect(rec.workspace_path).toBe('/workspaces/test');
+    expect(rec.branch).toBe('spec/run-001');
+    expect(rec.attempt).toBe(0);
+  });
+
+  it('captureRunEvent transition sets from/to stage from params', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun({ stage: 'intake' });
+
+    await journal.captureRunEvent(run, 'transition', 'intake', 'speccing');
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.event_type).toBe('transition');
+    expect(rec.from_stage).toBe('intake');
+    expect(rec.to_stage).toBe('speccing');
+  });
+
+  it('captureRunEvent pruned sets to_stage null', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun({ stage: 'speccing' });
+
+    await journal.captureRunEvent(run, 'pruned');
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.event_type).toBe('pruned');
+    expect(rec.from_stage).toBe('speccing');
+    expect(rec.to_stage).toBeNull();
+  });
+
+  it('captureRunEvent demoted sets to_stage to failed', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun({ stage: 'implementing' });
+
+    await journal.captureRunEvent(run, 'demoted');
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.event_type).toBe('demoted');
+    expect(rec.from_stage).toBe('implementing');
+    expect(rec.to_stage).toBe('failed');
+  });
+
+  it('captureInboundMessage writes a messages record with redacted content', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    const message = { content: 'Hello, my api_key=sk-1234567890abcdef', received_at: '2024-01-01T00:00:00.000Z' };
+    await journal.captureInboundMessage(run, message, 'idea', 'classified');
+
+    expect(calls).toHaveLength(1);
+    const { stream, record } = calls[0];
+    expect(stream).toBe('messages');
+    const rec = record as Record<string, unknown>;
+    expect(rec.direction).toBe('in');
+    expect(rec.ts).toBe('2024-01-01T00:00:00.000Z');
+    expect(rec.content).not.toContain('sk-1234567890abcdef');
+    expect(rec.content).toContain('[REDACTED]');
+    expect(rec.intent).toBe('idea');
+    expect(rec.classification_status).toBe('classified');
+    expect(rec.author_principal).toBe('slack:msg-789');
+    expect(rec.origin_message_id).toBe('slack:C123:T456:msg-789');
+    expect(rec.conversation_id).toBe('slack:C123:T456');
+    expect(rec.run_id).toBe('run-001');
+    expect(rec.request_id).toBe('req-001');
+  });
+
+  it('captureInboundMessage uses current time when received_at is absent', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    const before = Date.now();
+    await journal.captureInboundMessage(run, { content: 'hello' }, null, 'not_applicable');
+    const after = Date.now();
+
+    const rec = calls[0].record as Record<string, unknown>;
+    const ts = new Date(rec.ts as string).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('captureOutboundMessage writes a messages record', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureOutboundMessage(run, 'Here is your result', 'origin-msg-id');
+
+    expect(calls).toHaveLength(1);
+    const { stream, record } = calls[0];
+    expect(stream).toBe('messages');
+    const rec = record as Record<string, unknown>;
+    expect(rec.direction).toBe('out');
+    expect(rec.author_principal).toBe('autocatalyst');
+    expect(rec.content).toBe('Here is your result');
+    expect(rec.intent).toBeNull();
+    expect(rec.classification_status).toBe('not_applicable');
+    expect(rec.origin_message_id).toBe('origin-msg-id');
+    expect(rec.run_id).toBe('run-001');
+  });
+
+  it('captureOutboundMessage redacts secrets in text', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureOutboundMessage(run, 'Result with sk-supersecretkey123');
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.content).not.toContain('sk-supersecretkey123');
+    expect(rec.content).toContain('[REDACTED]');
+  });
+
+  it('captureSession increments session_seq per run', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    const baseParams = {
+      run,
+      ts_start: '2024-01-01T00:00:00.000Z',
+      ts_end: '2024-01-01T00:01:00.000Z',
+      step: 'artifact.create' as const,
+      round: 1,
+      model: { provider: 'anthropic', name: 'claude-sonnet-4-6' },
+      inference: { effort: 'medium' as const, thinking: null },
+      outcome: 'ok' as const,
+      runner: 'anthropic_agent' as const,
+    };
+
+    await journal.captureSession(baseParams);
+    await journal.captureSession({ ...baseParams, round: 2 });
+    await journal.captureSession({ ...baseParams, round: 3 });
+
+    expect(calls).toHaveLength(3);
+    expect((calls[0].record as Record<string, unknown>).session_seq).toBe(1);
+    expect((calls[1].record as Record<string, unknown>).session_seq).toBe(2);
+    expect((calls[2].record as Record<string, unknown>).session_seq).toBe(3);
+  });
+
+  it('captureSession uses independent counters per run', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run1 = makeRun({ id: 'run-aaa', request_id: 'req-aaa' });
+    const run2 = makeRun({ id: 'run-bbb', request_id: 'req-bbb' });
+
+    const baseParams = {
+      ts_start: '2024-01-01T00:00:00.000Z',
+      ts_end: '2024-01-01T00:01:00.000Z',
+      step: 'artifact.create' as const,
+      round: 1,
+      model: { provider: 'anthropic', name: 'claude-sonnet-4-6' },
+      inference: { effort: 'medium' as const, thinking: null },
+      outcome: 'ok' as const,
+      runner: 'anthropic_agent' as const,
+    };
+
+    await journal.captureSession({ ...baseParams, run: run1 });
+    await journal.captureSession({ ...baseParams, run: run2 });
+    await journal.captureSession({ ...baseParams, run: run1 });
+
+    const seqs = calls.map((c) => (c.record as Record<string, unknown>).session_seq);
+    const runIds = calls.map((c) => (c.record as Record<string, unknown>).run_id);
+
+    expect(runIds).toEqual(['run-aaa', 'run-bbb', 'run-aaa']);
+    expect(seqs).toEqual([1, 1, 2]);
+  });
+
+  it('captureFeedback writes a feedback record with redacted text', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureFeedback({
+      id: 'fb-001',
+      run,
+      target: 'artifact',
+      author_principal: 'slack:U123',
+      text: 'Please fix password=hunter2 in the code',
+      severity: 'warning',
+      category: 'human_feedback',
+    });
+
+    expect(calls).toHaveLength(1);
+    const { stream, record } = calls[0];
+    expect(stream).toBe('feedback');
+    const rec = record as Record<string, unknown>;
+    expect(rec.id).toBe('fb-001');
+    expect(rec.target).toBe('artifact');
+    expect(rec.author_principal).toBe('slack:U123');
+    expect(rec.text).not.toContain('hunter2');
+    expect(rec.text).toContain('[REDACTED]');
+    expect(rec.severity).toBe('warning');
+    expect(rec.category).toBe('human_feedback');
+    expect(rec.disposition).toBe('open');
+    expect(rec.gate).toBeNull();
+    expect(rec.anchor).toBeNull();
+    expect(rec.thread).toEqual([]);
+    expect(rec.run_id).toBe('run-001');
+    expect(rec.conversation_id).toBe('slack:C123:T456');
+  });
+
+  it('captureFeedback redacts secrets in thread items', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureFeedback({
+      id: 'fb-002',
+      run,
+      target: 'implementation',
+      author_principal: 'slack:U123',
+      text: 'normal feedback',
+      severity: 'info',
+      category: 'human_feedback',
+      thread: [
+        { author_principal: 'slack:U456', ts: '2024-01-01T00:00:00.000Z', text: 'Reply with api_key=verysecret123' },
+      ],
+    });
+
+    const rec = calls[0].record as Record<string, unknown>;
+    const thread = rec.thread as Array<Record<string, unknown>>;
+    expect(thread[0].text).not.toContain('verysecret123');
+    expect(thread[0].text).toContain('[REDACTED]');
+  });
+
+  it('errors from writer.append are caught and do not throw', async () => {
+    const failingWriter: JournalWriter = {
+      async append() {
+        throw new Error('disk full');
+      },
+    };
+    const journal = new RunJournal(failingWriter);
+    const run = makeRun();
+
+    // None of these should throw
+    await expect(journal.captureRunEvent(run, 'created')).resolves.toBeUndefined();
+    await expect(journal.captureInboundMessage(run, { content: 'hello' }, null, 'not_applicable')).resolves.toBeUndefined();
+    await expect(journal.captureOutboundMessage(run, 'hi')).resolves.toBeUndefined();
+    await expect(
+      journal.captureSession({
+        run,
+        ts_start: new Date().toISOString(),
+        ts_end: new Date().toISOString(),
+        step: 'artifact.create',
+        round: 1,
+        model: { provider: 'anthropic', name: 'claude-sonnet-4-6' },
+        inference: { effort: null, thinking: null },
+        outcome: 'ok',
+        runner: 'anthropic_agent',
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      journal.captureFeedback({
+        id: 'fb-err',
+        run,
+        target: 'artifact',
+        author_principal: 'slack:U1',
+        text: 'hi',
+        severity: 'info',
+        category: 'human_feedback',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('captureSession writes correct stream and fields', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureSession({
+      run,
+      ts_start: '2024-01-01T00:00:00.000Z',
+      ts_end: '2024-01-01T00:01:00.000Z',
+      phase: 'speccing',
+      step: 'artifact.create',
+      round: 2,
+      model: { provider: 'anthropic', name: 'claude-opus-4-5' },
+      inference: { effort: 'high', thinking: 'disabled' },
+      tokens: { input: 100, output: 50, cache_read: 10, cache_write: 5 },
+      assistant_turns: 3,
+      tool_calls: 4,
+      tool_results: 4,
+      outcome: 'ok',
+      runner: 'anthropic_agent',
+    });
+
+    const { stream, record } = calls[0];
+    expect(stream).toBe('sessions');
+    const rec = record as Record<string, unknown>;
+    expect(rec.session_seq).toBe(1);
+    expect(rec.ts_start).toBe('2024-01-01T00:00:00.000Z');
+    expect(rec.ts_end).toBe('2024-01-01T00:01:00.000Z');
+    expect(rec.phase).toBe('speccing');
+    expect(rec.step).toBe('artifact.create');
+    expect(rec.round).toBe(2);
+    expect(rec.role).toBeNull();
+    expect(rec.gate).toBeNull();
+    expect(rec.model).toEqual({ provider: 'anthropic', name: 'claude-opus-4-5' });
+    expect(rec.inference).toEqual({ effort: 'high', thinking: 'disabled' });
+    expect(rec.tokens).toEqual({ input: 100, output: 50, cache_read: 10, cache_write: 5 });
+    expect(rec.assistant_turns).toBe(3);
+    expect(rec.tool_calls).toBe(4);
+    expect(rec.tool_results).toBe(4);
+    expect(rec.outcome).toBe('ok');
+    expect(rec.runner).toBe('anthropic_agent');
+    expect(rec.conversation_id).toBe('slack:C123:T456');
+    expect(rec.run_id).toBe('run-001');
+    expect(rec.request_id).toBe('req-001');
+  });
+});

--- a/tests/core/journal/run-journal-facade.test.ts
+++ b/tests/core/journal/run-journal-facade.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { RunJournal } from '../../../src/core/journal/run-journal.js';
 import type { JournalStream, JournalWriter } from '../../../src/types/journal.js';
 import type { Run } from '../../../src/types/runs.js';

--- a/tests/core/journal/run-journal.test.ts
+++ b/tests/core/journal/run-journal.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  JournalMessageRecord,
+  JournalSessionRecord,
+  JournalFeedbackRecord,
+  JournalRunEventRecord,
+  NormalizedTokenUsage,
+} from '../../../src/types/journal.js';
+import { JournalWriter, NoopJournalWriter } from '../../../src/types/journal.js';
+
+describe('journal types (compile-focused)', () => {
+  it('constructs a valid JournalMessageRecord', () => {
+    const tokens: NormalizedTokenUsage = {
+      input: 100,
+      output: 50,
+      cache_read: 0,
+      cache_write: 0,
+    };
+
+    const record: JournalMessageRecord = {
+      seq: 1,
+      writer_id: 'test-writer',
+      ts: new Date().toISOString(),
+      conversation_id: 'slack:C123:T456',
+      topic_id: 'run-001',
+      run_id: 'run-001',
+      request_id: 'req-001',
+      direction: 'in',
+      author_principal: 'user:alice',
+      content: 'Hello world',
+      intent: 'idea',
+      classification_status: 'classified',
+      origin_message_id: null,
+    };
+
+    expect(record.conversation_id).toBe('slack:C123:T456');
+    expect(record.direction).toBe('in');
+    expect(record.classification_status).toBe('classified');
+    expect(tokens.input).toBe(100);
+  });
+
+  it('constructs a valid JournalSessionRecord', () => {
+    const tokens: NormalizedTokenUsage = {
+      input: 500,
+      output: 200,
+      cache_read: 100,
+      cache_write: 50,
+    };
+
+    const record: JournalSessionRecord = {
+      seq: 2,
+      writer_id: 'test-writer',
+      session_seq: 1,
+      ts_start: new Date().toISOString(),
+      ts_end: new Date().toISOString(),
+      conversation_id: 'slack:C123:T456',
+      topic_id: 'run-001',
+      run_id: 'run-001',
+      request_id: 'req-001',
+      phase: 'implementation',
+      step: 'implementation.run',
+      role: null,
+      round: 1,
+      gate: null,
+      model: { provider: 'anthropic', name: 'claude-opus-4-5' },
+      inference: { effort: 'high', thinking: 'disabled' },
+      tokens,
+      assistant_turns: 3,
+      tool_calls: 5,
+      tool_results: 5,
+      outcome: 'ok',
+      runner: 'anthropic_agent',
+    };
+
+    expect(record.session_seq).toBe(1);
+    expect(record.model.provider).toBe('anthropic');
+    expect(record.tokens?.input).toBe(500);
+    expect(record.assistant_turns).toBe(3);
+    expect(record.tool_calls).toBe(5);
+    expect(record.tool_results).toBe(5);
+  });
+
+  it('constructs a valid JournalFeedbackRecord', () => {
+    const record: JournalFeedbackRecord = {
+      seq: 3,
+      writer_id: 'test-writer',
+      id: 'fb-001',
+      ts_created: new Date().toISOString(),
+      conversation_id: 'slack:C123:T456',
+      topic_id: 'run-001',
+      run_id: 'run-001',
+      request_id: 'req-001',
+      target: 'implementation',
+      gate: null,
+      author_principal: 'user:alice',
+      text: 'Fix the bug on line 42',
+      anchor: null,
+      severity: 'warning',
+      category: 'correctness',
+      disposition: 'open',
+      thread: [],
+    };
+
+    expect(record.target).toBe('implementation');
+    expect(record.severity).toBe('warning');
+    expect(record.category).toBe('correctness');
+    expect(record.disposition).toBe('open');
+  });
+
+  it('constructs a valid JournalRunEventRecord', () => {
+    const record: JournalRunEventRecord = {
+      seq: 4,
+      writer_id: 'test-writer',
+      event_type: 'transition',
+      ts: new Date().toISOString(),
+      run_id: 'run-001',
+      request_id: 'req-001',
+      conversation_id: 'slack:C123:T456',
+      topic_id: 'run-001',
+      from_stage: 'intake',
+      to_stage: 'speccing',
+      attempt: 1,
+      intent: 'idea',
+      workspace_path: '/workspaces/my-project',
+      branch: 'feature/my-feature',
+      artifact_ref: null,
+      pr_url: null,
+      issue: null,
+    };
+
+    expect(record.event_type).toBe('transition');
+    expect(record.from_stage).toBe('intake');
+    expect(record.to_stage).toBe('speccing');
+  });
+
+  it('NoopJournalWriter implements JournalWriter and no-ops on append', async () => {
+    const writer: JournalWriter = new NoopJournalWriter();
+
+    await writer.append('messages', { seq: 1 });
+    await writer.append('sessions', { seq: 2 });
+    await writer.append('feedback', { seq: 3 });
+    await writer.append('run-events', { seq: 4 });
+
+    expect(true).toBe(true); // all calls resolved without error
+  });
+});

--- a/tests/core/journal/run-journal.test.ts
+++ b/tests/core/journal/run-journal.test.ts
@@ -6,7 +6,8 @@ import type {
   JournalRunEventRecord,
   NormalizedTokenUsage,
 } from '../../../src/types/journal.js';
-import { JournalWriter, NoopJournalWriter } from '../../../src/types/journal.js';
+import type { JournalWriter } from '../../../src/types/journal.js';
+import { NoopJournalWriter } from '../../../src/types/journal.js';
 
 describe('journal types (compile-focused)', () => {
   it('constructs a valid JournalMessageRecord', () => {
@@ -141,6 +142,6 @@ describe('journal types (compile-focused)', () => {
     await writer.append('feedback', { seq: 3 });
     await writer.append('run-events', { seq: 4 });
 
-    expect(true).toBe(true); // all calls resolved without error
+    // all calls resolved without error — no assertion needed
   });
 });

--- a/tests/core/run-store-journal.test.ts
+++ b/tests/core/run-store-journal.test.ts
@@ -1,0 +1,286 @@
+// tests/core/run-store-journal.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { FileRunStore } from '../../src/core/run-store.js';
+import { RunJournal } from '../../src/core/journal/run-journal.js';
+import { JsonlJournalWriter } from '../../src/core/journal/jsonl-writer.js';
+import type { Run } from '../../src/types/runs.js';
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: randomUUID(),
+    request_id: randomUUID(),
+    intent: 'idea',
+    stage: 'reviewing_spec',
+    workspace_path: '/tmp/placeholder',
+    branch: 'spec/test',
+    artifact: undefined,
+    impl_feedback_ref: undefined,
+    attempt: 0,
+    channel: { provider: 'test', id: 'C123' },
+    conversation: { provider: 'test', channel_id: 'C123', conversation_id: '100.0' },
+    origin: { provider: 'test', channel_id: 'C123', conversation_id: '100.0', message_id: '100.0' },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function readJournalLines(tempDir: string): Promise<Record<string, unknown>[]> {
+  const journalPath = path.join(tempDir, '.autocatalyst', 'journal', 'run-events.jsonl');
+  const content = await fsPromises.readFile(journalPath, 'utf-8');
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map(l => JSON.parse(l) as Record<string, unknown>);
+}
+
+let tempDir: string;
+
+afterEach(() => {
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────
+// Journal survives FileRunStore.load() prune (workspace deleted)
+// ─────────────────────────────────────────────
+
+describe('FileRunStore journal integration — prune', () => {
+  it('appends pruned event and preserves pre-existing journal lines when workspace is missing', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const writer = new JsonlJournalWriter(tempDir, { writerId: 'test' });
+    const journal = new RunJournal(writer);
+
+    const run = makeRun({
+      stage: 'reviewing_spec',
+      workspace_path: path.join(tempDir, 'nonexistent-workspace'),
+    });
+
+    // Pre-write a journal line to prove it survives the prune
+    await journal.captureRunEvent(run, 'created');
+
+    // Set up the store with the run persisted to disk
+    const autocatalystDir = path.join(tempDir, '.autocatalyst');
+    fs.mkdirSync(autocatalystDir, { recursive: true });
+    fs.writeFileSync(path.join(autocatalystDir, 'runs.json'), JSON.stringify([run]));
+
+    const store = new FileRunStore(tempDir, { journal });
+    const loaded = store.load();
+
+    // Wait for async journal writes to settle
+    await writer.close?.();
+
+    // Run was dropped because workspace doesn't exist
+    expect(loaded).toHaveLength(0);
+
+    const lines = await readJournalLines(tempDir);
+
+    // Original 'created' entry must still be there
+    expect(lines.some(l => l['event_type'] === 'created')).toBe(true);
+
+    // A 'pruned' entry was appended by the store
+    expect(lines.some(l => l['event_type'] === 'pruned')).toBe(true);
+
+    // Exactly two entries total
+    expect(lines).toHaveLength(2);
+  });
+
+  it('pruned event records the correct run_id and request_id', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const writer = new JsonlJournalWriter(tempDir, { writerId: 'test' });
+    const journal = new RunJournal(writer);
+
+    const run = makeRun({
+      stage: 'speccing',
+      workspace_path: path.join(tempDir, 'gone-workspace'),
+    });
+
+    const autocatalystDir = path.join(tempDir, '.autocatalyst');
+    fs.mkdirSync(autocatalystDir, { recursive: true });
+    fs.writeFileSync(path.join(autocatalystDir, 'runs.json'), JSON.stringify([run]));
+
+    const store = new FileRunStore(tempDir, { journal });
+    store.load();
+
+    await writer.close?.();
+
+    const lines = await readJournalLines(tempDir);
+    const prunedEntry = lines.find(l => l['event_type'] === 'pruned');
+    expect(prunedEntry).toBeDefined();
+    expect(prunedEntry!['run_id']).toBe(run.id);
+    expect(prunedEntry!['request_id']).toBe(run.request_id);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Journal survives FileRunStore.load() demote (stale run)
+// ─────────────────────────────────────────────
+
+describe('FileRunStore journal integration — demote', () => {
+  it('appends demoted event and preserves pre-existing journal lines when run is stale', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const workspacePath = path.join(tempDir, 'ws-stale');
+    fs.mkdirSync(workspacePath, { recursive: true });
+
+    const writer = new JsonlJournalWriter(tempDir, { writerId: 'test' });
+    const journal = new RunJournal(writer);
+
+    const run = makeRun({
+      stage: 'implementing',
+      workspace_path: workspacePath,
+    });
+
+    // Pre-write a journal line to prove it survives the demotion
+    await journal.captureRunEvent(run, 'created');
+
+    const autocatalystDir = path.join(tempDir, '.autocatalyst');
+    fs.mkdirSync(autocatalystDir, { recursive: true });
+    fs.writeFileSync(path.join(autocatalystDir, 'runs.json'), JSON.stringify([run]));
+
+    const store = new FileRunStore(tempDir, { journal });
+    const loaded = store.load();
+
+    // Wait for async journal writes to settle
+    await writer.close?.();
+
+    // Run was kept but demoted to 'failed'
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].stage).toBe('failed');
+
+    const lines = await readJournalLines(tempDir);
+
+    // Original 'created' entry must still be there
+    expect(lines.some(l => l['event_type'] === 'created')).toBe(true);
+
+    // A 'demoted' entry was appended by the store
+    expect(lines.some(l => l['event_type'] === 'demoted')).toBe(true);
+
+    // Exactly two entries total
+    expect(lines).toHaveLength(2);
+  });
+
+  it('demoted event records from_stage and to_stage correctly', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const workspacePath = path.join(tempDir, 'ws-speccing');
+    fs.mkdirSync(workspacePath, { recursive: true });
+
+    const writer = new JsonlJournalWriter(tempDir, { writerId: 'test' });
+    const journal = new RunJournal(writer);
+
+    const run = makeRun({
+      stage: 'speccing',
+      workspace_path: workspacePath,
+    });
+
+    const autocatalystDir = path.join(tempDir, '.autocatalyst');
+    fs.mkdirSync(autocatalystDir, { recursive: true });
+    fs.writeFileSync(path.join(autocatalystDir, 'runs.json'), JSON.stringify([run]));
+
+    const store = new FileRunStore(tempDir, { journal });
+    store.load();
+
+    await writer.close?.();
+
+    const lines = await readJournalLines(tempDir);
+    const demotedEntry = lines.find(l => l['event_type'] === 'demoted');
+    expect(demotedEntry).toBeDefined();
+    expect(demotedEntry!['from_stage']).toBe('speccing');
+    expect(demotedEntry!['to_stage']).toBe('failed');
+    expect(demotedEntry!['run_id']).toBe(run.id);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Disabled journal writes no files
+// ─────────────────────────────────────────────
+
+describe('FileRunStore — no journal (config-gating)', () => {
+  it('does not create a journal directory when no journal is configured', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    // Store created WITHOUT a journal option
+    const store = new FileRunStore(tempDir);
+    const loaded = store.load();
+
+    expect(loaded).toEqual([]);
+
+    const journalDir = path.join(tempDir, '.autocatalyst', 'journal');
+    expect(fs.existsSync(journalDir)).toBe(false);
+  });
+
+  it('does not create journal files when runs are pruned and no journal is configured', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const run = makeRun({
+      stage: 'reviewing_spec',
+      workspace_path: path.join(tempDir, 'nonexistent'),
+    });
+
+    const autocatalystDir = path.join(tempDir, '.autocatalyst');
+    fs.mkdirSync(autocatalystDir, { recursive: true });
+    fs.writeFileSync(path.join(autocatalystDir, 'runs.json'), JSON.stringify([run]));
+
+    const store = new FileRunStore(tempDir);
+    const loaded = store.load();
+
+    expect(loaded).toHaveLength(0);
+
+    const journalPath = path.join(tempDir, '.autocatalyst', 'journal', 'run-events.jsonl');
+    expect(fs.existsSync(journalPath)).toBe(false);
+  });
+
+  it('does not create journal files when runs are demoted and no journal is configured', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const workspacePath = path.join(tempDir, 'ws-demote');
+    fs.mkdirSync(workspacePath, { recursive: true });
+
+    const run = makeRun({
+      stage: 'implementing',
+      workspace_path: workspacePath,
+    });
+
+    const autocatalystDir = path.join(tempDir, '.autocatalyst');
+    fs.mkdirSync(autocatalystDir, { recursive: true });
+    fs.writeFileSync(path.join(autocatalystDir, 'runs.json'), JSON.stringify([run]));
+
+    const store = new FileRunStore(tempDir);
+    const loaded = store.load();
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].stage).toBe('failed');
+
+    const journalPath = path.join(tempDir, '.autocatalyst', 'journal', 'run-events.jsonl');
+    expect(fs.existsSync(journalPath)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// NoopJournalWriter unit test (config-gating via writer)
+// ─────────────────────────────────────────────
+
+describe('NoopJournalWriter — writes no files', () => {
+  it('NoopJournalWriter.append() resolves without creating any files', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runstore-journal-test-'));
+
+    const { NoopJournalWriter } = await import('../../src/types/journal.js');
+    const writer = new NoopJournalWriter();
+
+    await writer.append('run-events', { event_type: 'created', run_id: 'r1' });
+    await writer.append('messages', { content: 'test' });
+
+    // No files were written anywhere under tempDir
+    const journalDir = path.join(tempDir, '.autocatalyst', 'journal');
+    expect(fs.existsSync(journalDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Moved drainSummary declaration outside the try block in ImplementationReviewCoordinator.runReview() so the catch path receives it when readFile/parse throws after a successful drain
- Same fix applied to SpecReviewCoordinator.runSpecReview()
- Added test 'failed session after result-file read throws preserves drain counts and token usage' to implementation-review-coordinator.test.ts
- Added equivalent test to spec-review-coordinator.test.ts

## Verify

- [ ] When readFile throws after drainAgentRunner completes, the emitted session record has outcome: 'failed' and non-null assistant_turns/tool_calls/tool_results matching the drain
- [ ] When drainAgentRunner itself throws (no drain completes), the session record still has outcome: 'failed' with null counts — existing behavior preserved
- [ ] All 1475 tests pass (1473 prior + 2 new)

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/4990fe12-d821-483e-ba61-1734c96ac8cf
2. npm test

---
Spec: `context-human/specs/enhancement-append-only-backfill-journal.md`
Closes #192