### PR TITLE
fix: journal attribution and direct-call token capture

### DIFF
--- a/src/core/ai/model-intent-classifier.ts
+++ b/src/core/ai/model-intent-classifier.ts
@@ -8,6 +8,7 @@ import type {
   DirectModelRunner,
   Intent,
   IntentClassifier,
+  IntentClassifyResultListener,
 } from '../../types/ai.js';
 
 export interface ModelIntentClassifierOptions {
@@ -40,7 +41,11 @@ export class ModelIntentClassifier implements IntentClassifier {
     this.intentRegistry = options.intentRegistry ?? createBuiltInIntentRegistry();
   }
 
-  async classify(message: string, context: ClassificationContext): Promise<Intent> {
+  async classify(
+    message: string,
+    context: ClassificationContext,
+    onResult?: IntentClassifyResultListener,
+  ): Promise<Intent> {
     const fallback = this.intentRegistry.fallbackForContext(context) ?? 'feedback';
     if (!message.trim()) return fallback;
 
@@ -48,6 +53,7 @@ export class ModelIntentClassifier implements IntentClassifier {
     const validIntents = this.intentRegistry.validIntentsForContext(context);
     const promptIntents = validIntents.length > 0 ? validIntents : knownIntents;
     const route = { task: 'intent.classify' as const, stage: context };
+    const profile = this.options.routingPolicy?.resolve(route) ?? null;
     const prompt = buildPrompt(message, context, promptIntents, this.intentRegistry);
 
     let attempt = 0;
@@ -57,12 +63,13 @@ export class ModelIntentClassifier implements IntentClassifier {
       try {
         const response = await this.runner.run({
           route,
-          profile: this.options.routingPolicy?.resolve(route),
+          profile: profile ?? undefined,
           model: this.options.model,
           max_tokens: this.options.max_tokens ?? 20,
           messages: [{ role: 'user', content: prompt }],
         });
         sawModelResponse = true;
+        onResult?.({ usage: response.usage ?? null, profile });
         const intent = parseIntentFromResponse(response.text, knownIntents);
         if (intent && promptIntents.includes(intent)) {
           this.logger.info(

--- a/src/core/ai/pr-title-generator.ts
+++ b/src/core/ai/pr-title-generator.ts
@@ -4,6 +4,7 @@ import { createLogger } from '../logger.js';
 import type {
   AgentRoutingPolicy,
   DirectModelRunner,
+  IntentClassifyResultListener,
 } from '../../types/ai.js';
 import type { RequestIntent } from '../../types/runs.js';
 
@@ -13,8 +14,13 @@ export interface PRTitleInput {
   impl_summary: string | undefined;
 }
 
+/**
+ * Reuses {@link IntentClassifyResultListener}: an optional out-of-band signal
+ * carrying the direct-call token usage and resolved profile so the caller can
+ * journal the session. Resolves to the title (or null) regardless.
+ */
 export interface PRTitleGenerator {
-  generate(input: PRTitleInput): Promise<string | null>;
+  generate(input: PRTitleInput, onResult?: IntentClassifyResultListener): Promise<string | null>;
 }
 
 export interface ModelPRTitleGeneratorOptions {
@@ -34,7 +40,7 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
     this.logger = createLogger('pr-title-generator', { destination: options.logDestination });
   }
 
-  async generate(input: PRTitleInput): Promise<string | null> {
+  async generate(input: PRTitleInput, onResult?: IntentClassifyResultListener): Promise<string | null> {
     let content: string;
     try {
       content = await readFile(input.spec_path, 'utf8');
@@ -49,6 +55,7 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
     const truncated = truncateArtifact(content);
     const prompt = buildPrompt(input.intent, truncated, input.impl_summary);
     const route = { task: 'pr.title_generate' as const, intent: input.intent };
+    const profile = this.options.routingPolicy?.resolve(route) ?? null;
 
     let attempt = 0;
     let lastError: unknown;
@@ -56,11 +63,12 @@ export class ModelPRTitleGenerator implements PRTitleGenerator {
       try {
         const response = await this.runner.run({
           route,
-          profile: this.options.routingPolicy?.resolve(route),
+          profile: profile ?? undefined,
           model: this.options.model,
           max_tokens: this.options.max_tokens ?? 60,
           messages: [{ role: 'user', content: prompt }],
         });
+        onResult?.({ usage: response.usage ?? null, profile });
         const title = postProcess(response.text);
         if (title === null) {
           this.logger.warn(

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -11,7 +11,7 @@ import { markArtifactStatus, artifactPath, artifactPublisherId } from '../run-re
 import { getArtifactLifecyclePolicy } from '../../types/artifact.js';
 import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
-import type { AgentSessionCaptureFn, GateReviewExchange, ImplementationResult, ImplementationReviewExchange } from '../../types/ai.js';
+import type { AgentSessionCaptureFn, GateReviewExchange, ImplementationResult, ImplementationReviewExchange, IntentClassifyResult } from '../../types/ai.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
 
@@ -215,17 +215,21 @@ export class ImplementationApprovalHandler {
     const prTitleTs = new Date().toISOString();
     let generatedTitle: string | null;
     let prTitleOutcome: 'ok' | 'failed' = 'ok';
+    const prTitleResult: IntentClassifyResult = {};
     try {
       generatedTitle = await this.deps.prTitleGenerator.generate({
         intent: run.intent,
         spec_path: localPath ?? '',
         impl_summary: run.last_impl_result?.summary,
-      });
+      }, (r) => { prTitleResult.usage = r.usage; prTitleResult.profile = r.profile; });
     } catch (err) {
       prTitleOutcome = 'failed';
       generatedTitle = null;
     }
     if (this.deps.journal) {
+      const prTitleProfile = prTitleResult.profile ?? null;
+      const prTitleProvider = prTitleProfile?.provider ?? 'anthropic_direct';
+      const prTitleRunner: 'anthropic_direct' | 'openai_direct' = prTitleProvider === 'openai_direct' ? 'openai_direct' : 'anthropic_direct';
       void this.deps.journal.captureSession({
         run,
         ts_start: prTitleTs,
@@ -233,14 +237,14 @@ export class ImplementationApprovalHandler {
         phase: run.stage,
         step: 'pr.title_generate',
         round: 1,
-        model: { provider: 'anthropic_direct', name: null },
-        inference: { effort: null, thinking: null },
-        tokens: null,
+        model: { provider: prTitleProvider, name: prTitleProfile?.model ?? null },
+        inference: { effort: prTitleProfile?.effort ?? null, thinking: prTitleProfile?.thinking ?? null },
+        tokens: prTitleResult.usage ?? null,
         assistant_turns: null,
         tool_calls: null,
         tool_results: null,
         outcome: prTitleOutcome,
-        runner: 'anthropic_direct',
+        runner: prTitleRunner,
       }).catch(() => {});
     }
 

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -70,12 +70,12 @@ export class RunJournal {
 
   async captureInboundMessage(
     run: Run,
-    message: { content: string; received_at?: string },
+    message: { content: string; received_at?: string; author?: string },
     intent: Intent | null,
     classificationStatus: JournalClassificationStatus,
   ): Promise<void> {
     const identity = identityForRun(run);
-    const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${run.origin?.message_id ?? 'unknown'}`;
+    const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${message.author ?? 'unknown'}`;
     const ts = message.received_at ?? new Date().toISOString();
 
     const record: Omit<JournalMessageRecord, 'seq' | 'writer_id'> = {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -14,7 +14,7 @@ import type { Run, RunStage, RequestIntent } from '../types/runs.js';
 import { VALID_RUN_STAGES } from '../types/runs.js';
 import type { Request, InboundEvent } from '../types/events.js';
 import type { FeedbackSource } from '../types/feedback-source.js';
-import type { IntentClassifier, ClassificationContext, Intent } from '../types/intent.js';
+import type { IntentClassifier, ClassificationContext, Intent, IntentClassifyResult } from '../types/intent.js';
 import type { ArtifactLifecyclePolicy, ArtifactKind } from '../types/artifact.js';
 import type { SpecCommitter } from './spec-committer.js';
 import type { ImplementationReviewPublisher } from '../types/impl-feedback-page.js';
@@ -33,6 +33,7 @@ import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
 import type { RunJournal } from './journal/run-journal.js';
 import type { AgentProfile } from '../types/ai.js';
+import type { NormalizedTokenUsage } from '../types/journal.js';
 
 /** Maps an actionable review stage to the in-progress stage that prevents duplicate dispatch. */
 function stageAfterApproval(stage: RunStage): RunStage {
@@ -333,11 +334,12 @@ export class OrchestratorImpl implements Orchestrator {
       let stage1Intent: Intent = 'idea';
       if (this.deps.intentClassifier) {
         const classifyTs = new Date().toISOString();
+        const classifyResult: IntentClassifyResult = {};
         try {
-          stage1Intent = await this.deps.intentClassifier.classify(request.content, 'new_thread');
-          this.captureDirectSession(run, 'intent.classify', classifyTs, 'ok');
+          stage1Intent = await this.deps.intentClassifier.classify(request.content, 'new_thread', (r) => { classifyResult.usage = r.usage; classifyResult.profile = r.profile; });
+          this.captureDirectSession(run, 'intent.classify', classifyTs, 'ok', classifyResult.profile ?? null, classifyResult.usage ?? null);
         } catch (err) {
-          this.captureDirectSession(run, 'intent.classify', classifyTs, 'failed');
+          this.captureDirectSession(run, 'intent.classify', classifyTs, 'failed', classifyResult.profile ?? null, classifyResult.usage ?? null);
           await this.handleClassificationUnavailable(run, request.conversation, err);
           return;
         }
@@ -410,11 +412,12 @@ export class OrchestratorImpl implements Orchestrator {
         let intent: Intent = 'idea';
         if (this.deps.intentClassifier) {
           const classifyTs2 = new Date().toISOString();
+          const classifyResult2: IntentClassifyResult = {};
           try {
-            intent = await this.deps.intentClassifier.classify(enrichedMessage, 'existing_issue');
-            this.captureDirectSession(run, 'intent.classify', classifyTs2, 'ok');
+            intent = await this.deps.intentClassifier.classify(enrichedMessage, 'existing_issue', (r) => { classifyResult2.usage = r.usage; classifyResult2.profile = r.profile; });
+            this.captureDirectSession(run, 'intent.classify', classifyTs2, 'ok', classifyResult2.profile ?? null, classifyResult2.usage ?? null);
           } catch (err) {
-            this.captureDirectSession(run, 'intent.classify', classifyTs2, 'failed');
+            this.captureDirectSession(run, 'intent.classify', classifyTs2, 'failed', classifyResult2.profile ?? null, classifyResult2.usage ?? null);
             await this.handleClassificationUnavailable(run, request.conversation, err);
             return;
           }
@@ -545,11 +548,12 @@ export class OrchestratorImpl implements Orchestrator {
       if (this.deps.intentClassifier) {
         const context: ClassificationContext = routingStage as ClassificationContext;
         const classifyTs3 = new Date().toISOString();
+        const classifyResult3: IntentClassifyResult = {};
         try {
-          intent = await this.deps.intentClassifier.classify(feedback.content, context);
-          this.captureDirectSession(run, 'intent.classify', classifyTs3, 'ok');
+          intent = await this.deps.intentClassifier.classify(feedback.content, context, (r) => { classifyResult3.usage = r.usage; classifyResult3.profile = r.profile; });
+          this.captureDirectSession(run, 'intent.classify', classifyTs3, 'ok', classifyResult3.profile ?? null, classifyResult3.usage ?? null);
         } catch (err) {
-          this.captureDirectSession(run, 'intent.classify', classifyTs3, 'failed');
+          this.captureDirectSession(run, 'intent.classify', classifyTs3, 'failed', classifyResult3.profile ?? null, classifyResult3.usage ?? null);
           void this.deps.journal?.captureInboundMessage(
             run,
             { content: feedback.content, author: feedback.author },
@@ -821,6 +825,7 @@ export class OrchestratorImpl implements Orchestrator {
     ts_start: string,
     outcome: 'ok' | 'failed',
     profile?: AgentProfile | null,
+    usage?: NormalizedTokenUsage | null,
   ): void {
     if (!this.deps.journal) return;
     const ts_end = new Date().toISOString();
@@ -841,7 +846,7 @@ export class OrchestratorImpl implements Orchestrator {
         effort: profile?.effort ?? null,
         thinking: profile?.thinking ?? null,
       },
-      tokens: null,
+      tokens: usage ?? null,
       assistant_turns: null,
       tool_calls: null,
       tool_results: null,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -427,7 +427,7 @@ export class OrchestratorImpl implements Orchestrator {
         const stage2ClassificationStatus = this.deps.intentClassifier ? 'classified' : 'defaulted';
         void this.deps.journal?.captureInboundMessage(
           run,
-          { content: request.content },
+          { content: request.content, author: request.author },
           intent,
           stage2ClassificationStatus,
         ).catch(() => {});
@@ -478,7 +478,7 @@ export class OrchestratorImpl implements Orchestrator {
       const stage1ClassificationStatus = this.deps.intentClassifier ? 'classified' : 'defaulted';
       void this.deps.journal?.captureInboundMessage(
         run,
-        { content: request.content },
+        { content: request.content, author: request.author },
         intent,
         stage1ClassificationStatus,
       ).catch(() => {});
@@ -552,7 +552,7 @@ export class OrchestratorImpl implements Orchestrator {
           this.captureDirectSession(run, 'intent.classify', classifyTs3, 'failed');
           void this.deps.journal?.captureInboundMessage(
             run,
-            { content: feedback.content },
+            { content: feedback.content, author: feedback.author },
             null,
             'failed',
           ).catch(() => {});
@@ -566,7 +566,7 @@ export class OrchestratorImpl implements Orchestrator {
       const threadMsgClassificationStatus = this.deps.intentClassifier ? 'classified' : 'defaulted';
       void this.deps.journal?.captureInboundMessage(
         run,
-        { content: feedback.content },
+        { content: feedback.content, author: feedback.author },
         intent,
         threadMsgClassificationStatus,
       ).catch(() => {});
@@ -576,7 +576,7 @@ export class OrchestratorImpl implements Orchestrator {
       if (FEEDBACK_INTENTS.has(intent) && this.deps.journal) {
         const feedbackTarget = (routingStage === 'reviewing_spec' || routingStage === 'awaiting_planning_input')
           ? 'artifact' as const : 'implementation' as const;
-        const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${feedback.origin?.message_id ?? 'unknown'}`;
+        const authorPrincipal = `${run.conversation?.provider ?? 'unknown'}:${feedback.author ?? 'unknown'}`;
         void this.deps.journal.captureFeedback({
           id: `${feedback.request_id}:${feedback.received_at ?? new Date().toISOString()}`,
           run,

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,4 +1,4 @@
-import type { ClassificationContext, Intent, IntentClassifier } from './intent.js';
+import type { ClassificationContext, Intent, IntentClassifier, IntentClassifyResult, IntentClassifyResultListener } from './intent.js';
 import type { Request, ThreadMessage } from './events.js';
 import type { ArtifactKind } from './artifact.js';
 import type { RunStage } from './runs.js';
@@ -402,4 +402,4 @@ export interface SpecReviewAuthorResponseResult {
   error?: string;
 }
 
-export type { ClassificationContext, Intent, IntentClassifier };
+export type { ClassificationContext, Intent, IntentClassifier, IntentClassifyResult, IntentClassifyResultListener };

--- a/src/types/intent.ts
+++ b/src/types/intent.ts
@@ -1,4 +1,6 @@
 import type { RunStage } from './runs.js';
+import type { NormalizedTokenUsage } from './journal.js';
+import type { AgentProfile } from './ai.js';
 
 export type Intent =
   | 'idea'
@@ -14,8 +16,25 @@ export type Intent =
 
 export type ClassificationContext = 'new_thread' | 'existing_issue' | RunStage | string;
 
+/**
+ * Optional out-of-band signal emitted by a classifier when it performs a real
+ * direct-model call, so callers (e.g. the orchestrator) can journal the token
+ * usage and resolved profile for that call. Bare-string-returning classifiers
+ * and mocks may omit it entirely; `classify` still resolves to the Intent.
+ */
+export interface IntentClassifyResult {
+  usage?: NormalizedTokenUsage | null;
+  profile?: AgentProfile | null;
+}
+
+export type IntentClassifyResultListener = (result: IntentClassifyResult) => void;
+
 export interface IntentClassifier {
-  classify(message: string, context: ClassificationContext): Promise<Intent>;
+  classify(
+    message: string,
+    context: ClassificationContext,
+    onResult?: IntentClassifyResultListener,
+  ): Promise<Intent>;
 }
 
 export interface IntentDefinition {

--- a/tests/core/ai/model-intent-classifier.test.ts
+++ b/tests/core/ai/model-intent-classifier.test.ts
@@ -38,6 +38,51 @@ describe('ModelIntentClassifier', () => {
     expect(requests[0].messages[0].content).not.toContain('Slack message');
   });
 
+  test('emits the direct-call token usage and resolved profile via onResult', async () => {
+    const usage = { input: 200, output: 5, cache_read: 0, cache_write: 0 };
+    const resolvedProfile = { id: 'intent', provider: 'anthropic_direct', model: 'claude-haiku-4-5' };
+    const runner: DirectModelRunner = {
+      async run() {
+        return { text: 'question', usage };
+      },
+    };
+    const registry = new IntentRegistryImpl();
+    registry.register({ name: 'question', description: 'A question', valid_contexts: ['new_thread'] });
+    registry.register({ name: 'idea', description: 'An idea', valid_contexts: ['new_thread'], fallback_contexts: ['new_thread'] });
+
+    const routingPolicy = {
+      resolve: () => resolvedProfile as never,
+      resolveOptional: () => resolvedProfile as never,
+    };
+    const classifier = new ModelIntentClassifier(runner, { intentRegistry: registry, routingPolicy });
+
+    const seen: Array<{ usage?: unknown; profile?: unknown }> = [];
+    const intent = await classifier.classify('How many open issues?', 'new_thread', (r) => { seen.push(r); });
+
+    expect(intent).toBe('question');
+    expect(seen).toHaveLength(1);
+    expect(seen[0].usage).toEqual(usage);
+    expect(seen[0].profile).toEqual(resolvedProfile);
+  });
+
+  test('emits null usage via onResult when the runner provides none', async () => {
+    const runner: DirectModelRunner = {
+      async run() {
+        return { text: 'idea' };
+      },
+    };
+    const registry = new IntentRegistryImpl();
+    registry.register({ name: 'idea', description: 'An idea', valid_contexts: ['new_thread'], fallback_contexts: ['new_thread'] });
+
+    const classifier = new ModelIntentClassifier(runner, { intentRegistry: registry });
+
+    const seen: Array<{ usage?: unknown }> = [];
+    await classifier.classify('Build a thing', 'new_thread', (r) => { seen.push(r); });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].usage).toBeNull();
+  });
+
   test('throws a classification unavailable error when direct model calls fail', async () => {
     const runner: DirectModelRunner = {
       async run() {

--- a/tests/core/ai/pr-title-generator.test.ts
+++ b/tests/core/ai/pr-title-generator.test.ts
@@ -54,6 +54,31 @@ describe('ModelPRTitleGenerator', () => {
     expect(requests[0].messages[0].content).toContain('switched to dataSources.query');
   });
 
+  test('emits direct-call token usage and resolved profile via onResult', async () => {
+    const usage = { input: 900, output: 12, cache_read: 0, cache_write: 0 };
+    const resolvedProfile = { id: 'pr-title', provider: 'anthropic_direct', model: 'claude-haiku-4-5' };
+    const requests: DirectModelRunRequest[] = [];
+    const runner: DirectModelRunner = {
+      async run(request) {
+        requests.push(request);
+        return { text: 'add a setup wizard', usage };
+      },
+    };
+    const routingPolicy = {
+      resolve: () => resolvedProfile as never,
+      resolveOptional: () => resolvedProfile as never,
+    };
+    const gen = new ModelPRTitleGenerator(runner, { routingPolicy });
+    const seen: Array<{ usage?: unknown; profile?: unknown }> = [];
+    await withSpec('# Idea: setup wizard\n\ndetails', async (path) => {
+      const title = await gen.generate({ intent: 'idea', spec_path: path, impl_summary: 'added wizard' }, (r) => { seen.push(r); });
+      expect(title).toBe('add a setup wizard');
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].usage).toEqual(usage);
+    expect(seen[0].profile).toEqual(resolvedProfile);
+  });
+
   test('truncates the artifact at the first implementation-heavy heading', async () => {
     const { runner, requests } = fakeRunner('title ok');
     const gen = new ModelPRTitleGenerator(runner);

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -267,13 +267,56 @@ describe('ImplementationApprovalHandler', () => {
       intent: 'bug',
       spec_path: '/ws/request-001/context-human/specs/feature-test.md',
       impl_summary: 'Implemented it.',
-    });
+    }, expect.any(Function));
     expect(deps.prManager.createPR).toHaveBeenCalledWith(
       '/ws/request-001',
       'spec/request-001',
       expect.any(String),
       expect.objectContaining({ title: 'short descriptive title' }),
     );
+  });
+
+  it('journals pr.title_generate session with the usage emitted by the generator', async () => {
+    const usage = { input: 950, output: 9, cache_read: 0, cache_write: 0 };
+    const sessions: Array<Record<string, unknown>> = [];
+    const journal = {
+      captureSession: vi.fn().mockImplementation(async (rec: Record<string, unknown>) => { sessions.push(rec); }),
+      captureFeedback: vi.fn().mockResolvedValue(undefined),
+    };
+    const { handler } = makeHandler({
+      journal,
+      prTitleGenerator: {
+        generate: vi.fn().mockImplementation(async (_input, onResult) => {
+          onResult?.({ usage, profile: { id: 'pr', provider: 'anthropic_direct', model: 'claude-haiku' } });
+          return 'generated title';
+        }),
+      },
+    });
+
+    await handler.handle(makeRun(), makeFeedback());
+
+    const prTitleSession = sessions.find((s) => s.step === 'pr.title_generate');
+    expect(prTitleSession, 'expected a pr.title_generate session record').toBeDefined();
+    expect(prTitleSession!.tokens).toEqual(usage);
+    expect((prTitleSession!.model as { provider: string }).provider).toBe('anthropic_direct');
+  });
+
+  it('journals pr.title_generate session tokens as null when the generator emits no usage', async () => {
+    const sessions: Array<Record<string, unknown>> = [];
+    const journal = {
+      captureSession: vi.fn().mockImplementation(async (rec: Record<string, unknown>) => { sessions.push(rec); }),
+      captureFeedback: vi.fn().mockResolvedValue(undefined),
+    };
+    const { handler } = makeHandler({
+      journal,
+      prTitleGenerator: { generate: vi.fn().mockResolvedValue('generated title') },
+    });
+
+    await handler.handle(makeRun(), makeFeedback());
+
+    const prTitleSession = sessions.find((s) => s.step === 'pr.title_generate');
+    expect(prTitleSession, 'expected a pr.title_generate session record').toBeDefined();
+    expect(prTitleSession!.tokens).toBeNull();
   });
 
   it('omits title when the generator returns null', async () => {

--- a/tests/core/journal/run-journal-facade.test.ts
+++ b/tests/core/journal/run-journal-facade.test.ts
@@ -112,7 +112,7 @@ describe('RunJournal facade', () => {
     const journal = new RunJournal(writer);
     const run = makeRun();
 
-    const message = { content: 'Hello, my api_key=sk-1234567890abcdef', received_at: '2024-01-01T00:00:00.000Z' };
+    const message = { content: 'Hello, my api_key=sk-1234567890abcdef', received_at: '2024-01-01T00:00:00.000Z', author: 'U0ARZ2S9K0C' };
     await journal.captureInboundMessage(run, message, 'idea', 'classified');
 
     expect(calls).toHaveLength(1);
@@ -125,11 +125,23 @@ describe('RunJournal facade', () => {
     expect(rec.content).toContain('[REDACTED]');
     expect(rec.intent).toBe('idea');
     expect(rec.classification_status).toBe('classified');
-    expect(rec.author_principal).toBe('slack:msg-789');
+    // author_principal is derived from the real author (Slack user id), not the message id
+    expect(rec.author_principal).toBe('slack:U0ARZ2S9K0C');
     expect(rec.origin_message_id).toBe('slack:C123:T456:msg-789');
     expect(rec.conversation_id).toBe('slack:C123:T456');
     expect(rec.run_id).toBe('run-001');
     expect(rec.request_id).toBe('req-001');
+  });
+
+  it('captureInboundMessage falls back to unknown principal when author is absent', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureInboundMessage(run, { content: 'hello' }, null, 'not_applicable');
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.author_principal).toBe('slack:unknown');
   });
 
   it('captureInboundMessage uses current time when received_at is absent', async () => {

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -32,7 +32,7 @@ import type { ChannelRepoMap, RepoEntry } from '../../src/types/config.js';
 import type { ChannelRef, ConversationRef, MessageRef } from '../../src/types/channel.js';
 import { HandlerRegistryImpl } from '../../src/core/handler-registry.js';
 import { RunJournal } from '../../src/core/journal/run-journal.js';
-import type { JournalWriter, JournalStream } from '../../src/types/journal.js';
+import type { JournalWriter, JournalStream, NormalizedTokenUsage } from '../../src/types/journal.js';
 
 const nullDest = { write: () => {} };
 
@@ -1111,7 +1111,7 @@ describe('Orchestrator — intent classification routing', () => {
     adapter._emit({ type: 'thread_message', payload: makeFeedback({ content: 'thanks' }) });
     await new Promise(r => setTimeout(r, 50));
 
-    expect(classifier.classify).toHaveBeenCalledWith('thanks', 'awaiting_planning_input');
+    expect(classifier.classify).toHaveBeenCalledWith('thanks', 'awaiting_planning_input', expect.any(Function));
     expect(run.stage).toBe('awaiting_planning_input');
 
     const action = await (orch as unknown as { _classify(e: unknown): Promise<string> })._classify({
@@ -1140,6 +1140,7 @@ describe('Orchestrator — intent classification routing', () => {
     expect(ic.classify).toHaveBeenCalledWith(
       'wizard should not require all settings',
       'reviewing_spec',
+      expect.any(Function),
     );
   });
 
@@ -6634,5 +6635,74 @@ describe('Orchestrator — journal author attribution', () => {
     expect(feedbackRec, 'expected a feedback record').toBeDefined();
     expect(feedbackRec!.record.author_principal).toBe('slack:U0FEEDBACK1');
     expect(feedbackRec!.record.author_principal).not.toContain('1780808737.823699');
+  });
+});
+
+describe('Orchestrator — direct-call token threading', () => {
+  const SAMPLE_USAGE: NormalizedTokenUsage = { input: 120, output: 8, cache_read: 0, cache_write: 0 };
+
+  /** Classifier that emits a usage signal via the onResult callback, like the real ModelIntentClassifier. */
+  function makeUsageEmittingClassifier(intent: string, usage: NormalizedTokenUsage | null): IntentClassifier {
+    return {
+      classify: vi.fn().mockImplementation(async (_msg, _ctx, onResult) => {
+        onResult?.({ usage, profile: { id: 'p', provider: 'anthropic_direct', model: 'claude-haiku' } });
+        return intent;
+      }),
+    };
+  }
+
+  it('threads emitted usage into the intent.classify session record', async () => {
+    const adapter = makeMockAdapter();
+    const { journal, calls } = makeCapturingJournal();
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+        artifactPublisher: makeArtifactPublisher(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        channelRepoMap: makeChannelRepoMap(),
+        intentClassifier: makeUsageEmittingClassifier('idea', SAMPLE_USAGE),
+        journal,
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest({ author: 'U1' }) });
+    await new Promise(r => setTimeout(r, 80));
+    await orch.stop();
+
+    const classifySession = calls.find(c => c.stream === 'sessions' && c.record.step === 'intent.classify');
+    expect(classifySession, 'expected an intent.classify session record').toBeDefined();
+    expect(classifySession!.record.tokens).toEqual(SAMPLE_USAGE);
+    expect((classifySession!.record.model as { provider: string }).provider).toBe('anthropic_direct');
+  });
+
+  it('journals intent.classify tokens as null when the classifier emits no usage', async () => {
+    const adapter = makeMockAdapter();
+    const { journal, calls } = makeCapturingJournal();
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+        artifactPublisher: makeArtifactPublisher(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        channelRepoMap: makeChannelRepoMap(),
+        intentClassifier: makeUsageEmittingClassifier('idea', null),
+        journal,
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest({ author: 'U777' }) });
+    await new Promise(r => setTimeout(r, 80));
+    await orch.stop();
+
+    const classifySession = calls.find(c => c.stream === 'sessions' && c.record.step === 'intent.classify');
+    expect(classifySession, 'expected an intent.classify session record').toBeDefined();
+    expect(classifySession!.record.tokens).toBeNull();
   });
 });

--- a/tests/core/orchestrator.test.ts
+++ b/tests/core/orchestrator.test.ts
@@ -31,8 +31,20 @@ import type { CommandEvent, CommandRegistry } from '../../src/types/commands.js'
 import type { ChannelRepoMap, RepoEntry } from '../../src/types/config.js';
 import type { ChannelRef, ConversationRef, MessageRef } from '../../src/types/channel.js';
 import { HandlerRegistryImpl } from '../../src/core/handler-registry.js';
+import { RunJournal } from '../../src/core/journal/run-journal.js';
+import type { JournalWriter, JournalStream } from '../../src/types/journal.js';
 
 const nullDest = { write: () => {} };
+
+function makeCapturingJournal() {
+  const calls: Array<{ stream: JournalStream; record: Record<string, unknown> }> = [];
+  const writer: JournalWriter = {
+    append: vi.fn().mockImplementation(async (stream: JournalStream, record: unknown) => {
+      calls.push({ stream, record: record as Record<string, unknown> });
+    }),
+  };
+  return { journal: new RunJournal(writer), calls };
+}
 const DEFAULT_CHANNEL_ID = 'C123';
 const DEFAULT_CONVERSATION_ID = '100.0';
 
@@ -6561,5 +6573,66 @@ describe('Orchestrator — AI context clearing on stage transition', () => {
 
     expect(run.current_model).toBe('claude-opus-4-5');
     expect(run.last_agent_request_at).toBe('2026-01-01T00:00:00.000Z');
+  });
+});
+
+describe('Orchestrator — journal author attribution', () => {
+  it('journals inbound message author_principal from the real author (Slack user id)', async () => {
+    const adapter = makeMockAdapter();
+    const { journal, calls } = makeCapturingJournal();
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+        artifactPublisher: makeArtifactPublisher(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        channelRepoMap: makeChannelRepoMap(),
+        intentClassifier: makeIntentClassifier('idea'),
+        journal,
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+    adapter._emit({ type: 'new_request', payload: makeRequest({ author: 'U0ARZ2S9K0C' }) });
+    await new Promise(r => setTimeout(r, 80));
+    await orch.stop();
+
+    const messageRec = calls.find(c => c.stream === 'messages' && c.record.direction === 'in');
+    expect(messageRec, 'expected an inbound message record').toBeDefined();
+    expect(messageRec!.record.author_principal).toBe('slack:U0ARZ2S9K0C');
+  });
+
+  it('journals feedback author_principal from the real author, not the message id', async () => {
+    const adapter = makeMockAdapter();
+    const { journal, calls } = makeCapturingJournal();
+    const ic = makeIntentClassifier('feedback');
+    const orch = new OrchestratorImpl(
+      {
+        adapter: adapter as never,
+        workspaceManager: makeWorkspaceManager(),
+        artifactAuthoringAgent: makeArtifactAuthoringAgent(),
+        artifactPublisher: makeArtifactPublisher(),
+        postError: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue(undefined),
+        channelRepoMap: makeChannelRepoMap(),
+        intentClassifier: ic,
+        journal,
+      },
+      { logDestination: nullDest },
+    );
+    await orch.start();
+
+    const runs = (orch as unknown as { runs: Map<string, Run> }).runs;
+    runs.set('request-001', makeRun({ stage: 'reviewing_spec' }));
+    adapter._emit({ type: 'thread_message', payload: makeFeedback({ author: 'U0FEEDBACK1', origin: messageRef('C1', '100.0', '1780808737.823699') }) });
+    await new Promise(r => setTimeout(r, 80));
+    await orch.stop();
+
+    const feedbackRec = calls.find(c => c.stream === 'feedback');
+    expect(feedbackRec, 'expected a feedback record').toBeDefined();
+    expect(feedbackRec!.record.author_principal).toBe('slack:U0FEEDBACK1');
+    expect(feedbackRec!.record.author_principal).not.toContain('1780808737.823699');
   });
 });


### PR DESCRIPTION
Two live data-quality fixes to the backfill journal (#195), found while validating the live journal output. Based on `main` (includes #196). Convergence behavior is untouched.

## Fix 1 — real `author_principal` for messages & feedback
The journal was recording `author_principal` as `<provider>:<message_id>` (a message timestamp) for every human inbound message and feedback item, instead of the actual author. `Request.author`/`ThreadMessage.author` carry the real Slack user id — now threaded into `captureInboundMessage` and the feedback capture, so attribution reads e.g. `slack:U0ARZ2S9K0C` instead of `slack:1780808737.823699`.

## Fix 2 — thread token usage into `anthropic_direct` sessions
Orchestrator-owned direct calls (`intent.classify`, `pr.title_generate`) journaled `tokens: null` because `IntentClassifier.classify` / `PRTitleGenerator` dropped the underlying `DirectModelRunResult.usage`. Added an optional `onResult` listener (no change to `classify()`'s return contract — lowest churn across 4 callers + mocks) that surfaces usage + resolved profile; `captureDirectSession` now records the real token breakdown. (OpenAI-agent `tokens: null` is an expected provider gap, left as-is.)

## Verification
- `npm run lint` clean; `npm test` 1525 passed (88 files) — baseline 1515 + 10 new tests covering both fixes (real-author and absent-author; usage-present and usage-absent paths).