### PR TITLE
feat: enable bounded convergence for implementation review with role routing

### DIFF
--- a/context-human/specs/enhancement-bounded-convergence-review.md
+++ b/context-human/specs/enhancement-bounded-convergence-review.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-07
 last_updated: 2026-06-07
-status: implementing
+status: complete
 issue: 193
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-bounded-convergence-review.md
+++ b/context-human/specs/enhancement-bounded-convergence-review.md
@@ -1,0 +1,632 @@
+---
+created: 2026-06-07
+last_updated: 2026-06-07
+status: implementing
+issue: 193
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Bounded convergence implementation review
+
+## Parent feature
+
+Primary parent feature:
+- `feature-approval-to-implementation.md` — provides the implementation lifecycle, human testing guide, implementation approval path, and terminal run states.
+Related specs that this enhancement extends or interlocks with:
+- `enhancement-two-part-implementation-review.md` — adds initial and final implementation review checkpoints, reviewer findings, implementer responses, and `run.review_exchanges`.
+- `enhancement-model-provider-config.md` and `feature-openai-agent-sdk-runner.md` — provide provider-neutral AI profiles and route-based model selection.
+- `enhancement-append-only-backfill-journal.md` — provides durable `sessions.jsonl` and `feedback.jsonl` streams that this enhancement enriches with role and round metadata.
+- `enhancement-run-status-workspace-ai-context.md` — surfaces active model request metadata while implementation and review agents are running.
+GitHub issue: [#193 — Generalize implementation review into a bounded convergence loop with role-distinct routing](https://github.com/markdstafford/autocatalyst-v0/issues/193)
+## What
+
+Autocatalyst turns implementation review from a one-pass challenge into a bounded convergence loop. The existing reviewer still inspects the implementation after an implementation pass and before human handoff or PR creation. When the reviewer finds blockers or warnings, the implementer revises or explains the implementation, and the reviewer then reviews the current revision again. The loop stops when the latest critic result has no blocker or warning findings, when the configured round budget is exhausted, or when the system detects oscillation.
+The critic may still return info-only findings for optional notes, but those findings do not block convergence. The preferred critic behavior is to return `status: "no_findings"` when no blocker or warning findings remain; if a provider returns `status: "findings"` with only `info` severity items, Autocatalyst records those notes and treats the gate as converged.
+The enhancement also adds role-aware model routing. A route may resolve by `task:role`, such as `implementation.review.initial:critic` or `implementation.run:proposer`, and falls back to the current task-only key when no role-specific route exists. This keeps current configs working while allowing operators to make proposer and critic model choices explicit.
+The feature is config-gated and off by default. With convergence disabled, implementation review behaves like today: one reviewer pass, one implementer response when findings exist, no re-review of that response, and task-only route fallback.
+## Why
+
+Autocatalyst already uses distinct models adversarially: one model implements and another model reviews. The gap is that the loop does not converge. Today the reviewer runs once, the implementer responds once, and Autocatalyst proceeds without asking the reviewer whether the response fixed the current code.
+That behavior lets a model patch and ship instead of iterating to agreement. It also means configured round limits are validated but not enforced at runtime. A bounded convergence loop makes the existing review feature match its intent: reviewer blocker and warning findings must be resolved on the current revision or the run fails with an auditable record.
+Role-aware routing gives the loop a stable foundation for future convergence work. Later work can add more gates and altitudes, but this issue proves the mechanism at the current build-level implementation review checkpoint.
+## User stories
+
+- As Enzo, I can enable convergence for implementation review and know the critic re-reviews the implementer's latest revision before human handoff.
+- As Enzo, I can see a run fail when review findings do not converge within the configured round budget.
+- As Enzo, I can inspect the testing guide and see each review round, findings, implementer responses, and whether the gate converged.
+- As Phoebe, I can understand from the testing guide whether AI review converged without reading raw model transcripts.
+- As an operator, I can configure proposer and critic profiles by role while preserving old task-only routing keys.
+- As an operator, I receive a clear configuration error if proposer and critic resolve to the same profile without an explicit override.
+- As an operator, I can leave convergence disabled and get behavior identical to today's single-pass review.
+- As an analytics agent, I can read `sessions.jsonl` and distinguish model sessions by `role`, `round`, `gate`, route task, and profile.
+- As an importer implementer, I can read `feedback.jsonl` and identify critic-authored findings with stable attribution and lifecycle disposition.
+## Design changes
+
+This is a backend workflow enhancement. It adds no new primary UI. The existing implementation testing guide gains richer AI review history when convergence is enabled.
+### Goals
+
+- Re-review the implementer's current revision after reviewer blocker or warning findings are addressed.
+- Stop a review gate only when the current reviewer result has no blocker or warning findings, or when a bounded failure condition is reached.
+- Enforce `implementation_review.max_initial_rounds` and `implementation_review.max_final_rounds` at runtime.
+- Fail the run on non-convergence instead of continuing with unresolved blocker or warning findings or escalating to the human.
+- Detect finding oscillation so taste disagreements or non-shrinking churn do not burn the entire round budget.
+- Add optional `AgentRoute.role` and route lookup by `task:role`, with fallback to the current task-only lookup.
+- Enforce distinct proposer and critic profiles within a review gate unless an explicit single-model override is configured.
+- Preserve backward compatibility for existing runs, configs, `review_exchanges`, and testing-guide rendering.
+- Persist convergence history with gate, round, proposer profile, critic profile, findings, responses, and convergence status.
+- Add `role` and `round` to journal session records for proposer and critic sessions, and write AI review findings to `feedback.jsonl` with critic attribution.
+- Add per-round structured logs for diagnosis and cost/latency analysis.
+### Non-goals
+
+- Adding layout, public API, private API, or other altitude-specific gates.
+- Adding a staged implementer, layered diffs, or multi-step build plans beyond the current implementation agent flow.
+- Adding new `RunStage` values or changing `VALID_RUN_STAGES`.
+- Adding multi-critic fan-out, voting, or consensus protocols.
+- Replacing human implementation approval.
+- Giving the critic model write access or authority to decide what ships.
+- Building a new UI for convergence history beyond existing testing-guide and journal surfaces.
+- Guaranteeing role isolation at the provider sandbox level. Autocatalyst can enforce routing and prompt boundaries, but provider-level runtime isolation depends on the runner/provider.
+### Personas and narratives
+
+- **Enzo: Engineer/operator** — wants reviewer findings to be rechecked on the latest code before he tests or approves a PR.
+- **Phoebe: Product manager** — wants the testing guide to show whether the AI review converged or failed, without needing to read raw logs.
+- **Autocatalyst operator** — configures model profiles and needs clear errors when proposer and critic routing collapses to the same model unexpectedly.
+- **Analytics agent** — reads journals later to compare cost, latency, and quality by role, round, gate, and model profile.
+A review can converge after one revision: Enzo approves a spec and Autocatalyst implements it. The initial critic finds a blocker because the code handles the happy path but misses a regression test for invalid provider config. Autocatalyst asks the proposer to respond. The proposer adds the missing test and updates the implementation result. Instead of handing the work to Enzo immediately, Autocatalyst runs the critic again on the current revision. The critic returns `no_findings`. The testing guide shows two rounds: round 1 had one blocker and a fixed response, and round 2 converged. Enzo starts testing with more confidence because the reviewer checked the actual revision he is about to test.
+A review can fail instead of shipping unresolved work: a final review finds a security issue before PR creation. The proposer declines it as not applicable. The critic re-reviews and returns the same blocker because the code still exposes the risky behavior. The round budget is reached. Autocatalyst fails the run and records the open finding, the proposer response, and both model profiles. It does not open a PR and does not ask the human to arbitrate in the live loop. Enzo debugs from the recorded state when he has time.
+Routing stays compatible while roles become explicit. An existing repository may only have task-level routes:
+```yaml
+ai:
+  routing:
+    implementation.run: grove-sonnet-4.6-medium
+    implementation.review.initial: grove-gpt-5.5-high
+```
+After upgrade, the same config still resolves because `task:role` lookup falls back to `task`. An operator who wants more control can add:
+```yaml
+ai:
+  routing:
+    implementation.run: grove-sonnet-4.6-medium
+    implementation.run:proposer: grove-sonnet-4.6-medium
+    implementation.review.initial:critic: grove-gpt-5.5-high
+```
+The journal now records `role: "proposer"` for proposer sessions and `role: "critic"` for critic sessions. The analytics agent can compare cost and outcomes by role without inferring roles from task names.
+### Review gate lifecycle
+
+The implementation review coordinator keeps its current placement inside implementation handlers. It does not become a new run stage.
+```mermaid
+flowchart TD
+  Start[Implementation result complete] --> Enabled{Convergence enabled?}
+  Enabled -->|no| Current[Current single review and response behavior]
+  Enabled -->|yes| CriticRound[Critic reviews current revision]
+  CriticRound --> CriticStatus{Critic result}
+  CriticStatus -->|no blockers or warnings| Converged[Record converged gate and continue]
+  CriticStatus -->|failed| ReviewFailure[Apply on_review_failure policy]
+  CriticStatus -->|blocker or warning findings| Budget{Round budget or oscillation reached?}
+  Budget -->|yes| Failed[Record non-convergence and fail run]
+  Budget -->|no| Proposer[Proposer revises or responds]
+  Proposer --> ProposerStatus{Proposer result}
+  ProposerStatus -->|complete| BranchGuard[Run branch guard]
+  ProposerStatus -->|needs_input| AwaitInput[Return needs_input]
+  ProposerStatus -->|failed| Failed
+  BranchGuard --> CriticRound
+```
+A review gate is the existing review phase: `initial` or `final`. In this issue, both gates operate at the current build lens only. Later altitude work can reuse the same gate history shape with additional gate names.
+### Convergence rules
+
+- A gate converges when a critic round on the current revision returns no blocker or warning findings.
+- `status: "no_findings"` always converges.
+- `status: "findings"` with only `info` findings also converges; Autocatalyst records the notes but does not treat them as open blocking work.
+- A gate does not converge if the critic returns blocker or warning findings through `max_rounds`.
+- The preferred critic behavior is to return `no_findings` when only optional notes remain.
+- A reviewer `status: "failed"` is still governed by `implementation_review.on_review_failure`.
+- A proposer `status: "needs_input"` returns the normal awaiting-input behavior.
+- A proposer `status: "failed"`, branch-guard failure, max-round exhaustion, or oscillation failure returns `ImplementationResult.status: "failed"` so the handler fails the run.
+### Round limits and feature gate
+
+Add an explicit convergence gate under `implementation_review`:
+```yaml
+implementation_review:
+  convergence:
+    enabled: false
+    allow_same_model: false
+  max_initial_rounds: 2
+  max_final_rounds: 2
+  on_review_failure: warn
+  retest_on_behavior_change: true
+```
+Rules:
+- Missing `implementation_review.convergence.enabled` means `false`.
+- With convergence disabled, behavior matches today exactly, including a single reviewer pass and one proposer response when findings exist.
+- With convergence enabled, `max_initial_rounds` and `max_final_rounds` are enforced as the maximum number of critic rounds for the matching gate.
+- If a max value is absent while convergence is enabled, default to `2` for both gates. This keeps cost bounded while allowing one revision and one re-review by default.
+- The only today-equivalent mode is convergence disabled. That disabled path remains the safe rollout setting for repositories that want current behavior: one critic pass, one proposer response when findings exist, and no re-review of that response.
+- With convergence enabled, `max_rounds: 1` is valid but intentionally strict: Autocatalyst runs one critic round only. If that first critic round has any blocker or warning findings, the gate fails as non-converged immediately; no proposer response runs because there is no remaining critic round to verify it. Use this for strict single-pass gating and regression tests, not for today-equivalent rollout.
+- Recommended rollout is disabled first, then enabled with `max_initial_rounds: 2` and `max_final_rounds: 2` so the proposer gets one chance to respond and the critic gets one re-review.
+- `allow_same_model` defaults to `false`. If proposer and critic resolve to the same profile and this value is false, the run fails with a clear configuration error before starting the gate.
+The configuration is evaluated per review gate invocation, so each run can execute with the policy active at the time that run reaches implementation review. If a later command-level per-run override exists, it should feed the same resolved policy; this issue does not require a new human command surface.
+### Role-aware routing
+
+Add optional `role` to `AgentRoute`:
+```typescript
+export type AgentRole = 'proposer' | 'critic';
+
+export interface AgentRoute {
+  task: AgentTaskKind;
+  role?: AgentRole | string;
+  stage?: RunStage | 'new_thread' | string;
+  intent?: Intent;
+  artifact_kind?: ArtifactKind;
+}
+```
+`DefaultAgentRoutingPolicy` resolves routes with this order:
+1. If `route.role` exists, look up `${route.task}:${route.role}`.
+2. If no role-specific profile exists, look up `route.task`.
+3. If no task-level profile exists, keep the current required/optional behavior: `resolve()` throws and `resolveOptional()` returns `null`.
+This is non-breaking because all existing route keys are still task-level keys.
+Route construction in the convergence path uses:
+- Proposer route: `{ task: 'implementation.run', role: 'proposer' }`.
+- Initial critic route: `{ task: 'implementation.review.initial', role: 'critic' }`.
+- Final critic route: `{ task: 'implementation.review.final', role: 'critic' }`, with the existing final-to-initial fallback preserved.
+The proposer review-response implementation must use the role-aware route in the actual agent invocation, not only in preflight comparison. The coordinator should either pass `agentRoute: { task: 'implementation.run', role: 'proposer' }` through to the existing implementation-agent/agent-service call that performs review-response work, or pass a resolved proposer profile plus route metadata produced from that route. Existing call signatures that only accept the task-only `implementation.run` route must be extended so convergence review-response sessions can select `implementation.run:proposer` when configured and record that same route/profile in session capture. Tests must assert the proposer review-response agent call and captured session use the role-specific route/profile when `implementation.run:proposer` is configured, and fall back to task-only `implementation.run` only when no role-specific route exists.
+### Same-model enforcement
+
+For each gate, compare resolved proposer and critic profiles before the first critic round.
+Profiles are considered the same when they resolve to the same profile ID. If profile IDs differ but provider/model/base URL are identical, log a warning because the operator may still have configured two aliases for the same model. The hard failure is profile-ID equality unless future implementation chooses a stricter comparator and updates tests accordingly.
+When same-profile routing is detected and `allow_same_model` is false, fail the run with an error such as:
+```plain text
+Implementation review convergence requires distinct proposer and critic profiles for initial review. Both resolved to grove-sonnet-4.6-medium. Configure implementation.run:proposer and implementation.review.initial:critic differently, or set implementation_review.convergence.allow_same_model: true.
+```
+### Oscillation guard
+
+The guard detects non-shrinking or cycling blocker and warning findings. It should be simple, deterministic, and cheap.
+For each critic round, compute a finding signature from blocker and warning findings only:
+```plain text
+severity|category|normalized finding text
+```
+Normalization lowercases text, trims whitespace, collapses internal whitespace, and strips volatile IDs. Suggested actions are excluded from the signature so a critic cannot appear to make progress by rewording advice while preserving the same issue.
+Trigger non-convergence when either condition is true:
+- The same blocking signature set appears in two critic rounds with no decrease in blocker+warning count after a proposer response.
+- The blocker+warning count increases for two consecutive critic rounds after proposer responses.
+On oscillation, record the latest open blocker and warning findings and fail the run with a non-convergence error. Do not continue burning remaining rounds. `info` findings alone do not contribute to oscillation detection.
+### Persistence model
+
+Keep `run.review_exchanges` for backward compatibility. Add `run.gate_exchanges` as an additive field that captures convergence-specific history.
+```typescript
+export interface GateReviewExchange {
+  id: string;
+  gate: 'initial' | 'final' | string;
+  round: number;
+  created_at: string;
+  proposer_profile: AgentProfileSummary;
+  critic_profile: AgentProfileSummary;
+  review_status: ImplementationReviewExchangeStatus | 'non_converged' | 'converged';
+  review_summary: string;
+  findings: ImplementationReviewFinding[];
+  responses: ImplementationReviewResponseItem[];
+  converged: boolean;
+  non_convergence_reason?: 'max_rounds' | 'oscillation';
+  requires_human_retest: boolean;
+}
+
+export interface Run {
+  review_exchanges?: ImplementationReviewExchange[];
+  gate_exchanges?: GateReviewExchange[];
+}
+```
+Compatibility rules:
+- Existing `review_exchanges` readers continue to work.
+- When convergence is disabled, Autocatalyst may write only `review_exchanges` as today.
+- When convergence is enabled, Autocatalyst writes `gate_exchanges` for each critic round. `gate_exchanges` is the single source of truth for convergence feedback emission to `feedback.jsonl`.
+- When convergence is enabled, Autocatalyst may also append a summarized legacy `review_exchanges` entry so current testing-guide rendering remains useful until it reads `gate_exchanges` directly. That legacy entry is rendering-only for convergence runs and must be excluded from journal feedback capture so critic findings are not written twice.
+- Existing stored runs without `gate_exchanges` load without migration.
+### Testing guide rendering
+
+When `gate_exchanges` exists, the AI review section groups by gate and round:
+```markdown
+AI review
+
+### Initial review
+
+Convergence: converged
+Rounds: 2
+Proposer model: `grove-sonnet-4.6-medium`
+Critic model: `grove-gpt-5.5-high`
+
+#### Round 1 — findings
+
+- [x] [INIT-1] Missing regression test for invalid provider config.
+  Fixed — added coverage for unknown profile routing.
+
+#### Round 2 — converged
+
+- No blocker or warning findings.
+```
+For non-convergence:
+```markdown
+### Final review
+
+Convergence: failed (`max_rounds`)
+Rounds: 2
+
+#### Open findings
+
+- [ ] [FINAL-2] Security check still allows raw token output in logs.
+  Last proposer response: Declined — token is only a config name.
+```
+Rules:
+- Hide raw prompts, raw model transcripts, secrets, and chain-of-thought.
+- Preserve stable finding IDs from critic results.
+- Show concise proposer responses for each finding.
+- Existing `review_exchanges` rendering remains the fallback when no `gate_exchanges` exists.
+- Info-only findings may be shown as notes, but they must not be rendered as open blocking work when no blocker or warning findings remain.
+### Journal interlock
+
+Convergence enriches the journal from `enhancement-append-only-backfill-journal.md`.
+`sessions.jsonl` additions:
+- Critic sessions write `role: "critic"`, the current `round`, and `gate: "initial"` or `"final"`.
+- Proposer review-response sessions write `role: "proposer"`, the round they are responding to, and the same gate.
+- Existing non-convergence model sessions may keep `role: null` and `round: 1`.
+`feedback.jsonl` additions:
+- For convergence-enabled gates, feedback capture reads from `gate_exchanges` only. The legacy `review_exchanges` feedback capture added by `enhancement-append-only-backfill-journal.md` must be suppressed for rendering-only convergence summaries.
+- Each critic finding writes a feedback record with the critic profile as `author_principal`.
+- `target` is `"implementation"`.
+- `category` and `severity` come from the finding.
+- `disposition` uses the existing journal enum from `enhancement-append-only-backfill-journal.md`: fixed/addressed findings become `addressed`, declined findings become `wont_fix`, and open non-converged blocker or warning findings remain `open`.
+- Info-only findings may be recorded as non-blocking notes with `disposition: "addressed"` when the gate converges, and must not force an open non-converged disposition.
+- Capture happens at append time or dedupes by stable gate-exchange/finding ID so retries do not duplicate records. If implementation keeps both `gate_exchanges` and legacy `review_exchanges` eligible for capture for any reason, both paths must share an explicit stable finding ID dedup key and tests must prove a finding appears in `feedback.jsonl` only once.
+### Progress updates
+
+Post best-effort progress messages through the existing progress callback:
+```plain text
+Initial review round 1 started with grove-gpt-5.5-high
+Initial review round 1 returned 2 findings — asking proposer to revise
+Initial review round 2 started with grove-gpt-5.5-high
+Initial review converged after 2 rounds
+Final review did not converge after 2 rounds — failing run
+```
+Failed progress sends must not fail the run. They log `progress_failed` with phase, gate, round, and run ID.
+### Cost and latency ceiling
+
+Each convergence round can add one critic session and, when blocker or warning findings exist, one proposer session. With `max_initial_rounds: 2` and `max_final_rounds: 2`, a run can add up to four critic sessions and up to two proposer response sessions across both gates, depending on where blocking findings appear.
+Because v0 has seen gateway timeouts on long calls, convergence must remain bounded. Operators should start with `max_*_rounds: 2`. Higher values require explicit configuration and should be monitored through per-round logs and journal session records.
+### Risks and mitigations
+
+- **Risk: Convergence increases cost and latency.** Mitigation: keep convergence off by default, enforce positive finite max rounds, recommend a default of 2 when enabled, and log/journal per-round usage.
+- **Risk: The loop gets stuck in taste disagreement.** Mitigation: use an oscillation guard and fail with recorded state instead of burning the remaining budget.
+- **Risk: Same-model routing silently weakens adversarial review.** Mitigation: fail same-profile proposer/critic routing by default and require an explicit override for single-model operation.
+- **Risk: Backward compatibility breaks testing-guide or run-store readers.** Mitigation: add `gate_exchanges` as optional, keep `review_exchanges`, and use legacy rendering when gate history is absent.
+- **Risk: Role-specific routing creates confusing config errors.** Mitigation: keep task-level fallback, use clear error messages, and test both `resolve()` and `resolveOptional()` paths.
+- **Risk: Providers cannot enforce critic read-only behavior.** Mitigation: treat critic authority as logical only: prompts and runner wiring instruct review-only behavior, branch guard detects unexpected branch changes after proposer work, and provider-level sandbox limits remain runner-specific.
+## Technical changes
+
+### Affected files
+
+- `src/types/ai.ts` — add `AgentRoute.role`, an `AgentRole` union, gate exchange types, and role/round/gate fields on session capture data if they are not already available through journal types.
+- `src/types/runs.ts` — add optional `gate_exchanges?: GateReviewExchange[]` to `Run`.
+- `src/types/config.ts` — add typed `implementation_review.convergence` config with `enabled` and `allow_same_model`.
+- `src/core/config.ts` — validate and resolve convergence policy; preserve current review policy defaults when convergence is disabled, and resolve absent max-round values to `2` for both gates when convergence is enabled.
+- `src/core/ai/routing-policy.ts` — implement `task:role` lookup with task-level fallback for both required and optional resolution.
+- `src/core/ai/implementation-review-coordinator.ts` — replace the single-round implementation with the bounded convergence loop when enabled; enforce max rounds, same-model checks, oscillation guard, role-aware proposer/critic route resolution, session capture metadata, gate exchange persistence, and non-convergence failure.
+- `src/core/ai/agent-services.ts` — update review and proposer-response prompts only as needed to include gate and round context; extend proposer review-response call parameters to accept a role-aware `AgentRoute` or pre-resolved proposer profile, and preserve existing structured result contracts.
+- `src/core/handlers/implementation-start-handler.ts` — pass journal/session capture through with gate and round values, and fail the run when the coordinator returns non-convergence failure.
+- `src/core/handlers/implementation-feedback-handler.ts` — same as implementation start for feedback passes.
+- `src/core/handlers/implementation-approval-handler.ts` — same as implementation start for final review before PR creation.
+- `src/types/impl-feedback-page.ts` — allow testing-guide update inputs to include `gate_exchanges`.
+- `src/adapters/notion/implementation-feedback-page.ts` — render round-by-round gate history when present, with legacy fallback.
+- `src/core/journal/run-journal.ts` and `src/types/journal.ts` — ensure `role`, `round`, and `gate` are stored for convergence sessions and feedback records map critic findings correctly.
+- `tests/core/ai/implementation-review-coordinator.test.ts` — add convergence, max-round, oscillation, same-model, routing-role, and legacy-disabled tests.
+- `tests/core/ai/routing-policy.test.ts` or equivalent — cover `task:role` lookup and fallback.
+- `tests/core/config.test.ts` — cover convergence config validation and defaults.
+- `tests/core/handlers/implementation-start-handler.test.ts`, `implementation-feedback-handler.test.ts`, and `implementation-approval-handler.test.ts` — cover handler-level failure and success behavior.
+- `tests/adapters/notion/implementation-feedback-page.test.ts` — cover gate exchange rendering.
+- `tests/core/journal/run-journal-facade.test.ts` — cover role, round, gate, and AI finding feedback persistence.
+### Config resolver
+
+Extend the resolved review policy used by the coordinator:
+```typescript
+export interface ImplementationReviewConvergencePolicy {
+  enabled: boolean;
+  allow_same_model: boolean;
+}
+
+export interface ImplementationReviewPolicy {
+  max_initial_rounds: number;
+  max_final_rounds: number;
+  on_review_failure: 'warn' | 'block';
+  retest_on_behavior_change: boolean;
+  convergence: ImplementationReviewConvergencePolicy;
+}
+```
+Validation rules:
+- `implementation_review.convergence` must be an object when present.
+- `enabled` must be boolean when present.
+- `allow_same_model` must be boolean when present.
+- `max_initial_rounds` and `max_final_rounds` remain positive integers.
+- Missing convergence block resolves to `{ enabled: false, allow_same_model: false }`.
+- When convergence is disabled, absent max-round values preserve today's resolved defaults and behavior.
+- When convergence is enabled and either max-round value is absent, the absent value resolves to `2` for that gate.
+### Coordinator algorithm
+
+Pseudo-code:
+```typescript
+if (!policy.convergence.enabled) {
+  return runSinglePassReviewAsToday(params);
+}
+
+const gate = phase;
+const maxRounds = phase === 'initial'
+  ? policy.max_initial_rounds
+  : policy.max_final_rounds;
+
+const proposerProfile = routingPolicy.resolve({ task: 'implementation.run', role: 'proposer' });
+const criticProfile = resolveCriticProfile(phase, { role: 'critic' });
+assertDistinctProfiles(proposerProfile, criticProfile, policy);
+
+let currentResult = implementation_result;
+let previousBlockingSignatures: Set[] = [];
+
+for (let round = 1; round <= maxRounds; round++) {
+  // Rebuild critic context inside the loop so each round sees the latest
+  // workspace diff and proposer changes, not a stale pre-loop snapshot.
+  const reviewResult = await runCritic({ gate, round, currentResult, criticProfile });
+
+  if (reviewResult.status === 'failed') {
+    return handleReviewFailure(...);
+  }
+
+  const blockingFindings = blockerOrWarningFindings(reviewResult.findings ?? []);
+  if (reviewResult.status === 'no_findings' || blockingFindings.length === 0) {
+    appendGateExchange({
+      gate,
+      round,
+      findings: reviewResult.findings ?? [],
+      responses: [],
+      converged: true,
+    });
+    return currentResult;
+  }
+
+  if (round === maxRounds || isOscillating(previousBlockingSignatures, blockingFindings)) {
+    appendGateExchange({
+      gate,
+      round,
+      findings: reviewResult.findings,
+      responses: [],
+      converged: false,
+      non_convergence_reason,
+    });
+    return { status: 'failed', error: `Implementation review ${gate} did not converge` };
+  }
+
+  const proposerResult = await runProposerResponse({ gate, round, findings: reviewResult.findings });
+  if (proposerResult.status !== 'complete') return proposerResult;
+
+  await branchGuard.check(working_directory, run.branch);
+  validateResponses(reviewResult.findings, proposerResult.review_responses ?? []);
+
+  appendGateExchange({
+    gate,
+    round,
+    findings: reviewResult.findings,
+    responses: proposerResult.review_responses ?? [],
+    converged: false,
+  });
+  currentResult = proposerResult;
+  previousBlockingSignatures.push(signatureSet(blockingFindings));
+}
+```
+Implementation may factor the existing single-pass body into helpers instead of literally keeping a separate method. The disabled path must remain behavior-identical and should be protected by tests.
+### Prompt changes
+
+Critic prompts should state:
+- The gate (`initial` or `final`).
+- The convergence round number.
+- The critic reviews the current workspace revision, not only the previous implementer summary.
+- `no_findings` should be returned when no blocker or warning findings remain; optional notes may be returned as `info`, but they will not block convergence.
+- Repeated findings should keep stable IDs when possible.
+Proposer response prompts should state:
+- The gate and round being addressed.
+- The proposer must either fix, decline with a concrete reason, request input, or fail.
+- The proposer must include `review_responses` for every finding ID.
+- Declining a blocker does not guarantee progress; the critic will re-review the current revision.
+### Telemetry
+
+Add structured logs:
+- `implementation.review.convergence_started` — run ID, gate, max rounds, proposer profile, critic profile.
+- `implementation.review.round_started` — run ID, gate, round, critic profile.
+- `implementation.review.round_completed` — run ID, gate, round, blocker/warning/info counts, elapsed ms.
+- `implementation.review.proposer_started` — run ID, gate, round, proposer profile, finding count.
+- `implementation.review.proposer_completed` — run ID, gate, round, disposition counts, elapsed ms.
+- `implementation.review.converged` — run ID, gate, rounds used.
+- `implementation.review.non_converged` — run ID, gate, reason, rounds used, open finding count.
+- `implementation.review.same_model_rejected` — run ID, gate, profile ID.
+- `implementation.review.oscillation_detected` — run ID, gate, round, signature count.
+Follow `context-agent/standards/logging.md`: logs go through pino, redact secrets, and include enough IDs for agents to diagnose failures.
+### Testing plan
+
+Coordinator tests:
+- Convergence disabled runs the legacy one-pass path: one critic call, one proposer response when findings exist, no re-review, and `review_exchanges` shape unchanged.
+- A critic returning blocker or warning `findings` in round 1 and `no_findings` in round 2 converges and returns the proposer result.
+- A critic returning `no_findings` in round 1 records a converged gate and does not call the proposer.
+- A critic returning only `info` findings records the notes, converges, and does not call the proposer.
+- A critic returning blockers through `max_initial_rounds` returns `ImplementationResult.status: "failed"` with open findings recorded.
+- `max_final_rounds` is enforced independently from `max_initial_rounds`.
+- With convergence enabled, `max_rounds: 1` is a strict single critic gate: blocker or warning findings fail as non-converged immediately, and no proposer response is run.
+- The only today-equivalent one-pass-plus-response behavior is convergence disabled.
+- The round 2 critic context is re-derived from the workspace after the round 1 proposer response, so round 2 sees round 1 edits instead of a stale initial diff.
+- The proposer review-response agent call uses `{ task: 'implementation.run', role: 'proposer' }` or the profile resolved from that route, and the captured proposer session records the role-specific route/profile when configured.
+- A repeated non-shrinking blocker or warning signature triggers oscillation non-convergence before remaining budget is spent.
+- `status: "failed"` from the critic uses `on_review_failure: warn | block` as today.
+- `needs_input` from the proposer returns awaiting-input behavior.
+- Branch guard failure after a proposer response fails the result.
+- Missing review route still skips review or falls back final-to-initial as today when convergence is disabled.
+Routing and config tests:
+- `routing["implementation.review.initial:critic"]` resolves before `routing["implementation.review.initial"]` when `role: "critic"` is present.
+- Missing role-specific routing falls back to task-level routing.
+- `resolveOptional()` returns `null` only when neither role-specific nor task-level routing exists.
+- Existing task-only config produces the same profiles as before.
+- With convergence enabled and absent `max_initial_rounds`/`max_final_rounds`, both gate budgets resolve to `2`.
+- With convergence disabled and absent `max_initial_rounds`/`max_final_rounds`, the resolver preserves today's default max-round behavior instead of applying convergence defaults.
+- Same-profile proposer/critic routing fails when convergence is enabled and `allow_same_model` is false.
+- Same-profile proposer/critic routing is allowed only when `allow_same_model` is true.
+- Invalid convergence config values fail validation with clear errors.
+Persistence and journal tests:
+- `gate_exchanges` records gate, round, proposer profile, critic profile, findings, responses, convergence status, and non-convergence reason.
+- Existing runs without `gate_exchanges` load without migration.
+- Testing-guide rendering uses `gate_exchanges` when present and legacy `review_exchanges` otherwise.
+- Critic sessions write `role: "critic"`, `round`, and `gate` to `sessions.jsonl`.
+- Proposer response sessions write `role: "proposer"`, `round`, and `gate` to `sessions.jsonl`.
+- Critic findings write `feedback.jsonl` records with critic attribution, target `implementation`, severity, category, and disposition.
+- Info-only critic findings are persisted as non-blocking notes and do not mark a converged gate as non-converged.
+- When convergence is enabled, `gate_exchanges` are the only feedback-emission source; any legacy `review_exchanges` summaries are ignored by feedback capture.
+- Repeated persistence or handler retries do not duplicate AI finding feedback records.
+Handler tests:
+- Initial review convergence happens before creating or updating the testing guide.
+- Feedback-pass convergence happens before updating the existing testing guide.
+- Final review convergence happens before PR creation.
+- Non-convergence in initial or feedback review fails the run and does not publish a ready-for-testing message.
+- Non-convergence in final review fails the run and does not create a PR.
+- Progress message failures are logged and do not change review outcome.
+### Acceptance criteria
+
+- [ ] Coordinator re-reviews the implementer's current revision and loops until the critic returns no blocker or warning findings, `max_rounds` is reached, or oscillation is detected.
+- [ ] `status: "no_findings"` and info-only finding results both count as converged; blocker or warning findings do not.
+- [ ] `max_initial_rounds` and `max_final_rounds` are enforced at runtime when convergence is enabled.
+- [ ] When convergence is enabled and max-round values are absent, both `max_initial_rounds` and `max_final_rounds` resolve to `2`; when convergence is disabled, absent max-round values preserve today's default behavior.
+- [ ] Reaching max rounds or oscillation without convergence fails the run with open blocker or warning findings and last model positions recorded.
+- [ ] Convergence is config-gated off by default; with it off, implementation review behavior is identical to today's single-pass behavior.
+- [ ] `AgentRoute.role` exists and `routing["task:role"]` resolves with task-level fallback.
+- [ ] Proposer review-response runs pass `{ task: "implementation.run", role: "proposer" }` or its resolved profile into the actual implementation agent call, so configured `implementation.run:proposer` routes are used for proposer sessions.
+- [ ] Existing task-only routing config remains behavior-identical.
+- [ ] Proposer and critic same-profile routing is rejected with a clear error unless an explicit override allows it.
+- [ ] `gate_exchanges` persists gate, round, proposer profile, critic profile, findings, responses, convergence status, and non-convergence reason.
+- [ ] Existing `review_exchanges` data remains backward-compatible and readable.
+- [ ] Testing guides show round-by-round convergence history when `gate_exchanges` exists.
+- [ ] Sessions journal records carry `role`, `round`, and `gate` for critic and proposer convergence sessions.
+- [ ] Critic findings are emitted to `feedback.jsonl` with model profile attribution and target `implementation`.
+- [ ] Per-round structured logs include round index, finding counts by severity, converged/non-converged outcome, profile IDs, and elapsed time.
+- [ ] No new run stages are added.
+- [ ] No multi-critic, altitude, staged-implementer, or PR-flow changes are included.
+## Task list
+
+### Story 1 — Add convergence policy and role-aware routing
+
+- [ ] **Task: Add ****`implementation_review.convergence`**** config support**
+	- **Description**: Extend workflow config types and validators with `implementation_review.convergence.enabled` and `implementation_review.convergence.allow_same_model`.
+	- **Acceptance criteria**:
+		- [ ] Missing convergence config resolves to disabled and `allow_same_model: false`.
+		- [ ] Boolean values are accepted.
+		- [ ] Non-object convergence config fails validation.
+		- [ ] Non-boolean fields fail validation with clear messages.
+		- [ ] With convergence disabled, existing `max_initial_rounds`, `max_final_rounds`, `on_review_failure`, and `retest_on_behavior_change` behavior is preserved.
+		- [ ] With convergence enabled and absent max-round values, `max_initial_rounds` and `max_final_rounds` both resolve to `2`.
+	- **Dependencies**: None.
+- [ ] **Task: Add ****`AgentRoute.role`**** and role-keyed route lookup**
+	- **Description**: Add optional `role` to `AgentRoute` and update `DefaultAgentRoutingPolicy` to resolve `${task}:${role}` before `task`.
+	- **Acceptance criteria**:
+		- [ ] Role-keyed entries take precedence when present.
+		- [ ] Task-level fallback preserves existing configs.
+		- [ ] `resolve()` throws only after both lookups fail.
+		- [ ] `resolveOptional()` returns `null` only after both lookups fail.
+	- **Dependencies**: Convergence config types may be done in parallel.
+### Story 2 — Persist and render gate exchange history
+
+- [ ] **Task: Add gate exchange types to run state**
+	- **Description**: Define `GateReviewExchange` and add optional `gate_exchanges` to `Run` without migrating existing records.
+	- **Acceptance criteria**:
+		- [ ] Type captures gate, round, proposer profile, critic profile, findings, responses, convergence state, and non-convergence reason.
+		- [ ] Existing run fixtures compile with no `gate_exchanges` field.
+		- [ ] Run-store load/save preserves the optional field.
+	- **Dependencies**: Role route types.
+- [ ] **Task: Render convergence history in the testing guide**
+	- **Description**: Update implementation feedback page rendering to show round-by-round gate history when `gate_exchanges` exists, with legacy `review_exchanges` fallback.
+	- **Acceptance criteria**:
+		- [ ] Converged gates show rounds used and final no-blocker/no-warning state.
+		- [ ] Info-only findings may be shown as non-blocking notes on converged gates.
+		- [ ] Non-converged gates show reason and open blocker or warning findings.
+		- [ ] Raw prompts, secrets, and chain-of-thought are not rendered.
+		- [ ] Existing AI review rendering still works for legacy runs.
+	- **Dependencies**: Gate exchange types.
+### Story 3 — Implement the bounded convergence loop
+
+- [ ] **Task: Factor the existing single-pass review path**
+	- **Description**: Refactor `ImplementationReviewCoordinator` so the current behavior remains callable and testable when convergence is disabled.
+	- **Acceptance criteria**:
+		- [ ] Disabled convergence produces one critic pass and at most one proposer response.
+		- [ ] Existing review failure policy behavior is unchanged.
+		- [ ] Existing review exchange append behavior is unchanged for disabled mode.
+	- **Dependencies**: Config policy.
+- [ ] **Task: Add the enabled convergence loop**
+	- **Description**: Implement critic-review and proposer-response looping for initial and final gates, using current workspace state each round.
+	- **Acceptance criteria**:
+		- [ ] Critic re-runs after proposer completes a response when blocker or warning findings remain.
+		- [ ] Critic context is re-derived from the workspace inside each round, so later rounds include the previous proposer response's edits and do not reuse stale git-diff context.
+		- [ ] Proposer response calls pass the role-aware proposer route or resolved proposer profile into the actual implementation agent invocation.
+		- [ ] A critic result with no blocker or warning findings converges and returns the latest complete proposer result.
+		- [ ] Info-only findings converge, are recorded as notes, and do not call the proposer.
+		- [ ] Max-round exhaustion returns failed result with open blocker or warning findings recorded.
+		- [ ] Branch guard runs after each complete proposer response.
+		- [ ] `needs_input` and proposer failure preserve normal implementation handling.
+	- **Dependencies**: Single-pass factorization; gate exchange types.
+- [ ] **Task: Enforce proposer/critic distinction**
+	- **Description**: Resolve proposer and critic profiles by role and reject same-profile configuration unless `allow_same_model` is true.
+	- **Acceptance criteria**:
+		- [ ] Same profile ID fails before a convergence gate starts.
+		- [ ] Error message names the gate and profile ID.
+		- [ ] `allow_same_model: true` permits the run and logs that adversarial separation is disabled.
+	- **Dependencies**: Role-aware routing; convergence loop.
+- [ ] **Task: Add oscillation detection**
+	- **Description**: Track blocker/warning finding signatures across rounds and fail on repeated non-shrinking or increasing churn.
+	- **Acceptance criteria**:
+		- [ ] Repeated blocker/warning signature set triggers non-convergence.
+		- [ ] Two consecutive increases in blocker/warning count trigger non-convergence.
+		- [ ] `info` findings alone do not trigger blocking oscillation.
+		- [ ] Failure records `non_convergence_reason: "oscillation"`.
+	- **Dependencies**: Convergence loop.
+### Story 4 — Wire journals, telemetry, and progress
+
+- [ ] **Task: Add role, round, and gate to session capture**
+	- **Description**: Thread convergence metadata through critic and proposer session capture to `RunJournal.captureSession()`.
+	- **Acceptance criteria**:
+		- [ ] Critic sessions write `role: "critic"`.
+		- [ ] Proposer review-response sessions write `role: "proposer"`.
+		- [ ] Both session types write correct `round` and `gate`.
+		- [ ] Non-convergence session capture remains backward-compatible for existing call sites.
+	- **Dependencies**: Convergence loop.
+- [ ] **Task: Emit AI review feedback records from gate exchanges**
+	- **Description**: Capture critic findings into `feedback.jsonl` with critic attribution and lifecycle disposition.
+	- **Acceptance criteria**:
+		- [ ] Finding records use reviewer/critic profile as author principal.
+		- [ ] Target is `implementation`.
+		- [ ] Category, severity, and redacted text come from the finding.
+		- [ ] Dispositions use only the existing journal enum: fixed/addressed responses map to `addressed`, declined responses map to `wont_fix`, unresolved non-converged blocker/warning findings map to `open`, and converged info-only notes map to `addressed`.
+		- [ ] In convergence-enabled runs, `gate_exchanges` are the single feedback-emission source and any legacy `review_exchanges` summary is excluded from feedback capture.
+		- [ ] Duplicate capture is prevented by stable gate-exchange/finding IDs.
+	- **Dependencies**: Gate exchange append path; journal session metadata.
+- [ ] **Task: Add convergence logs and progress messages**
+	- **Description**: Add per-round structured logs and best-effort human progress updates.
+	- **Acceptance criteria**:
+		- [ ] Logs include gate, round, profile IDs, finding counts, elapsed time, and outcome.
+		- [ ] Non-convergence logs include reason and open finding count.
+		- [ ] Progress messages identify gate and round.
+		- [ ] Progress failures log `progress_failed` and do not affect review outcome.
+	- **Dependencies**: Convergence loop.
+### Story 5 — Verify handler integration and compatibility
+
+- [ ] **Task: Update implementation handlers**
+	- **Description**: Ensure start, feedback, and approval handlers pass capture callbacks and treat coordinator non-convergence failures as run failures.
+	- **Acceptance criteria**:
+		- [ ] Initial review convergence completes before testing-guide creation/update.
+		- [ ] Feedback-pass convergence completes before testing-guide update.
+		- [ ] Final review convergence completes before PR creation.
+		- [ ] Non-convergence prevents ready-for-testing or PR-open messages.
+	- **Dependencies**: Journal/progress wiring.
+- [ ] **Task: Add compatibility and regression tests**
+	- **Description**: Add tests proving disabled convergence and task-only routing preserve current behavior.
+	- **Acceptance criteria**:
+		- [ ] Existing coordinator tests still pass.
+		- [ ] Existing handler tests still pass or are updated only for intentional new assertions.
+		- [ ] No new `RunStage` values are introduced.
+		- [ ] Task-only `autocatalyst.yaml` routing resolves as before.
+	- **Dependencies**: Handler updates.

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -9,7 +9,7 @@ import type {
   ImplementationReviewStatus,
   PublishedImplementationReview,
 } from '../../types/impl-feedback-page.js';
-import type { ImplementationReviewExchange } from '../../types/ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange } from '../../types/ai.js';
 export type {
   FeedbackItem,
   ImplementationReviewInput,
@@ -65,6 +65,60 @@ function buildAiReviewBlocks(exchanges: ImplementationReviewExchange[]): unknown
     }
   }
   return blocks;
+}
+
+function gateTitle(gate: string): string {
+  return gate === 'initial' ? 'Initial review' : gate === 'final' ? 'Final review' : `${gate} review`;
+}
+
+function renderGateReviewMarkdown(exchanges: GateReviewExchange[]): string {
+  const lines: string[] = [];
+  const gates = [...new Set(exchanges.map(exchange => exchange.gate))];
+  for (const gate of gates) {
+    const gateExchanges = exchanges.filter(exchange => exchange.gate === gate).sort((a, b) => a.round - b.round);
+    const latest = gateExchanges[gateExchanges.length - 1];
+    const converged = latest?.converged === true;
+    lines.push(`### ${gateTitle(gate)}`);
+    lines.push('');
+    lines.push(converged ? 'Convergence: converged' : `Convergence: failed (\`${latest?.non_convergence_reason ?? 'max_rounds'}\`)`);
+    lines.push(`Rounds: ${gateExchanges.length}`);
+    lines.push(`Proposer model: \`${latest?.proposer_profile.profile ?? 'unknown'}\``);
+    lines.push(`Critic model: \`${latest?.critic_profile.profile ?? 'unknown'}\``);
+    lines.push('');
+
+    if (!converged) {
+      lines.push('#### Open findings');
+      lines.push('');
+      const blockingFindings = latest.findings.filter(finding => finding.severity === 'blocker' || finding.severity === 'warning');
+      for (const finding of blockingFindings) {
+        const response = latest.responses.find(item => item.id === finding.id);
+        lines.push(`- [ ] [${finding.id}] ${finding.finding}`);
+        if (response) lines.push(`  Last proposer response: ${response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input'} — ${response.response}`);
+      }
+      lines.push('');
+      continue;
+    }
+
+    for (const exchange of gateExchanges) {
+      const blockingFindings = exchange.findings.filter(finding => finding.severity === 'blocker' || finding.severity === 'warning');
+      const infoFindings = exchange.findings.filter(finding => finding.severity === 'info');
+      lines.push(`#### Round ${exchange.round} — ${exchange.converged ? 'converged' : 'findings'}`);
+      lines.push('');
+      if (blockingFindings.length === 0 && infoFindings.length === 0) {
+        lines.push('- No blocker or warning findings.');
+      }
+      for (const finding of blockingFindings) {
+        const response = exchange.responses.find(item => item.id === finding.id);
+        lines.push(`- [x] [${finding.id}] ${finding.finding}`);
+        if (response) lines.push(`  ${response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input'} — ${response.response}`);
+      }
+      for (const finding of infoFindings) {
+        lines.push(`- Note [${finding.id}] ${finding.finding}`);
+      }
+      lines.push('');
+    }
+  }
+  return lines.join('\n');
 }
 
 interface NotionImplementationFeedbackPageOptions {
@@ -194,7 +248,18 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
           type: 'heading_2',
           heading_2: { rich_text: [{ text: { content: 'Human review' } }] },
         } as never,
-        ...(input.review_exchanges?.length
+        ...(input.gate_exchanges?.length
+          ? [
+              {
+                type: 'heading_2',
+                heading_2: { rich_text: [{ text: { content: 'AI review' } }] },
+              } as never,
+              {
+                type: 'paragraph',
+                paragraph: { rich_text: [{ text: { content: renderGateReviewMarkdown(input.gate_exchanges) } }] },
+              } as never,
+            ]
+          : input.review_exchanges?.length
           ? [
               {
                 type: 'heading_2',
@@ -286,6 +351,7 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
         resolution_comment: string;
       }>;
       review_exchanges?: ImplementationReviewExchange[];
+      gate_exchanges?: GateReviewExchange[];
     },
   ): Promise<void> {
     let markdown = await this.client.pages.getMarkdown(page_id);
@@ -406,7 +472,19 @@ export class NotionImplementationFeedbackPage implements ImplementationReviewPub
     }
 
     // --- Replace or append AI review section ---
-    if (options.review_exchanges !== undefined) {
+    if (options.gate_exchanges !== undefined) {
+      const aiReviewContent = renderGateReviewMarkdown(options.gate_exchanges);
+      const aiReviewHeading = '\n## AI review\n';
+      const aiReviewPattern = /\n## AI review\n[\s\S]*$/;
+      if (aiReviewPattern.test(markdown)) {
+        markdown = markdown.replace(aiReviewPattern, `${aiReviewHeading}\n${aiReviewContent}`);
+      } else {
+        if (!markdown.includes('\n## Human review\n') && !markdown.includes('\n## Feedback\n')) {
+          this.logger.warn({ event: 'implementation.missing_human_review', page_id }, 'Page missing Human review section; appending AI review at end');
+        }
+        markdown = markdown.trimEnd() + `\n\n## AI review\n\n${aiReviewContent}`;
+      }
+    } else if (options.review_exchanges !== undefined) {
       const aiReviewContent = renderAiReviewMarkdown(options.review_exchanges);
       const aiReviewHeading = '\n## AI review\n';
       const aiReviewPattern = /\n## AI review\n[\s\S]*$/;

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -90,10 +90,17 @@ function renderGateReviewMarkdown(exchanges: GateReviewExchange[]): string {
       lines.push('#### Open findings');
       lines.push('');
       const blockingFindings = latest.findings.filter(finding => finding.severity === 'blocker' || finding.severity === 'warning');
+      // Build a map of the last known proposer response per finding ID from prior addressed rounds
+      const lastResponseById = new Map<string, (typeof latest.responses)[number]>();
+      for (const ex of gateExchanges) {
+        for (const r of ex.responses) {
+          lastResponseById.set(r.id, r);
+        }
+      }
       for (const finding of blockingFindings) {
-        const response = latest.responses.find(item => item.id === finding.id);
-        lines.push(`- [ ] [${finding.id}] ${finding.finding}`);
-        if (response) lines.push(`  Last proposer response: ${response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input'} — ${response.response}`);
+        const response = lastResponseById.get(finding.id);
+        lines.push(`- [ ] [${finding.id}] ${redactSecrets(finding.finding)}`);
+        if (response) lines.push(`  Last proposer response: ${response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input'} — ${redactSecrets(response.response)}`);
       }
       lines.push('');
       continue;
@@ -109,11 +116,11 @@ function renderGateReviewMarkdown(exchanges: GateReviewExchange[]): string {
       }
       for (const finding of blockingFindings) {
         const response = exchange.responses.find(item => item.id === finding.id);
-        lines.push(`- [x] [${finding.id}] ${finding.finding}`);
-        if (response) lines.push(`  ${response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input'} — ${response.response}`);
+        lines.push(`- [x] [${finding.id}] ${redactSecrets(finding.finding)}`);
+        if (response) lines.push(`  ${response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input'} — ${redactSecrets(response.response)}`);
       }
       for (const finding of infoFindings) {
-        lines.push(`- Note [${finding.id}] ${finding.finding}`);
+        lines.push(`- Note [${finding.id}] ${redactSecrets(finding.finding)}`);
       }
       lines.push('');
     }

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -69,6 +69,9 @@ function emitSessionRecord(
     tool_results: drainSummary?.tool_result_count ?? null,
     outcome,
     runner,
+    ...(telemetry.role !== undefined ? { role: telemetry.role } : {}),
+    ...(telemetry.round !== undefined ? { round: telemetry.round } : {}),
+    ...(telemetry.gate !== undefined ? { gate: telemetry.gate } : {}),
   });
 }
 
@@ -447,7 +450,7 @@ export class AgentRunnerImplementationAgent implements ImplementationAgent {
   ): Promise<ImplementationResult> {
     const resultFilePath = join(working_directory, '.autocatalyst', 'impl-result.json');
     const prompt = buildImplementationPrompt(artifact_path, resultFilePath, additional_context, plan_path);
-    const route = { task: 'implementation.run' as const };
+    const route = telemetry?.route ?? { task: 'implementation.run' as const };
 
     this.logger.debug(
       { event: 'impl.agent_invoked', working_directory, has_additional_context: Boolean(additional_context), ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}), ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}) },
@@ -1627,6 +1630,7 @@ export function buildInitialReviewPrompt(
   impl_result: ImplementationResult,
   diff_context: string,
   changed_files: string[],
+  convergenceContext?: { gate: string; round: number },
 ): string {
   const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
   const summaryLines = [
@@ -1640,7 +1644,18 @@ export function buildInitialReviewPrompt(
     impl_result.testing_instructions ? `Testing instructions: ${impl_result.testing_instructions}` : '',
   ].filter(Boolean);
 
+  const convergenceLines = convergenceContext
+    ? [
+        `Convergence gate: ${convergenceContext.gate}`,
+        `Convergence round: ${convergenceContext.round}`,
+        `Review the current workspace revision for this round, not only the previous implementer summary.`,
+        `Return status: "no_findings" when no blocker or warning findings remain. Optional info findings do not block convergence.`,
+        ``,
+      ]
+    : [];
+
   return [
+    ...convergenceLines,
     `You are an adversarial code reviewer. Your job is to inspect the implementation and find issues.`,
     `Do NOT edit any files. Read only.`,
     ``,
@@ -1698,6 +1713,7 @@ export function buildFinalReviewPrompt(
   impl_result: ImplementationResult,
   diff_context: string,
   changed_files: string[],
+  convergenceContext?: { gate: string; round: number },
 ): string {
   const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
   const summaryLines = [
@@ -1707,7 +1723,18 @@ export function buildFinalReviewPrompt(
       : '',
   ].filter(Boolean);
 
+  const convergenceLines = convergenceContext
+    ? [
+        `Convergence gate: ${convergenceContext.gate}`,
+        `Convergence round: ${convergenceContext.round}`,
+        `Review the current workspace revision for this round, not only the previous implementer summary.`,
+        `Return status: "no_findings" when no blocker or warning findings remain. Optional info findings do not block convergence.`,
+        ``,
+      ]
+    : [];
+
   return [
+    ...convergenceLines,
     `You are an adversarial code reviewer performing a final pre-PR security and readiness check.`,
     `Do NOT edit any files. Read only.`,
     ``,
@@ -1763,8 +1790,21 @@ export function buildImplementerResponsePrompt(
   working_directory: string,
   impl_result: ImplementationResult,
   findings: ImplementationReviewFinding[],
+  convergenceContext?: { gate: string; round: number },
 ): string {
   const resultFilePath = join(working_directory, '.autocatalyst', 'impl-result.json');
+
+  const convergenceLines = convergenceContext
+    ? [
+        `Convergence gate: ${convergenceContext.gate}`,
+        `Convergence round: ${convergenceContext.round}`,
+        `Review the current workspace revision for this round, not only the previous implementer summary.`,
+        `Return status: "no_findings" when no blocker or warning findings remain. Optional info findings do not block convergence.`,
+        `The critic will re-review the current revision after your response.`,
+        `Declining a blocker or warning does not guarantee convergence.`,
+        ``,
+      ]
+    : [];
 
   const findingBlocks = findings.map(f => [
     `[REVIEW_ID: ${f.id}]`,
@@ -1775,6 +1815,7 @@ export function buildImplementerResponsePrompt(
   ].join('\n'));
 
   return [
+    ...convergenceLines,
     `Review findings require your response.`,
     ``,
     BRANCH_OWNERSHIP_POLICY,

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -373,6 +373,8 @@ export class ImplementationReviewCoordinator {
     );
 
     let currentResult: ImplementationResult = implementation_result;
+    const previousSignatures: Set<string>[] = [];
+    const previousBlockingCounts: number[] = [];
 
     for (let round = 1; round <= maxRounds; round++) {
       const roundStart = performance.now();
@@ -499,6 +501,35 @@ export class ImplementationReviewCoordinator {
         return currentResult;
       }
 
+      // Oscillation check (only after at least one proposer response)
+      if (previousSignatures.length > 0 && this.isOscillating(previousSignatures, previousBlockingCounts, reviewResult.findings)) {
+        this.appendGateExchange(run, {
+          id: randomUUID(),
+          gate: phase,
+          round,
+          created_at: new Date().toISOString(),
+          proposer_profile: proposerSummary,
+          critic_profile: criticSummary,
+          review_status: 'non_converged',
+          review_summary: reviewResult.summary,
+          findings: reviewResult.findings,
+          responses: [],
+          converged: false,
+          non_convergence_reason: 'oscillation',
+          requires_human_retest: reviewResult.requires_human_retest ?? false,
+        }, captureFeedback);
+
+        this.deps.logger.warn(
+          { event: 'implementation.review.oscillation_detected', run_id: run.id, gate: phase, round, signature_count: this.signatureSet(reviewResult.findings).size },
+          'Implementation review did not converge: oscillation detected',
+        );
+
+        const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
+        await this.sendProgress(onProgress, run, phase, round, `${phaseLabel} did not converge: oscillation detected after ${round} round${round === 1 ? '' : 's'}`);
+
+        return { status: 'failed', error: `Implementation review ${phase} did not converge because oscillation was detected` };
+      }
+
       // Max rounds check
       if (round === maxRounds) {
         this.appendGateExchange(run, {
@@ -589,6 +620,10 @@ export class ImplementationReviewCoordinator {
       }, captureFeedback);
 
       currentResult = proposerResult;
+
+      // Track signatures after proposer response for oscillation detection in next round
+      previousSignatures.push(this.signatureSet(blockingFindings));
+      previousBlockingCounts.push(blockingFindings.length);
 
       const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
       await this.sendProgress(
@@ -717,6 +752,48 @@ export class ImplementationReviewCoordinator {
 
   private blockingFindings(findings: ImplementationReviewFinding[]): ImplementationReviewFinding[] {
     return findings.filter(f => f.severity === 'blocker' || f.severity === 'warning');
+  }
+
+  private findingSignature(finding: ImplementationReviewFinding): string {
+    const normalized = finding.finding
+      .toLowerCase()
+      .replace(/\b(?:[a-f0-9]{7,40}|[A-Z]+-\d+)\b/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return `${finding.severity}|${finding.category}|${normalized}`;
+  }
+
+  private signatureSet(findings: ImplementationReviewFinding[]): Set<string> {
+    const blocking = this.blockingFindings(findings);
+    return new Set(blocking.map(f => this.findingSignature(f)));
+  }
+
+  private isOscillating(
+    previousSignatures: Set<string>[],
+    previousCounts: number[],
+    currentFindings: ImplementationReviewFinding[],
+  ): boolean {
+    const currentBlocking = this.blockingFindings(currentFindings);
+    const currentCount = currentBlocking.length;
+    const currentSigs = this.signatureSet(currentFindings);
+
+    // Check if same signature set appeared before with no shrink
+    for (const prev of previousSignatures) {
+      if (prev.size === currentSigs.size && [...prev].every(sig => currentSigs.has(sig))) {
+        return true; // repeated non-shrinking signature set
+      }
+    }
+
+    // Check two consecutive count increases
+    if (previousCounts.length >= 2) {
+      const last = previousCounts[previousCounts.length - 1]!;
+      const secondLast = previousCounts[previousCounts.length - 2]!;
+      if (currentCount > last && last > secondLast) {
+        return true; // two consecutive increases
+      }
+    }
+
+    return false;
   }
 
   private appendGateExchange(

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -443,9 +443,9 @@ export class ImplementationReviewCoordinator {
 
         const reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
         reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
-        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'ok', drainSummary);
+        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'ok', drainSummary, { role: 'critic', round, gate: phase });
       } catch (err) {
-        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'failed', drainSummary);
+        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'failed', drainSummary, { role: 'critic', round, gate: phase });
         this.deps.logger.error(
           { event: 'implementation.review.round_failed', phase, gate: phase, round, run_id: run.id, error: String(err) },
           'Convergence review round failed',
@@ -681,6 +681,7 @@ export class ImplementationReviewCoordinator {
     ts_start: string,
     outcome: 'ok' | 'failed',
     drainSummary: AgentDrainSummary | undefined,
+    convergenceMeta?: { role: 'critic' | 'proposer'; round: number; gate: 'initial' | 'final' | string },
   ): void {
     if (!captureSession) return;
     const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
@@ -697,6 +698,7 @@ export class ImplementationReviewCoordinator {
       tool_results: drainSummary?.tool_result_count ?? null,
       outcome,
       runner,
+      ...(convergenceMeta ?? {}),
     });
   }
 

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -356,6 +356,10 @@ export class ImplementationReviewCoordinator {
     const criticSummary = agentProfileSummary(criticProfile);
     const proposerSummary = proposerProfile ? agentProfileSummary(proposerProfile) : { profile: 'implementation.run', provider: 'unknown' };
 
+    // Same-model enforcement
+    const sameModelResult = this.assertDistinctProfiles(phase, proposerProfile, criticProfile);
+    if (sameModelResult) return sameModelResult;
+
     const maxRounds = phase === 'initial' ? this.deps.policy.max_initial_rounds : this.deps.policy.max_final_rounds;
     const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
 
@@ -598,6 +602,41 @@ export class ImplementationReviewCoordinator {
 
     // Should not reach here
     return { status: 'failed', error: `Implementation review ${phase} did not converge` };
+  }
+
+  private assertDistinctProfiles(
+    phase: 'initial' | 'final',
+    proposerProfile: AgentProfile | null,
+    criticProfile: AgentProfile,
+  ): ImplementationResult | null {
+    if (!proposerProfile) return null; // no proposer configured, cannot compare
+
+    if (proposerProfile.id === criticProfile.id) {
+      if (!this.deps.policy.convergence.allow_same_model) {
+        this.deps.logger.warn(
+          { event: 'implementation.review.same_model_rejected', gate: phase, profile_id: proposerProfile.id },
+          'Same-profile proposer and critic rejected',
+        );
+        return {
+          status: 'failed',
+          error: `Implementation review convergence requires distinct proposer and critic profiles for ${phase} review. Both resolved to ${proposerProfile.id}. Configure implementation.run:proposer and implementation.review.${phase}:critic differently, or set implementation_review.convergence.allow_same_model: true.`,
+        };
+      }
+      // allow_same_model: true — warn but continue
+      this.deps.logger.warn(
+        { event: 'implementation.review.same_model_allowed', gate: phase, profile_id: proposerProfile.id },
+        'Same-profile proposer and critic allowed by configuration',
+      );
+    } else {
+      // Different IDs — check for same provider/model alias and warn
+      if (proposerProfile.provider === criticProfile.provider && proposerProfile.model === criticProfile.model) {
+        this.deps.logger.warn(
+          { event: 'implementation.review.same_model_alias_warning', gate: phase, proposer_id: proposerProfile.id, critic_id: criticProfile.id },
+          'Proposer and critic have different profile IDs but same provider/model',
+        );
+      }
+    }
+    return null;
   }
 
   private emitSessionRecord(

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -35,6 +35,10 @@ export interface ImplementationReviewPolicy {
   max_final_rounds: number;
   on_review_failure: 'warn' | 'block';
   retest_on_behavior_change: boolean;
+  convergence: {
+    enabled: boolean;
+    allow_same_model: boolean;
+  };
 }
 
 export interface ImplementationReviewCoordinatorDeps {
@@ -74,6 +78,17 @@ export class ImplementationReviewCoordinator {
   }
 
   private async runReview(
+    phase: 'initial' | 'final',
+    routeTask: 'implementation.review.initial' | 'implementation.review.final',
+    params: ReviewRunParams,
+  ): Promise<ImplementationResult> {
+    if (!this.deps.policy.convergence.enabled) {
+      return this.runSinglePassReview(phase, routeTask, params);
+    }
+    return this.runConvergenceReview(phase, routeTask, params);
+  }
+
+  private async runSinglePassReview(
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
     { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback }: ReviewRunParams,
@@ -302,6 +317,15 @@ export class ImplementationReviewCoordinator {
     }, captureFeedback);
 
     return implementerResult;
+  }
+
+  private async runConvergenceReview(
+    phase: 'initial' | 'final',
+    routeTask: 'implementation.review.initial' | 'implementation.review.final',
+    params: ReviewRunParams,
+  ): Promise<ImplementationResult> {
+    this.deps.logger.warn({ event: 'implementation.review.convergence_unimplemented', phase, run_id: params.run.id }, 'Convergence path is not implemented yet');
+    return { status: 'failed', error: `Implementation review ${phase} convergence path is not implemented` };
   }
 
   private emitSessionRecord(

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -8,9 +8,12 @@ import type pino from 'pino';
 import type {
   AgentInvocationMetadata,
   AgentProfile,
+  AgentRoute,
   AgentRunner,
   AgentRoutingPolicy,
+  AgentServiceTelemetry,
   AgentSessionCaptureFn,
+  GateReviewExchange,
   ImplementationAgent,
   ImplementationResult,
   ImplementationReviewExchange,
@@ -59,7 +62,7 @@ export interface ReviewRunParams {
   onProgress?: (message: string) => Promise<void>;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
   captureSession?: AgentSessionCaptureFn;
-  captureFeedback?: (exchange: ImplementationReviewExchange, run: Run) => void;
+  captureFeedback?: (exchange: ImplementationReviewExchange | GateReviewExchange, run: Run) => void;
 }
 
 export class ImplementationReviewCoordinator {
@@ -322,10 +325,279 @@ export class ImplementationReviewCoordinator {
   private async runConvergenceReview(
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
-    params: ReviewRunParams,
+    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback }: ReviewRunParams,
   ): Promise<ImplementationResult> {
-    this.deps.logger.warn({ event: 'implementation.review.convergence_unimplemented', phase, run_id: params.run.id }, 'Convergence path is not implemented yet');
-    return { status: 'failed', error: `Implementation review ${phase} convergence path is not implemented` };
+    // Resolve critic profile — fall back to initial when final is absent
+    let criticProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask, role: 'critic' });
+    if (!criticProfile && phase === 'final') {
+      criticProfile = this.deps.routingPolicy.resolveOptional({ task: 'implementation.review.initial', role: 'critic' });
+    }
+    // Also fall back to non-role route
+    if (!criticProfile) {
+      criticProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask });
+    }
+    if (!criticProfile && phase === 'final') {
+      criticProfile = this.deps.routingPolicy.resolveOptional({ task: 'implementation.review.initial' });
+    }
+
+    if (!criticProfile) {
+      this.deps.logger.warn(
+        { event: 'implementation.review.skipped', phase, run_id: run.id },
+        'No review route configured — skipping review',
+      );
+      return implementation_result;
+    }
+
+    // Resolve proposer profile
+    const proposerProfileOptional = this.deps.routingPolicy.resolveOptional({ task: 'implementation.run', role: 'proposer' });
+    const proposerProfile = proposerProfileOptional ?? this.deps.routingPolicy.resolveOptional({ task: 'implementation.run' });
+    const proposerRoute: AgentRoute = { task: 'implementation.run', role: 'proposer' };
+
+    const criticSummary = agentProfileSummary(criticProfile);
+    const proposerSummary = proposerProfile ? agentProfileSummary(proposerProfile) : { profile: 'implementation.run', provider: 'unknown' };
+
+    const maxRounds = phase === 'initial' ? this.deps.policy.max_initial_rounds : this.deps.policy.max_final_rounds;
+    const reviewResultPath = join(working_directory, '.autocatalyst', 'impl-review-result.json');
+
+    try {
+      await mkdir(dirname(reviewResultPath), { recursive: true });
+    } catch { /* ignore */ }
+
+    this.deps.logger.info(
+      { event: 'implementation.review.convergence_started', phase, gate: phase, run_id: run.id, max_rounds: maxRounds, critic_profile: criticSummary.profile },
+      'Starting convergence review',
+    );
+
+    let currentResult: ImplementationResult = implementation_result;
+
+    for (let round = 1; round <= maxRounds; round++) {
+      const roundStart = performance.now();
+
+      this.deps.logger.info(
+        { event: 'implementation.review.round_started', phase, gate: phase, round, run_id: run.id, review_profile: criticProfile.id },
+        'Convergence review round started',
+      );
+
+      // Re-derive git diff and changed files fresh inside the loop
+      const diffContext = await this.getGitDiff(working_directory);
+      const changedFiles = await this.getChangedFiles(working_directory);
+
+      // Build critic prompt with convergence context
+      const convergenceContext = { gate: phase, round };
+      const prompt = phase === 'initial'
+        ? buildInitialReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext)
+        : buildFinalReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext);
+
+      // Run critic
+      let reviewResult: ReturnType<typeof parseImplementationReviewResult>;
+      let drainSummary: AgentDrainSummary | undefined;
+      const ts_start = new Date().toISOString();
+
+      try {
+        if (onAgentRequest) {
+          onAgentRequest({
+            model: criticProfile.model?.trim() || 'unknown',
+            requested_at: new Date().toISOString(),
+            route: { task: routeTask, role: 'critic' },
+          });
+        }
+
+        const progressWithHeartbeat: typeof onProgress =
+          onProgress && onAgentRequest
+            ? async (msg: string) => {
+                onAgentRequest({
+                  model: criticProfile!.model?.trim() || 'unknown',
+                  requested_at: new Date().toISOString(),
+                  route: { task: routeTask, role: 'critic' },
+                  is_heartbeat: true,
+                });
+                return onProgress(msg);
+              }
+            : onProgress;
+
+        drainSummary = await drainAgentRunner(
+          this.deps.runner.run({
+            route: { task: routeTask, role: 'critic' },
+            profile: criticProfile,
+            working_directory,
+            prompt,
+            telemetry: {
+              run_id: run.id,
+              request_id: run.request_id,
+              phase: `implementation_review_${phase}_critic`,
+              route_task: routeTask,
+              handler: 'ImplementationReviewCoordinator.convergence',
+            },
+          }),
+          progressWithHeartbeat,
+          this.deps.logger,
+          `implementation_review_${phase}_critic`,
+          { run_id: run.id, request_id: run.request_id },
+        );
+
+        const reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
+        reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
+        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'ok', drainSummary);
+      } catch (err) {
+        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'failed', drainSummary);
+        this.deps.logger.error(
+          { event: 'implementation.review.round_failed', phase, gate: phase, round, run_id: run.id, error: String(err) },
+          'Convergence review round failed',
+        );
+        return this.handleReviewFailure(phase, run, currentResult, proposerSummary, criticSummary, String(err), captureFeedback);
+      }
+
+      if (reviewResult.status === 'failed') {
+        this.deps.logger.error(
+          { event: 'implementation.review.round_failed', phase, gate: phase, round, run_id: run.id, reason: 'review_agent_status_failed', error: reviewResult.error },
+          'Convergence review round failed: review agent reported failure',
+        );
+        return this.handleReviewFailure(phase, run, currentResult, proposerSummary, criticSummary, reviewResult.error ?? 'Review model reported failure', captureFeedback);
+      }
+
+      const duration_ms = Math.round(performance.now() - roundStart);
+      const blockerCount = reviewResult.findings.filter(f => f.severity === 'blocker').length;
+      const warningCount = reviewResult.findings.filter(f => f.severity === 'warning').length;
+      const infoCount = reviewResult.findings.filter(f => f.severity === 'info').length;
+
+      this.deps.logger.info(
+        { event: 'implementation.review.round_completed', phase, gate: phase, round, run_id: run.id, review_profile: criticProfile.id, duration_ms, blocker_count: blockerCount, warning_count: warningCount, info_count: infoCount },
+        'Convergence review round completed',
+      );
+
+      const blockingFindings = this.blockingFindings(reviewResult.findings);
+
+      // Check for convergence
+      if (reviewResult.status === 'no_findings' || blockingFindings.length === 0) {
+        this.appendGateExchange(run, {
+          id: randomUUID(),
+          gate: phase,
+          round,
+          created_at: new Date().toISOString(),
+          proposer_profile: proposerSummary,
+          critic_profile: criticSummary,
+          review_status: 'converged',
+          review_summary: reviewResult.summary,
+          findings: reviewResult.findings,
+          responses: [],
+          converged: true,
+          requires_human_retest: reviewResult.requires_human_retest ?? false,
+        }, captureFeedback);
+
+        this.deps.logger.info(
+          { event: 'implementation.review.converged', phase, gate: phase, round, run_id: run.id },
+          'Implementation review converged',
+        );
+
+        const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
+        await this.sendProgress(onProgress, run, phase, round, `${phaseLabel} converged after ${round} round${round === 1 ? '' : 's'}`);
+
+        return currentResult;
+      }
+
+      // Max rounds check
+      if (round === maxRounds) {
+        this.appendGateExchange(run, {
+          id: randomUUID(),
+          gate: phase,
+          round,
+          created_at: new Date().toISOString(),
+          proposer_profile: proposerSummary,
+          critic_profile: criticSummary,
+          review_status: 'non_converged',
+          review_summary: reviewResult.summary,
+          findings: reviewResult.findings,
+          responses: [],
+          converged: false,
+          non_convergence_reason: 'max_rounds',
+          requires_human_retest: reviewResult.requires_human_retest ?? false,
+        }, captureFeedback);
+
+        this.deps.logger.warn(
+          { event: 'implementation.review.non_converged', phase, gate: phase, round, run_id: run.id, reason: 'max_rounds' },
+          'Implementation review did not converge: max_rounds reached',
+        );
+
+        const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
+        await this.sendProgress(onProgress, run, phase, round, `${phaseLabel} did not converge after ${maxRounds} round${maxRounds === 1 ? '' : 's'}`);
+
+        return { status: 'failed', error: `Implementation review ${phase} did not converge after ${maxRounds} rounds` };
+      }
+
+      // Run proposer response
+      const responsePrompt = buildImplementerResponsePrompt(artifact_path, working_directory, currentResult, blockingFindings, convergenceContext);
+      const proposerTelemetry: AgentServiceTelemetry = {
+        run_id: run.id,
+        request_id: run.request_id,
+        phase: `implementation_review_${phase}_proposer`,
+        route: proposerRoute,
+        role: 'proposer',
+        round,
+        gate: phase,
+        captureSession,
+        onAgentRequest,
+      };
+
+      let proposerResult: ImplementationResult;
+      try {
+        proposerResult = await this.deps.implementer.implement(
+          artifact_path,
+          working_directory,
+          responsePrompt,
+          onProgress ?? ((_msg: string) => Promise.resolve()),
+          proposerTelemetry,
+        );
+      } catch (err) {
+        return { status: 'failed', error: `Proposer response to review failed: ${String(err)}` };
+      }
+
+      if (proposerResult.status !== 'complete') {
+        return proposerResult;
+      }
+
+      // Branch guard after proposer response
+      if (this.deps.branchGuard) {
+        try {
+          await this.deps.branchGuard.check(working_directory, run.branch);
+        } catch (err) {
+          return { status: 'failed', error: `Branch guard failed after proposer response: ${String(err)}` };
+        }
+      }
+
+      // Validate responses
+      const responses = proposerResult.review_responses ?? [];
+      this.validateResponses(run, blockingFindings, responses);
+
+      // Append addressed gate exchange
+      this.appendGateExchange(run, {
+        id: randomUUID(),
+        gate: phase,
+        round,
+        created_at: new Date().toISOString(),
+        proposer_profile: proposerSummary,
+        critic_profile: criticSummary,
+        review_status: 'addressed',
+        review_summary: reviewResult.summary,
+        findings: reviewResult.findings,
+        responses,
+        converged: false,
+        requires_human_retest: proposerResult.requires_human_retest ?? false,
+      }, captureFeedback);
+
+      currentResult = proposerResult;
+
+      const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
+      await this.sendProgress(
+        onProgress,
+        run,
+        phase,
+        round,
+        `${phaseLabel} round ${round} returned ${blockingFindings.length} finding${blockingFindings.length === 1 ? '' : 's'} — asking proposer to revise`,
+      );
+    }
+
+    // Should not reach here
+    return { status: 'failed', error: `Implementation review ${phase} did not converge` };
   }
 
   private emitSessionRecord(
@@ -361,7 +633,7 @@ export class ImplementationReviewCoordinator {
     implSummary: ReturnType<typeof agentProfileSummary>,
     reviewSummary: ReturnType<typeof agentProfileSummary>,
     errorMsg: string,
-    captureFeedback?: (exchange: ImplementationReviewExchange, run: Run) => void,
+    captureFeedback?: (exchange: ImplementationReviewExchange | GateReviewExchange, run: Run) => void,
   ): ImplementationResult {
     this.deps.logger.warn(
       { event: 'implementation.review.failed', phase, run_id: run.id, error: errorMsg },
@@ -398,10 +670,42 @@ export class ImplementationReviewCoordinator {
     }
   }
 
-  private appendExchange(run: Run, exchange: ImplementationReviewExchange, captureFeedback?: (exchange: ImplementationReviewExchange, run: Run) => void): void {
+  private appendExchange(run: Run, exchange: ImplementationReviewExchange, captureFeedback?: (exchange: ImplementationReviewExchange | GateReviewExchange, run: Run) => void): void {
     if (!run.review_exchanges) run.review_exchanges = [];
     run.review_exchanges.push(exchange);
     captureFeedback?.(exchange, run);
+  }
+
+  private blockingFindings(findings: ImplementationReviewFinding[]): ImplementationReviewFinding[] {
+    return findings.filter(f => f.severity === 'blocker' || f.severity === 'warning');
+  }
+
+  private appendGateExchange(
+    run: Run,
+    exchange: GateReviewExchange,
+    captureFeedback?: (exchange: ImplementationReviewExchange | GateReviewExchange, run: Run) => void,
+  ): void {
+    if (!run.gate_exchanges) run.gate_exchanges = [];
+    run.gate_exchanges.push(exchange);
+    captureFeedback?.(exchange, run);
+  }
+
+  private async sendProgress(
+    onProgress: ((message: string) => Promise<void>) | undefined,
+    run: Run,
+    phase: 'initial' | 'final',
+    round: number,
+    message: string,
+  ): Promise<void> {
+    if (!onProgress) return;
+    try {
+      await onProgress(message);
+    } catch (err) {
+      this.deps.logger.warn(
+        { event: 'progress_failed', phase, gate: phase, round, run_id: run.id, error: String(err) },
+        'Progress message failed to send',
+      );
+    }
   }
 
   private async getGitDiff(working_directory: string): Promise<string> {

--- a/src/core/ai/routing-policy.ts
+++ b/src/core/ai/routing-policy.ts
@@ -10,9 +10,21 @@ export class DefaultAgentRoutingPolicy implements AgentRoutingPolicy {
     this.config = config;
   }
 
+  private profileNameFor(route: AgentRoute): string | undefined {
+    if (route.role) {
+      const roleKey = `${route.task}:${route.role}`;
+      const roleProfileName = this.config.routing[roleKey];
+      if (roleProfileName) return roleProfileName;
+    }
+    return this.config.routing[route.task];
+  }
+
   resolve(route: AgentRoute): AgentProfile {
-    const profileName = this.config.routing[route.task];
+    const profileName = this.profileNameFor(route);
     if (!profileName) {
+      if (route.role) {
+        throw new Error(`No routing entry for task '${route.task}' or role key '${route.task}:${route.role}'`);
+      }
       throw new Error(`No routing entry for task '${route.task}'`);
     }
     const profile = this.config.profiles.find(p => p.name === profileName)!;
@@ -22,7 +34,7 @@ export class DefaultAgentRoutingPolicy implements AgentRoutingPolicy {
   }
 
   resolveOptional(route: AgentRoute): AgentProfile | null {
-    const profileName = this.config.routing[route.task];
+    const profileName = this.profileNameFor(route);
     if (!profileName) return null;
     const profile = this.config.profiles.find(p => p.name === profileName);
     if (!profile) return null;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -183,6 +183,18 @@ export function validateConfig(config: WorkflowConfig): void {
         throw new Error('implementation_review.max_final_rounds must be a positive integer');
       }
     }
+    if (rr['convergence'] !== undefined) {
+      if (typeof rr['convergence'] !== 'object' || rr['convergence'] === null || Array.isArray(rr['convergence'])) {
+        throw new Error('implementation_review.convergence must be an object');
+      }
+      const convergence = rr['convergence'] as Record<string, unknown>;
+      if (convergence['enabled'] !== undefined && typeof convergence['enabled'] !== 'boolean') {
+        throw new Error('implementation_review.convergence.enabled must be a boolean');
+      }
+      if (convergence['allow_same_model'] !== undefined && typeof convergence['allow_same_model'] !== 'boolean') {
+        throw new Error('implementation_review.convergence.allow_same_model must be a boolean');
+      }
+    }
   }
 
   const rawJournal = (config as Record<string, unknown>)['journal'];
@@ -430,13 +442,21 @@ export function getImplementationReviewPolicy(config: WorkflowConfig): {
   max_final_rounds: number;
   on_review_failure: 'warn' | 'block';
   retest_on_behavior_change: boolean;
+  convergence: { enabled: boolean; allow_same_model: boolean };
 } {
   const raw = (config as Record<string, unknown>)['implementation_review'] as Record<string, unknown> | undefined;
+  const rawConvergence = raw?.['convergence'] as Record<string, unknown> | undefined;
+  const convergenceEnabled = rawConvergence?.['enabled'] === true;
+  const defaultMaxRounds = convergenceEnabled ? 2 : 1;
   return {
-    max_initial_rounds: typeof raw?.['max_initial_rounds'] === 'number' ? raw['max_initial_rounds'] as number : 1,
-    max_final_rounds: typeof raw?.['max_final_rounds'] === 'number' ? raw['max_final_rounds'] as number : 1,
+    max_initial_rounds: typeof raw?.['max_initial_rounds'] === 'number' ? raw['max_initial_rounds'] as number : defaultMaxRounds,
+    max_final_rounds: typeof raw?.['max_final_rounds'] === 'number' ? raw['max_final_rounds'] as number : defaultMaxRounds,
     on_review_failure: (raw?.['on_review_failure'] === 'block' ? 'block' : 'warn'),
     retest_on_behavior_change: raw?.['retest_on_behavior_change'] === false ? false : true,
+    convergence: {
+      enabled: convergenceEnabled,
+      allow_same_model: rawConvergence?.['allow_same_model'] === true,
+    },
   };
 }
 

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -88,7 +88,7 @@ export class ImplementationApprovalHandler {
     if (this.deps.reviewCoordinator) {
       const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
       const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
-        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: data.round ?? 1, role: data.role ?? null, gate: data.gate ?? null }).catch(() => {}); }
         : undefined;
       const currentResult: ImplementationResult = {
         status: 'complete',

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -176,6 +176,7 @@ export class ImplementationApprovalHandler {
             await this.deps.implFeedbackPage?.update?.(run.impl_feedback_ref, {
               summary: reviewedResult.summary,
               review_exchanges: run.review_exchanges,
+              gate_exchanges: run.gate_exchanges,
             });
           } catch (err) {
             this.deps.logger.error(

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -11,7 +11,7 @@ import { markArtifactStatus, artifactPath, artifactPublisherId } from '../run-re
 import { getArtifactLifecyclePolicy } from '../../types/artifact.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
-import type { AgentSessionCaptureFn, ImplementationResult } from '../../types/ai.js';
+import type { AgentSessionCaptureFn, GateReviewExchange, ImplementationResult, ImplementationReviewExchange } from '../../types/ai.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
 
@@ -29,7 +29,7 @@ export interface ImplementationApprovalDeps {
   now?: () => Date;
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runFinalReview'>;
-  journal?: Pick<RunJournal, 'captureSession'>;
+  journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
 }
 
 export type ImplementationApprovalResult =
@@ -97,6 +97,50 @@ export class ImplementationApprovalHandler {
         review_summary: run.last_impl_result?.review_summary,
         testing_steps: run.last_impl_result?.testing_steps,
       };
+      const captureFeedbackForReview = this.deps.journal
+        ? (exchange: ImplementationReviewExchange | GateReviewExchange, captureRun: Run) => {
+            if ('gate' in exchange && 'round' in exchange) {
+              // GateReviewExchange — emit feedback per finding with gate-aware disposition
+              const criticProfile = exchange.critic_profile;
+              for (const finding of exchange.findings) {
+                const response = exchange.responses.find(r => r.id === finding.id);
+                const isBlocking = finding.severity === 'blocker' || finding.severity === 'warning';
+                const disposition =
+                  response?.disposition === 'fixed' ? 'addressed' as const
+                  : response?.disposition === 'declined' ? 'wont_fix' as const
+                  : exchange.converged || finding.severity === 'info' ? 'addressed' as const
+                  : isBlocking ? 'open' as const
+                  : 'addressed' as const;
+                void this.deps.journal!.captureFeedback({
+                  id: `${exchange.id}:${finding.id}`,
+                  run: captureRun,
+                  target: 'implementation',
+                  gate: exchange.gate,
+                  author_principal: `review:${criticProfile.provider}:${criticProfile.profile}`,
+                  text: finding.finding,
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition,
+                }).catch(() => {});
+              }
+            } else {
+              // Legacy ImplementationReviewExchange — keep existing behavior
+              const reviewProfile = exchange.review_profile;
+              for (const finding of exchange.findings) {
+                void this.deps.journal!.captureFeedback({
+                  id: finding.id,
+                  run: captureRun,
+                  target: 'implementation',
+                  author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
+                  text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
+                }).catch(() => {});
+              }
+            }
+          }
+        : undefined;
       const reviewedResult = await this.deps.reviewCoordinator.runFinalReview({
         run,
         artifact_path: localPath ?? '',
@@ -104,6 +148,7 @@ export class ImplementationApprovalHandler {
         working_directory: run.workspace_path,
         onAgentRequest,
         captureSession: captureSessionForReview,
+        captureFeedback: captureFeedbackForReview,
       });
 
       if (reviewedResult.status === 'needs_input') {

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -90,18 +90,45 @@ export class ImplementationFeedbackHandler {
         : undefined;
       const captureFeedback = this.deps.journal
         ? (exchange: ImplementationReviewExchange | GateReviewExchange, captureRun: Run) => {
-            const reviewProfile = 'review_profile' in exchange ? exchange.review_profile : exchange.critic_profile;
-            for (const finding of exchange.findings) {
-              void this.deps.journal!.captureFeedback({
-                id: finding.id,
-                run: captureRun,
-                target: 'implementation',
-                author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
-                text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
-                severity: finding.severity,
-                category: finding.category,
-                disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
-              }).catch(() => {});
+            if ('gate' in exchange && 'round' in exchange) {
+              // GateReviewExchange — emit feedback per finding with gate-aware disposition
+              const criticProfile = exchange.critic_profile;
+              for (const finding of exchange.findings) {
+                const response = exchange.responses.find(r => r.id === finding.id);
+                const isBlocking = finding.severity === 'blocker' || finding.severity === 'warning';
+                const disposition =
+                  response?.disposition === 'fixed' ? 'addressed' as const
+                  : response?.disposition === 'declined' ? 'wont_fix' as const
+                  : exchange.converged || finding.severity === 'info' ? 'addressed' as const
+                  : isBlocking ? 'open' as const
+                  : 'addressed' as const;
+                void this.deps.journal!.captureFeedback({
+                  id: `${exchange.id}:${finding.id}`,
+                  run: captureRun,
+                  target: 'implementation',
+                  gate: exchange.gate,
+                  author_principal: `review:${criticProfile.provider}:${criticProfile.profile}`,
+                  text: finding.finding,
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition,
+                }).catch(() => {});
+              }
+            } else {
+              // Legacy ImplementationReviewExchange — keep existing behavior
+              const reviewProfile = exchange.review_profile;
+              for (const finding of exchange.findings) {
+                void this.deps.journal!.captureFeedback({
+                  id: finding.id,
+                  run: captureRun,
+                  target: 'implementation',
+                  author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
+                  text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
+                }).catch(() => {});
+              }
             }
           }
         : undefined;

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -58,7 +58,7 @@ export class ImplementationFeedbackHandler {
     let result;
     try {
       const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
-        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: data.round ?? 1, role: data.role ?? null, gate: data.gate ?? null }).catch(() => {}); }
         : undefined;
       result = await this.deps.implementer.implement(
         localPath,
@@ -86,7 +86,7 @@ export class ImplementationFeedbackHandler {
     let reviewedResult = result;
     if (this.deps.reviewCoordinator) {
       const captureSessionForReview: AgentSessionCaptureFn | undefined = this.deps.journal
-        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: data.round ?? 1, role: data.role ?? null, gate: data.gate ?? null }).catch(() => {}); }
         : undefined;
       const captureFeedback = this.deps.journal
         ? (exchange: ImplementationReviewExchange | GateReviewExchange, captureRun: Run) => {

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ImplementationAgent, AgentSessionCaptureFn, ImplementationReviewExchange } from '../../types/ai.js';
+import type { ImplementationAgent, AgentSessionCaptureFn, GateReviewExchange, ImplementationReviewExchange } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { FeedbackItem, ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
 import type { Run, RunStage } from '../../types/runs.js';
@@ -89,13 +89,14 @@ export class ImplementationFeedbackHandler {
         ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
         : undefined;
       const captureFeedback = this.deps.journal
-        ? (exchange: ImplementationReviewExchange, captureRun: Run) => {
+        ? (exchange: ImplementationReviewExchange | GateReviewExchange, captureRun: Run) => {
+            const reviewProfile = 'review_profile' in exchange ? exchange.review_profile : exchange.critic_profile;
             for (const finding of exchange.findings) {
               void this.deps.journal!.captureFeedback({
                 id: finding.id,
                 run: captureRun,
                 target: 'implementation',
-                author_principal: `review:${exchange.review_profile.provider}:${exchange.review_profile.profile}`,
+                author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
                 text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
                 severity: finding.severity,
                 category: finding.category,

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -206,6 +206,7 @@ export class ImplementationFeedbackHandler {
           testing_steps: reviewedResult.testing_steps,
           resolved_items: reviewedResult.resolved_feedback_items ?? [],
           review_exchanges: run.review_exchanges,
+          gate_exchanges: run.gate_exchanges,
         });
       } catch (err) {
         this.deps.logger.error(

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -96,18 +96,45 @@ export class ImplementationStartHandler {
     if (this.deps.reviewCoordinator) {
       const captureFeedback = this.deps.journal
         ? (exchange: ImplementationReviewExchange | GateReviewExchange, captureRun: Run) => {
-            const reviewProfile = 'review_profile' in exchange ? exchange.review_profile : exchange.critic_profile;
-            for (const finding of exchange.findings) {
-              void this.deps.journal!.captureFeedback({
-                id: finding.id,
-                run: captureRun,
-                target: 'implementation',
-                author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
-                text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
-                severity: finding.severity,
-                category: finding.category,
-                disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
-              }).catch(() => {});
+            if ('gate' in exchange && 'round' in exchange) {
+              // GateReviewExchange — emit feedback per finding with gate-aware disposition
+              const criticProfile = exchange.critic_profile;
+              for (const finding of exchange.findings) {
+                const response = exchange.responses.find(r => r.id === finding.id);
+                const isBlocking = finding.severity === 'blocker' || finding.severity === 'warning';
+                const disposition =
+                  response?.disposition === 'fixed' ? 'addressed' as const
+                  : response?.disposition === 'declined' ? 'wont_fix' as const
+                  : exchange.converged || finding.severity === 'info' ? 'addressed' as const
+                  : isBlocking ? 'open' as const
+                  : 'addressed' as const;
+                void this.deps.journal!.captureFeedback({
+                  id: `${exchange.id}:${finding.id}`,
+                  run: captureRun,
+                  target: 'implementation',
+                  gate: exchange.gate,
+                  author_principal: `review:${criticProfile.provider}:${criticProfile.profile}`,
+                  text: finding.finding,
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition,
+                }).catch(() => {});
+              }
+            } else {
+              // Legacy ImplementationReviewExchange — keep existing behavior
+              const reviewProfile = exchange.review_profile;
+              for (const finding of exchange.findings) {
+                void this.deps.journal!.captureFeedback({
+                  id: finding.id,
+                  run: captureRun,
+                  target: 'implementation',
+                  author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
+                  text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition: exchange.responses.some(r => r.id === finding.id && r.disposition === 'fixed') ? 'addressed' : 'open',
+                }).catch(() => {});
+              }
             }
           }
         : undefined;

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -63,7 +63,7 @@ export class ImplementationStartHandler {
 
     const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
     const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
-      ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+      ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: data.round ?? 1, role: data.role ?? null, gate: data.gate ?? null }).catch(() => {}); }
       : undefined;
 
     let result;

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -210,6 +210,7 @@ export class ImplementationStartHandler {
         review_summary: reviewedResult.review_summary,
         testing_steps: reviewedResult.testing_steps,
         review_exchanges: run.review_exchanges,
+        gate_exchanges: run.gate_exchanges,
       });
       run.impl_feedback_ref = publishedReview.id;
       this.deps.persist();

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ImplementationAgent, AgentSessionCaptureFn, ImplementationReviewExchange } from '../../types/ai.js';
+import type { ImplementationAgent, AgentSessionCaptureFn, GateReviewExchange, ImplementationReviewExchange } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
 import type { ImplementationReviewPublisher } from '../../types/impl-feedback-page.js';
 import { titleFromArtifactPath } from '../../types/publisher.js';
@@ -95,13 +95,14 @@ export class ImplementationStartHandler {
     let reviewedResult = result;
     if (this.deps.reviewCoordinator) {
       const captureFeedback = this.deps.journal
-        ? (exchange: ImplementationReviewExchange, captureRun: Run) => {
+        ? (exchange: ImplementationReviewExchange | GateReviewExchange, captureRun: Run) => {
+            const reviewProfile = 'review_profile' in exchange ? exchange.review_profile : exchange.critic_profile;
             for (const finding of exchange.findings) {
               void this.deps.journal!.captureFeedback({
                 id: finding.id,
                 run: captureRun,
                 target: 'implementation',
-                author_principal: `review:${exchange.review_profile.provider}:${exchange.review_profile.profile}`,
+                author_principal: `review:${reviewProfile.provider}:${reviewProfile.profile}`,
                 text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
                 severity: finding.severity,
                 category: finding.category,

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -28,7 +28,9 @@ export interface CaptureSessionParams {
   ts_end: string;
   phase?: string | null;
   step: AgentTaskKind | string;
+  role?: string | null;
   round: number;
+  gate?: string | null;
   model: { provider: string; name: string | null };
   inference: { effort: AgentEffort | null; thinking: AgentThinking | null };
   tokens?: NormalizedTokenUsage | null;
@@ -43,6 +45,7 @@ export interface CaptureFeedbackParams {
   id: string;
   run: Run;
   target: JournalFeedbackTarget;
+  gate?: string | null;
   author_principal: string;
   text: string;
   severity: JournalFeedbackSeverity;
@@ -121,7 +124,7 @@ export class RunJournal {
   }
 
   async captureSession(params: CaptureSessionParams): Promise<void> {
-    const { run, ts_start, ts_end, phase, step, round, model, inference, tokens, assistant_turns, tool_calls, tool_results, outcome, runner } = params;
+    const { run, ts_start, ts_end, phase, step, role, round, gate, model, inference, tokens, assistant_turns, tool_calls, tool_results, outcome, runner } = params;
     const identity = identityForRun(run);
 
     const runId = run.id;
@@ -139,9 +142,9 @@ export class RunJournal {
       request_id: identity.request_id,
       phase: phase ?? null,
       step,
-      role: null,
+      role: role ?? null,
       round,
-      gate: null,
+      gate: gate ?? null,
       model,
       inference,
       tokens: tokens ?? null,
@@ -160,7 +163,7 @@ export class RunJournal {
   }
 
   async captureFeedback(params: CaptureFeedbackParams): Promise<void> {
-    const { id, run, target, author_principal, text, severity, category, disposition = 'open', thread = [], received_at } = params;
+    const { id, run, target, gate, author_principal, text, severity, category, disposition = 'open', thread = [], received_at } = params;
     const identity = identityForRun(run);
 
     const record: Omit<JournalFeedbackRecord, 'seq' | 'writer_id'> = {
@@ -171,7 +174,7 @@ export class RunJournal {
       run_id: identity.run_id,
       request_id: identity.request_id,
       target,
-      gate: null,
+      gate: gate ?? null,
       author_principal,
       text: redactSecrets(text),
       anchor: null,

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -148,6 +148,25 @@ export interface ImplementationReviewExchange {
   requires_human_retest: boolean;
 }
 
+export type GateReviewName = 'initial' | 'final' | string;
+export type GateNonConvergenceReason = 'max_rounds' | 'oscillation';
+
+export interface GateReviewExchange {
+  id: string;
+  gate: GateReviewName;
+  round: number;
+  created_at: string;
+  proposer_profile: AgentProfileSummary;
+  critic_profile: AgentProfileSummary;
+  review_status: ImplementationReviewExchangeStatus | 'non_converged' | 'converged';
+  review_summary: string;
+  findings: ImplementationReviewFinding[];
+  responses: ImplementationReviewResponseItem[];
+  converged: boolean;
+  non_convergence_reason?: GateNonConvergenceReason;
+  requires_human_retest: boolean;
+}
+
 export interface AgentRoutingPolicy {
   resolve(route: AgentRoute): AgentProfile;
   resolveOptional(route: AgentRoute): AgentProfile | null;

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -33,8 +33,11 @@ export type AgentTaskKind =
   | 'issue.triage'
   | 'pr.title_generate';
 
+export type AgentRole = 'proposer' | 'critic';
+
 export interface AgentRoute {
   task: AgentTaskKind;
+  role?: AgentRole | string;
   stage?: RunStage | 'new_thread' | string;
   intent?: Intent;
   artifact_kind?: ArtifactKind;

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -18,6 +18,9 @@ export type AgentSessionCaptureFn = (data: {
   tool_results: number | null;
   outcome: 'ok' | 'failed' | 'incomplete';
   runner: 'anthropic_agent' | 'openai_agent';
+  role?: AgentRole | string | null;
+  round?: number;
+  gate?: 'initial' | 'final' | string | null;
 }) => void;
 
 export type AgentTaskKind =
@@ -56,6 +59,10 @@ export interface AgentServiceTelemetry {
   phase?: string;
   captureSession?: AgentSessionCaptureFn;
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+  route?: AgentRoute;
+  role?: AgentRole | string;
+  round?: number;
+  gate?: 'initial' | 'final' | string;
 }
 
 export type AgentEffort = 'low' | 'medium' | 'high' | 'max';

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -65,11 +65,17 @@ export interface SpecReviewPolicy {
   template_conformance?: boolean;
 }
 
+export interface ImplementationReviewConvergencePolicy {
+  enabled?: boolean;
+  allow_same_model?: boolean;
+}
+
 export interface ImplementationReviewPolicy {
   max_initial_rounds?: number;
   max_final_rounds?: number;
   on_review_failure?: 'warn' | 'block';
   retest_on_behavior_change?: boolean;
+  convergence?: ImplementationReviewConvergencePolicy;
 }
 
 export interface AiConfig {

--- a/src/types/impl-feedback-page.ts
+++ b/src/types/impl-feedback-page.ts
@@ -1,4 +1,4 @@
-import type { ImplementationReviewExchange } from './ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange } from './ai.js';
 
 export type ImplementationReviewStatus =
   | 'not_started'
@@ -33,6 +33,7 @@ export interface ImplementationReviewInput {
   };
   testing_steps?: string[];
   review_exchanges?: ImplementationReviewExchange[];
+  gate_exchanges?: GateReviewExchange[];
 }
 
 export interface ImplementationReviewPublisher {
@@ -54,6 +55,7 @@ export interface ImplementationReviewPublisher {
         resolution_comment: string;
       }>;
       review_exchanges?: ImplementationReviewExchange[];
+      gate_exchanges?: GateReviewExchange[];
     },
   ): Promise<void>;
 

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -69,9 +69,9 @@ export interface JournalSessionRecord extends JournalBaseRecord {
   request_id: string | null;
   phase: string | null;
   step: AgentTaskKind | string;
-  role: null;
+  role: string | null;
   round: number;
-  gate: null;
+  gate: string | null;
   model: { provider: string; name: string | null };
   inference: { effort: AgentEffort | null; thinking: AgentThinking | null };
   /** null means token usage was unavailable (e.g. OpenAI Agent SDK did not provide counts), not zero. */
@@ -97,7 +97,7 @@ export interface JournalFeedbackRecord extends JournalBaseRecord {
   run_id: string | null;
   request_id: string | null;
   target: JournalFeedbackTarget;
-  gate: null;
+  gate: string | null;
   author_principal: string;
   text: string;
   anchor: unknown | null;

--- a/src/types/runs.ts
+++ b/src/types/runs.ts
@@ -1,7 +1,7 @@
 // src/types/runs.ts
 import type { ChannelRef, ConversationRef, MessageRef } from './channel.js';
 import type { Artifact } from './artifact.js';
-import type { ImplementationReviewExchange } from './ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange } from './ai.js';
 
 export type RunStage =
   | 'intake'
@@ -64,6 +64,7 @@ export interface Run {
   pr_url: string | undefined;
   last_impl_result: LastImplementationResult | undefined;
   review_exchanges?: ImplementationReviewExchange[];
+  gate_exchanges?: GateReviewExchange[];
   created_at: string;
   updated_at: string;
 }

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -1175,6 +1175,147 @@ describe('Gate exchange rendering', () => {
     expect(markdown).toContain('Last proposer response: Declined — Only config names are logged.');
   });
 
+  it('redacts secret-like text in gate exchange finding and response text', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      {
+        id: 'gate-secret-1',
+        gate: 'initial',
+        round: 1,
+        created_at: '2026-06-07T00:00:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'addressed',
+        review_summary: 'Secret in finding.',
+        findings: [{ id: 'INIT-S1', severity: 'blocker', category: 'security', finding: 'Token sk-abc12345678 was logged.' }],
+        responses: [{ id: 'INIT-S1', disposition: 'fixed', response: 'Removed key api_key=supersecretvalue from output.' }],
+        converged: false,
+        requires_human_retest: false,
+      },
+      {
+        id: 'gate-secret-2',
+        gate: 'initial',
+        round: 2,
+        created_at: '2026-06-07T00:01:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'converged',
+        review_summary: 'Resolved.',
+        findings: [],
+        responses: [],
+        converged: true,
+        requires_human_retest: false,
+      },
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(markdown).not.toContain('sk-abc12345678');
+    expect(markdown).not.toContain('supersecretvalue');
+    expect(markdown).toContain('[REDACTED]');
+  });
+
+  it('redacts secret-like text in non-converged open finding and last proposer response', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      {
+        id: 'gate-nc-1',
+        gate: 'final',
+        round: 1,
+        created_at: '2026-06-07T00:00:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'addressed',
+        review_summary: 'Blocker found.',
+        findings: [{ id: 'FINAL-S1', severity: 'blocker', category: 'security', finding: 'Key sk-secretvalue123 exposed.' }],
+        responses: [{ id: 'FINAL-S1', disposition: 'declined', response: 'That token api_key=plainvalue is not sensitive.' }],
+        converged: false,
+        requires_human_retest: false,
+      },
+      {
+        id: 'gate-nc-2',
+        gate: 'final',
+        round: 2,
+        created_at: '2026-06-07T00:01:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'non_converged',
+        review_summary: 'Still blocked.',
+        findings: [{ id: 'FINAL-S1', severity: 'blocker', category: 'security', finding: 'Key sk-secretvalue123 still exposed.' }],
+        responses: [],
+        converged: false,
+        non_convergence_reason: 'max_rounds',
+        requires_human_retest: false,
+      },
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(markdown).not.toContain('sk-secretvalue123');
+    expect(markdown).not.toContain('plainvalue');
+    expect(markdown).toContain('[REDACTED]');
+    // The last proposer response from round 1 should appear (via lookback)
+    expect(markdown).toContain('Last proposer response: Declined');
+  });
+
+  it('shows last proposer response from prior round for non-converged open findings when terminal exchange has empty responses', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    // Round 1 addressed exchange holds the proposer's last response.
+    // Round 2 is the terminal non_converged exchange with responses: [] (matches actual coordinator output).
+    const gate_exchanges: GateReviewExchange[] = [
+      {
+        id: 'gate-lb-1',
+        gate: 'initial',
+        round: 1,
+        created_at: '2026-06-07T00:00:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'addressed',
+        review_summary: 'Blocker.',
+        findings: [{ id: 'INIT-LB1', severity: 'blocker', category: 'correctness', finding: 'Missing coverage.' }],
+        responses: [{ id: 'INIT-LB1', disposition: 'declined', response: 'Not applicable per spec.' }],
+        converged: false,
+        requires_human_retest: false,
+      },
+      {
+        id: 'gate-lb-2',
+        gate: 'initial',
+        round: 2,
+        created_at: '2026-06-07T00:01:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'non_converged',
+        review_summary: 'Still blocked.',
+        findings: [{ id: 'INIT-LB1', severity: 'blocker', category: 'correctness', finding: 'Missing coverage.' }],
+        responses: [],
+        converged: false,
+        non_convergence_reason: 'max_rounds',
+        requires_human_retest: false,
+      },
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(markdown).toContain('#### Open findings');
+    // The proposer response from round 1 should appear in the open findings section
+    expect(markdown).toContain('Last proposer response: Declined — Not applicable per spec.');
+  });
+
   it('continues to render legacy review_exchanges when gate_exchanges are absent', async () => {
     const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
     const client = makeNotionClient({ pagesCreate });

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NotionImplementationFeedbackPage } from '../../../src/adapters/notion/implementation-feedback-page.js';
 import type { NotionClient } from '../../../src/adapters/notion/notion-client.js';
 import type { ImplementationReviewInput } from '../../../src/types/impl-feedback-page.js';
-import type { ImplementationReviewExchange } from '../../../src/types/ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange } from '../../../src/types/ai.js';
 
 const nullDest = { write: () => {} };
 
@@ -1080,6 +1080,120 @@ describe('AI review section', () => {
     const newMarkdown = (client.pages.updateMarkdown as ReturnType<typeof vi.fn>).mock.calls[0][1].replace_content.new_str as string;
     expect(newMarkdown).toContain('## AI review');
     expect(newMarkdown.indexOf('## AI review')).toBeGreaterThan(newMarkdown.indexOf('## Summary'));
+  });
+});
+
+describe('Gate exchange rendering', () => {
+  it('renders gate_exchanges grouped by gate and round when creating the testing guide', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      {
+        id: 'gate-1',
+        gate: 'initial',
+        round: 1,
+        created_at: '2026-06-07T00:00:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk', model: 'gpt-5.5' },
+        review_status: 'addressed',
+        review_summary: 'One blocker found.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing regression test.' }],
+        responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added invalid provider config coverage.' }],
+        converged: false,
+        requires_human_retest: false,
+      },
+      {
+        id: 'gate-2',
+        gate: 'initial',
+        round: 2,
+        created_at: '2026-06-07T00:01:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk', model: 'gpt-5.5' },
+        review_status: 'converged',
+        review_summary: 'No blockers remain.',
+        findings: [],
+        responses: [],
+        converged: true,
+        requires_human_retest: false,
+      },
+    ];
+
+    await page.create(makeReviewInput({ gate_exchanges }));
+
+    const createCall = pagesCreate.mock.calls[0][0] as {
+      children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> }; paragraph?: { rich_text: Array<{ text: { content: string } }> } }>;
+    };
+
+    // Collect all text content from the created blocks
+    const allTexts = createCall.children.flatMap(b => {
+      if (b.type === 'heading_2') return [b.heading_2!.rich_text[0].text.content];
+      if (b.type === 'paragraph') return [b.paragraph!.rich_text[0].text.content];
+      return [];
+    });
+
+    expect(allTexts).toContain('AI review');
+    const combined = allTexts.join('\n');
+    expect(combined).toContain('Initial review');
+    expect(combined).toContain('Convergence: converged');
+    expect(combined).toContain('Rounds: 2');
+    expect(combined).toContain('[INIT-1] Missing regression test.');
+    expect(combined).toContain('Fixed — Added invalid provider config coverage.');
+    expect(combined).toContain('Round 2 — converged');
+  });
+
+  it('renders non-converged open findings from gate_exchanges when updating the testing guide', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [{
+      id: 'gate-3',
+      gate: 'final',
+      round: 2,
+      created_at: '2026-06-07T00:02:00.000Z',
+      proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+      critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+      review_status: 'non_converged',
+      review_summary: 'Security blocker still open.',
+      findings: [{ id: 'FINAL-2', severity: 'blocker', category: 'security', finding: 'Token output can appear in logs.' }],
+      responses: [{ id: 'FINAL-2', disposition: 'declined', response: 'Only config names are logged.' }],
+      converged: false,
+      non_convergence_reason: 'max_rounds',
+      requires_human_retest: false,
+    }];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(markdown).toContain('### Final review');
+    expect(markdown).toContain('Convergence: failed (`max_rounds`)');
+    expect(markdown).toContain('#### Open findings');
+    expect(markdown).toContain('- [ ] [FINAL-2] Token output can appear in logs.');
+    expect(markdown).toContain('Last proposer response: Declined — Only config names are logged.');
+  });
+
+  it('continues to render legacy review_exchanges when gate_exchanges are absent', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+    const exchange = makeReviewExchange({ review_status: 'addressed' });
+
+    await page.create(makeReviewInput({ review_exchanges: [exchange] }));
+
+    const createCall = pagesCreate.mock.calls[0][0] as {
+      children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> }; paragraph?: { rich_text: Array<{ text: { content: string } }> } }>;
+    };
+    const allTexts = createCall.children.flatMap(b => {
+      if (b.type === 'heading_2') return [b.heading_2!.rich_text[0].text.content];
+      if (b.type === 'paragraph') return [b.paragraph!.rich_text[0].text.content];
+      return [];
+    });
+
+    // Legacy rendering produces "Review status: addressed" in the blocks
+    expect(allTexts.join('\n')).toContain('Review status: addressed');
   });
 });
 

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -1663,4 +1663,65 @@ describe('AgentServiceTelemetry captureSession callback', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  test('implementation.run uses telemetry.route when provided (proposer route override)', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-route-override-'));
+    try {
+      const calls: import('../../../src/types/ai.js').AgentRunRequest[] = [];
+      const specPath = join(workspace, 'spec.md');
+      await mkdir(workspace, { recursive: true });
+      await writeFile(specPath, '# Spec', 'utf8');
+
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'proposer done', review_summary: { changes: [], confirm: [] }, testing_steps: [], resolved_feedback_items: [] }), 'utf8');
+      });
+
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+      const proposerRoute = { task: 'implementation.run' as const, role: 'proposer' };
+      await service.implement(specPath, workspace, undefined, undefined, { route: proposerRoute });
+
+      expect(calls[0].route).toEqual(proposerRoute);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('implementation.run captureSession receives role, round, and gate from telemetry', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-impl-session-meta-'));
+    try {
+      const captures: Array<Record<string, unknown>> = [];
+      const specPath = join(workspace, 'spec.md');
+      await mkdir(workspace, { recursive: true });
+      await writeFile(specPath, '# Spec', 'utf8');
+
+      const runner = fakeAgentRunner(async request => {
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ status: 'complete', summary: 'done', review_summary: { changes: [], confirm: [] }, testing_steps: [], resolved_feedback_items: [] }), 'utf8');
+      });
+
+      const captureSession = vi.fn((data: Record<string, unknown>) => captures.push(data));
+      const service = new AgentRunnerImplementationAgent(runner, makePolicy());
+      await service.implement(specPath, workspace, undefined, undefined, {
+        captureSession,
+        role: 'proposer',
+        round: 2,
+        gate: 'initial',
+      });
+
+      expect(captureSession).toHaveBeenCalledOnce();
+      expect(captures[0]['role']).toBe('proposer');
+      expect(captures[0]['round']).toBe(2);
+      expect(captures[0]['gate']).toBe('initial');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -550,6 +550,31 @@ describe('ImplementationReviewCoordinator', () => {
       expect(run.gate_exchanges![0]).toMatchObject({ converged: false, review_status: 'non_converged', non_convergence_reason: 'max_rounds' });
     });
 
+    it('calls captureFeedback once per gate exchange during convergence', async () => {
+      const captureFeedback = vi.fn();
+      const deps = makeConvergenceDeps([
+        { status: 'findings', summary: 'Round 1.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }] },
+        { status: 'no_findings', summary: 'Round 2 clean.', findings: [] },
+      ], {
+        implementer: makeImplementer(makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] })),
+      });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, captureFeedback });
+
+      expect(captureFeedback).toHaveBeenCalledTimes(2); // once per gate exchange
+      expect(captureFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ gate: 'initial', round: 1 }),
+        run,
+      );
+      expect(captureFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ gate: 'initial', round: 2, converged: true }),
+        run,
+      );
+      expect(run.review_exchanges).toHaveLength(0); // no legacy exchanges in convergence mode
+    });
+
     it('passes the proposer role route into the actual implementer review-response call', async () => {
       const deps = makeConvergenceDeps([
         { status: 'findings', summary: 'Round 1.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }] },

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -631,6 +631,60 @@ describe('ImplementationReviewCoordinator', () => {
     });
   });
 
+  describe('convergence oscillation', () => {
+    function makeOscillationDeps(reviewResults: ImplementationReviewResult[]) {
+      let callCount = 0;
+      const readFile = vi.fn().mockImplementation(async () => {
+        const result = reviewResults[callCount] ?? { status: 'no_findings', summary: 'ok', findings: [] };
+        callCount++;
+        return JSON.stringify(result);
+      });
+      // Need enough rounds (3) for oscillation
+      const proposerResult = makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'declined', response: 'Not applicable.' }] });
+      const deps = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] }, {
+        readFile,
+        implementer: makeImplementer(proposerResult),
+      });
+      deps.policy = { ...deps.policy, max_initial_rounds: 3, max_final_rounds: 3, convergence: { enabled: true, allow_same_model: true } };
+      return deps;
+    }
+
+    it('detects repeated non-shrinking blocker signature and fails with oscillation', async () => {
+      const sameFinding = { id: 'INIT-1', severity: 'blocker' as const, category: 'correctness' as const, finding: 'Bug remains unchanged.' };
+      const deps = makeOscillationDeps([
+        { status: 'findings', summary: 'Round 1.', findings: [sameFinding] },
+        { status: 'findings', summary: 'Round 2 same.', findings: [sameFinding] },
+        { status: 'no_findings', summary: 'Round 3.', findings: [] }, // should never reach
+      ]);
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('oscillation');
+      expect(run.gate_exchanges!.at(-1)).toMatchObject({ review_status: 'non_converged', non_convergence_reason: 'oscillation' });
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'implementation.review.oscillation_detected' }),
+        expect.any(String),
+      );
+    });
+
+    it('does not trigger oscillation for info-only repeated findings', async () => {
+      // Info-only repeated findings should converge (info doesn't count for oscillation)
+      const deps = makeOscillationDeps([
+        { status: 'findings', summary: 'Round 1 info only.', findings: [{ id: 'INIT-INFO-1', severity: 'info' as const, category: 'docs' as const, finding: 'Note about docs.' }] },
+      ]);
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.status).toBe('complete');
+      expect(run.gate_exchanges![0]).toMatchObject({ converged: true });
+    });
+  });
+
   describe('convergence same-model enforcement', () => {
     function makeSameModelDeps(allow_same_model: boolean) {
       // Create a routing policy where both implementation.run and implementation.review.initial

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -64,7 +64,7 @@ function makeDeps(reviewResult: ImplementationReviewResult = { status: 'no_findi
     runner: makeRunner(),
     implementer: makeImplementer(),
     routingPolicy: makeRoutingPolicy(),
-    policy: { max_initial_rounds: 1, max_final_rounds: 1, on_review_failure: 'warn' as const, retest_on_behavior_change: true },
+    policy: { max_initial_rounds: 1, max_final_rounds: 1, on_review_failure: 'warn' as const, retest_on_behavior_change: true, convergence: { enabled: false, allow_same_model: false } },
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     readFile: vi.fn().mockResolvedValue(reviewJson),
@@ -453,6 +453,36 @@ describe('ImplementationReviewCoordinator', () => {
       expect(completed!['blocker_count']).toBe(1);
       expect(completed!['warning_count']).toBe(2);
       expect(completed!['info_count']).toBe(1);
+    });
+  });
+
+  describe('convergence disabled', () => {
+    it('keeps legacy one-pass-plus-response behavior without gate_exchanges', async () => {
+      const findingsResult: ImplementationReviewResult = {
+        status: 'findings',
+        summary: 'Found issue.',
+        findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }],
+      };
+      const implResult = makeCompleteResult({
+        summary: 'Updated once.',
+        review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }],
+      });
+      const deps = makeDeps(findingsResult, { implementer: makeImplementer(implResult) });
+      // Ensure convergence is disabled (it is by default in makeDeps)
+      deps.policy = { ...deps.policy, convergence: { enabled: false, allow_same_model: false } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.summary).toBe('Updated once.');
+      // One critic (runner.run) call, one implementer call
+      expect(deps.runner.run).toHaveBeenCalledTimes(1);
+      expect(deps.implementer.implement).toHaveBeenCalledTimes(1);
+      // review_exchanges has exactly one entry
+      expect(run.review_exchanges).toHaveLength(1);
+      // gate_exchanges is not set
+      expect((run as Record<string, unknown>)['gate_exchanges']).toBeUndefined();
     });
   });
 

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -575,6 +575,27 @@ describe('ImplementationReviewCoordinator', () => {
       expect(run.review_exchanges).toHaveLength(0); // no legacy exchanges in convergence mode
     });
 
+    it('captureSession for critic includes role: critic, round, and gate', async () => {
+      const deps = makeConvergenceDeps([
+        { status: 'findings', summary: 'Round 1.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }] },
+        { status: 'no_findings', summary: 'Round 2 clean.', findings: [] },
+      ], {
+        implementer: makeImplementer(makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] })),
+      });
+      const captureSession = vi.fn();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+
+      await coordinator.runInitialReview({ run: makeRun(), artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, captureSession });
+
+      // Both critic sessions (round 1 and round 2) should have role, round, and gate
+      const criticCalls = (captureSession.mock.calls as Array<[Record<string, unknown>]>)
+        .map(c => c[0])
+        .filter(r => r['role'] === 'critic');
+      expect(criticCalls).toHaveLength(2);
+      expect(criticCalls[0]).toMatchObject({ role: 'critic', round: 1, gate: 'initial' });
+      expect(criticCalls[1]).toMatchObject({ role: 'critic', round: 2, gate: 'initial' });
+    });
+
     it('passes the proposer role route into the actual implementer review-response call', async () => {
       const deps = makeConvergenceDeps([
         { status: 'findings', summary: 'Round 1.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }] },

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -630,4 +630,49 @@ describe('ImplementationReviewCoordinator', () => {
       expect(callbacks[0].is_heartbeat).toBeFalsy();
     });
   });
+
+  describe('convergence same-model enforcement', () => {
+    function makeSameModelDeps(allow_same_model: boolean) {
+      // Create a routing policy where both implementation.run and implementation.review.initial
+      // resolve to the same profile id
+      const sameProfile: AgentProfile = { id: 'same-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' };
+      const routingPolicy: AgentRoutingPolicy = {
+        resolve: vi.fn().mockReturnValue(sameProfile),
+        resolveOptional: vi.fn().mockReturnValue(sameProfile),
+      };
+      const deps = makeDeps({ status: 'no_findings', summary: 'ok', findings: [] }, { routingPolicy });
+      deps.policy = { ...deps.policy, convergence: { enabled: true, allow_same_model } };
+      return { deps, sameProfile };
+    }
+
+    it('fails before critic execution when same profile and allow_same_model is false', async () => {
+      const { deps } = makeSameModelDeps(false);
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('requires distinct proposer and critic profiles for initial review');
+      expect(deps.runner.run).not.toHaveBeenCalled();
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'implementation.review.same_model_rejected', profile_id: 'same-agent' }),
+        expect.any(String),
+      );
+    });
+
+    it('allows same profile when allow_same_model is true and logs a warning', async () => {
+      const { deps } = makeSameModelDeps(true);
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.status).toBe('complete');
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'implementation.review.same_model_allowed', profile_id: 'same-agent' }),
+        expect.any(String),
+      );
+    });
+  });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
-import type { AgentRunner, AgentRoutingPolicy, ImplementationAgent, ImplementationResult, ImplementationReviewResult, AgentProfile } from '../../../src/types/ai.js';
+import type { AgentRunner, AgentRoutingPolicy, ImplementationAgent, ImplementationResult, ImplementationReviewResult, AgentProfile, GateReviewExchange } from '../../../src/types/ai.js';
 import type { Run } from '../../../src/types/runs.js';
 
 const WORKING_DIR = '/ws/test';
@@ -483,6 +483,94 @@ describe('ImplementationReviewCoordinator', () => {
       expect(run.review_exchanges).toHaveLength(1);
       // gate_exchanges is not set
       expect((run as Record<string, unknown>)['gate_exchanges']).toBeUndefined();
+    });
+  });
+
+  describe('convergence enabled', () => {
+    function makeConvergenceDeps(reviewResults: ImplementationReviewResult[], overrides: Record<string, unknown> = {}) {
+      let callCount = 0;
+      const readFile = vi.fn().mockImplementation(async () => {
+        const result = reviewResults[callCount] ?? { status: 'no_findings', summary: 'ok', findings: [] };
+        callCount++;
+        return JSON.stringify(result);
+      });
+      const deps = makeDeps({ status: 'no_findings', summary: 'unused', findings: [] }, { readFile, ...overrides });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, max_final_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      return deps;
+    }
+
+    it('re-reviews after a proposer response and converges on round 2', async () => {
+      const deps = makeConvergenceDeps([
+        { status: 'findings', summary: 'Round 1.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }] },
+        { status: 'no_findings', summary: 'Round 2 clean.', findings: [] },
+      ], {
+        implementer: makeImplementer(makeCompleteResult({ summary: 'Updated after round 1.', review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] })),
+      });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.summary).toBe('Updated after round 1.');
+      expect(deps.runner.run).toHaveBeenCalledTimes(2);
+      expect(deps.implementer.implement).toHaveBeenCalledTimes(1);
+      expect(run.gate_exchanges).toHaveLength(2);
+      expect(run.gate_exchanges![0]).toMatchObject({ gate: 'initial', round: 1, converged: false, review_status: 'addressed' });
+      expect(run.gate_exchanges![1]).toMatchObject({ gate: 'initial', round: 2, converged: true, review_status: 'converged' });
+    });
+
+    it('treats info-only findings as converged and does not call proposer', async () => {
+      const deps = makeConvergenceDeps([
+        { status: 'findings', summary: 'Only notes.', findings: [{ id: 'INIT-INFO-1', severity: 'info', category: 'docs', finding: 'Optional note.' }] },
+      ]);
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.status).toBe('complete');
+      expect(deps.implementer.implement).not.toHaveBeenCalled();
+      expect(run.gate_exchanges![0]).toMatchObject({ converged: true, review_status: 'converged' });
+      expect((run.gate_exchanges as GateReviewExchange[])[0].findings[0].severity).toBe('info');
+    });
+
+    it('fails immediately with max_rounds when max_initial_rounds is 1 and blockers are present', async () => {
+      const deps = makeConvergenceDeps([
+        { status: 'findings', summary: 'Still blocked.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'correctness', finding: 'Bug remains.' }] },
+      ]);
+      deps.policy = { ...deps.policy, max_initial_rounds: 1 };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.runInitialReview({ run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('initial did not converge');
+      expect(deps.implementer.implement).not.toHaveBeenCalled();
+      expect(run.gate_exchanges![0]).toMatchObject({ converged: false, review_status: 'non_converged', non_convergence_reason: 'max_rounds' });
+    });
+
+    it('passes the proposer role route into the actual implementer review-response call', async () => {
+      const deps = makeConvergenceDeps([
+        { status: 'findings', summary: 'Round 1.', findings: [{ id: 'INIT-1', severity: 'blocker', category: 'test', finding: 'Missing test.' }] },
+        { status: 'no_findings', summary: 'Round 2 clean.', findings: [] },
+      ], {
+        implementer: makeImplementer(makeCompleteResult({ review_responses: [{ id: 'INIT-1', disposition: 'fixed', response: 'Added test.' }] })),
+      });
+      const coordinator = new ImplementationReviewCoordinator(deps);
+
+      await coordinator.runInitialReview({ run: makeRun(), artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR });
+
+      expect(deps.implementer.implement).toHaveBeenCalledWith(
+        '/ws/spec.md',
+        WORKING_DIR,
+        expect.stringContaining('Convergence gate: initial'),
+        expect.any(Function),
+        expect.objectContaining({
+          phase: 'implementation_review_initial_proposer',
+          route: { task: 'implementation.run', role: 'proposer' },
+        }),
+      );
     });
   });
 

--- a/tests/core/ai/routing-policy.test.ts
+++ b/tests/core/ai/routing-policy.test.ts
@@ -216,6 +216,49 @@ describe('DefaultAgentRoutingPolicy', () => {
       provider: 'anthropic',
     });
   });
+
+  test('role-keyed routing takes precedence over task-level routing', () => {
+    const config = makeAiConfig();
+    config.profiles.push({
+      name: 'critic-agent',
+      endpoint: 'ep',
+      model: 'gpt-5.5',
+      runner: 'openai_agent_sdk',
+    });
+    config.routing['implementation.review.initial'] = 'agent-default';
+    config.routing['implementation.review.initial:critic'] = 'critic-agent';
+    const policy = new DefaultAgentRoutingPolicy(config);
+
+    expect(policy.resolve({ task: 'implementation.review.initial', role: 'critic' })).toMatchObject({
+      id: 'critic-agent',
+      provider: 'openai_agent_sdk',
+    });
+  });
+
+  test('role-keyed routing falls back to task-level routing', () => {
+    const config = makeAiConfig();
+    config.routing['implementation.review.initial'] = 'agent-default';
+    const policy = new DefaultAgentRoutingPolicy(config);
+
+    expect(policy.resolve({ task: 'implementation.review.initial', role: 'critic' })).toMatchObject({
+      id: 'agent-default',
+      provider: 'claude_agent_sdk',
+    });
+  });
+
+  test('resolve throws only after role-specific and task-level routing are both missing', () => {
+    const policy = new DefaultAgentRoutingPolicy(makeAiConfig());
+
+    expect(() => policy.resolve({ task: 'implementation.review.initial', role: 'critic' })).toThrow(
+      "No routing entry for task 'implementation.review.initial' or role key 'implementation.review.initial:critic'",
+    );
+  });
+
+  test('resolveOptional returns null only after role-specific and task-level routing are both missing', () => {
+    const policy = new DefaultAgentRoutingPolicy(makeAiConfig());
+
+    expect(policy.resolveOptional({ task: 'implementation.review.initial', role: 'critic' })).toBeNull();
+  });
 });
 
 describe('agentProfileSummary', () => {

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -421,6 +421,36 @@ describe('validateConfig: implementation_review', () => {
       validateConfig({ implementation_review: { max_final_rounds: -1 } } as unknown as WorkflowConfig),
     ).toThrow('max_final_rounds must be a positive integer');
   });
+
+  it('passes for a valid implementation_review.convergence block', () => {
+    expect(() =>
+      validateConfig({
+        implementation_review: {
+          convergence: { enabled: true, allow_same_model: false },
+          max_initial_rounds: 2,
+          max_final_rounds: 2,
+        },
+      } as unknown as WorkflowConfig),
+    ).not.toThrow();
+  });
+
+  it('throws when implementation_review.convergence is not an object', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { convergence: true } } as unknown as WorkflowConfig),
+    ).toThrow('implementation_review.convergence must be an object');
+  });
+
+  it('throws when implementation_review.convergence.enabled is not boolean', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { convergence: { enabled: 'yes' } } } as unknown as WorkflowConfig),
+    ).toThrow('implementation_review.convergence.enabled must be a boolean');
+  });
+
+  it('throws when implementation_review.convergence.allow_same_model is not boolean', () => {
+    expect(() =>
+      validateConfig({ implementation_review: { convergence: { allow_same_model: 'no' } } } as unknown as WorkflowConfig),
+    ).toThrow('implementation_review.convergence.allow_same_model must be a boolean');
+  });
 });
 
 // ─── validateConfig: workspace.auto_prune ────────────────────────────────────
@@ -449,6 +479,7 @@ describe('getImplementationReviewPolicy', () => {
       max_final_rounds: 1,
       on_review_failure: 'warn',
       retest_on_behavior_change: true,
+      convergence: { enabled: false, allow_same_model: false },
     });
   });
 
@@ -475,6 +506,42 @@ describe('getImplementationReviewPolicy', () => {
   it('defaults on_review_failure to warn when not set', () => {
     const policy = getImplementationReviewPolicy({ implementation_review: { max_initial_rounds: 2 } } as unknown as WorkflowConfig);
     expect(policy.on_review_failure).toBe('warn');
+  });
+
+  it('defaults convergence to disabled with same-model disallowed', () => {
+    const policy = getImplementationReviewPolicy({} as WorkflowConfig);
+    expect(policy.convergence).toEqual({ enabled: false, allow_same_model: false });
+  });
+
+  it('preserves legacy max-round defaults when convergence is disabled and max values are absent', () => {
+    const policy = getImplementationReviewPolicy({
+      implementation_review: { convergence: { enabled: false } },
+    } as unknown as WorkflowConfig);
+    expect(policy.max_initial_rounds).toBe(1);
+    expect(policy.max_final_rounds).toBe(1);
+  });
+
+  it('uses convergence max-round defaults of 2 when enabled and max values are absent', () => {
+    const policy = getImplementationReviewPolicy({
+      implementation_review: { convergence: { enabled: true } },
+    } as unknown as WorkflowConfig);
+    expect(policy.max_initial_rounds).toBe(2);
+    expect(policy.max_final_rounds).toBe(2);
+  });
+
+  it('keeps explicit max-round values when convergence is enabled', () => {
+    const policy = getImplementationReviewPolicy({
+      implementation_review: {
+        convergence: { enabled: true, allow_same_model: true },
+        max_initial_rounds: 3,
+        max_final_rounds: 4,
+      },
+    } as unknown as WorkflowConfig);
+    expect(policy).toMatchObject({
+      max_initial_rounds: 3,
+      max_final_rounds: 4,
+      convergence: { enabled: true, allow_same_model: true },
+    });
   });
 });
 

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -453,6 +453,23 @@ describe('ImplementationApprovalHandler with reviewCoordinator', () => {
     expect(deps.failRun).toHaveBeenCalled();
   });
 
+  it('fails run when final review returns non-convergence failed result', async () => {
+    const coord = {
+      runFinalReview: vi.fn().mockResolvedValue({
+        status: 'failed',
+        error: 'Implementation review final did not converge after 2 rounds',
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalled();
+    expect(deps.prManager.createPR).not.toHaveBeenCalled();
+  });
+
   it('proceeds to PR creation without coordinator when not configured', async () => {
     const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
     const result = await handler.handle(makeRun(), makeFeedback());

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -4,7 +4,7 @@ import type { ThreadMessage } from '../../../src/types/events.js';
 import type { Run } from '../../../src/types/runs.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
 import type { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
-import type { ImplementationResult } from '../../../src/types/ai.js';
+import type { GateReviewExchange, ImplementationResult } from '../../../src/types/ai.js';
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
@@ -534,6 +534,34 @@ describe('ImplementationApprovalHandler with reviewCoordinator', () => {
       'spec/request-001',
       '/ws/request-001/context-human/specs/feature-test.md',
       expect.objectContaining({ impl_result: expectedImplResult }),
+    );
+  });
+
+  it('passes gate_exchanges to implFeedbackPage.update on final review retest path', async () => {
+    const gateExchange: GateReviewExchange = {
+      id: 'gate-001',
+      gate: 'final',
+      round: 1,
+      created_at: new Date().toISOString(),
+      proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+      critic_profile: { profile: 'review-agent', provider: 'claude_agent_sdk' },
+      review_status: 'no_findings',
+      review_summary: 'Final gate passed.',
+      findings: [],
+      responses: [],
+      converged: true,
+      requires_human_retest: false,
+    };
+    const coord = makeReviewCoordinator({ requires_human_retest: true });
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun({ impl_feedback_ref: 'feedback-page-id', gate_exchanges: [gateExchange] });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'reviewing_implementation' });
+    expect(deps.implFeedbackPage?.update).toHaveBeenCalledWith(
+      'feedback-page-id',
+      expect.objectContaining({ gate_exchanges: [gateExchange] }),
     );
   });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -5,7 +5,7 @@ import type { FeedbackItem } from '../../../src/types/impl-feedback-page.js';
 import type { Run } from '../../../src/types/runs.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
 import type { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
-import type { ImplementationReviewExchange } from '../../../src/types/ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange } from '../../../src/types/ai.js';
 
 function makeReviewExchange(overrides: Partial<ImplementationReviewExchange> = {}): ImplementationReviewExchange {
   return {
@@ -478,6 +478,32 @@ describe('ImplementationFeedbackHandler', () => {
     expect(deps.logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ event: 'implementation.review_contract_legacy', run_id: 'run-001' }),
       expect.any(String),
+    );
+  });
+
+  it('passes gate_exchanges to implFeedbackPage.update when present', async () => {
+    const gateExchange: GateReviewExchange = {
+      id: 'gate-001',
+      gate: 'initial',
+      round: 1,
+      created_at: new Date().toISOString(),
+      proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+      critic_profile: { profile: 'review-agent', provider: 'claude_agent_sdk' },
+      review_status: 'no_findings',
+      review_summary: 'Gate passed.',
+      findings: [],
+      responses: [],
+      converged: true,
+      requires_human_retest: false,
+    };
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ impl_feedback_ref: 'feedback-page-id', gate_exchanges: [gateExchange] });
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(deps.implFeedbackPage?.update).toHaveBeenCalledWith(
+      'feedback-page-id',
+      expect.objectContaining({ gate_exchanges: [gateExchange] }),
     );
   });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -561,6 +561,23 @@ describe('ImplementationFeedbackHandler with reviewCoordinator', () => {
     });
   });
 
+  it('fails run when coordinator returns non-convergence failed result', async () => {
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockResolvedValue({
+        status: 'failed',
+        error: 'Implementation review initial did not converge after 2 rounds',
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun({ impl_feedback_ref: 'page-id' });
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalled();
+    expect(deps.implFeedbackPage?.update).not.toHaveBeenCalled();
+  });
+
   it('proceeds normally without coordinator when not configured', async () => {
     const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
     const run = makeRun({ impl_feedback_ref: 'page-id' });

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -462,6 +462,27 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     expect(deps.failRun).toHaveBeenCalled();
   });
 
+  it('fails run when coordinator returns non-convergence failed result', async () => {
+    const coord: Pick<ImplementationReviewCoordinator, 'runInitialReview'> = {
+      runInitialReview: vi.fn().mockResolvedValue({
+        status: 'failed',
+        error: 'Implementation review initial did not converge after 2 rounds',
+      }),
+    };
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.failRun).toHaveBeenCalled();
+    expect(deps.implFeedbackPage?.create).not.toHaveBeenCalled();
+    expect(deps.postMessage).not.toHaveBeenCalledWith(
+      TEST_CONVERSATION,
+      expect.stringContaining('Implementation complete'),
+    );
+  });
+
   it('proceeds normally without coordinator when not configured', async () => {
     const { handler, deps } = makeHandler({ reviewCoordinator: undefined });
     const run = makeRun();

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -4,7 +4,7 @@ import type { ThreadMessage } from '../../../src/types/events.js';
 import type { Run } from '../../../src/types/runs.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN } from '../../helpers/channel-refs.js';
 import type { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
-import type { ImplementationReviewExchange } from '../../../src/types/ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange } from '../../../src/types/ai.js';
 
 function makeReviewExchange(overrides: Partial<ImplementationReviewExchange> = {}): ImplementationReviewExchange {
   return {
@@ -524,6 +524,31 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     expect(deps.postMessage).toHaveBeenCalledWith(
       TEST_CONVERSATION,
       'Implementation complete. Feedback page: https://example.test/feedback-page-id',
+    );
+  });
+
+  it('passes gate_exchanges to implFeedbackPage.create when present', async () => {
+    const gateExchange: GateReviewExchange = {
+      id: 'gate-001',
+      gate: 'initial',
+      round: 1,
+      created_at: new Date().toISOString(),
+      proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+      critic_profile: { profile: 'review-agent', provider: 'claude_agent_sdk' },
+      review_status: 'no_findings',
+      review_summary: 'Gate passed.',
+      findings: [],
+      responses: [],
+      converged: true,
+      requires_human_retest: false,
+    };
+    const { handler, deps } = makeHandler();
+    const run = makeRun({ gate_exchanges: [gateExchange] });
+
+    await handler.handle(run, makeFeedback());
+
+    expect(deps.implFeedbackPage?.create).toHaveBeenCalledWith(
+      expect.objectContaining({ gate_exchanges: [gateExchange] }),
     );
   });
 });

--- a/tests/core/invariants.test.ts
+++ b/tests/core/invariants.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { rmSync } from 'node:fs';
 import { loadConfig, redactConfig } from '../../src/core/config.js';
+import { VALID_RUN_STAGES } from '../../src/types/runs.js';
 
 describe('cross-cutting: JSON output validity', () => {
   let tempDir: string;
@@ -55,5 +56,23 @@ describe('cross-cutting: no secret leakage', () => {
     expect(redacted.value).toBe('[from env]');
     // Substring should NOT be redacted (it's a different value)
     expect(redacted.other).toBe('xabcx');
+  });
+});
+
+describe('run stage invariants', () => {
+  it('does not introduce new run stages beyond the approved set', () => {
+    expect([...VALID_RUN_STAGES].sort()).toEqual([
+      'awaiting_impl_input',
+      'awaiting_planning_input',
+      'done',
+      'failed',
+      'implementing',
+      'intake',
+      'planning',
+      'pr_open',
+      'reviewing_implementation',
+      'reviewing_spec',
+      'speccing',
+    ]);
   });
 });

--- a/tests/core/journal/run-journal-facade.test.ts
+++ b/tests/core/journal/run-journal-facade.test.ts
@@ -331,6 +331,35 @@ describe('RunJournal facade', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('writes role, round, and gate to sessions.jsonl when provided', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureSession({
+      run,
+      ts_start: '2026-06-07T00:00:00.000Z',
+      ts_end: '2026-06-07T00:00:01.000Z',
+      phase: 'implementation_review',
+      step: 'implementation.review.initial',
+      role: 'critic',
+      round: 2,
+      gate: 'initial',
+      model: { provider: 'openai_agent_sdk', name: 'gpt-5.5' },
+      inference: { effort: null, thinking: null },
+      tokens: null,
+      assistant_turns: null,
+      tool_calls: null,
+      tool_results: null,
+      outcome: 'ok',
+      runner: 'openai_agent',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].stream).toBe('sessions');
+    expect(calls[0].record).toMatchObject({ role: 'critic', round: 2, gate: 'initial' });
+  });
+
   it('captureSession writes correct stream and fields', async () => {
     const { writer, calls } = makeMockWriter();
     const journal = new RunJournal(writer);

--- a/tests/core/run-store.test.ts
+++ b/tests/core/run-store.test.ts
@@ -697,6 +697,42 @@ describe('FileRunStore.save — round-trip', () => {
 });
 
 // ─────────────────────────────────────────────
+// save — gate_exchanges round-trip
+// ─────────────────────────────────────────────
+
+describe('FileRunStore.save — gate_exchanges round-trip', () => {
+  it('preserves optional gate_exchanges when present', () => {
+    const { dest } = makeLogCapture();
+    const store = new FileRunStore(tmpDir, { logDestination: dest });
+
+    const run = makeRun({
+      workspace_path: tmpDir,
+      stage: 'reviewing_spec',
+      gate_exchanges: [{
+        id: 'gate-1',
+        gate: 'initial',
+        round: 1,
+        created_at: '2026-06-07T00:00:00.000Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk', model: 'gpt-5.5' },
+        review_status: 'converged',
+        review_summary: 'No blockers remain.',
+        findings: [],
+        responses: [],
+        converged: true,
+        requires_human_retest: false,
+      }],
+    });
+
+    store.save(new Map([[run.request_id, run]]));
+    const loaded = store.load();
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].gate_exchanges).toEqual(run.gate_exchanges);
+  });
+});
+
+// ─────────────────────────────────────────────
 // save — write failure non-fatal
 // ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- renderGateReviewMarkdown now applies redactSecrets to all finding text, response text, and info notes in every branch (converged, non-converged, round-by-round)
- emitSessionRecord extended with optional convergenceMeta; critic sessions in runConvergenceReview now capture role: 'critic', round, and gate
- Non-converged gate renderer builds lastResponseById across all prior gate exchanges so the last proposer response per finding ID is shown even when the terminal exchange has responses: []
- Three regression tests added: INIT-1 (secret redaction in gate renders), INIT-2 (critic captureSession carries role/round/gate), INIT-3 (lookback for last proposer response)

## Verify

- [ ] Verify that a testing guide rendered from a convergence run with secret-like text in findings does not expose raw token values in the Notion page
- [ ] Check sessions.jsonl for a convergence-enabled run: critic session records should have role='critic', round=N, gate='initial'/'final'
- [ ] Confirm non-converged gates in the testing guide show the last proposer response from prior rounds (not blank) when the critic re-raised the same finding
- [ ] Run npm test — all 1515 tests pass

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/8aac515c-f9fe-41bf-b541-69e0a994407f
2. npm test
3. Confirm 1515 tests pass with no failures

---
Spec: `context-human/specs/enhancement-bounded-convergence-review.md`
Closes #193