### PR TITLE
feat: add build-gated layered diff convergence with altitude-aware critic review

### DIFF
--- a/context-human/specs/enhancement-layered-diff-convergence.md
+++ b/context-human/specs/enhancement-layered-diff-convergence.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-07
 last_updated: 2026-06-07
-status: implementing
+status: complete
 issue: 194
 specced_by: autocatalyst
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-layered-diff-convergence.md
+++ b/context-human/specs/enhancement-layered-diff-convergence.md
@@ -1,0 +1,918 @@
+---
+created: 2026-06-07
+last_updated: 2026-06-07
+status: implementing
+issue: 194
+specced_by: autocatalyst
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Layered-diff convergence
+
+## Parent feature
+
+Primary parent feature:
+- `feature-approval-to-implementation.md` — provides the implementation lifecycle, human testing guide, implementation approval path, and terminal run states.
+Related specs that this enhancement extends or interlocks with:
+- `enhancement-two-part-implementation-review.md` — adds initial and final implementation review checkpoints and review exchange records.
+- `enhancement-bounded-convergence-review.md` — provides the bounded proposer/critic convergence loop, role-aware routing, `gate_exchanges`, same-model guard, and role/round/gate journal fields.
+- `enhancement-append-only-backfill-journal.md` — provides durable `sessions.jsonl` and `feedback.jsonl` streams that this enhancement enriches by altitude.
+- `enhancement-run-status-workspace-ai-context.md` — surfaces active model request metadata while implementation and review agents are running.
+- `enhancement-model-provider-config.md` and `feature-openai-agent-sdk-runner.md` — provide provider-neutral AI profiles and route-based model selection.
+GitHub issue: [#194 — Layered-diff convergence: altitude-staged implementer with layout/public/private/build review lenses](https://github.com/markdstafford/autocatalyst-v0/issues/194)
+## What
+
+Autocatalyst changes implementation from one large build pass into an optional descending-altitude build loop. When enabled, the implementation phase runs ordered altitude passes before the human sees a testing guide:
+1. **Layout** — files, classes, modules, exported names as comments, and intent comments only.
+2. **Public API** — exported signatures, public types, module boundary contracts, and expected error contracts.
+3. **Private API** — internal helper signatures, responsibilities, docstrings, and internal seams.
+4. **Build** — bodies, tests, docs updates, and the existing build-level bounded convergence review.
+A proposer model fills only the current layer. A critic model reviews the current partial git diff for that altitude. If the critic finds blocker or warning issues that are in scope for that altitude, the proposer revises the current layer and the critic reviews again. The loop reuses the bounded convergence rules from issue 193: it converges when no blocker or warning findings remain, fails on max-round exhaustion, and fails on oscillation.
+Every altitude reviews real source code through git diff context. Autocatalyst does not introduce design artifact files, manifest parsers, or new run stages. Intermediate code may not compile at the layout, public API, or private API altitudes; that is expected. The final build altitude must produce compiling, tested code according to the existing implementation contract.
+The enhancement is config-gated under the existing implementation review convergence switch and remains off by default. With convergence disabled, behavior is unchanged. With convergence enabled and depth set to `build_only`, behavior matches the bounded build-level convergence model from issue 193.
+## Why
+
+The current bounded convergence loop catches implementation problems after the implementer has already produced a full diff. That is useful, but it catches the most expensive disagreements late. If the reviewer dislikes the file layout, public API shape, or helper boundaries after bodies and tests exist, the implementer must rewrite more code and may preserve accidental structure because it is already embedded in the diff.
+Layered convergence moves those disagreements earlier. The critic can challenge wrong files, awkward exported contracts, or weak helper boundaries while the diff is still cheap to change. The implementer then builds bodies only after the higher-altitude structure has converged.
+This keeps the experiment cheap to build because the artifact under review is always a git diff. The same coordinator, reviewer context, exchange persistence, role routing, and journal fields can be reused with altitude-specific prompts and context selection.
+## User stories
+
+- As Enzo, I can enable full layered convergence for feature work so layout, public API, private API, and build decisions each receive critic review before the next layer is written.
+- As Enzo, I can run build-only convergence for chores and get behavior identical to issue 193.
+- As Enzo, I can see a run fail when an early altitude does not converge instead of watching later code pile onto a bad structure.
+- As Enzo, I can inspect the testing guide and journal records to see which altitude produced findings, how many rounds it took, and why a gate failed if it did.
+- As Phoebe, I can read the testing guide and understand that the implementation passed staged AI review without reading raw model transcripts.
+- As an operator, I can choose a depth ladder per repository or run so expensive early gates are used only when they are worth the cost.
+- As an operator, I can set a hard per-run model-session budget so layered convergence cannot fan out indefinitely across feedback passes.
+- As Enzo, I can have small human feedback default to build-only reconvergence instead of paying for the full altitude ladder again.
+- As an operator, I can trust ordinary runs because the feature is off by default and build-only mode preserves current convergence behavior.
+- As an analytics agent, I can compare findings, rounds, cost, and latency by altitude using `sessions.jsonl`, `feedback.jsonl`, and `gate_exchanges`.
+## Design changes
+
+This is a backend workflow enhancement. It adds no new primary UI. Existing testing-guide and progress-message surfaces gain altitude-specific review history when layered convergence is enabled.
+### Goals
+
+- Split implementation into ordered altitude passes: `layout`, `public_api`, `private_api`, and `build`.
+- Ensure each enabled altitude converges through the issue 193 bounded loop or fails the run before the next altitude starts.
+- Keep all altitude review context as real git diffs; do not introduce separate design artifacts or parsers.
+- Feed critics the correct partial diff for the current altitude through a `getContext(gate)` strategy.
+- Use altitude-specific proposer, critic, and revise prompts for every enabled altitude.
+- Mechanically prevent early-altitude critics from filing missing-body or missing-implementation findings.
+- Mechanically reject early-altitude proposer diffs that add lower-altitude bodies or tests before the build gate.
+- Enforce a global model-session ceiling across initial implementation, layered gates, and implementation feedback passes.
+- Verify that the build altitude preserves converged layout/public/private contracts unless an upper gate is explicitly re-run.
+- Checkpoint each converged altitude before starting the next altitude.
+- Add a depth ladder so cost can be tuned from build-only to full layered convergence.
+- Persist gate history and journal sessions with altitude gate names.
+- Add per-altitude telemetry with gate ID, round, finding counts, elapsed time, profile IDs, and outcome.
+- Preserve all existing behavior when convergence is disabled.
+### Non-goals
+
+- Replacing the issue 193 convergence engine, role routing, same-model guard, oscillation guard, or exchange persistence.
+- Adding new `RunStage` values or human approval points between altitudes.
+- Adding multi-critic fan-out, voting, or consensus protocols.
+- Adding first-class design artifacts, schemas, or parsers for layout or API plans.
+- Guaranteeing layout/API critics have compiler or test signal. Early gates review by reading because intermediate code may not compile.
+- Changing final post-human-approval PR review beyond preserving the existing build-level bounded review.
+- Guaranteeing provider-level read-only critic isolation. Autocatalyst can enforce prompts, routing, and branch guards; provider sandbox behavior remains runner-specific.
+### Personas and narratives
+
+- **Enzo: Engineer/operator** — wants expensive structural disagreement to happen before bodies and tests are written.
+- **Phoebe: Product manager** — wants a simple testing guide that says staged AI review happened and whether it converged.
+- **Autocatalyst operator** — chooses the depth ladder and model profiles for cost, speed, and quality.
+- **Analytics agent** — reads per-altitude journals to decide whether each gate earns its cost.
+A full feature run starts after spec approval and implementation planning. Autocatalyst asks the proposer to create only a layout: new files, module/class declarations if useful, and intent comments. The layout critic flags that a new helper file duplicates an existing service boundary. The proposer moves the skeleton into the existing module, and the critic converges. Only then does Autocatalyst ask for public signatures.
+At the public API altitude, the critic challenges an exported function because it returns `boolean` where callers need an error reason. The proposer changes the signature to return a discriminated result type. The critic converges before any body exists, so the later build altitude can implement the better contract directly.
+For a small chore, the operator sets depth to `build_only`. Autocatalyst skips layout and API altitudes and runs the issue 193 build-level convergence loop exactly as before. The cost stays low, and existing run behavior remains predictable.
+### Altitude contracts
+
+Each altitude has a strict output contract. The proposer must fill only the current layer and must not sneak lower-altitude work into earlier passes.
+
+Altitude
+Proposer may add
+Proposer must not add
+Critic focus
+Allowed finding categories
+
+`layout`
+Skeleton files, modules, classes, exported-name comments, high-level intent comments, `TODO(gate-layout)` markers
+Function signatures, type definitions with meaningful fields, bodies, tests
+File placement, naming, reuse of existing modules, missing call sites, needless new files
+`maintainability`, `docs`
+
+`public_api`
+Exported signatures, public types, public constants, module boundary error contracts, public doc comments, `TODO(gate-public_api)` markers
+Private helper signatures, bodies, tests
+Exported names, parameter shape, return shape, public error contracts, boundary ownership
+`maintainability`, `docs`, `security`
+
+`private_api`
+Internal helper signatures, internal types, docstrings, responsibility comments, `TODO(gate-private_api)` markers
+Bodies and tests except tiny placeholder throws when required by TypeScript syntax
+Helper seams, duplicated helpers, dead helpers, responsibility split, private error flow
+`maintainability`, `docs`, `security`
+
+`build`
+Bodies, tests, docs updates, config updates, final cleanup
+Unreviewed large structural pivots unless required to satisfy build findings
+Correctness, tests, security, maintainability, docs, PR readiness where applicable
+Existing issue 193 build/final category set
+
+Early-altitude critic prompts must state this contract directly:
+```plain text
+You are reviewing a -only diff. Signatures and/or bodies may be intentionally absent and out of scope. TODO(gate-*) markers are expected and correct at this altitude. Do not file missing-body, missing-test, or missing-implementation findings for work that belongs to a lower altitude.
+```
+The prompt is not the only guard. The coordinator filters findings by each altitude's category allowlist and by normalized finding scope before deciding whether the gate blocks. Early-altitude critic verdicts must include backward-compatible metadata on each finding:
+```typescript
+type LayeredFindingScope = 'current_altitude' | 'lower_altitude' | 'prior_context';
+type LayeredFindingReasonCode =
+  | 'altitude_contract_violation'
+  | 'layout_boundary'
+  | 'public_api_contract'
+  | 'private_api_contract'
+  | 'security_contract'
+  | 'documentation_gap'
+  | 'missing_lower_altitude_body'
+  | 'missing_lower_altitude_test'
+  | 'missing_lower_altitude_implementation'
+  | 'build_signal_unavailable_until_build';
+```
+The existing `ImplementationReviewResult` and finding category enum remain closed. The new `scope` and `reason_code` fields are optional for backward compatibility on stored results. Altitude critic prompts must require them for new layered verdicts, but parser/coordinator handling is fail-open for early gates: a finding with missing or invalid `scope` or `reason_code` is downgraded to a recorded non-blocking note with filter reason `invalid_layered_metadata`. The coordinator must not infer these fields from free text and must not fail the whole critic verdict solely because optional layered metadata is absent. Other structured-output errors that make the verdict unreadable still use the existing structured-output recovery path.
+Filtering order is deterministic:
+1. Findings with `severity: "info"` never block.
+2. At `layout`, `public_api`, or `private_api`, findings with missing or invalid `scope` or `reason_code` are recorded as non-blocking notes with filter reason `invalid_layered_metadata`. They do not block, even when their category is otherwise allowed.
+3. At `layout`, `public_api`, or `private_api`, findings with `scope: "lower_altitude"` or reason code `missing_lower_altitude_body`, `missing_lower_altitude_test`, `missing_lower_altitude_implementation`, or `build_signal_unavailable_until_build` are recorded as out-of-scope notes and must not block, even when the category is otherwise allowed such as `maintainability`.
+4. Findings whose category is not allowed for the current altitude are recorded as out-of-scope notes and must not block.
+5. Remaining blocker or warning findings block convergence.
+A critic result with invalid layered metadata, disallowed categories, or out-of-scope lower-altitude reason codes is recorded for diagnostics but does not block the gate. If all findings are filtered or info-only, the gate converges with notes. This keeps early gates from failing because bodies or tests are absent, even if a critic labels that request as an allowed category such as `maintainability`, and keeps gate success from depending on a critic model always emitting novel metadata correctly.
+### Required altitude contract validation
+
+Prompts and critic review are not sufficient to preserve altitude separation. The coordinator must run a required mechanical validator after every `layout`, `public_api`, and `private_api` proposer pass and after every proposer revision in those gates, before calling the critic and before creating a checkpoint. The validator operates on the changed regions in the cumulative diff for supported TypeScript/JavaScript source files.
+Rules:
+- `layout` diffs are rejected when changed regions add non-comment function or method bodies, meaningful type/interface fields, executable statements, test files, or assertions. Empty declarations, comments, and `TODO(gate-layout)` markers are allowed.
+- `public_api` diffs are rejected when changed regions add private helper signatures, executable bodies, tests, or assertions. Exported signatures, public types, public constants, public doc comments, and `TODO(gate-public_api)` markers are allowed.
+- `private_api` diffs are rejected when changed regions add executable bodies, tests, or assertions beyond tiny syntax placeholders such as a single `throw new Error("TODO(gate-private_api)")` needed to keep TypeScript syntax representable.
+- Validation failures are represented as synthetic in-scope findings with reason code `altitude_contract_violation`. If a revision round remains and the global session budget allows it, the proposer is asked to revise. If the violation persists or no revision budget remains, the gate fails before any lower altitude starts.
+- The required v0 validator must cover TypeScript and JavaScript files because this repository is TypeScript. Unsupported changed file types must be logged as unsupported validation coverage and still reviewed by prompts/critics, but they do not satisfy the TypeScript/JavaScript mechanical acceptance criteria.
+### Build contract preservation
+
+The accepted upper altitudes become contracts for the build proposer. Before the build gate can converge, Autocatalyst must compare the build result against the most recent accepted upper-altitude checkpoints and verify that reviewed structure remains intact.
+Rules:
+- The check compares exported names, exported signatures, public type shapes, module/file layout, and private helper signatures when a corresponding upper altitude was enabled.
+- The build proposer may fill bodies, tests, docs, and final cleanup, but must not silently change a converged public API, move reviewed layout boundaries, or reshape private seams.
+- If the build pass discovers that an upper contract must change to satisfy correctness, Autocatalyst must either rerun the affected upper altitude and downstream altitudes within the remaining model-session budget or fail with a clear contract-drift error. It must not let the build gate pass with unreviewed upper-altitude drift.
+- The build critic prompt must include the accepted upper-altitude summaries/checkpoint references and explicitly ask the critic to flag unapproved contract drift.
+V0 comparison mechanics are intentionally narrow and deterministic:
+- Supported languages are TypeScript and JavaScript source files: `.ts`, `.tsx`, `.js`, `.jsx`, `.mts`, `.cts`, `.mjs`, and `.cjs`. Declaration files are compared as public API text after normalization. Unsupported file types are included in module/file layout comparisons by path only and are logged as unsupported symbol extraction coverage.
+- Extraction must use the TypeScript compiler API or an existing structured AST helper, not regex-only parsing, for supported files.
+- Module/file layout is the sorted set of changed source paths accepted at each enabled upper altitude, normalized to POSIX separators and repository-relative paths. Adding tests or docs during build is allowed. Moving, deleting, or renaming an upper-altitude source path is drift unless the affected upper altitude is rerun.
+- Exported names are the sorted set of explicit exported declarations and re-exports per module. Default exports normalize to the name `default`; anonymous default declarations include their syntactic kind.
+- Exported signatures include exported functions, methods on exported classes/interfaces, constructors on exported classes, exported variables/constants, exported enums, and exported type/interface aliases. Signatures are compared after formatting-insensitive normalization: comments, whitespace, semicolons, quote style, parameter names on function types where TypeScript treats them as non-semantic, and body text are ignored. Parameter count/order, optional/rest markers, type annotations, generic parameter names/count/constraints/defaults, overload sets, return types, readonly/static/async/export modifiers, enum member names/values, and thrown/returned public error-contract comments marked by the public API prompt are significant.
+- Public type shapes include exported interface/type/class public fields and methods, public enum members, discriminated-union members, literal property names, optional/readonly markers, and public constant literal types. Adding, removing, renaming, or changing these shapes is drift.
+- Private helper signatures include non-exported top-level functions/classes/types and private or unexported class methods added by the private API altitude. Bodies and comments are ignored; helper name, containing path/class, parameter count/order/types, generic constraints, return type, visibility, and async/static modifiers are significant.
+- Rename handling is v0 conservative: a path or symbol rename is reported as delete+add drift unless the affected upper altitude is explicitly rerun. No fuzzy rename matching is required.
+- Allowed final cleanup includes filling or replacing placeholder bodies, removing `TODO(gate-*)` comments, formatting, adding imports required by bodies without changing exported surfaces, adding tests, adding docs, and updating config needed by the build. Cleanup must not alter extracted upper-altitude symbols or source path layout.
+- Example pass: the build altitude replaces `throw new Error("TODO(gate-private_api)")` with real logic inside an already-reviewed helper and adds tests, while exported signatures and helper signatures remain unchanged.
+- Example fail: the build altitude changes `export function parseConfig(input: string): Result` to return `boolean`, moves `src/core/config.ts` to `src/config/index.ts`, or adds a new unreviewed private helper that changes the reviewed helper seam without rerunning the private API altitude.
+### Depth ladder and config
+
+Extend the existing convergence config:
+```yaml
+implementation_review:
+  convergence:
+    enabled: false
+    allow_same_model: false
+    depth: build_only # build_only | layout | public_api | full
+    feedback_depth: build_only # build_only | layout | public_api | full | inherit
+    max_model_sessions_per_run: 24
+```
+Rules:
+- Missing `implementation_review.convergence.enabled` means `false`.
+- Missing `implementation_review.convergence.depth` means `build_only`.
+- Missing `implementation_review.convergence.feedback_depth` means `build_only`. `inherit` means implementation feedback uses the initial `depth` value.
+- Missing `implementation_review.convergence.max_model_sessions_per_run` means `24`. Values must be positive integers.
+- `enabled: false` disables all convergence behavior and preserves current single-pass review behavior.
+- `enabled: true` with `depth: build_only` runs only the issue 193 build convergence gate.
+- `depth: layout` enables `layout` then `build`.
+- `depth: public_api` enables `layout`, `public_api`, then `build`.
+- `depth: full` enables `layout`, `public_api`, `private_api`, then `build`.
+- The altitude list is always ordered by descending altitude. Operators cannot reorder gates.
+- Invalid depth values fail config validation with a clear error.
+- Max-round config from issue 193 applies to each enabled altitude unless a later implementation adds explicit per-altitude budgets. The recommended default remains 2 critic rounds when convergence is enabled.
+- The global `max_model_sessions_per_run` budget is enforced across the whole run, including the initial implementation, all altitude proposer/critic/revise calls, final review calls, and all implementation feedback passes. Before starting a model session, the coordinator reserves one budget slot. If no slot remains, the run fails safely with a clear budget-exhausted error before making another provider call.
+- Feedback passes use `feedback_depth`, not `depth`, by default. This makes small human feedback build-only unless the operator explicitly opts back into full layered reconvergence with `feedback_depth: inherit` or another layered value.
+Budget accounting must be durable per run, not per handler invocation. The implementation must use one of these equivalent mechanisms:
+- Preferred: append a `model_session_reserved` journal entry with a stable `session_id`, run ID, gate, role, round, pass kind, and reservation sequence before each provider call; append a matching completion/failure session record when the call finishes. On process restart or later human feedback, reconstruct consumed budget by counting unique reservation `session_id` values for the run.
+- Acceptable: maintain a run-level persisted counter that is updated atomically before every provider call and can be read by all implementation, feedback, and final-review handlers.
+Rules:
+- The reservation is the unit counted against the limit, even if the provider call later fails, because it consumed or attempted to consume a model session.
+- `session_id` must be stable and unique for the reserved call so retrying journal writes or re-reading journals does not double-count.
+- If a reservation was written but no completion record exists after a crash, the reserved slot still counts. This fail-safe behavior prevents restarts from exceeding the run-wide ceiling.
+- Existing `sessions.jsonl` entries may satisfy the reconstruction requirement only if they are written before provider calls and contain stable unique IDs; otherwise the implementation must add the reservation event or persisted counter.
+This ladder lets a chore run build-only, a moderate backend change run layout plus build, and a feature run the full set. The session ceiling prevents repeated feedback rounds from expanding into unbounded model calls.
+### Lifecycle placement
+
+Layering happens inside the existing implementation phase. It does not add run stages.
+```mermaid
+flowchart TD
+  PlanDone[Implementation plan complete] --> Implementing[Run stage: implementing]
+  Implementing --> Enabled{Convergence enabled and depth > build_only?}
+  Enabled -->|no| BuildOnly[Existing implementation pass + build convergence]
+  Enabled -->|yes| Layout[Proposer writes layout layer]
+  Layout --> LayoutReview[Layout convergence gate]
+  LayoutReview -->|converged| LayoutCommit[Checkpoint layout]
+  LayoutReview -->|failed| Failed[Fail run]
+  LayoutCommit --> Public{Public API enabled?}
+  Public -->|yes| PublicPass[Proposer writes public API layer]
+  PublicPass --> PublicReview[Public API convergence gate]
+  PublicReview -->|converged| PublicCommit[Checkpoint public API]
+  PublicReview -->|failed| Failed
+  Public -->|no| BuildPass
+  PublicCommit --> Private{Private API enabled?}
+  Private -->|yes| PrivatePass[Proposer writes private API layer]
+  PrivatePass --> PrivateReview[Private API convergence gate]
+  PrivateReview -->|converged| PrivateCommit[Checkpoint private API]
+  PrivateReview -->|failed| Failed
+  Private -->|no| BuildPass[Proposer writes bodies and tests]
+  PrivateCommit --> BuildPass
+  BuildPass --> BuildReview[Build convergence gate]
+  BuildReview -->|converged| TestingGuide[Create/update testing guide]
+  BuildReview -->|failed| Failed
+```
+The implementation start handler uses `depth` when convergence is enabled. The implementation feedback handler uses `feedback_depth` when convergence is enabled, defaulting to build-only feedback reconvergence. Final review after human approval remains the existing build-level final review because there is no new staged build at PR time.
+Implementation feedback passes start from a branch that may already contain a complete prior implementation with bodies and tests. For feedback passes, Autocatalyst creates a new feedback base checkpoint at the current run-branch state before the feedback proposer writes any changes. Layered altitude contracts apply only to the incremental feedback-pass diff from that feedback base, not to complete bodies and tests that already existed in the base. Existing lower-altitude code may appear as unchanged context and is not a violation. During `layout`, `public_api`, and `private_api` feedback passes, the proposer may adjust the relevant structure or signatures needed for the human feedback but must not add or rewrite lower-altitude bodies or tests in the incremental diff except syntax placeholders allowed by the altitude contract. The `build` feedback gate then implements bodies, tests, and final cleanup for the cumulative feedback-pass diff.
+### Checkpoints and branch guard
+
+After an altitude converges, Autocatalyst creates a local checkpoint before starting the next altitude. The preferred checkpoint strategy is an internal local git reference under a namespace such as `refs/autocatalyst/runs//` that points at a snapshot commit created from the current index and working tree, similar to `git stash create` plus `git update-ref`. This avoids adding non-compiling intermediate commits to the run branch and bypasses repository commit hooks because no branch commit is created. A branch commit checkpoint is allowed only as an explicit fallback when internal snapshot refs are unavailable or intentionally disabled by repository configuration, and that fallback must be visible in telemetry.
+Rules:
+- Checkpoints are local to the existing run repository and must not switch the checked-out run branch. Internal checkpoint refs are preferred over commits on the run branch.
+- Autocatalyst does not create, switch, push, merge, or open branches as part of this enhancement.
+- Checkpoint messages should include the run ID and altitude, such as `autocatalyst: layout checkpoint for `.
+- The branch guard runs after each proposer pass and before each checkpoint.
+- Early checkpoint commits may not compile. Build and test commands must not run until the build altitude unless a later implementation adds syntax-only checks that tolerate placeholders.
+- If checkpoint creation fails, the run fails before the next altitude starts because the next `getContext(gate)` could otherwise review the wrong diff.
+- Checkpoints must include staged and unstaged run changes exactly as the critic reviewed them. Creating a checkpoint must not clean, reset, restage, or otherwise rewrite the working tree or index except for the temporary plumbing needed to create the snapshot.
+- Checkpoints must include newly-created untracked files that are not ignored by git. Ignored files remain excluded unless they are already tracked. The preferred implementation is a temporary index populated with the tracked index, tracked working-tree content, and non-ignored untracked paths discovered with `git ls-files --others --exclude-standard`; the temporary index is then written to a tree and committed under the internal checkpoint ref. This temporary plumbing must not mutate the user's real index or leave untracked files staged after checkpointing.
+- Pre-existing dirty state at the start of an implementation or feedback pass is part of that pass's base only after the branch guard accepts it and the base checkpoint is captured. If the branch guard rejects the state, the run fails before any altitude work starts.
+- Internal checkpoint refs must be excluded from PR history by construction. If the fallback branch-commit strategy is used, the implementation must either squash/remove intermediate checkpoint commits before PR creation through the existing Autocatalyst PR preparation path or fail with a clear error if the repository policy does not allow such cleanup. Non-compiling checkpoint commits must never be pushed as the final PR history.
+- Branch-commit fallback honors repository commit hooks by default. If an existing Autocatalyst git helper has an explicit, configured `--no-verify` policy, that policy must be logged with the checkpoint strategy; hook or commit failure fails the run before the next altitude.
+### Diff context strategy
+
+Replace the hardcoded full git diff in implementation review with a gate-aware context strategy:
+```typescript
+export interface ConvergenceGateContext {
+  gate: 'layout' | 'public_api' | 'private_api' | 'build' | string;
+  base_ref: string;
+  checkpoint_ref?: string;
+  working_directory: string;
+}
+
+type GetGateContext = (context: ConvergenceGateContext) => Promise;
+```
+This spec chooses **cumulative diff to the current altitude** rather than incremental-only diff. The critic sees all current source decisions from the original base through the current altitude. This costs more tokens than reviewing only the latest layer, but it gives the critic enough context to judge whether public API choices match the layout and whether private seams match public contracts.
+Rules:
+- For an initial implementation pass, `base_ref` is the pre-implementation run-branch base captured before the layout/build proposer starts.
+- For an implementation feedback pass, `base_ref` is the feedback base checkpoint captured from the current run-branch state before feedback changes begin. This means prior full implementation bodies and tests are baseline context, not lower-altitude violations.
+- Context must include non-ignored untracked files created by the proposer, not only files visible to `git diff  --`. Untracked file content is rendered as new-file diff hunks using `--no-index`-equivalent formatting or a structured git helper that produces the same patch semantics, and those paths are included in `changed_files`.
+- `layout` context is base-to-layout for the current pass.
+- `public_api` context is base-to-public-api for the current pass, including the accepted layout changes from that pass.
+- `private_api` context is base-to-private-api for the current pass, including accepted layout and public API changes from that pass.
+- `build` context is base-to-current working tree for the current pass, including bodies and tests added or changed in that pass.
+- `getContext(gate)` runs inside each critic round, not once before the loop, so re-reviews see proposer revisions from prior rounds.
+- The context builder must redact secrets using the same redaction path used by existing prompts and journal capture.
+### Reusable gate shape
+
+Factor the convergence coordinator around a reusable gate shape:
+```typescript
+export interface ConvergenceGate {
+  gate: 'layout' | 'public_api' | 'private_api' | 'build' | string;
+  enabled: boolean;
+  proposerRoute: AgentRoute;
+  criticRoute: AgentRoute;
+  allowedFindingCategories: ImplementationReviewFindingCategory[];
+  buildProposePrompt(input: GatePromptInput): string;
+  buildCritiquePrompt(input: GatePromptInput): string;
+  buildRevisePrompt(input: GateRevisionPromptInput): string;
+  parseArtifact?(content: string): TArtifact;
+  parseVerdict(content: string): TVerdict;
+  maxRounds: number;
+  getContext: GetGateContext;
+}
+```
+For layered implementation modes with depth greater than `build_only`, the current issue 193 initial implementation review behavior becomes the altitude `build` gate. The upper altitudes use the same bounded loop with different prompts, allowed categories, and `getContext` labels. The implementation does not need generic type parameters if that adds complexity, but the code should preserve these separations: route, prompt, parse, category allowlist, max rounds, and context.
+Build-only mode is the compatibility path and preserves issue 193 gate names and semantics. With convergence enabled and `depth: build_only`, the initial implementation review persists `gate: "initial"` and the final post-human-approval review persists `gate: "final"` in `gate_exchanges`, exactly as issue 193 specifies. Implementations may add additive metadata such as `altitude: "build"` or `lens: "build"` to those records, but existing readers must continue to work from `initial`/`final`. In layered modes, pre-human-handoff implementation altitude records use `layout`, `public_api`, `private_api`, and `build`; the post-human-approval final review still uses `final` because it is not a layered construction pass.
+### Proposer prompts by altitude
+
+Each proposer pass receives the approved spec, implementation plan, prior altitude checkpoint summaries, and current gate contract.
+The prompt must require:
+- Only current-altitude work.
+- No lower-altitude bodies or tests before the build gate.
+- `TODO(gate-)` placeholders where needed to keep the tree readable.
+- A short altitude summary in the implementation result.
+- Structured review responses when revising after critic findings.
+If the proposer violates the altitude contract, the critic may file an in-scope maintainability finding, but the critic is not the primary enforcement mechanism. The coordinator must run the required mechanical altitude contract validation described above after every early-altitude proposer pass and revision. A validation failure rejects the layer before checkpointing; if revision budget remains, the proposer receives a structured synthetic `altitude_contract_violation` finding, otherwise the gate fails before any lower altitude starts.
+### Critic prompts by altitude
+
+Each critic prompt receives:
+- The approved spec path.
+- The implementation plan path when available.
+- The current altitude name and contract.
+- The cumulative git diff for the current altitude.
+- Changed files.
+- Prior gate summaries if available.
+- The allowed finding categories and out-of-scope finding rules.
+The critic must return the existing `ImplementationReviewResult` JSON shape, augmented for layered early gates with the `scope` and `reason_code` metadata described in Finding filtering. It should keep stable finding IDs within a gate when a finding repeats across rounds. Findings that omit or garble only layered metadata are preserved as non-blocking notes rather than causing a verdict parse failure.
+Early critics must not request tests, working bodies, or complete implementations. The build critic uses the issue 193 lens and may file correctness, test, security, maintainability, docs, and PR-readiness findings according to the existing initial/final review rules. Build critic prompts must also state that the build proposer is expected to preserve converged layout, public API, and private API contracts from prior altitude checkpoints; unapproved signature, exported-type, module-boundary, or large layout drift is an in-scope build finding.
+### Finding filtering
+
+Because `ImplementationReviewFindingCategory` is intentionally closed, altitude-specific focus is expressed through prompts, category allowlists, and backward-compatible `scope`/`reason_code` finding metadata rather than new category enum values.
+Rules:
+- The parser continues to accept only the current closed category set.
+- Layered early-gate prompts require `scope` and `reason_code` on each finding, but parsing fails open for those metadata fields: missing or invalid metadata downgrades only that finding to a non-blocking recorded note with filter reason `invalid_layered_metadata`.
+- Each gate defines allowed categories.
+- For `layout`, `public_api`, and `private_api`, findings with invalid layered metadata and any finding scoped to `lower_altitude` or carrying a lower-altitude missing-body/test/implementation reason code are filtered before category allowlists are evaluated.
+- Disallowed blocker or warning findings are downgraded to recorded notes for that gate and must not block convergence.
+- The coordinator logs `implementation.review.finding_filtered` with run ID, gate, round, finding ID, original severity, category, scope, reason code, and filter reason.
+- Tests must prove that a body-less `layout`, `public_api`, or `private_api` diff does not fail because the critic asks for implementation bodies or tests, including when that finding uses an otherwise-allowed category such as `maintainability` or omits the new layered metadata.
+### Persistence and testing-guide display
+
+Reuse `run.gate_exchanges` from issue 193. For layered implementation gates:
+- `gate` is one of `layout`, `public_api`, `private_api`, or `build`.
+- `round` is the critic round within that altitude.
+- `proposer_profile` and `critic_profile` are recorded for every gate.
+- `review_status`, `findings`, `responses`, `converged`, `non_convergence_reason`, and `requires_human_retest` use the existing gate exchange meanings.
+Layered metadata and filtered findings are persisted additively so existing readers can ignore unknown fields:
+```typescript
+type LayeredFindingDisposition =
+  | 'blocking'
+  | 'info'
+  | 'filtered_note';
+
+type LayeredFindingFilterReason =
+  | 'invalid_layered_metadata'
+  | 'lower_altitude_scope'
+  | 'lower_altitude_reason_code'
+  | 'category_not_allowed';
+
+interface StoredLayeredFindingMetadata {
+  scope?: LayeredFindingScope;
+  reason_code?: LayeredFindingReasonCode;
+  disposition: LayeredFindingDisposition;
+  filter_reason?: LayeredFindingFilterReason;
+  original_severity: ImplementationReviewFindingSeverity;
+  original_category: ImplementationReviewFindingCategory;
+}
+```
+Storage rules:
+- `gate_exchanges[].findings[]` keeps every critic finding that parsed, including filtered early-altitude notes. The original `severity` and `category` fields are preserved exactly as the critic emitted them.
+- Each stored layered finding adds a `layered` object matching `StoredLayeredFindingMetadata`. For non-layered or legacy gates this object may be absent.
+- In-scope blocker/warning findings store `layered.disposition: "blocking"` and have no `filter_reason`.
+- Info findings store `layered.disposition: "info"` and have no `filter_reason`; they never block.
+- Filtered early-altitude findings store `layered.disposition: "filtered_note"` and a required `filter_reason`. The coordinator must not rewrite their severity to `info`, because readers need to see the original model claim and the reason Autocatalyst made it non-blocking.
+- Existing exchange-level convergence decisions count only findings with `layered.disposition: "blocking"` or legacy blocker/warning findings from gates that do not use layered filtering. Readers distinguish blocking findings from notes through `layered.disposition`; if absent, they fall back to the existing severity/category rules.
+- If a critic finding cannot be parsed into the existing finding shape at all, the existing structured-output recovery path applies and no partial layered finding is stored.
+Compatibility rules:
+- Disabled convergence keeps the legacy issue 193/two-part review persistence behavior.
+- Build-only convergence preserves issue 193 `gate: "initial"` before human handoff and `gate: "final"` before PR creation. It may add optional build-lens metadata but must not require readers to understand `gate: "build"` for build-only runs.
+- Layered convergence uses altitude gate names only for the staged implementation construction before human handoff. Final post-human-approval review remains `gate: "final"`.
+- Existing stored runs that use only `initial`/`final`, only altitude gate names, or no `gate_exchanges` must render without migration.
+Testing guides group AI review history by altitude:
+```markdown
+## AI review
+
+### Layered implementation review
+
+Depth: `full`
+Convergence: converged
+
+#### Layout — converged in 2 rounds
+
+- [x] [LAYOUT-1] New file duplicates the existing review coordinator boundary.
+  Fixed — moved the skeleton into `implementation-review-coordinator.ts`.
+
+#### Public API — converged in 1 round
+
+- No blocker or warning findings.
+
+#### Private API — converged in 1 round
+
+- No blocker or warning findings.
+
+#### Build — converged in 2 rounds
+
+- [x] [BUILD-1] Missing regression test for depth fallback.
+  Fixed — added config resolver coverage.
+```
+Rules:
+- Hide raw prompts, raw model transcripts, secrets, and chain-of-thought.
+- Make it clear when early altitudes did not compile by design.
+- Render filtered early-altitude findings under a non-blocking "Notes filtered by altitude" subsection when useful for diagnostics. Include finding ID, original severity/category, scope, reason code, and filter reason, and do not display them as open testing obligations.
+- Show non-converged altitude, reason, and open blocker or warning findings when the run fails before human handoff.
+- Preserve legacy AI review rendering when `gate_exchanges` is absent.
+### Journal interlock
+
+`sessions.jsonl` records:
+- Model-session budget reservations write a durable unique `session_id`, run ID, `role`, `round`, `gate`, pass kind, reservation sequence, and `budget_limit` before each proposer, critic, revise, or final-review provider call when `sessions.jsonl` is used as the budget reconstruction source.
+- Proposer sessions write `role: "proposer"`, `round`, and `gate: `.
+- Critic sessions write `role: "critic"`, `round`, and `gate: `.
+- Build-only mode keeps the issue 193 initial/final gate behavior, with optional additive build-lens metadata only.
+`feedback.jsonl` records:
+- Critic findings from `gate_exchanges` write `target: "implementation"` and `gate: `.
+- `author_principal` identifies the critic profile.
+- Disallowed or otherwise filtered early-altitude findings that are mirrored to `feedback.jsonl` use `disposition: "not_applicable"` when that disposition exists; otherwise they use `disposition: "addressed"` with additive fields `note_kind: "filtered_layered_finding"`, `filter_reason`, `scope`, `reason_code`, `original_severity`, and `original_category`. They must not become open blocking feedback.
+- Open non-converged blocker or warning findings remain `disposition: "open"`.
+- Fixed findings become `addressed`; declined findings become `wont_fix`; info-only converged notes become `addressed`.
+### Progress updates
+
+Post best-effort progress updates through the existing progress callback:
+```plain text
+Layered implementation enabled — depth full
+Layout pass started with grove-sonnet-4.6-medium
+Layout review round 1 returned 1 finding — asking proposer to revise
+Layout converged after 2 rounds — checkpointing layer
+Public API pass started with grove-sonnet-4.6-medium
+Build converged after 2 rounds — creating testing guide
+```
+Progress send failures must not fail the run. They log `progress_failed` with run ID, gate, round when known, and phase.
+### Telemetry
+
+Add structured logs following `context-agent/standards/logging.md`:
+- `implementation.layered.started` — run ID, request ID, depth, feedback depth, enabled altitudes, model-session budget, model sessions already used.
+- `implementation.layer.started` — run ID, gate, proposer profile, checkpoint base.
+- `implementation.layer.completed` — run ID, gate, elapsed ms, changed file count.
+- `implementation.layer.checkpoint_started` — run ID, gate, branch, checkpoint strategy.
+- `implementation.layer.checkpoint_completed` — run ID, gate, checkpoint ref, elapsed ms.
+- `implementation.layer.checkpoint_failed` — run ID, gate, error.
+- `implementation.review.context_built` — run ID, gate, round, context kind, changed file count, diff byte count.
+- `implementation.review.budget_reserved` — run ID, gate, role, round, model sessions used, model-session budget.
+- `implementation.review.budget_exhausted` — run ID, gate when known, role when known, model sessions used, model-session budget.
+- `implementation.layer.contract_validation_failed` — run ID, gate, round, file count, violation count, validation mode.
+- `implementation.build.contract_drift_detected` — run ID, gate, drift kind, file count, symbol count when available.
+- `implementation.review.finding_filtered` — run ID, gate, round, finding ID, category, reason.
+- `implementation.review.converged` and `implementation.review.non_converged` — include gate, rounds used, finding counts, and elapsed ms.
+Logs must not contain raw prompts, raw diffs, secrets, tokens, or credential values.
+### Risks and mitigations
+
+- **Risk: Cost and latency increase sharply.** Mitigation: keep the feature off by default, support build-only mode, default feedback passes to `build_only`, enforce `max_model_sessions_per_run`, preserve max-round bounds, and log per-altitude cost and elapsed time through journal session records.
+- **Risk: Early code does not compile.** Mitigation: do not run typecheck/test until the build altitude; document that early gates review by reading only.
+- **Risk: The proposer writes bodies too early.** Mitigation: use strict prompts, expected `TODO(gate-*)` markers, required mechanical TypeScript/JavaScript altitude contract validation, synthetic revision findings, and fail before the next altitude if the layer remains invalid.
+- **Risk: Critics file missing-implementation findings anyway.** Mitigation: use explicit prompt contracts, requested scope/reason-code metadata, fail-open metadata filtering, mechanical lower-altitude filtering before category filtering, and tests with body-less diffs in otherwise-allowed categories.
+- **Risk: The build layer silently changes converged upper-altitude contracts.** Mitigation: snapshot upper-altitude checkpoints, run a build-contract preservation check before build convergence can pass, instruct the build critic to flag drift, and require tests for public signature/layout preservation.
+- **Risk: Cumulative diffs become too large.** Mitigation: start with cumulative diffs for correctness, record token/latency data, and leave incremental or summarized contexts as a later optimization.
+- **Risk: Agreement theater.** Mitigation: persist findings and rounds by altitude so later analysis can measure whether early gates reduce build-level findings or merely add cost.
+- **Risk: Intermediate checkpoint commits are non-compiling.** Mitigation: prefer internal checkpoint refs that do not enter PR history; keep branch-commit fallback explicit and config-gated; document that only final build must pass compilation/tests.
+## Technical changes
+
+### Affected files
+
+- `src/types/config.ts` — add `implementation_review.convergence.depth`, `feedback_depth`, and `max_model_sessions_per_run` types and validation.
+- `src/core/config.ts` — resolve depth, feedback-depth, and session-budget defaults and derive the ordered enabled altitude list.
+- `src/core/ai/implementation-review-coordinator.ts` — factor convergence into reusable gate execution, add altitude gates, context strategy, fail-open metadata filtering, required altitude contract validation, build contract preservation, global session-budget checks, and altitude exchange persistence.
+- `src/core/ai/agent-services.ts` — add altitude-specific proposer, critic, and revise prompt builders or extend existing builders with altitude contracts.
+- `src/types/ai.ts` — add altitude gate type aliases if useful; preserve the closed finding category set unless implementation chooses a backward-compatible metadata field.
+- `src/core/handlers/implementation-start-handler.ts` — run layered implementation before testing-guide creation when enabled.
+- `src/core/handlers/implementation-feedback-handler.ts` — run layered implementation for implementation feedback passes when enabled.
+- `src/core/handlers/implementation-approval-handler.ts` — preserve existing final build-level review behavior and ensure layered gate history renders before PR flow when present.
+- `src/core/git-branch-guard.ts` or a new nearby helper — support checkpoint creation/verification if no existing git helper fits.
+- `src/types/impl-feedback-page.ts` — ensure update input can render altitude `gate_exchanges`.
+- `src/adapters/notion/implementation-feedback-page.ts` — render altitude-grouped gate history.
+- `src/core/journal/run-journal.ts` and `src/types/journal.ts` — ensure altitude gate values are captured and feedback dispositions handle filtered findings.
+- `tests/core/config.test.ts` — cover depth validation and defaults.
+- `tests/core/ai/implementation-review-coordinator.test.ts` — cover altitude ordering, context strategy, fail-open metadata/category filtering, required contract validation, build contract preservation, session-budget exhaustion, convergence, non-convergence, and build-only compatibility.
+- `tests/core/handlers/implementation-start-handler.test.ts` and `implementation-feedback-handler.test.ts` — cover layered flow placement and failure behavior.
+- `tests/core/handlers/implementation-approval-handler.test.ts` — cover final review compatibility.
+- `tests/adapters/notion/implementation-feedback-page.test.ts` — cover altitude rendering.
+- `tests/core/journal/run-journal-facade.test.ts` — cover altitude gate sessions and findings.
+### Config resolver
+
+Add a depth union:
+```typescript
+export type ImplementationReviewConvergenceDepth =
+  | 'build_only'
+  | 'layout'
+  | 'public_api'
+  | 'full';
+
+export interface ImplementationReviewConvergencePolicy {
+  enabled: boolean;
+  allow_same_model: boolean;
+  depth: ImplementationReviewConvergenceDepth;
+  feedback_depth: ImplementationReviewConvergenceDepth | 'inherit';
+  max_model_sessions_per_run: number;
+}
+```
+Derived altitude lists:
+```typescript
+const ALTITUDES_BY_DEPTH = {
+  build_only: ['build'],
+  layout: ['layout', 'build'],
+  public_api: ['layout', 'public_api', 'build'],
+  full: ['layout', 'public_api', 'private_api', 'build'],
+} as const;
+```
+Validation rules:
+- `depth` must be one of the supported values when present.
+- Missing depth resolves to `build_only`.
+- Missing feedback depth resolves to `build_only`; `inherit` resolves to the initial implementation depth for feedback passes.
+- Missing max model sessions resolves to `24`; invalid or non-positive values fail validation.
+- Missing convergence config resolves to `{ enabled: false, allow_same_model: false, depth: 'build_only', feedback_depth: 'build_only', max_model_sessions_per_run: 24 }`.
+- Existing convergence max-round defaults from issue 193 remain unchanged within the global session ceiling.
+### Coordinator algorithm
+
+Pseudo-code:
+```typescript
+const policy = resolveImplementationReviewPolicy(config);
+const sessionBudget = await loadRunModelSessionBudget({
+  runId: params.run.id,
+  limit: policy.convergence.max_model_sessions_per_run,
+  journal: params.runJournal,
+  // Reconstructs used count from durable unique reservations or reads
+  // the persisted run-level counter before this handler reserves anything.
+});
+
+if (!policy.convergence.enabled) {
+  return runSinglePassReviewAsToday(params);
+}
+
+const selectedDepth = params.passKind === 'feedback'
+  ? resolveFeedbackDepth(policy.convergence.feedback_depth, policy.convergence.depth)
+  : policy.convergence.depth;
+const altitudes = altitudesForDepth(selectedDepth);
+
+if (altitudes.length === 1 && altitudes[0] === 'build') {
+  return runIssue193BuildConvergence({ ...params, sessionBudget });
+}
+
+let currentResult: ImplementationResult = seedLayeredImplementationResult(params.implementation_result);
+let checkpointBase = await captureBaseRef(params.working_directory);
+
+for (const altitude of altitudes) {
+  await postProgress(`${label(altitude)} pass started`);
+
+  await sessionBudget.reserve({ gate: altitude, role: 'proposer' });
+  currentResult = await runProposerLayer({
+    altitude,
+    previousResult: currentResult,
+    specPath: params.artifact_path,
+    planPath: params.run.implementation_plan_path,
+    workingDirectory: params.working_directory,
+  });
+
+  if (currentResult.status !== 'complete') return currentResult;
+
+  await branchGuard.check(params.working_directory, params.run.branch);
+
+  const contractValidation = await validateAltitudeContract({
+    altitude,
+    baseRef: checkpointBase,
+    workingDirectory: params.working_directory,
+  });
+  if (!contractValidation.valid) {
+    await sessionBudget.reserve({ gate: altitude, role: 'proposer', reason: 'contract_validation_revision' });
+    currentResult = await reviseFromSyntheticAltitudeViolationOrFail(contractValidation);
+    if (currentResult.status !== 'complete') return currentResult;
+  }
+
+  const gateResult = await runConvergenceGate({
+    gate: altitude,
+    currentResult,
+    allowedFindingCategories: allowedCategoriesFor(altitude),
+    getContext: () => getContext({
+      gate: altitude,
+      base_ref: checkpointBase,
+      working_directory: params.working_directory,
+    }),
+    sessionBudget,
+    validateBeforeConverged: altitude === 'build'
+      ? () => validateBuildPreservedConvergedContracts({
+          upperContractRefs: acceptedUpperAltitudeCheckpoints,
+          workingDirectory: params.working_directory,
+        })
+      : undefined,
+  });
+
+  if (gateResult.status !== 'converged') {
+    return {
+      status: 'failed',
+      error: `Layered implementation ${altitude} gate did not converge`,
+    };
+  }
+
+  currentResult = gateResult.implementationResult;
+  await branchGuard.check(params.working_directory, params.run.branch);
+  await createAltitudeCheckpoint(params.working_directory, params.run.id, altitude);
+}
+
+return currentResult;
+```
+For initial implementation, `checkpointBase` is captured before the first implementation proposer changes files. For implementation feedback, `checkpointBase` is captured from the accepted current run-branch state before the feedback proposer changes files; previous complete bodies/tests are baseline and not subject to early-altitude missing-body rules. `runConvergenceGate` reserves budget for each critic and proposer-revision model session before provider calls. For the build altitude, contract-preservation validation runs inside the gate before it can report `converged`; detected drift is treated as a synthetic blocker unless the coordinator explicitly reruns the affected upper altitude within the remaining budget. The real implementation may merge proposer-layer and gate execution for the `build` altitude if that keeps the issue 193 path simpler. The observable behavior must still be ordered altitude passes and per-altitude gate exchanges for layered modes, while build-only mode preserves issue 193 `initial`/`final` gate persistence.
+### Context strategy details
+
+Use git commands through existing repository helpers where available. Avoid fragile string parsing when a helper API exists.
+Minimum command behavior:
+- Capture the base ref before the first altitude changes files. On implementation feedback passes, capture this base from the current full implementation state before applying feedback changes.
+- For each gate, compute `git diff  --` and `git diff --name-only  --` from the run workspace.
+- Augment both commands with non-ignored untracked paths from `git ls-files --others --exclude-standard`. The helper must append new-file patch sections for those paths to the critic diff and append the paths to `changed_files`. Ignored untracked files are excluded, and tracked files are never duplicated between the ordinary diff and the untracked overlay.
+- If checkpoint commits are used, store the checkpoint commit SHA for diagnostics but keep critic context cumulative from base to current altitude.
+- If the working tree is dirty during a critic review, include staged and unstaged changes in the diff so the critic reviews the actual current layer.
+### Prompt contracts
+
+Add prompt builders or prompt sections for:
+- `buildLayoutProposePrompt`
+- `buildLayoutCritiquePrompt`
+- `buildLayoutRevisePrompt`
+- `buildPublicApiProposePrompt`
+- `buildPublicApiCritiquePrompt`
+- `buildPublicApiRevisePrompt`
+- `buildPrivateApiProposePrompt`
+- `buildPrivateApiCritiquePrompt`
+- `buildPrivateApiRevisePrompt`
+- Build altitude prompts may reuse issue 193 implementation review prompts with `gate: "build"` metadata.
+Every early-altitude prompt must include:
+- The altitude contract table row in plain language.
+- The rule that missing lower-altitude work is expected.
+- The required `TODO(gate-*)` marker convention.
+- The existing JSON output contract.
+- Secret-handling rules.
+### Testing plan
+
+Coordinator tests:
+- `depth: build_only` calls the existing issue 193 build convergence path and does not run layout/API proposer prompts.
+- `depth: layout` runs `layout` before `build` and checkpoints after layout convergence.
+- `depth: public_api` runs `layout`, `public_api`, then `build` in that order.
+- `depth: full` runs all four altitudes in order.
+- A non-converged layout gate fails the run before public API or build prompts run.
+- A non-converged public API gate fails the run before private API or build prompts run.
+- A non-converged private API gate fails the run before build prompts run.
+- The build gate still fails on blocker or warning findings through max rounds according to issue 193.
+- `getContext(gate)` is called inside every critic round and includes proposer revisions from the prior round.
+- `getContext(gate)` includes newly-created non-ignored untracked files in both diff text and `changed_files`.
+- Context for `public_api` includes the accepted layout diff.
+- Context for `private_api` includes accepted layout and public API diffs.
+- Context for `build` includes the full current diff.
+- Branch guard runs after each proposer layer and after each proposer revision.
+- Checkpoint creation failure fails the run before the next altitude starts.
+- Checkpoints include newly-created non-ignored unstaged files without leaving those files staged in the real index.
+- Required altitude contract validation rejects TypeScript/JavaScript layout diffs that add non-comment function or method bodies, non-placeholder statements, or tests.
+- Required altitude contract validation rejects public/private API diffs that add lower-altitude bodies or tests beyond allowed syntax placeholders.
+- Build contract preservation validation fails when the build diff changes converged exported signatures, public types, or layout/module boundaries without rerunning the affected upper altitude.
+- Build contract preservation validation passes when build only fills bodies, removes TODO markers, formats code, and adds tests without changing extracted TypeScript/JavaScript upper-altitude symbols.
+- Build contract preservation validation fails for TypeScript/JavaScript exported signature drift, public type-shape drift, private helper signature drift, source path moves/deletes, and v0 conservative symbol renames.
+- Early-altitude disallowed categories are filtered and do not block convergence.
+- A body-less layout diff reviewed by a critic that asks for bodies does not fail as missing implementation, even if the critic omits layered metadata.
+- The global model-session budget is reserved before every proposer/critic call and exhaustion fails safely before another provider request.
+- Model-session budget consumption survives a later implementation feedback handler call and a simulated process restart by reconstructing unique durable reservations or reading the persisted run-level counter.
+- Same-model guard, role routing, max-round exhaustion, and oscillation behavior remain inherited from issue 193.
+Config tests:
+- Missing convergence config resolves to disabled and `depth: build_only`.
+- Missing depth with convergence enabled resolves to `build_only`.
+- Valid depth values derive the expected ordered altitude lists.
+- Invalid depth values fail validation with a clear error.
+- Existing configs without depth remain behavior-compatible.
+- Missing feedback depth resolves to `build_only`; `inherit` resolves to the initial depth for feedback passes.
+- Missing max model sessions resolves to `24`; invalid or exhausted budgets fail with clear errors.
+Handler tests:
+- Initial implementation start runs layered convergence before creating the testing guide.
+- Implementation feedback passes use `feedback_depth` and default to build-only reconvergence before updating the testing guide.
+- Final approval still runs the existing final build-level review and does not restart layered construction.
+- Non-convergence in an early altitude fails the run and does not publish ready-for-testing or PR-open messages.
+- Progress message failures are logged and do not alter review outcome.
+Persistence and rendering tests:
+- `gate_exchanges` records altitude gate names, rounds, profiles, findings, responses, convergence status, and non-convergence reason.
+- `gate_exchanges` stores filtered early-altitude findings with original severity/category plus `layered.disposition: "filtered_note"` and `filter_reason`, while convergence decisions ignore them.
+- Testing-guide rendering groups by altitude and falls back to legacy review rendering when no altitude exchanges exist.
+- Testing-guide rendering shows filtered findings only as non-blocking altitude-filtered notes with filter reasons.
+- Critic sessions write `role: "critic"`, correct `round`, and correct altitude `gate` to `sessions.jsonl`.
+- Proposer sessions write `role: "proposer"`, correct `round`, and correct altitude `gate` to `sessions.jsonl`.
+- Critic findings write `feedback.jsonl` records with altitude gate values and correct dispositions.
+- Filtered critic findings mirrored to `feedback.jsonl` preserve original severity/category in additive fields and never use `disposition: "open"`.
+- Filtered early-altitude findings do not create open blocking feedback.
+### Acceptance criteria
+
+- [ ] Layered implementation is config-gated under implementation review convergence and remains off by default.
+- [ ] With convergence disabled, implementation review behavior is unchanged.
+- [ ] With convergence enabled and `depth: build_only`, behavior equals issue 193 build-level bounded convergence, including persisted `initial` and `final` gate names.
+- [ ] Depth values select ordered altitudes as specified: `build_only`, `layout`, `public_api`, and `full`.
+- [ ] Feedback depth defaults to `build_only`, supports `inherit`, and controls feedback-pass altitude selection separately from initial implementation depth.
+- [ ] A positive global `max_model_sessions_per_run` budget is enforced across initial implementation, final review, and all feedback passes; exhaustion fails safely before starting another model session.
+- [ ] Model-session budget usage is durable per run and is reconstructed or read correctly across feedback passes and process restarts.
+- [ ] The implementer builds enabled altitudes in order and does not start a lower altitude until the current altitude converges.
+- [ ] Each enabled altitude converges through the bounded issue 193 loop or fails the run.
+- [ ] Layout, public API, and private API prompts explicitly state that missing lower-altitude work is expected.
+- [ ] Layout/API critics cannot block on missing implementation bodies or tests, including when metadata is missing or invalid; tests verify this mechanically.
+- [ ] Early-altitude proposer diffs are mechanically validated for supported TypeScript/JavaScript changed regions and rejected when they add lower-altitude bodies or tests.
+- [ ] Missing-body, missing-test, and missing-implementation findings with otherwise-allowed categories such as `maintainability` are filtered at early altitudes when their scope/reason code marks them as lower-altitude work.
+- [ ] Per-gate category allowlists and scope/reason-code filters remove out-of-scope findings before convergence decisions are made, and missing/invalid layered metadata is downgraded to non-blocking notes rather than failing the verdict.
+- [ ] `getContext(gate)` replaces hardcoded full-diff context and returns the cumulative partial diff for the current altitude.
+- [ ] `getContext(gate)` includes non-ignored untracked files in both diff text and `changed_files`.
+- [ ] Critic context is rebuilt each round, so re-reviews see proposer revisions.
+- [ ] A local checkpoint is created after each converged altitude before the next altitude starts.
+- [ ] Checkpoints include non-ignored untracked files exactly as reviewed and do not leave those files staged.
+- [ ] Checkpoints prefer internal local refs/snapshots and do not leave non-compiling intermediate commits in final PR history.
+- [ ] Branch guard checks run after proposer work and before checkpoints.
+- [ ] Early checkpoints may be non-compiling; build/test requirements apply at the build altitude.
+- [ ] The build altitude mechanically verifies that converged upper-altitude contracts are preserved, and the build critic is prompted to flag any contract drift.
+- [ ] Build contract preservation uses the specified v0 TypeScript/JavaScript AST extraction, normalization, unsupported-file, and conservative rename rules.
+- [ ] `gate_exchanges` distinguishes `layout`, `public_api`, `private_api`, and `build` altitudes.
+- [ ] Filtered early-altitude findings remain in `gate_exchanges` as non-blocking notes with original severity/category, layered disposition, and filter reason.
+- [ ] Build-only `gate_exchanges` remain compatible with issue 193 `initial`/`final` gate names, with any build altitude metadata added only as optional additive data.
+- [ ] `sessions.jsonl` records role, round, and altitude gate for proposer and critic sessions.
+- [ ] `feedback.jsonl` records critic findings with altitude gate, critic attribution, and correct disposition.
+- [ ] Filtered findings mirrored to `feedback.jsonl` preserve original severity/category as additive metadata and never become open blocking feedback.
+- [ ] Testing guides show altitude-grouped convergence history when altitude gate exchanges exist.
+- [ ] Per-altitude structured logs include gate, round, finding counts, filtered finding counts, converged/non-converged outcome, elapsed time, and profile IDs.
+- [ ] No new `RunStage` values are added.
+- [ ] No first-class design artifacts, artifact parsers, branch creation, push, merge, or PR operations are added.
+## Task list
+
+### Story 1 — Add depth configuration and altitude selection
+
+- [ ] **Task: Add convergence depth config**
+	- **Description**: Extend config types and validation with `implementation_review.convergence.depth`, `feedback_depth`, and `max_model_sessions_per_run`.
+	- **Acceptance criteria**:
+		- [ ] Missing convergence config resolves to disabled with `depth: "build_only"`.
+		- [ ] Missing depth resolves to `build_only`.
+		- [ ] `build_only`, `layout`, `public_api`, and `full` are accepted.
+		- [ ] Invalid depth values fail validation with a clear error.
+		- [ ] Existing configs without depth keep current behavior.
+		- [ ] Missing `feedback_depth` resolves to `build_only`; `inherit` reuses the initial depth for feedback passes.
+		- [ ] Missing `max_model_sessions_per_run` resolves to `24`; invalid values fail validation.
+	- **Dependencies**: None.
+- [ ] **Task: Derive enabled altitude order from depth**
+	- **Description**: Add a resolver helper that maps initial and feedback depth values to ordered altitude arrays.
+	- **Acceptance criteria**:
+		- [ ] `build_only` returns `['build']`.
+		- [ ] `layout` returns `['layout', 'build']`.
+		- [ ] `public_api` returns `['layout', 'public_api', 'build']`.
+		- [ ] `full` returns `['layout', 'public_api', 'private_api', 'build']`.
+		- [ ] Callers cannot reorder altitudes through config.
+		- [ ] Feedback passes use `feedback_depth` and default to `['build']`.
+	- **Dependencies**: Depth config.
+- [ ] **Task: Enforce global model-session budget**
+	- **Description**: Track and reserve model-session budget slots across initial implementation, review gates, final review, and implementation feedback passes.
+	- **Acceptance criteria**:
+		- [ ] Every proposer, critic, and revise model session reserves one slot before the provider call starts.
+		- [ ] Budget exhaustion fails safely with a clear error before making another provider request.
+		- [ ] Budget usage and limit are logged and included in failure diagnostics.
+		- [ ] The budget is per run and survives multiple human feedback passes in the same run through durable unique reservation records or an atomic persisted run-level counter.
+		- [ ] Restart tests prove consumed budget is reconstructed without double-counting stable session IDs and without forgiving reserved-but-incomplete calls.
+	- **Dependencies**: Depth config.
+### Story 2 — Build gate-aware diff context, contracts, and checkpoints
+
+- [ ] **Task: Add ****`getContext(gate)`**** for cumulative partial diffs**
+	- **Description**: Replace hardcoded full-diff context with a gate-aware context builder that returns cumulative diff and changed files for the current altitude.
+	- **Acceptance criteria**:
+		- [ ] Context includes staged and unstaged changes in the run workspace.
+		- [ ] Context includes non-ignored untracked files as new-file diff hunks and includes those paths in `changed_files`.
+		- [ ] Context is cumulative from the pre-layer base to the current altitude.
+		- [ ] Context is rebuilt inside each critic round.
+		- [ ] Changed files are returned alongside diff text.
+		- [ ] Existing build-only review still receives the same full-diff information as issue 193.
+		- [ ] Feedback-pass context starts from a feedback base captured after the prior full implementation, so previous bodies/tests are baseline rather than early-altitude violations.
+	- **Dependencies**: None.
+- [ ] **Task: Add altitude checkpoint helper**
+	- **Description**: Create a local checkpoint after each converged altitude and expose checkpoint metadata for later context and diagnostics.
+	- **Acceptance criteria**:
+		- [ ] Checkpoints stay local to the current run repository and do not switch the checked-out run branch.
+		- [ ] No branch creation, checkout, push, merge, or PR operation occurs.
+		- [ ] Checkpoint metadata includes run ID, altitude, and git ref or commit SHA.
+		- [ ] Checkpoint failure fails the run before the next altitude starts.
+		- [ ] Early non-compiling checkpoints are allowed.
+		- [ ] Checkpoints include non-ignored untracked files exactly as reviewed without mutating the real index or leaving files staged.
+		- [ ] Internal checkpoint refs are preferred and branch-commit fallback is explicit, logged, and prevented from polluting final PR history.
+	- **Dependencies**: Context builder.
+- [ ] **Task: Add required altitude contract validator**
+	- **Description**: Mechanically validate supported TypeScript/JavaScript early-altitude diffs before critics run and before checkpoints are created.
+	- **Acceptance criteria**:
+		- [ ] `layout` rejects changed regions containing non-comment function or method bodies, meaningful type fields, non-placeholder statements, or tests.
+		- [ ] `public_api` rejects private helper additions, bodies, and tests beyond allowed placeholder syntax.
+		- [ ] `private_api` rejects bodies and tests beyond tiny syntax placeholders.
+		- [ ] Validation failures create synthetic `altitude_contract_violation` revision input when budget remains and fail the gate when they persist.
+		- [ ] Unsupported file types are logged with validation mode and cannot be used to claim mechanical TypeScript/JavaScript validation coverage.
+	- **Dependencies**: Context builder.
+- [ ] **Task: Verify build preserves converged contracts**
+	- **Description**: Compare the build result against accepted upper-altitude checkpoints so bodies cannot silently alter reviewed structure or signatures.
+	- **Acceptance criteria**:
+		- [ ] The check uses the v0 TypeScript/JavaScript AST extraction and normalization rules specified in Build contract preservation.
+		- [ ] The check detects changes to exported names, exported signatures, public types, private helper signatures, and module/file layout from the converged upper-altitude checkpoints.
+		- [ ] The check allows body changes, TODO cleanup, formatting, tests, docs, and config updates that do not alter extracted upper-altitude contracts.
+		- [ ] Unsupported file types are logged as unsupported symbol extraction coverage and compared by path only for layout.
+		- [ ] Detected drift fails the build gate or forces an explicit rerun of the affected upper altitude within the remaining session budget.
+		- [ ] Build critic prompts also instruct the critic to flag unapproved contract drift.
+		- [ ] Tests cover build-time public signature/layout drift, private helper signature drift, path moves/deletes, conservative rename handling, and allowed body-only changes.
+	- **Dependencies**: Context builder; checkpoint helper.
+### Story 3 — Add altitude prompts and finding filters
+
+- [ ] **Task: Add layout prompt set**
+	- **Description**: Add proposer, critic, and revise prompts for the layout altitude.
+	- **Acceptance criteria**:
+		- [ ] Proposer is told to write skeleton files/classes/comments only.
+		- [ ] Proposer is told not to write signatures, bodies, or tests.
+		- [ ] Critic is told missing signatures and bodies are expected.
+		- [ ] Prompts require or explain `TODO(gate-layout)` markers.
+	- **Dependencies**: None.
+- [ ] **Task: Add public API prompt set**
+	- **Description**: Add proposer, critic, and revise prompts for exported signatures and public contracts.
+	- **Acceptance criteria**:
+		- [ ] Proposer is told to write exported signatures, public types, and error contracts only.
+		- [ ] Proposer is told not to write private helpers, bodies, or tests.
+		- [ ] Critic focuses on public names, parameters, returns, and boundary errors.
+		- [ ] Missing bodies do not count as findings.
+	- **Dependencies**: Layout prompts may be done in parallel.
+- [ ] **Task: Add private API prompt set**
+	- **Description**: Add proposer, critic, and revise prompts for internal helper signatures and responsibilities.
+	- **Acceptance criteria**:
+		- [ ] Proposer is told to write internal signatures/docstrings only.
+		- [ ] Proposer is told not to write bodies or tests except syntax placeholders if needed.
+		- [ ] Critic focuses on helper seams, duplicates, dead helpers, and responsibility split.
+		- [ ] Missing bodies do not count as findings.
+	- **Dependencies**: Public API prompts may be done in parallel.
+- [ ] **Task: Implement per-altitude finding category filtering**
+	- **Description**: Add allowlists for early gates and ensure disallowed findings do not block convergence.
+	- **Acceptance criteria**:
+		- [ ] Layout allows only `maintainability` and `docs` as blocking categories.
+		- [ ] Public API allows only `maintainability`, `docs`, and `security` as blocking categories.
+		- [ ] Private API allows only `maintainability`, `docs`, and `security` as blocking categories.
+		- [ ] Build keeps the existing issue 193 category behavior.
+		- [ ] Filtered findings are logged and, if persisted, marked as non-blocking notes.
+		- [ ] Tests prove missing-body findings cannot fail early gates.
+		- [ ] Tests prove missing or invalid layered metadata downgrades the affected finding to a non-blocking note rather than failing the verdict or gate.
+		- [ ] Tests prove maintainability-category missing-body/test/implementation findings with lower-altitude reason codes are filtered before blocking decisions.
+	- **Dependencies**: Altitude prompts.
+### Story 4 — Run layered implementation inside handlers
+
+- [ ] **Task: Add layered implementation coordinator path**
+	- **Description**: Extend implementation review coordination or add a small layered coordinator that runs proposer altitude passes and gate convergence in order.
+	- **Acceptance criteria**:
+		- [ ] Build-only mode delegates to existing issue 193 convergence behavior.
+		- [ ] Layout/public/private/build modes run the selected altitudes in order.
+		- [ ] A failed altitude returns `ImplementationResult.status: "failed"`.
+		- [ ] `needs_input` from the proposer preserves existing awaiting-input behavior.
+		- [ ] Branch guard runs after each proposer pass and proposer revision.
+	- **Dependencies**: Depth selection; context builder; prompts.
+- [ ] **Task: Wire layered implementation into start and feedback handlers**
+	- **Description**: Use the layered path for initial implementation and the `feedback_depth` path for implementation feedback passes when convergence requires it.
+	- **Acceptance criteria**:
+		- [ ] Initial implementation completes all enabled altitudes before testing-guide creation.
+		- [ ] Feedback implementation completes all altitudes selected by `feedback_depth` before testing-guide update.
+		- [ ] Feedback defaults to build-only reconvergence unless `feedback_depth` is explicitly configured otherwise.
+		- [ ] Non-convergence fails the run and does not post ready-for-testing.
+		- [ ] Existing disabled and build-only behavior remains unchanged.
+		- [ ] Feedback passes use a new feedback base checkpoint and apply altitude contracts only to incremental feedback changes.
+	- **Dependencies**: Layered coordinator path.
+- [ ] **Task: Preserve final approval review behavior**
+	- **Description**: Ensure final post-human-approval review stays as the issue 193 build-level final review and does not restart layered implementation.
+	- **Acceptance criteria**:
+		- [ ] Final review still runs before PR creation when configured.
+		- [ ] Final review records gate history using existing `final` gate semantics, with optional build-lens metadata only.
+		- [ ] No new run stages or human checkpoints are introduced.
+	- **Dependencies**: Handler wiring.
+### Story 5 — Persist, render, and journal altitude history
+
+- [ ] **Task: Persist altitude ****`gate_exchanges`**
+	- **Description**: Write gate exchange records for each altitude round.
+	- **Acceptance criteria**:
+		- [ ] `gate` values distinguish `layout`, `public_api`, `private_api`, and `build`.
+		- [ ] Build-only records preserve issue 193 `initial`/`final` gate values for compatibility.
+		- [ ] Records include round, proposer profile, critic profile, findings, responses, convergence state, and non-convergence reason.
+		- [ ] Existing runs without altitude exchanges load without migration.
+	- **Dependencies**: Layered coordinator path.
+- [ ] **Task: Render altitude history in testing guides**
+	- **Description**: Update testing-guide rendering to group AI review history by altitude when altitude exchanges exist.
+	- **Acceptance criteria**:
+		- [ ] Converged altitudes show rounds used and resolved findings.
+		- [ ] Non-converged altitudes show reason and open blocker/warning findings.
+		- [ ] Early-altitude sections explain that code may not have compiled yet.
+		- [ ] Raw prompts, raw diffs, secrets, and chain-of-thought are not rendered.
+		- [ ] Legacy rendering still works when no altitude exchanges exist.
+	- **Dependencies**: Altitude exchange persistence.
+- [ ] **Task: Capture altitude sessions and feedback in journals**
+	- **Description**: Thread altitude metadata through session and feedback capture.
+	- **Acceptance criteria**:
+		- [ ] Proposer sessions record `role: "proposer"`, round, and altitude gate.
+		- [ ] Critic sessions record `role: "critic"`, round, and altitude gate.
+		- [ ] Critic findings record target `implementation`, altitude gate, critic attribution, severity, category, and disposition.
+		- [ ] Filtered findings do not create open blocking feedback.
+		- [ ] Duplicate feedback records are prevented by stable exchange/finding IDs.
+	- **Dependencies**: Altitude exchange persistence.
+### Story 6 — Telemetry and compatibility verification
+
+- [ ] **Task: Add layered implementation logs and progress messages**
+	- **Description**: Emit structured logs and best-effort human progress updates for altitude passes, reviews, filtering, and checkpoints.
+	- **Acceptance criteria**:
+		- [ ] Logs include run ID, request ID, gate, round, profile IDs, finding counts, filtered count, elapsed ms, model-session budget usage, and outcome where applicable.
+		- [ ] Checkpoint logs include checkpoint strategy and ref or error.
+		- [ ] Progress messages identify depth, altitude, round, and convergence outcome.
+		- [ ] Progress failures log `progress_failed` and do not affect review outcome.
+	- **Dependencies**: Layered coordinator path; checkpoint helper.
+- [ ] **Task: Add compatibility and regression tests**
+	- **Description**: Protect existing convergence and review behavior while adding layered modes.
+	- **Acceptance criteria**:
+		- [ ] Existing issue 193 convergence tests pass unchanged or are updated only for intentional metadata additions.
+		- [ ] Disabled convergence still uses current single-pass behavior.
+		- [ ] Build-only convergence still matches issue 193 behavior, including persisted gate names.
+		- [ ] Default feedback reconvergence is build-only and does not rerun layout/public/private gates unless configured.
+		- [ ] Contract validation and build contract preservation tests cover the most likely overshoot/drift cases.
+		- [ ] No new `RunStage` values are introduced.
+		- [ ] No branch creation, checkout, push, merge, or PR operation is introduced by layered implementation.
+	- **Dependencies**: All implementation tasks.

--- a/src/adapters/notion/implementation-feedback-page.ts
+++ b/src/adapters/notion/implementation-feedback-page.ts
@@ -9,7 +9,7 @@ import type {
   ImplementationReviewStatus,
   PublishedImplementationReview,
 } from '../../types/impl-feedback-page.js';
-import type { GateReviewExchange, ImplementationReviewExchange } from '../../types/ai.js';
+import type { GateReviewExchange, ImplementationReviewExchange, LayeredConvergenceGateName } from '../../types/ai.js';
 export type {
   FeedbackItem,
   ImplementationReviewInput,
@@ -67,11 +67,141 @@ function buildAiReviewBlocks(exchanges: ImplementationReviewExchange[]): unknown
   return blocks;
 }
 
+const ALTITUDE_GATES: ReadonlyArray<LayeredConvergenceGateName> = ['layout', 'public_api', 'private_api', 'build'];
+
+const ALTITUDE_DISPLAY_NAMES: Record<LayeredConvergenceGateName, string> = {
+  layout: 'Layout',
+  public_api: 'Public API',
+  private_api: 'Private API',
+  build: 'Build',
+};
+
+const EARLY_ALTITUDE_GATES: ReadonlySet<LayeredConvergenceGateName> = new Set(['layout', 'public_api', 'private_api']);
+
+function hasAltitudeGates(exchanges: GateReviewExchange[]): boolean {
+  return exchanges.some(ex => (ALTITUDE_GATES as ReadonlyArray<string>).includes(ex.gate));
+}
+
+function renderLayeredAltitudeMarkdown(exchanges: GateReviewExchange[]): string {
+  const lines: string[] = [];
+
+  lines.push('### Layered implementation review');
+  lines.push('');
+
+  // Determine overall convergence: all altitudes must have converged
+  const altitudesPresent = ALTITUDE_GATES.filter(gate =>
+    exchanges.some(ex => ex.gate === gate),
+  );
+  const allConverged = altitudesPresent.every(gate => {
+    const gateExchanges = exchanges.filter(ex => ex.gate === gate).sort((a, b) => a.round - b.round);
+    const latest = gateExchanges[gateExchanges.length - 1];
+    return latest?.converged === true;
+  });
+  const depth = 'full';
+
+  lines.push(`Depth: \`${depth}\``);
+  lines.push(`Convergence: ${allConverged ? 'converged' : 'non-converged'}`);
+  lines.push('');
+
+  // Render each altitude in order
+  for (const gate of altitudesPresent) {
+    const gateExchanges = exchanges.filter(ex => ex.gate === gate).sort((a, b) => a.round - b.round);
+    const latest = gateExchanges[gateExchanges.length - 1];
+    const converged = latest?.converged === true;
+    const displayName = ALTITUDE_DISPLAY_NAMES[gate];
+    const roundWord = gateExchanges.length === 1 ? 'round' : 'rounds';
+    const convergenceLabel = converged ? `converged in ${gateExchanges.length} ${roundWord}` : 'non-converged';
+
+    lines.push(`#### ${displayName} — ${convergenceLabel}`);
+    lines.push('');
+
+    if ((EARLY_ALTITUDE_GATES as ReadonlySet<string>).has(gate)) {
+      lines.push('Intermediate code at this altitude may not compile; review was by diff context.');
+      lines.push('');
+    }
+
+    if (!converged && latest) {
+      const reason = latest.non_convergence_reason ?? 'max_rounds';
+      lines.push(`Non-convergence reason: \`${reason}\``);
+      lines.push('');
+      const blockingFindings = latest.findings.filter(f => f.severity === 'blocker' || f.severity === 'warning');
+      // Exclude filtered_note findings
+      const openFindings = blockingFindings.filter(f => f.layered?.disposition !== 'filtered_note');
+      if (openFindings.length === 0) {
+        lines.push('- No blocker or warning findings.');
+      } else {
+        const lastResponseById = new Map<string, (typeof latest.responses)[number]>();
+        for (const ex of gateExchanges) {
+          for (const r of ex.responses) {
+            lastResponseById.set(r.id, r);
+          }
+        }
+        for (const finding of openFindings) {
+          const response = lastResponseById.get(finding.id);
+          lines.push(`- [ ] [${finding.id}] ${redactSecrets(finding.finding)}`);
+          if (response) {
+            const label = response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input';
+            lines.push(`  Last proposer response: ${label} — ${redactSecrets(response.response)}`);
+          }
+        }
+      }
+      lines.push('');
+      continue;
+    }
+
+    // Converged: render per-round findings
+    for (const exchange of gateExchanges) {
+      const blockingFindings = exchange.findings.filter(
+        f => (f.severity === 'blocker' || f.severity === 'warning') && f.layered?.disposition !== 'filtered_note',
+      );
+      if (blockingFindings.length === 0) {
+        lines.push('- No blocker or warning findings.');
+      } else {
+        for (const finding of blockingFindings) {
+          const response = exchange.responses.find(r => r.id === finding.id);
+          lines.push(`- [x] [${finding.id}] ${redactSecrets(finding.finding)}`);
+          if (response) {
+            const label = response.disposition === 'fixed' ? 'Fixed' : response.disposition === 'declined' ? 'Declined' : 'Needs input';
+            lines.push(`  ${label} — ${redactSecrets(response.response)}`);
+          }
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  // Collect all filtered_note findings across all altitudes
+  const filteredNotes = exchanges.flatMap(ex =>
+    ex.findings
+      .filter(f => f.layered?.disposition === 'filtered_note')
+      .map(f => ({ gate: ex.gate, finding: f })),
+  );
+
+  if (filteredNotes.length > 0) {
+    lines.push('#### Notes filtered by altitude');
+    lines.push('');
+    for (const { gate, finding } of filteredNotes) {
+      const displayName = (ALTITUDE_DISPLAY_NAMES as Record<string, string>)[gate] ?? gate;
+      const filterReason = finding.layered?.filter_reason ?? 'unknown';
+      const originalSeverity = finding.layered?.original_severity ?? finding.severity;
+      const originalCategory = finding.layered?.original_category ?? finding.category;
+      lines.push(`- [${displayName.toUpperCase().replace(/ /g, '-')}-${finding.id}] (${originalSeverity}/${originalCategory}) filtered: ${filterReason} — ${redactSecrets(finding.finding)}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
 function gateTitle(gate: string): string {
   return gate === 'initial' ? 'Initial review' : gate === 'final' ? 'Final review' : `${gate} review`;
 }
 
 function renderGateReviewMarkdown(exchanges: GateReviewExchange[]): string {
+  if (hasAltitudeGates(exchanges)) {
+    return renderLayeredAltitudeMarkdown(exchanges);
+  }
+
   const lines: string[] = [];
   const gates = [...new Set(exchanges.map(exchange => exchange.gate))];
   for (const gate of gates) {

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -2110,12 +2110,31 @@ export function parseImplementationReviewResult(content: string, path: string): 
       if (typeof raw !== 'object' || raw === null) continue;
       const f = raw as Record<string, unknown>;
       if (typeof f['id'] === 'string' && typeof f['severity'] === 'string' && typeof f['category'] === 'string' && typeof f['finding'] === 'string') {
+        const VALID_SCOPES = new Set(['current_altitude', 'lower_altitude', 'prior_context']);
+        const VALID_REASON_CODES = new Set([
+          'altitude_contract_violation',
+          'layout_boundary',
+          'public_api_contract',
+          'private_api_contract',
+          'security_contract',
+          'documentation_gap',
+          'missing_lower_altitude_body',
+          'missing_lower_altitude_test',
+          'missing_lower_altitude_implementation',
+          'build_signal_unavailable_until_build',
+        ]);
+        const rawScope = f['scope'];
+        const rawReasonCode = f['reason_code'];
+        const scope = typeof rawScope === 'string' && VALID_SCOPES.has(rawScope) ? rawScope as ImplementationReviewFinding['scope'] : undefined;
+        const reason_code = typeof rawReasonCode === 'string' && VALID_REASON_CODES.has(rawReasonCode) ? rawReasonCode as ImplementationReviewFinding['reason_code'] : undefined;
         findings.push({
           id: f['id'],
           severity: f['severity'] as ImplementationReviewFinding['severity'],
           category: f['category'] as ImplementationReviewFinding['category'],
           finding: f['finding'],
           ...(typeof f['suggested_action'] === 'string' ? { suggested_action: f['suggested_action'] } : {}),
+          ...(scope !== undefined ? { scope } : {}),
+          ...(reason_code !== undefined ? { reason_code } : {}),
         });
       }
     }

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -46,6 +46,23 @@ import type { ArtifactCommentAnchorCodec } from '../../types/publisher.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
+export interface GatePromptInput {
+  gate: 'layout' | 'public_api' | 'private_api' | 'build' | string;
+  artifactPath: string;
+  workingDirectory: string;
+  planPath?: string;
+  implementationResult?: unknown;
+  diffContext?: string;
+  changedFiles?: string[];
+  round?: number;
+  allowedCategories?: string[];
+  priorSummaries?: Array<{ gate: string; summary: string; checkpoint_ref?: string }>;
+}
+
+export interface GateRevisionPromptInput extends GatePromptInput {
+  findings: Array<{ id: string; severity: string; category: string; finding: string; suggested_action?: string }>;
+}
+
 function emitSessionRecord(
   telemetry: AgentServiceTelemetry | undefined,
   profile: AgentProfile,
@@ -2147,4 +2164,104 @@ export function parseImplementationReviewResult(content: string, path: string): 
     requires_human_retest: obj['requires_human_retest'] === true,
     ...(typeof obj['error'] === 'string' ? { error: obj['error'] } : {}),
   };
+}
+
+export function buildLayeredProposePrompt(input: GatePromptInput): string {
+  const { gate, artifactPath, planPath, priorSummaries = [] } = input;
+  const gateLabel = gate === 'public_api' ? 'Public API' : gate === 'private_api' ? 'Private API' : gate.charAt(0).toUpperCase() + gate.slice(1);
+
+  const priorSummaryText = priorSummaries.length > 0
+    ? `\n\nPrior altitude summaries:\n${priorSummaries.map(s => `- ${s.gate}: ${s.summary}`).join('\n')}`
+    : '';
+
+  const gateInstructions = ({
+    layout: `Layout altitude: Write skeleton files, modules, classes, exported-name comments, and high-level intent comments only.
+Do not add function signatures, type definitions with meaningful fields, bodies, or tests.
+Use TODO(gate-layout) markers where lower-altitude work will go.`,
+    public_api: `Public API altitude: Write exported signatures, public types, public constants, module boundary error contracts, and public doc comments only.
+Do not add private helper signatures, bodies, or tests.
+Use TODO(gate-public_api) markers where lower-altitude work will go.`,
+    private_api: `Private API altitude: Write internal helper signatures, internal types, docstrings, and responsibility comments only.
+Do not add bodies or tests except a single \`throw new Error("TODO(gate-private_api)")\` placeholder if TypeScript syntax requires it.
+Use TODO(gate-private_api) markers where lower-altitude work will go.`,
+    build: `Build altitude: Implement all function bodies, tests, documentation updates, and final cleanup.
+Preserve the converged layout, public API, and private API contracts from prior altitudes unless a build finding requires changing them.`,
+  } as Record<string, string>)[gate] ?? `${gateLabel} altitude: Implement only the work appropriate for this altitude.`;
+
+  return `You are implementing the ${gateLabel} altitude of a layered implementation pass.
+
+Spec: ${artifactPath}${planPath ? `\nPlan: ${planPath}` : ''}${priorSummaryText}
+
+${gateInstructions}
+
+Provide a short altitude summary describing what you added at this altitude.
+Output structured implementation results as required by the implementation contract.
+Never include secrets, credentials, or sensitive values in your output.`;
+}
+
+export function buildLayeredCritiquePrompt(input: GatePromptInput): string {
+  const { gate, artifactPath, diffContext = '', changedFiles = [], round = 1, allowedCategories = [], priorSummaries = [] } = input;
+  const isEarlyGate = gate === 'layout' || gate === 'public_api' || gate === 'private_api';
+  const gateLabel = gate === 'public_api' ? 'Public API' : gate === 'private_api' ? 'Private API' : gate.charAt(0).toUpperCase() + gate.slice(1);
+
+  const priorSummaryText = priorSummaries.length > 0
+    ? `\n\nPrior accepted altitudes:\n${priorSummaries.map(s => `- ${s.gate}: ${s.summary}`).join('\n')}`
+    : '';
+
+  const earlyGateContract = isEarlyGate ? `
+You are reviewing a ${gate}-only diff. Signatures and/or bodies may be intentionally absent and out of scope.
+TODO(gate-*) markers are expected and correct at this altitude.
+Do not file missing-body, missing-test, or missing-implementation findings for work that belongs to a lower altitude.
+
+Allowed finding categories: ${allowedCategories.join(', ')}
+Findings with categories outside this list will not block convergence.
+
+For each finding, you MUST include:
+- "scope": "current_altitude" | "lower_altitude" | "prior_context"
+- "reason_code": one of altitude_contract_violation, layout_boundary, public_api_contract, private_api_contract, security_contract, documentation_gap, missing_lower_altitude_body, missing_lower_altitude_test, missing_lower_altitude_implementation, build_signal_unavailable_until_build
+
+If a finding is about missing bodies, tests, or implementation that belongs to a lower altitude, use scope: "lower_altitude" and the appropriate reason_code.` : `
+Review for correctness, test coverage, security, maintainability, documentation, and PR readiness.
+The build proposer should preserve converged layout, public API, and private API contracts from prior altitudes.
+Flag any unapproved changes to exported signatures, public types, module boundaries, or private helper signatures.`;
+
+  return `You are reviewing the ${gateLabel} altitude of a layered implementation pass. This is round ${round}.
+
+Spec: ${artifactPath}${priorSummaryText}
+
+Changed files: ${changedFiles.join(', ') || 'none'}
+
+Git diff:
+\`\`\`diff
+${diffContext}
+\`\`\`
+${earlyGateContract}
+
+Output your review as a JSON object with the existing ImplementationReviewResult structure.
+Never include raw prompts, secrets, or credential values in your output.
+Do not edit files — only review.`;
+}
+
+export function buildLayeredRevisePrompt(input: GateRevisionPromptInput): string {
+  const { gate, artifactPath, planPath, findings, priorSummaries = [] } = input;
+  const gateLabel = gate === 'public_api' ? 'Public API' : gate === 'private_api' ? 'Private API' : gate.charAt(0).toUpperCase() + gate.slice(1);
+
+  const findingsList = findings
+    .map(f => `- [${f.id}] (${f.severity}/${f.category}): ${f.finding}${f.suggested_action ? ` — Suggested: ${f.suggested_action}` : ''}`)
+    .join('\n');
+
+  const priorSummaryText = priorSummaries.length > 0
+    ? `\n\nPrior altitude summaries:\n${priorSummaries.map(s => `- ${s.gate}: ${s.summary}`).join('\n')}`
+    : '';
+
+  return `You are revising the ${gateLabel} altitude implementation to address critic findings.
+
+Spec: ${artifactPath}${planPath ? `\nPlan: ${planPath}` : ''}${priorSummaryText}
+
+Findings to address:
+${findingsList}
+
+Address each finding above. Stay within the ${gateLabel} altitude contract — do not add lower-altitude work.
+Output structured implementation results as required by the implementation contract.
+Never include secrets, credentials, or sensitive values in your output.`;
 }

--- a/src/core/ai/altitude-contract-validator.ts
+++ b/src/core/ai/altitude-contract-validator.ts
@@ -1,0 +1,199 @@
+const TS_JS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs']);
+
+const BODY_PATTERNS = [
+  // Function/method body opening with real statements (not just `{` on declaration line)
+  /^\+\s*((?:export\s+)?(?:async\s+)?function\s+\w+[^{]*\{)\s*(?![\s}])/, // function with immediate statement
+  /^\+\s*(?:return|throw|const|let|var|if|for|while|do|switch)\s+/, // executable statements
+  /^\+\s*\w+\s*\(.*\)\s*;/, // function calls
+  /^\+\s*(?:it|test|describe|beforeEach|afterEach|beforeAll|afterAll)\s*\(/, // test assertions
+  /^\+\s*expect\s*\(/, // jest/vitest expect
+  /^\+\s*assert\s*[\.(]/, // assertions
+];
+
+const TEST_FILE_PATTERNS = [/\.test\.[jt]sx?$/, /\.spec\.[jt]sx?$/, /__tests__\//];
+
+function isTestFile(filePath: string): boolean {
+  return TEST_FILE_PATTERNS.some(p => p.test(filePath));
+}
+
+function isSupportedFile(filePath: string): boolean {
+  const ext = filePath.match(/\.[^.]+$/)?.[0] ?? '';
+  return TS_JS_EXTENSIONS.has(ext);
+}
+
+function getAddedLines(diff: string, filePath: string): string[] {
+  const lines = diff.split('\n');
+  const addedLines: string[] = [];
+  let inFile = false;
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      inFile = line.includes(` b/${filePath}`) || line.includes(` b/${filePath.replace(/\\/g, '/')}`);
+    }
+    if (inFile && line.startsWith('+') && !line.startsWith('+++')) {
+      addedLines.push(line);
+    }
+  }
+  return addedLines;
+}
+
+export interface AltitudeContractViolation {
+  id: string;
+  file: string;
+  message: string;
+  reason_code: 'altitude_contract_violation';
+}
+
+export interface AltitudeContractValidationResult {
+  valid: boolean;
+  violations: AltitudeContractViolation[];
+  unsupported_files: string[];
+}
+
+export async function validateAltitudeContract(args: {
+  gate: 'layout' | 'public_api' | 'private_api' | string;
+  diff: string;
+  changedFiles: string[];
+  workingDirectory?: string;
+}): Promise<AltitudeContractValidationResult> {
+  const { gate, diff, changedFiles } = args;
+
+  if (gate === 'build') {
+    return { valid: true, violations: [], unsupported_files: [] };
+  }
+
+  const violations: AltitudeContractViolation[] = [];
+  const unsupported_files: string[] = [];
+  let violationIdx = 0;
+
+  for (const filePath of changedFiles) {
+    if (!isSupportedFile(filePath)) {
+      unsupported_files.push(filePath);
+      continue;
+    }
+
+    const addedLines = getAddedLines(diff, filePath);
+
+    if (gate === 'layout') {
+      // Reject test files
+      if (isTestFile(filePath)) {
+        violationIdx++;
+        violations.push({
+          id: `ALTITUDE-CONTRACT-${violationIdx}`,
+          file: filePath,
+          message: `layout altitude may not add test files: ${filePath}`,
+          reason_code: 'altitude_contract_violation',
+        });
+        continue;
+      }
+
+      // Check added lines for body/statement patterns
+      for (const line of addedLines) {
+        // Skip comment lines
+        if (/^\+\s*\/\//.test(line) || /^\+\s*\/\*/.test(line) || /^\+\s*\*/.test(line)) continue;
+        // Skip TODO markers
+        if (/TODO\(gate-layout\)/.test(line)) continue;
+
+        if (BODY_PATTERNS.some(p => p.test(line))) {
+          violationIdx++;
+          violations.push({
+            id: `ALTITUDE-CONTRACT-${violationIdx}`,
+            file: filePath,
+            message: `layout altitude added lower-altitude work in ${filePath}: ${line.slice(0, 80).trim()}`,
+            reason_code: 'altitude_contract_violation',
+          });
+          break; // one violation per file is enough
+        }
+      }
+    } else if (gate === 'public_api') {
+      // Reject test files
+      if (isTestFile(filePath)) {
+        violationIdx++;
+        violations.push({
+          id: `ALTITUDE-CONTRACT-${violationIdx}`,
+          file: filePath,
+          message: `public_api altitude may not add test files: ${filePath}`,
+          reason_code: 'altitude_contract_violation',
+        });
+        continue;
+      }
+
+      for (const line of addedLines) {
+        if (/^\+\s*\/\//.test(line) || /^\+\s*\/\*/.test(line) || /^\+\s*\*/.test(line)) continue;
+        if (/TODO\(gate-public_api\)/.test(line)) continue;
+
+        // Reject executable bodies and statements
+        const bodyPatterns = [
+          /^\+\s*(?:return|throw|const|let|var|if|for|while|do|switch)\s+/,
+          /^\+\s*\w+\s*\(.*\)\s*;/,
+          /^\+\s*(?:it|test|describe|expect|assert)\s*[\(.(]/,
+        ];
+        if (bodyPatterns.some(p => p.test(line))) {
+          violationIdx++;
+          violations.push({
+            id: `ALTITUDE-CONTRACT-${violationIdx}`,
+            file: filePath,
+            message: `public_api altitude added lower-altitude work in ${filePath}: ${line.slice(0, 80).trim()}`,
+            reason_code: 'altitude_contract_violation',
+          });
+          break;
+        }
+      }
+    } else if (gate === 'private_api') {
+      // Reject test files
+      if (isTestFile(filePath)) {
+        violationIdx++;
+        violations.push({
+          id: `ALTITUDE-CONTRACT-${violationIdx}`,
+          file: filePath,
+          message: `private_api altitude may not add test files: ${filePath}`,
+          reason_code: 'altitude_contract_violation',
+        });
+        continue;
+      }
+
+      // Count placeholder throws - only one is allowed
+      const throwPlaceholders = addedLines.filter(l => /throw new Error\("TODO\(gate-private_api\)"\)/.test(l)).length;
+      let hasBody = false;
+
+      for (const line of addedLines) {
+        if (/^\+\s*\/\//.test(line) || /^\+\s*\/\*/.test(line) || /^\+\s*\*/.test(line)) continue;
+        if (/TODO\(gate-private_api\)/.test(line)) continue;
+
+        // Allow single placeholder throw
+        if (/throw new Error\(/.test(line) && throwPlaceholders === 1) continue;
+
+        const bodyPatterns = [
+          /^\+\s*(?:return|throw)\s+(?!new Error\("TODO)/, // throw not matching placeholder
+          /^\+\s*const\s+\w+\s*=\s*(?!\s*\(|\s*async\s*\()/, // const assignment (not arrow fn declaration)
+          /^\+\s*(?:let|var)\s+/,
+          /^\+\s*if\s*\(/,
+          /^\+\s*for\s*[\s(]/,
+          /^\+\s*while\s*\(/,
+          /^\+\s*(?:it|test|describe|expect|assert)\s*[\(.(]/,
+        ];
+
+        if (bodyPatterns.some(p => p.test(line))) {
+          hasBody = true;
+          break;
+        }
+      }
+
+      if (hasBody) {
+        violationIdx++;
+        violations.push({
+          id: `ALTITUDE-CONTRACT-${violationIdx}`,
+          file: filePath,
+          message: `private_api altitude added bodies or tests beyond syntax placeholders in ${filePath}`,
+          reason_code: 'altitude_contract_violation',
+        });
+      }
+    }
+  }
+
+  return {
+    valid: violations.length === 0,
+    violations,
+    unsupported_files,
+  };
+}

--- a/src/core/ai/build-contract-preservation.ts
+++ b/src/core/ai/build-contract-preservation.ts
@@ -1,0 +1,269 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+
+const TS_JS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs']);
+
+function isSupportedFile(filePath: string): boolean {
+  const ext = filePath.match(/\.[^.]+$/)?.[0] ?? '';
+  return TS_JS_EXTENSIONS.has(ext);
+}
+
+export interface AcceptedAltitudeCheckpoint {
+  gate: 'layout' | 'public_api' | 'private_api';
+  ref: string;  // git ref (commit SHA or ref name)
+}
+
+export type BuildContractDriftKind =
+  | 'source_path'
+  | 'exported_name'
+  | 'exported_signature'
+  | 'public_type_shape'
+  | 'private_helper_signature';
+
+export interface BuildContractDrift {
+  kind: BuildContractDriftKind;
+  file: string;
+  symbol?: string;
+  message: string;
+}
+
+export interface BuildContractComparisonResult {
+  valid: boolean;
+  drift: BuildContractDrift[];
+  unsupported_files: string[];
+}
+
+// Extract exported names from a TypeScript/JavaScript source file text
+function extractExportedNames(source: string): string[] {
+  const names: string[] = [];
+  const patterns = [
+    /^export\s+(?:default\s+)?(?:function|class|const|let|var|enum|type|interface)\s+(\w+)/gm,
+    /^export\s+\{\s*([^}]+)\s*\}/gm,
+    /^export\s+default\s+(\w+)/gm,
+  ];
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(source)) !== null) {
+      if (match[1]) {
+        // Handle re-export lists: "export { a, b as c }"
+        if (match[1].includes(',') || match[1].includes(' as ')) {
+          const parts = match[1].split(',').map(p => p.trim().split(' as ').pop()!.trim());
+          names.push(...parts.filter(Boolean));
+        } else {
+          names.push(match[1].trim());
+        }
+      }
+    }
+  }
+  return [...new Set(names)].sort();
+}
+
+// Extract exported function/interface/type signatures (normalized, bodies stripped)
+function extractExportedSignatures(source: string): string[] {
+  const signatures: string[] = [];
+
+  // Exported function declarations (strip body)
+  const funcPattern = /^(export\s+(?:async\s+)?function\s+\w+\s*(?:<[^>]*>)?\s*\([^)]*\)(?:\s*:\s*[^{;]+)?)/gm;
+  let match;
+  while ((match = funcPattern.exec(source)) !== null) {
+    signatures.push(match[1]!.replace(/\s+/g, ' ').trim());
+  }
+
+  // Exported interface declarations
+  const interfacePattern = /^(export\s+(?:default\s+)?interface\s+\w+(?:\s+extends\s+[^{]+)?)\s*\{([^}]*)\}/gm;
+  while ((match = interfacePattern.exec(source)) !== null) {
+    const body = match[2]!.split('\n').map(l => l.trim()).filter(Boolean).join('; ');
+    signatures.push(`${match[1]!.trim()} { ${body} }`.replace(/\s+/g, ' '));
+  }
+
+  // Exported type aliases
+  const typePattern = /^export\s+type\s+(\w+)(?:\s*=\s*([^;]+))?;/gm;
+  while ((match = typePattern.exec(source)) !== null) {
+    signatures.push(`export type ${match[1]} = ${(match[2] ?? '').trim()}`.replace(/\s+/g, ' '));
+  }
+
+  return [...new Set(signatures)].sort();
+}
+
+// Extract private (non-exported) top-level function signatures
+function extractPrivateHelperSignatures(source: string): string[] {
+  const signatures: string[] = [];
+  const pattern = /^(?!export)((?:async\s+)?function\s+\w+\s*(?:<[^>]*>)?\s*\([^)]*\)(?:\s*:\s*[^{;]+)?)/gm;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    signatures.push(match[1]!.replace(/\s+/g, ' ').trim());
+  }
+  return [...new Set(signatures)].sort();
+}
+
+async function listFilesAtRef(workingDirectory: string, ref: string): Promise<string[]> {
+  const result = await exec('git', ['ls-tree', '--name-only', '-r', ref], { cwd: workingDirectory });
+  return result.stdout.split('\n').filter(Boolean);
+}
+
+async function readFileAtRef(workingDirectory: string, ref: string, path: string): Promise<string> {
+  const result = await exec('git', ['show', `${ref}:${path}`], { cwd: workingDirectory });
+  return result.stdout;
+}
+
+async function getCurrentFiles(workingDirectory: string): Promise<string[]> {
+  // Get tracked files + untracked non-ignored files
+  const tracked = await exec('git', ['ls-files'], { cwd: workingDirectory });
+  const untracked = await exec('git', ['ls-files', '--others', '--exclude-standard'], { cwd: workingDirectory });
+  const all = [...tracked.stdout.split('\n'), ...untracked.stdout.split('\n')].filter(Boolean);
+  return [...new Set(all)].sort();
+}
+
+async function readCurrentFile(workingDirectory: string, path: string): Promise<string> {
+  const { readFile } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  return readFile(join(workingDirectory, path), 'utf8');
+}
+
+export async function compareBuildToAcceptedContracts(args: {
+  workingDirectory: string;
+  acceptedCheckpoints: AcceptedAltitudeCheckpoint[];
+  currentRef?: string;
+  // Injectable for testing
+  readFileAtRef?: (ref: string, path: string) => Promise<string>;
+  listFilesAtRef?: (ref: string) => Promise<string[]>;
+}): Promise<BuildContractComparisonResult> {
+  if (args.acceptedCheckpoints.length === 0) {
+    return { valid: true, drift: [], unsupported_files: [] };
+  }
+
+  const {
+    workingDirectory,
+    acceptedCheckpoints,
+    readFileAtRef: readFile = (ref, path) => readFileAtRef(workingDirectory, ref, path),
+    listFilesAtRef: listFiles = (ref) => listFilesAtRef(workingDirectory, ref),
+  } = args;
+
+  const drift: BuildContractDrift[] = [];
+  const unsupported_files: string[] = [];
+
+  // Get current file list
+  const currentFiles = await getCurrentFiles(workingDirectory).catch(() => [] as string[]);
+
+  for (const checkpoint of acceptedCheckpoints) {
+    const checkpointFiles = await listFiles(checkpoint.ref).catch(() => [] as string[]);
+    const checkpointSourceFiles = checkpointFiles.filter(isSupportedFile);
+
+    // Check source path layout drift
+    const currentSourceFiles = new Set(currentFiles.filter(isSupportedFile));
+    for (const file of checkpointSourceFiles) {
+      // Allow test files and docs to be added in build
+      if (file.match(/\.test\.[jt]sx?$/) || file.match(/\.spec\.[jt]sx?$/)) continue;
+
+      if (!currentSourceFiles.has(file)) {
+        // Fall back to checking if the file exists on disk (handles non-git working directories)
+        const existsOnDisk = await readCurrentFile(workingDirectory, file).then(() => true).catch(() => false);
+        if (!existsOnDisk) {
+          drift.push({
+            kind: 'source_path',
+            file,
+            message: `source file ${file} from ${checkpoint.gate} checkpoint is missing in build result (moved or deleted)`,
+          });
+        }
+      }
+    }
+
+    // Check per-file signature drift
+    for (const file of checkpointSourceFiles) {
+      if (!isSupportedFile(file)) {
+        unsupported_files.push(file);
+        continue;
+      }
+
+      let checkpointSource: string;
+      let currentSource: string;
+
+      try {
+        checkpointSource = await readFile(checkpoint.ref, file);
+      } catch {
+        continue; // File didn't exist at checkpoint; skip
+      }
+
+      try {
+        currentSource = await readCurrentFile(workingDirectory, file);
+      } catch {
+        continue; // File doesn't exist currently (handled by path drift above)
+      }
+
+      const checkpointExportedNames = extractExportedNames(checkpointSource);
+      const currentExportedNames = extractExportedNames(currentSource);
+
+      if (checkpoint.gate === 'public_api' || checkpoint.gate === 'layout') {
+        // Check for exported name drift
+        const removedNames = checkpointExportedNames.filter(n => !currentExportedNames.includes(n));
+        const addedNames = currentExportedNames.filter(n => !checkpointExportedNames.includes(n));
+
+        for (const name of removedNames) {
+          drift.push({
+            kind: 'exported_name',
+            file,
+            symbol: name,
+            message: `exported name '${name}' from ${checkpoint.gate} checkpoint was removed or renamed in build`,
+          });
+        }
+
+        // New exported names in build are allowed (build adds implementations)
+        // Only flag if a previously accepted name was removed (rename is delete+add)
+        for (const name of addedNames) {
+          // A new name alongside a removed name indicates a rename
+          const isRename = removedNames.length > 0;
+          if (isRename) {
+            drift.push({
+              kind: 'exported_name',
+              file,
+              symbol: name,
+              message: `exported name '${name}' was not present in ${checkpoint.gate} checkpoint — possible rename of reviewed symbol`,
+            });
+          }
+        }
+      }
+
+      if (checkpoint.gate === 'public_api') {
+        // Check exported signature drift
+        const checkpointSigs = extractExportedSignatures(checkpointSource);
+        const currentSigs = extractExportedSignatures(currentSource);
+
+        const removedSigs = checkpointSigs.filter(s => !currentSigs.some(cs => cs.startsWith(s.split('{')[0]!.trim())));
+        for (const sig of removedSigs) {
+          // Only report if not just a TODO replaced by implementation (bodies added = OK)
+          // Conservative: report any removed/changed signature
+          drift.push({
+            kind: 'exported_signature',
+            file,
+            symbol: sig.match(/\s(\w+)\s*[<(]/)?.[1],
+            message: `exported signature from ${checkpoint.gate} checkpoint changed in build: ${sig.slice(0, 60)}`,
+          });
+        }
+      }
+
+      if (checkpoint.gate === 'private_api') {
+        // Check private helper signature drift
+        const checkpointPriv = extractPrivateHelperSignatures(checkpointSource);
+        const currentPriv = extractPrivateHelperSignatures(currentSource);
+
+        const removedPriv = checkpointPriv.filter(s => !currentPriv.includes(s));
+        for (const sig of removedPriv) {
+          drift.push({
+            kind: 'private_helper_signature',
+            file,
+            symbol: sig.match(/function\s+(\w+)/)?.[1],
+            message: `private helper from ${checkpoint.gate} checkpoint changed in build: ${sig.slice(0, 60)}`,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    valid: drift.length === 0,
+    drift,
+    unsupported_files: [...new Set(unsupported_files)],
+  };
+}

--- a/src/core/ai/gate-context.ts
+++ b/src/core/ai/gate-context.ts
@@ -1,0 +1,95 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+
+export interface ConvergenceGateContext {
+  gate: string;
+  base_ref: string;
+  checkpoint_ref?: string;
+  working_directory: string;
+}
+
+export interface BuiltGateContext {
+  gate: string;
+  base_ref: string;
+  diff: string;
+  changed_files: string[];
+  diff_byte_count: number;
+}
+
+export async function buildGateContext(context: ConvergenceGateContext): Promise<BuiltGateContext> {
+  const { gate, base_ref, working_directory } = context;
+
+  // Get tracked changes diff from base_ref
+  let trackedDiff = '';
+  try {
+    const result = await exec('git', ['diff', base_ref, '--patch', '--', '.'], { cwd: working_directory, maxBuffer: 10 * 1024 * 1024 });
+    trackedDiff = result.stdout;
+  } catch {
+    // If base_ref doesn't exist or diff fails, return empty
+  }
+
+  // Get tracked changed files
+  let trackedFiles: string[] = [];
+  try {
+    const result = await exec('git', ['diff', '--name-only', base_ref, '--', '.'], { cwd: working_directory });
+    trackedFiles = result.stdout.split('\n').filter(Boolean);
+  } catch {
+    // ignore
+  }
+
+  // Get non-ignored untracked files
+  let untrackedFiles: string[] = [];
+  try {
+    const result = await exec('git', ['ls-files', '--others', '--exclude-standard'], { cwd: working_directory });
+    untrackedFiles = result.stdout.split('\n').filter(Boolean);
+  } catch {
+    // ignore
+  }
+
+  // Build untracked file patches using git diff --no-index
+  let untrackedDiff = '';
+  for (const filePath of untrackedFiles) {
+    try {
+      // git diff --no-index /dev/null <file> exits with code 1 when there are differences (which is always for new files)
+      // We need to catch the error and use stdout
+      const fullPath = `${working_directory}/${filePath}`;
+      let patchOutput = '';
+      try {
+        const result = await exec('git', ['diff', '--no-index', '--', '/dev/null', fullPath], { cwd: working_directory, maxBuffer: 1024 * 1024 });
+        patchOutput = result.stdout;
+      } catch (err: unknown) {
+        // git diff --no-index always exits with code 1 when files differ
+        if (err && typeof err === 'object' && 'stdout' in err) {
+          patchOutput = (err as { stdout: string }).stdout;
+        }
+      }
+      if (patchOutput) {
+        // Normalize the path in the diff header to be repo-relative
+        patchOutput = patchOutput
+          .replace(/^diff --git a\/dev\/null b\/.*$/m, `diff --git a/${filePath} b/${filePath}`)
+          .replace(/^--- \/dev\/null$/m, '--- /dev/null')
+          .replace(/^\+\+\+ b\/.*$/m, `+++ b/${filePath}`);
+        untrackedDiff += patchOutput;
+      }
+    } catch {
+      // Skip files we can't read
+    }
+  }
+
+  // Normalize changed files: unique, sorted, POSIX paths
+  const allChangedFiles = [...new Set([...trackedFiles, ...untrackedFiles])]
+    .map(f => f.replace(/\\/g, '/'))
+    .sort();
+
+  const fullDiff = trackedDiff + untrackedDiff;
+
+  return {
+    gate,
+    base_ref,
+    diff: fullDiff,
+    changed_files: allChangedFiles,
+    diff_byte_count: Buffer.byteLength(fullDiff, 'utf8'),
+  };
+}

--- a/src/core/ai/gate-context.ts
+++ b/src/core/ai/gate-context.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { redactSecrets } from '../journal/redaction.js';
 
 const exec = promisify(execFile);
 
@@ -83,13 +84,13 @@ export async function buildGateContext(context: ConvergenceGateContext): Promise
     .map(f => f.replace(/\\/g, '/'))
     .sort();
 
-  const fullDiff = trackedDiff + untrackedDiff;
+  const redactedDiff = redactSecrets(trackedDiff + untrackedDiff);
 
   return {
     gate,
     base_ref,
-    diff: fullDiff,
+    diff: redactedDiff,
     changed_files: allChangedFiles,
-    diff_byte_count: Buffer.byteLength(fullDiff, 'utf8'),
+    diff_byte_count: Buffer.byteLength(redactedDiff, 'utf8'),
   };
 }

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -26,11 +26,14 @@ import {
   buildInitialReviewPrompt,
   buildFinalReviewPrompt,
   buildImplementerResponsePrompt,
+  buildLayeredCritiquePrompt,
+  buildLayeredRevisePrompt,
   parseImplementationReviewResult,
   drainAgentRunner,
 } from './agent-services.js';
 import { agentProfileSummary } from './routing-policy.js';
-import type { LayeredConvergenceGate } from './layered-convergence-policy.js';
+import { allowedCategoriesForGate, type LayeredConvergenceGate } from './layered-convergence-policy.js';
+import { filterLayeredFindings } from './layered-finding-filter.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
@@ -443,11 +446,24 @@ export class ImplementationReviewCoordinator {
       const diffContext = await this.getGitDiff(working_directory);
       const changedFiles = await this.getChangedFiles(working_directory);
 
-      // Build critic prompt with convergence context
+      // Build critic prompt with convergence context.
+      // For early layered altitudes, use the altitude-aware critique prompt with
+      // allowed-category guidance; build/initial/final keep the existing prompts.
       const convergenceContext = { gate, round };
-      const prompt = phase === 'initial'
-        ? buildInitialReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext)
-        : buildFinalReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext);
+      const isEarlyLayeredGate = gate === 'layout' || gate === 'public_api' || gate === 'private_api';
+      const prompt = isEarlyLayeredGate
+        ? buildLayeredCritiquePrompt({
+            gate,
+            artifactPath: artifact_path,
+            workingDirectory: working_directory,
+            diffContext,
+            changedFiles,
+            round,
+            allowedCategories: allowedCategoriesForGate(gate as LayeredConvergenceGate),
+          })
+        : phase === 'initial'
+          ? buildInitialReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext)
+          : buildFinalReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext);
 
       // Run critic
       let reviewResult: ReturnType<typeof parseImplementationReviewResult>;
@@ -526,7 +542,17 @@ export class ImplementationReviewCoordinator {
         'Convergence review round completed',
       );
 
-      const blockingFindings = this.blockingFindings(reviewResult.findings);
+      // For layered early altitudes, enrich findings with disposition metadata
+      // and use the filter-derived blocking set; otherwise keep legacy behavior.
+      let effectiveFindings = reviewResult.findings;
+      let blockingFindings: ImplementationReviewFinding[];
+      if (isEarlyLayeredGate) {
+        const filterResult = filterLayeredFindings({ gate, round, findings: reviewResult.findings, runId: run.id });
+        effectiveFindings = filterResult.findings;
+        blockingFindings = filterResult.blockingFindings;
+      } else {
+        blockingFindings = this.blockingFindings(reviewResult.findings);
+      }
 
       // Check for convergence
       if (reviewResult.status === 'no_findings' || blockingFindings.length === 0) {
@@ -539,7 +565,7 @@ export class ImplementationReviewCoordinator {
           critic_profile: criticSummary,
           review_status: 'converged',
           review_summary: reviewResult.summary,
-          findings: reviewResult.findings,
+          findings: effectiveFindings,
           responses: [],
           converged: true,
           requires_human_retest: reviewResult.requires_human_retest ?? false,
@@ -567,7 +593,7 @@ export class ImplementationReviewCoordinator {
           critic_profile: criticSummary,
           review_status: 'non_converged',
           review_summary: reviewResult.summary,
-          findings: reviewResult.findings,
+          findings: effectiveFindings,
           responses: [],
           converged: false,
           non_convergence_reason: 'oscillation',
@@ -596,7 +622,7 @@ export class ImplementationReviewCoordinator {
           critic_profile: criticSummary,
           review_status: 'non_converged',
           review_summary: reviewResult.summary,
-          findings: reviewResult.findings,
+          findings: effectiveFindings,
           responses: [],
           converged: false,
           non_convergence_reason: 'max_rounds',
@@ -614,8 +640,22 @@ export class ImplementationReviewCoordinator {
         return { status: 'failed', error: `Implementation review ${phase} did not converge after ${maxRounds} rounds` };
       }
 
-      // Run proposer response
-      const responsePrompt = buildImplementerResponsePrompt(artifact_path, working_directory, currentResult, blockingFindings, convergenceContext);
+      // Run proposer response. Early layered altitudes use the altitude-aware
+      // revise prompt so the proposer stays within the current altitude contract.
+      const responsePrompt = isEarlyLayeredGate
+        ? buildLayeredRevisePrompt({
+            gate,
+            artifactPath: artifact_path,
+            workingDirectory: working_directory,
+            findings: blockingFindings.map(f => ({
+              id: f.id,
+              severity: f.severity,
+              category: f.category,
+              finding: f.finding,
+              ...(f.suggested_action ? { suggested_action: f.suggested_action } : {}),
+            })),
+          })
+        : buildImplementerResponsePrompt(artifact_path, working_directory, currentResult, blockingFindings, convergenceContext);
       const proposerTelemetry: AgentServiceTelemetry = {
         run_id: run.id,
         request_id: run.request_id,
@@ -668,7 +708,7 @@ export class ImplementationReviewCoordinator {
         critic_profile: criticSummary,
         review_status: 'addressed',
         review_summary: reviewResult.summary,
-        findings: reviewResult.findings,
+        findings: effectiveFindings,
         responses,
         converged: false,
         requires_human_retest: proposerResult.requires_human_retest ?? false,

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -30,6 +30,7 @@ import {
   drainAgentRunner,
 } from './agent-services.js';
 import { agentProfileSummary } from './routing-policy.js';
+import type { LayeredConvergenceGate } from './layered-convergence-policy.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
@@ -325,8 +326,62 @@ export class ImplementationReviewCoordinator {
   private async runConvergenceReview(
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
-    { run, artifact_path, implementation_result, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback }: ReviewRunParams,
+    params: ReviewRunParams,
   ): Promise<ImplementationResult> {
+    return this.runConvergenceLoop(phase, phase, routeTask, params, params.implementation_result);
+  }
+
+  /**
+   * Run the layered implementation review across altitudes. This is the public
+   * entry point for the layered-diff convergence feature. Thin routing:
+   *  - If convergence is disabled, delegate to the existing single-pass path.
+   *  - If altitudes is exactly ['build'], delegate to the existing build
+   *    convergence path (preserving gate: "initial" in exchanges).
+   *  - For layered altitudes, run each altitude convergence in order and
+   *    return failure if any altitude does not converge.
+   */
+  async runLayeredImplementation(
+    params: ReviewRunParams,
+    opts: { altitudes: readonly LayeredConvergenceGate[] },
+  ): Promise<ImplementationResult> {
+    const altitudes = opts.altitudes;
+
+    // Convergence disabled → existing single-pass behavior.
+    if (!this.deps.policy.convergence.enabled) {
+      return this.runInitialReview(params);
+    }
+
+    // Build-only mode → existing convergence path (preserves gate: "initial").
+    if (altitudes.length === 1 && altitudes[0] === 'build') {
+      return this.runInitialReview(params);
+    }
+
+    // Layered altitudes: run each altitude convergence loop in order.
+    let currentResult = params.implementation_result;
+    for (const altitude of altitudes) {
+      const result = await this.runConvergenceLoop(
+        altitude,
+        'initial',
+        'implementation.review.initial',
+        { ...params, implementation_result: currentResult },
+        currentResult,
+      );
+      if (result.status !== 'complete') {
+        return result;
+      }
+      currentResult = result;
+    }
+    return currentResult;
+  }
+
+  private async runConvergenceLoop(
+    gate: 'initial' | 'final' | LayeredConvergenceGate,
+    phase: 'initial' | 'final',
+    routeTask: 'implementation.review.initial' | 'implementation.review.final',
+    { run, artifact_path, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback }: ReviewRunParams,
+    initialResult: ImplementationResult,
+  ): Promise<ImplementationResult> {
+    const implementation_result = initialResult;
     // Resolve critic profile — fall back to initial when final is absent
     let criticProfile = this.deps.routingPolicy.resolveOptional({ task: routeTask, role: 'critic' });
     if (!criticProfile && phase === 'final') {
@@ -368,7 +423,7 @@ export class ImplementationReviewCoordinator {
     } catch { /* ignore */ }
 
     this.deps.logger.info(
-      { event: 'implementation.review.convergence_started', phase, gate: phase, run_id: run.id, max_rounds: maxRounds, critic_profile: criticSummary.profile },
+      { event: 'implementation.review.convergence_started', phase, gate, run_id: run.id, max_rounds: maxRounds, critic_profile: criticSummary.profile },
       'Starting convergence review',
     );
 
@@ -380,7 +435,7 @@ export class ImplementationReviewCoordinator {
       const roundStart = performance.now();
 
       this.deps.logger.info(
-        { event: 'implementation.review.round_started', phase, gate: phase, round, run_id: run.id, review_profile: criticProfile.id },
+        { event: 'implementation.review.round_started', phase, gate, round, run_id: run.id, review_profile: criticProfile.id },
         'Convergence review round started',
       );
 
@@ -389,7 +444,7 @@ export class ImplementationReviewCoordinator {
       const changedFiles = await this.getChangedFiles(working_directory);
 
       // Build critic prompt with convergence context
-      const convergenceContext = { gate: phase, round };
+      const convergenceContext = { gate, round };
       const prompt = phase === 'initial'
         ? buildInitialReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext)
         : buildFinalReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext);
@@ -443,11 +498,11 @@ export class ImplementationReviewCoordinator {
 
         const reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
         reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
-        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'ok', drainSummary, { role: 'critic', round, gate: phase });
+        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'ok', drainSummary, { role: 'critic', round, gate });
       } catch (err) {
-        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'failed', drainSummary, { role: 'critic', round, gate: phase });
+        this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'failed', drainSummary, { role: 'critic', round, gate });
         this.deps.logger.error(
-          { event: 'implementation.review.round_failed', phase, gate: phase, round, run_id: run.id, error: String(err) },
+          { event: 'implementation.review.round_failed', phase, gate, round, run_id: run.id, error: String(err) },
           'Convergence review round failed',
         );
         return this.handleReviewFailure(phase, run, currentResult, proposerSummary, criticSummary, String(err), captureFeedback);
@@ -455,7 +510,7 @@ export class ImplementationReviewCoordinator {
 
       if (reviewResult.status === 'failed') {
         this.deps.logger.error(
-          { event: 'implementation.review.round_failed', phase, gate: phase, round, run_id: run.id, reason: 'review_agent_status_failed', error: reviewResult.error },
+          { event: 'implementation.review.round_failed', phase, gate, round, run_id: run.id, reason: 'review_agent_status_failed', error: reviewResult.error },
           'Convergence review round failed: review agent reported failure',
         );
         return this.handleReviewFailure(phase, run, currentResult, proposerSummary, criticSummary, reviewResult.error ?? 'Review model reported failure', captureFeedback);
@@ -467,7 +522,7 @@ export class ImplementationReviewCoordinator {
       const infoCount = reviewResult.findings.filter(f => f.severity === 'info').length;
 
       this.deps.logger.info(
-        { event: 'implementation.review.round_completed', phase, gate: phase, round, run_id: run.id, review_profile: criticProfile.id, duration_ms, blocker_count: blockerCount, warning_count: warningCount, info_count: infoCount },
+        { event: 'implementation.review.round_completed', phase, gate, round, run_id: run.id, review_profile: criticProfile.id, duration_ms, blocker_count: blockerCount, warning_count: warningCount, info_count: infoCount },
         'Convergence review round completed',
       );
 
@@ -477,7 +532,7 @@ export class ImplementationReviewCoordinator {
       if (reviewResult.status === 'no_findings' || blockingFindings.length === 0) {
         this.appendGateExchange(run, {
           id: randomUUID(),
-          gate: phase,
+          gate,
           round,
           created_at: new Date().toISOString(),
           proposer_profile: proposerSummary,
@@ -491,7 +546,7 @@ export class ImplementationReviewCoordinator {
         }, captureFeedback);
 
         this.deps.logger.info(
-          { event: 'implementation.review.converged', phase, gate: phase, round, run_id: run.id },
+          { event: 'implementation.review.converged', phase, gate, round, run_id: run.id },
           'Implementation review converged',
         );
 
@@ -505,7 +560,7 @@ export class ImplementationReviewCoordinator {
       if (previousSignatures.length > 0 && this.isOscillating(previousSignatures, previousBlockingCounts, reviewResult.findings)) {
         this.appendGateExchange(run, {
           id: randomUUID(),
-          gate: phase,
+          gate,
           round,
           created_at: new Date().toISOString(),
           proposer_profile: proposerSummary,
@@ -520,7 +575,7 @@ export class ImplementationReviewCoordinator {
         }, captureFeedback);
 
         this.deps.logger.warn(
-          { event: 'implementation.review.oscillation_detected', run_id: run.id, gate: phase, round, signature_count: this.signatureSet(reviewResult.findings).size },
+          { event: 'implementation.review.oscillation_detected', run_id: run.id, gate, round, signature_count: this.signatureSet(reviewResult.findings).size },
           'Implementation review did not converge: oscillation detected',
         );
 
@@ -534,7 +589,7 @@ export class ImplementationReviewCoordinator {
       if (round === maxRounds) {
         this.appendGateExchange(run, {
           id: randomUUID(),
-          gate: phase,
+          gate,
           round,
           created_at: new Date().toISOString(),
           proposer_profile: proposerSummary,
@@ -549,7 +604,7 @@ export class ImplementationReviewCoordinator {
         }, captureFeedback);
 
         this.deps.logger.warn(
-          { event: 'implementation.review.non_converged', phase, gate: phase, round, run_id: run.id, reason: 'max_rounds' },
+          { event: 'implementation.review.non_converged', phase, gate, round, run_id: run.id, reason: 'max_rounds' },
           'Implementation review did not converge: max_rounds reached',
         );
 
@@ -568,7 +623,7 @@ export class ImplementationReviewCoordinator {
         route: proposerRoute,
         role: 'proposer',
         round,
-        gate: phase,
+        gate,
         captureSession,
         onAgentRequest,
       };
@@ -606,7 +661,7 @@ export class ImplementationReviewCoordinator {
       // Append addressed gate exchange
       this.appendGateExchange(run, {
         id: randomUUID(),
-        gate: phase,
+        gate,
         round,
         created_at: new Date().toISOString(),
         proposer_profile: proposerSummary,

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -35,6 +35,10 @@ import { agentProfileSummary } from './routing-policy.js';
 import { allowedCategoriesForGate, gateLabel, type LayeredConvergenceGate } from './layered-convergence-policy.js';
 import { filterLayeredFindings } from './layered-finding-filter.js';
 import { type ModelSessionBudget } from '../journal/model-session-budget.js';
+import { buildGateContext } from './gate-context.js';
+import { createGitSnapshotCheckpoint } from '../git-checkpoints.js';
+import { validateAltitudeContract } from './altitude-contract-validator.js';
+import { compareBuildToAcceptedContracts, type AcceptedAltitudeCheckpoint } from './build-contract-preservation.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
@@ -57,6 +61,14 @@ export interface ImplementationReviewCoordinatorDeps {
   branchGuard?: BranchGuard;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'debug' | 'error'>;
   readFile?: ReadFileFn;
+  /** Injectable for testing: replaces buildGateContext from gate-context.ts */
+  buildGateContext?: typeof buildGateContext;
+  /** Injectable for testing: replaces createGitSnapshotCheckpoint from git-checkpoints.ts */
+  createGitSnapshotCheckpoint?: typeof createGitSnapshotCheckpoint;
+  /** Injectable for testing: replaces validateAltitudeContract from altitude-contract-validator.ts */
+  validateAltitudeContract?: typeof validateAltitudeContract;
+  /** Injectable for testing: replaces compareBuildToAcceptedContracts from build-contract-preservation.ts */
+  compareBuildToAcceptedContracts?: typeof compareBuildToAcceptedContracts;
 }
 
 export interface ReviewRunParams {
@@ -382,6 +394,21 @@ export class ImplementationReviewCoordinator {
       );
     }
 
+    // Capture the pre-implementation base ref so each altitude's cumulative diff
+    // is correctly scoped from the same starting point.
+    let baseRef: string;
+    try {
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const exec = promisify(execFile);
+      const { stdout } = await exec('git', ['rev-parse', 'HEAD'], { cwd: params.working_directory });
+      baseRef = stdout.trim();
+    } catch {
+      baseRef = 'HEAD';
+    }
+
+    const acceptedCheckpoints: AcceptedAltitudeCheckpoint[] = [];
+
     let currentResult = params.implementation_result;
     for (const altitude of altitudes) {
       const result = await this.runConvergenceLoop(
@@ -390,11 +417,46 @@ export class ImplementationReviewCoordinator {
         'implementation.review.initial',
         { ...params, implementation_result: currentResult },
         currentResult,
+        { base_ref: baseRef, acceptedCheckpoints: altitude === 'build' ? [...acceptedCheckpoints] : [] },
       );
       if (result.status !== 'complete') {
         return result;
       }
       currentResult = result;
+
+      // After each non-build altitude converges, create a local checkpoint.
+      // The checkpoint ref becomes the base_ref for the next altitude's cumulative diff.
+      if (altitude !== 'build') {
+        this.deps.logger.info(
+          { event: 'implementation.layer.checkpoint_started', run_id: params.run.id, gate: altitude, strategy: 'internal_ref' },
+          'Creating altitude checkpoint',
+        );
+        try {
+          const checkpoint = await (this.deps.createGitSnapshotCheckpoint ?? createGitSnapshotCheckpoint)({
+            workingDirectory: params.working_directory,
+            runId: params.run.id,
+            gate: altitude,
+          });
+          this.deps.logger.info(
+            { event: 'implementation.layer.checkpoint_completed', run_id: params.run.id, gate: altitude, checkpoint_ref: checkpoint.ref },
+            'Altitude checkpoint created',
+          );
+          // Progress: emit only after checkpoint succeeds
+          try {
+            await params.onProgress?.(`${gateLabel(altitude as LayeredConvergenceGate)} converged — checkpointing layer`);
+          } catch (progressErr) {
+            this.deps.logger.warn({ event: 'progress_failed', run_id: params.run.id, gate: altitude, error: String(progressErr) }, 'Progress message failed to send');
+          }
+          baseRef = checkpoint.ref;
+          acceptedCheckpoints.push({ gate: altitude as 'layout' | 'public_api' | 'private_api', ref: checkpoint.ref });
+        } catch (err) {
+          this.deps.logger.error(
+            { event: 'implementation.layer.checkpoint_failed', run_id: params.run.id, gate: altitude, error: String(err) },
+            'Checkpoint creation failed — failing run before next altitude',
+          );
+          return { status: 'failed', error: `Checkpoint creation failed for ${altitude}: ${String(err)}` };
+        }
+      }
     }
     return currentResult;
   }
@@ -405,6 +467,7 @@ export class ImplementationReviewCoordinator {
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
     { run, artifact_path, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback, sessionBudget }: ReviewRunParams,
     initialResult: ImplementationResult,
+    loopOpts?: { base_ref?: string; acceptedCheckpoints?: AcceptedAltitudeCheckpoint[] },
   ): Promise<ImplementationResult> {
     const implementation_result = initialResult;
     // Resolve critic profile — fall back to initial when final is absent
@@ -483,15 +546,110 @@ export class ImplementationReviewCoordinator {
         'Convergence review round started',
       );
 
-      // Re-derive git diff and changed files fresh inside the loop
-      const diffContext = await this.getGitDiff(working_directory);
-      const changedFiles = await this.getChangedFiles(working_directory);
+      // Re-derive git diff and changed files fresh inside the loop.
+      // Named gates (layered altitudes) use gate-context cumulative diff from the
+      // altitude base ref so each altitude sees only its own cumulative changes.
+      // Legacy 'initial'/'final' gates keep the existing getGitDiff path.
+      const isEarlyLayeredGate = gate === 'layout' || gate === 'public_api' || gate === 'private_api';
+      const isNamedLayeredGate = isEarlyLayeredGate || gate === 'build';
+      let diffContext: string;
+      let changedFiles: string[];
+      if (isNamedLayeredGate && loopOpts?.base_ref) {
+        const gateCtx = await (this.deps.buildGateContext ?? buildGateContext)({ gate: String(gate), base_ref: loopOpts.base_ref, working_directory });
+        diffContext = gateCtx.diff;
+        changedFiles = gateCtx.changed_files;
+        this.deps.logger.info(
+          { event: 'implementation.review.context_built', run_id: run.id, gate, round, context_kind: 'cumulative', changed_file_count: changedFiles.length, diff_byte_count: gateCtx.diff_byte_count },
+          'Gate context built from cumulative diff',
+        );
+      } else {
+        diffContext = await this.getGitDiff(working_directory);
+        changedFiles = await this.getChangedFiles(working_directory);
+      }
+
+      // For early layered altitudes, mechanically validate that the proposer has not
+      // written lower-altitude work before running the critic.
+      if (isEarlyLayeredGate && loopOpts?.base_ref) {
+        const contractResult = await (this.deps.validateAltitudeContract ?? validateAltitudeContract)({
+          gate: gate as 'layout' | 'public_api' | 'private_api',
+          diff: diffContext,
+          changedFiles,
+          workingDirectory: working_directory,
+        });
+        if (contractResult.unsupported_files.length > 0) {
+          this.deps.logger.info(
+            { event: 'implementation.layer.contract_validation_unsupported', run_id: run.id, gate, round, unsupported_files: contractResult.unsupported_files },
+            'Altitude contract: unsupported file types skipped (reviewed by prompts/critics)',
+          );
+        }
+        if (!contractResult.valid) {
+          this.deps.logger.info(
+            { event: 'implementation.layer.contract_validation_failed', run_id: run.id, gate, round, violation_count: contractResult.violations.length },
+            'Altitude contract validation failed — injecting synthetic findings for proposer revision',
+          );
+          const contractFindings: ImplementationReviewFinding[] = contractResult.violations.map(v => ({
+            id: v.id,
+            severity: 'blocker' as const,
+            category: 'maintainability' as const,
+            finding: v.message,
+            scope: 'current_altitude' as const,
+            reason_code: v.reason_code,
+          } as ImplementationReviewFinding));
+
+          if (round === maxRounds) {
+            this.appendGateExchange(run, {
+              id: randomUUID(), gate, round, created_at: new Date().toISOString(),
+              proposer_profile: proposerSummary, critic_profile: criticSummary,
+              review_status: 'non_converged', review_summary: 'Altitude contract violations persist after max rounds',
+              findings: contractFindings, responses: [], converged: false,
+              non_convergence_reason: 'max_rounds', requires_human_retest: false,
+            }, captureFeedback);
+            return { status: 'failed', error: `Altitude contract violations at ${String(gate)} gate persisted after ${maxRounds} rounds: ${contractResult.violations.map(v => v.message).join('; ')}` };
+          }
+
+          // Reserve budget for proposer revision
+          let contractRevisionSessionId: string | undefined;
+          if (sessionBudget) {
+            try {
+              const r = await sessionBudget.reserve({ gate: String(gate), role: 'proposer', round, passKind: 'initial' });
+              contractRevisionSessionId = r.session_id;
+            } catch (err) {
+              this.deps.logger.warn({ event: 'implementation.review.budget_exhausted', run_id: run.id, gate, role: 'proposer', round, error: String(err) }, 'Budget exhausted before contract violation revision');
+              return { status: 'failed', error: String(err) };
+            }
+          }
+
+          const contractRevisePrompt = buildLayeredRevisePrompt({ gate, artifactPath: artifact_path, workingDirectory: working_directory, findings: contractFindings.map(f => ({ id: f.id, severity: f.severity, category: f.category, finding: f.finding })) });
+          let contractReviseResult: ImplementationResult;
+          try {
+            contractReviseResult = await this.deps.implementer.implement(artifact_path, working_directory, contractRevisePrompt, onProgress ?? ((_msg: string) => Promise.resolve()), { run_id: run.id, request_id: run.request_id, phase: `implementation_review_${phase}_proposer`, route: { task: 'implementation.run', role: 'proposer' }, role: 'proposer', round, gate, captureSession, onAgentRequest });
+          } catch (err) {
+            if (sessionBudget && contractRevisionSessionId) await sessionBudget.complete(contractRevisionSessionId, 'failed').catch(() => {});
+            return { status: 'failed', error: `Proposer revision for altitude contract violation failed: ${String(err)}` };
+          }
+          if (sessionBudget && contractRevisionSessionId) await sessionBudget.complete(contractRevisionSessionId, 'ok').catch(() => {});
+
+          if (contractReviseResult.status !== 'complete') return contractReviseResult;
+
+          this.appendGateExchange(run, {
+            id: randomUUID(), gate, round, created_at: new Date().toISOString(),
+            proposer_profile: proposerSummary, critic_profile: criticSummary,
+            review_status: 'addressed', review_summary: 'Altitude contract violations — proposer asked to revise',
+            findings: contractFindings, responses: contractReviseResult.review_responses ?? [], converged: false,
+            requires_human_retest: false,
+          }, captureFeedback);
+
+          currentResult = contractReviseResult;
+          previousSignatures.push(new Set(contractFindings.map(f => f.id)));
+          previousBlockingCounts.push(contractFindings.length);
+          continue; // Skip critic this round; re-validate next round
+        }
+      }
 
       // Build critic prompt with convergence context.
       // For early layered altitudes, use the altitude-aware critique prompt with
       // allowed-category guidance; build/initial/final keep the existing prompts.
       const convergenceContext = { gate, round };
-      const isEarlyLayeredGate = gate === 'layout' || gate === 'public_api' || gate === 'private_api';
       const prompt = isEarlyLayeredGate
         ? buildLayeredCritiquePrompt({
             gate,
@@ -618,6 +776,76 @@ export class ImplementationReviewCoordinator {
 
       // Check for convergence
       if (reviewResult.status === 'no_findings' || blockingFindings.length === 0) {
+        // For the build altitude, verify that converged upper-altitude contracts are
+        // preserved before reporting convergence. Drift is treated as a synthetic blocker.
+        if (gate === 'build' && loopOpts?.acceptedCheckpoints && loopOpts.acceptedCheckpoints.length > 0) {
+          const driftResult = await (this.deps.compareBuildToAcceptedContracts ?? compareBuildToAcceptedContracts)({
+            workingDirectory: working_directory,
+            acceptedCheckpoints: loopOpts.acceptedCheckpoints,
+          });
+          if (!driftResult.valid) {
+            this.deps.logger.info(
+              { event: 'implementation.build.contract_drift_detected', run_id: run.id, gate, round, drift_count: driftResult.drift.length },
+              'Build contract drift detected against accepted upper-altitude checkpoints',
+            );
+            const driftFindings: ImplementationReviewFinding[] = driftResult.drift.map((d, idx) => ({
+              id: `BUILD-CONTRACT-DRIFT-${idx + 1}`,
+              severity: 'blocker' as const,
+              category: 'maintainability' as const,
+              finding: d.message,
+              ...(d.symbol ? { suggested_action: `Restore the reviewed ${d.kind} '${d.symbol}' or rerun the affected upper altitude.` } : {}),
+            } as ImplementationReviewFinding));
+
+            if (round === maxRounds) {
+              this.appendGateExchange(run, {
+                id: randomUUID(), gate, round, created_at: new Date().toISOString(),
+                proposer_profile: proposerSummary, critic_profile: criticSummary,
+                review_status: 'non_converged', review_summary: 'Build contract drift persists after max rounds',
+                findings: [...effectiveFindings, ...driftFindings], responses: [], converged: false,
+                non_convergence_reason: 'max_rounds', requires_human_retest: false,
+              }, captureFeedback);
+              return { status: 'failed', error: `Build gate: contract drift detected and no revision budget remaining. Drift: ${driftResult.drift.map(d => d.message).join('; ')}` };
+            }
+
+            // Reserve proposer budget for drift revision
+            let driftRevisionSessionId: string | undefined;
+            if (sessionBudget) {
+              try {
+                const r = await sessionBudget.reserve({ gate: String(gate), role: 'proposer', round, passKind: 'initial' });
+                driftRevisionSessionId = r.session_id;
+              } catch (err) {
+                this.deps.logger.warn({ event: 'implementation.review.budget_exhausted', run_id: run.id, gate, role: 'proposer', round, error: String(err) }, 'Budget exhausted before contract drift revision');
+                return { status: 'failed', error: String(err) };
+              }
+            }
+
+            const driftRevisePrompt = buildImplementerResponsePrompt(artifact_path, working_directory, currentResult, driftFindings, { gate, round });
+            let driftReviseResult: ImplementationResult;
+            try {
+              driftReviseResult = await this.deps.implementer.implement(artifact_path, working_directory, driftRevisePrompt, onProgress ?? ((_msg: string) => Promise.resolve()), { run_id: run.id, request_id: run.request_id, phase: `implementation_review_${phase}_proposer`, route: { task: 'implementation.run', role: 'proposer' }, role: 'proposer', round, gate, captureSession, onAgentRequest });
+            } catch (err) {
+              if (sessionBudget && driftRevisionSessionId) await sessionBudget.complete(driftRevisionSessionId, 'failed').catch(() => {});
+              return { status: 'failed', error: `Proposer revision for build contract drift failed: ${String(err)}` };
+            }
+            if (sessionBudget && driftRevisionSessionId) await sessionBudget.complete(driftRevisionSessionId, 'ok').catch(() => {});
+
+            if (driftReviseResult.status !== 'complete') return driftReviseResult;
+
+            this.appendGateExchange(run, {
+              id: randomUUID(), gate, round, created_at: new Date().toISOString(),
+              proposer_profile: proposerSummary, critic_profile: criticSummary,
+              review_status: 'addressed', review_summary: 'Build contract drift — proposer asked to revise',
+              findings: [...effectiveFindings, ...driftFindings], responses: driftReviseResult.review_responses ?? [], converged: false,
+              requires_human_retest: false,
+            }, captureFeedback);
+
+            currentResult = driftReviseResult;
+            previousSignatures.push(new Set(driftFindings.map(f => f.id)));
+            previousBlockingCounts.push(driftFindings.length);
+            continue; // Loop back to re-run critic and re-check drift
+          }
+        }
+
         this.appendGateExchange(run, {
           id: randomUUID(),
           gate,
@@ -649,7 +877,7 @@ export class ImplementationReviewCoordinator {
         const convergedMsg = gate === 'build'
           ? `Build converged after ${round} round${round === 1 ? '' : 's'} — creating testing guide`
           : isNamedGate
-            ? `${altLabel} converged after ${round} round${round === 1 ? '' : 's'} — checkpointing layer`
+            ? `${altLabel} converged after ${round} round${round === 1 ? '' : 's'}`
             : `${altLabel} converged after ${round} round${round === 1 ? '' : 's'}`;
         await this.sendProgress(onProgress, run, phase, round, gate, convergedMsg);
 

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -32,7 +32,7 @@ import {
   drainAgentRunner,
 } from './agent-services.js';
 import { agentProfileSummary } from './routing-policy.js';
-import { allowedCategoriesForGate, type LayeredConvergenceGate } from './layered-convergence-policy.js';
+import { allowedCategoriesForGate, gateLabel, type LayeredConvergenceGate } from './layered-convergence-policy.js';
 import { filterLayeredFindings } from './layered-finding-filter.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
@@ -360,6 +360,26 @@ export class ImplementationReviewCoordinator {
     }
 
     // Layered altitudes: run each altitude convergence loop in order.
+    const depth = altitudes.join('+');
+    this.deps.logger.info(
+      {
+        event: 'implementation.layered.started',
+        run_id: params.run.id,
+        depth,
+        enabled_altitudes: [...altitudes],
+        model_session_budget: 24,
+      },
+      'Layered implementation enabled',
+    );
+    try {
+      await params.onProgress?.(`Layered implementation enabled — depth ${depth}`);
+    } catch (err) {
+      this.deps.logger.warn(
+        { event: 'progress_failed', run_id: params.run.id, error: String(err) },
+        'Progress message failed to send',
+      );
+    }
+
     let currentResult = params.implementation_result;
     for (const altitude of altitudes) {
       const result = await this.runConvergenceLoop(
@@ -430,9 +450,28 @@ export class ImplementationReviewCoordinator {
       'Starting convergence review',
     );
 
+    // Layer-started telemetry and progress message for layered altitudes.
+    const isNamedGate = gate !== 'initial' && gate !== 'final';
+    if (isNamedGate) {
+      const altLabel = gateLabel(gate as LayeredConvergenceGate);
+      this.deps.logger.info(
+        { event: 'implementation.layer.started', run_id: run.id, gate, proposer_profile: proposerSummary.profile },
+        'Layer altitude started',
+      );
+      try {
+        await onProgress?.(`${altLabel} pass started with ${proposerSummary.profile}`);
+      } catch (err) {
+        this.deps.logger.warn(
+          { event: 'progress_failed', run_id: run.id, gate, error: String(err) },
+          'Progress message failed to send',
+        );
+      }
+    }
+
     let currentResult: ImplementationResult = implementation_result;
     const previousSignatures: Set<string>[] = [];
     const previousBlockingCounts: number[] = [];
+    const layerStart = performance.now();
 
     for (let round = 1; round <= maxRounds; round++) {
       const roundStart = performance.now();
@@ -571,13 +610,25 @@ export class ImplementationReviewCoordinator {
           requires_human_retest: reviewResult.requires_human_retest ?? false,
         }, captureFeedback);
 
+        const layerElapsed_ms = Math.round(performance.now() - layerStart);
         this.deps.logger.info(
-          { event: 'implementation.review.converged', phase, gate, round, run_id: run.id },
+          { event: 'implementation.review.converged', phase, gate, round, run_id: run.id, rounds_used: round, finding_count: effectiveFindings.length, filtered_count: effectiveFindings.length - blockingFindings.length, elapsed_ms: layerElapsed_ms },
           'Implementation review converged',
         );
+        if (isNamedGate) {
+          this.deps.logger.info(
+            { event: 'implementation.layer.completed', run_id: run.id, gate, elapsed_ms: layerElapsed_ms },
+            'Layer altitude completed',
+          );
+        }
 
-        const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
-        await this.sendProgress(onProgress, run, phase, round, `${phaseLabel} converged after ${round} round${round === 1 ? '' : 's'}`);
+        const altLabel = isNamedGate ? gateLabel(gate as LayeredConvergenceGate) : (phase === 'initial' ? 'Initial review' : 'Final review');
+        const convergedMsg = gate === 'build'
+          ? `Build converged after ${round} round${round === 1 ? '' : 's'} — creating testing guide`
+          : isNamedGate
+            ? `${altLabel} converged after ${round} round${round === 1 ? '' : 's'} — checkpointing layer`
+            : `${altLabel} converged after ${round} round${round === 1 ? '' : 's'}`;
+        await this.sendProgress(onProgress, run, phase, round, gate, convergedMsg);
 
         return currentResult;
       }
@@ -600,13 +651,14 @@ export class ImplementationReviewCoordinator {
           requires_human_retest: reviewResult.requires_human_retest ?? false,
         }, captureFeedback);
 
+        const oscillationElapsed_ms = Math.round(performance.now() - layerStart);
         this.deps.logger.warn(
-          { event: 'implementation.review.oscillation_detected', run_id: run.id, gate, round, signature_count: this.signatureSet(reviewResult.findings).size },
+          { event: 'implementation.review.oscillation_detected', run_id: run.id, gate, round, rounds_used: round, elapsed_ms: oscillationElapsed_ms, signature_count: this.signatureSet(reviewResult.findings).size },
           'Implementation review did not converge: oscillation detected',
         );
 
-        const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
-        await this.sendProgress(onProgress, run, phase, round, `${phaseLabel} did not converge: oscillation detected after ${round} round${round === 1 ? '' : 's'}`);
+        const oscillationLabel = isNamedGate ? gateLabel(gate as LayeredConvergenceGate) : (phase === 'initial' ? 'Initial review' : 'Final review');
+        await this.sendProgress(onProgress, run, phase, round, gate, `${oscillationLabel} did not converge: oscillation detected after ${round} round${round === 1 ? '' : 's'}`);
 
         return { status: 'failed', error: `Implementation review ${phase} did not converge because oscillation was detected` };
       }
@@ -629,13 +681,14 @@ export class ImplementationReviewCoordinator {
           requires_human_retest: reviewResult.requires_human_retest ?? false,
         }, captureFeedback);
 
+        const maxRoundsElapsed_ms = Math.round(performance.now() - layerStart);
         this.deps.logger.warn(
-          { event: 'implementation.review.non_converged', phase, gate, round, run_id: run.id, reason: 'max_rounds' },
+          { event: 'implementation.review.non_converged', phase, gate, round, run_id: run.id, reason: 'max_rounds', rounds_used: round, elapsed_ms: maxRoundsElapsed_ms },
           'Implementation review did not converge: max_rounds reached',
         );
 
-        const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
-        await this.sendProgress(onProgress, run, phase, round, `${phaseLabel} did not converge after ${maxRounds} round${maxRounds === 1 ? '' : 's'}`);
+        const maxRoundsLabel = isNamedGate ? gateLabel(gate as LayeredConvergenceGate) : (phase === 'initial' ? 'Initial review' : 'Final review');
+        await this.sendProgress(onProgress, run, phase, round, gate, `${maxRoundsLabel} did not converge after ${maxRounds} round${maxRounds === 1 ? '' : 's'}`);
 
         return { status: 'failed', error: `Implementation review ${phase} did not converge after ${maxRounds} rounds` };
       }
@@ -720,13 +773,14 @@ export class ImplementationReviewCoordinator {
       previousSignatures.push(this.signatureSet(blockingFindings));
       previousBlockingCounts.push(blockingFindings.length);
 
-      const phaseLabel = phase === 'initial' ? 'Initial review' : 'Final review';
+      const reviseLabel = isNamedGate ? gateLabel(gate as LayeredConvergenceGate) : (phase === 'initial' ? 'Initial review' : 'Final review');
       await this.sendProgress(
         onProgress,
         run,
         phase,
         round,
-        `${phaseLabel} round ${round} returned ${blockingFindings.length} finding${blockingFindings.length === 1 ? '' : 's'} — asking proposer to revise`,
+        gate,
+        `${reviseLabel} review round ${round} returned ${blockingFindings.length} finding${blockingFindings.length === 1 ? '' : 's'} — asking proposer to revise`,
       );
     }
 
@@ -908,6 +962,7 @@ export class ImplementationReviewCoordinator {
     run: Run,
     phase: 'initial' | 'final',
     round: number,
+    gate: 'initial' | 'final' | LayeredConvergenceGate,
     message: string,
   ): Promise<void> {
     if (!onProgress) return;
@@ -915,7 +970,7 @@ export class ImplementationReviewCoordinator {
       await onProgress(message);
     } catch (err) {
       this.deps.logger.warn(
-        { event: 'progress_failed', phase, gate: phase, round, run_id: run.id, error: String(err) },
+        { event: 'progress_failed', phase, gate, round, run_id: run.id, error: String(err) },
         'Progress message failed to send',
       );
     }

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -507,9 +507,11 @@ export class ImplementationReviewCoordinator {
           : buildFinalReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext);
 
       // Reserve model-session budget slot before critic call
+      let criticSessionId: string | undefined;
       if (sessionBudget) {
         try {
-          await sessionBudget.reserve({ gate: String(gate), role: 'critic', round, passKind: phase === 'initial' ? 'initial' : 'final' });
+          const r = await sessionBudget.reserve({ gate: String(gate), role: 'critic', round, passKind: phase === 'initial' ? 'initial' : 'final' });
+          criticSessionId = r.session_id;
         } catch (err) {
           this.deps.logger.warn(
             { event: 'implementation.review.budget_exhausted', run_id: run.id, gate, role: 'critic', round, error: String(err) },
@@ -568,8 +570,14 @@ export class ImplementationReviewCoordinator {
 
         const reviewResultContent = await this.readFileFn(reviewResultPath, 'utf-8');
         reviewResult = parseImplementationReviewResult(reviewResultContent, reviewResultPath);
+        if (sessionBudget && criticSessionId) {
+          await sessionBudget.complete(criticSessionId, 'ok').catch(() => {});
+        }
         this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'ok', drainSummary, { role: 'critic', round, gate });
       } catch (err) {
+        if (sessionBudget && criticSessionId) {
+          await sessionBudget.complete(criticSessionId, 'failed').catch(() => {});
+        }
         this.emitSessionRecord(captureSession, criticProfile, routeTask, ts_start, 'failed', drainSummary, { role: 'critic', round, gate });
         this.deps.logger.error(
           { event: 'implementation.review.round_failed', phase, gate, round, run_id: run.id, error: String(err) },
@@ -737,9 +745,11 @@ export class ImplementationReviewCoordinator {
       };
 
       // Reserve model-session budget slot before proposer revision call
+      let proposerSessionId: string | undefined;
       if (sessionBudget) {
         try {
-          await sessionBudget.reserve({ gate: String(gate), role: 'proposer', round, passKind: phase === 'initial' ? 'initial' : 'final' });
+          const r = await sessionBudget.reserve({ gate: String(gate), role: 'proposer', round, passKind: phase === 'initial' ? 'initial' : 'final' });
+          proposerSessionId = r.session_id;
         } catch (err) {
           this.deps.logger.warn(
             { event: 'implementation.review.budget_exhausted', run_id: run.id, gate, role: 'proposer', round, error: String(err) },
@@ -759,7 +769,13 @@ export class ImplementationReviewCoordinator {
           proposerTelemetry,
         );
       } catch (err) {
+        if (sessionBudget && proposerSessionId) {
+          await sessionBudget.complete(proposerSessionId, 'failed').catch(() => {});
+        }
         return { status: 'failed', error: `Proposer response to review failed: ${String(err)}` };
+      }
+      if (sessionBudget && proposerSessionId) {
+        await sessionBudget.complete(proposerSessionId, 'ok').catch(() => {});
       }
 
       if (proposerResult.status !== 'complete') {

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -34,6 +34,7 @@ import {
 import { agentProfileSummary } from './routing-policy.js';
 import { allowedCategoriesForGate, gateLabel, type LayeredConvergenceGate } from './layered-convergence-policy.js';
 import { filterLayeredFindings } from './layered-finding-filter.js';
+import { type ModelSessionBudget } from '../journal/model-session-budget.js';
 
 type ReadFileFn = (path: string, encoding: 'utf-8') => Promise<string>;
 
@@ -67,6 +68,7 @@ export interface ReviewRunParams {
   onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
   captureSession?: AgentSessionCaptureFn;
   captureFeedback?: (exchange: ImplementationReviewExchange | GateReviewExchange, run: Run) => void;
+  sessionBudget?: ModelSessionBudget;
 }
 
 export class ImplementationReviewCoordinator {
@@ -401,7 +403,7 @@ export class ImplementationReviewCoordinator {
     gate: 'initial' | 'final' | LayeredConvergenceGate,
     phase: 'initial' | 'final',
     routeTask: 'implementation.review.initial' | 'implementation.review.final',
-    { run, artifact_path, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback }: ReviewRunParams,
+    { run, artifact_path, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback, sessionBudget }: ReviewRunParams,
     initialResult: ImplementationResult,
   ): Promise<ImplementationResult> {
     const implementation_result = initialResult;
@@ -503,6 +505,19 @@ export class ImplementationReviewCoordinator {
         : phase === 'initial'
           ? buildInitialReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext)
           : buildFinalReviewPrompt(artifact_path, working_directory, currentResult, diffContext, changedFiles, convergenceContext);
+
+      // Reserve model-session budget slot before critic call
+      if (sessionBudget) {
+        try {
+          await sessionBudget.reserve({ gate: String(gate), role: 'critic', round, passKind: phase === 'initial' ? 'initial' : 'final' });
+        } catch (err) {
+          this.deps.logger.warn(
+            { event: 'implementation.review.budget_exhausted', run_id: run.id, gate, role: 'critic', round, error: String(err) },
+            'Model-session budget exhausted before critic call',
+          );
+          return { status: 'failed', error: String(err) };
+        }
+      }
 
       // Run critic
       let reviewResult: ReturnType<typeof parseImplementationReviewResult>;
@@ -720,6 +735,19 @@ export class ImplementationReviewCoordinator {
         captureSession,
         onAgentRequest,
       };
+
+      // Reserve model-session budget slot before proposer revision call
+      if (sessionBudget) {
+        try {
+          await sessionBudget.reserve({ gate: String(gate), role: 'proposer', round, passKind: phase === 'initial' ? 'initial' : 'final' });
+        } catch (err) {
+          this.deps.logger.warn(
+            { event: 'implementation.review.budget_exhausted', run_id: run.id, gate, role: 'proposer', round, error: String(err) },
+            'Model-session budget exhausted before proposer revision call',
+          );
+          return { status: 'failed', error: String(err) };
+        }
+      }
 
       let proposerResult: ImplementationResult;
       try {

--- a/src/core/ai/implementation-review-coordinator.ts
+++ b/src/core/ai/implementation-review-coordinator.ts
@@ -394,17 +394,20 @@ export class ImplementationReviewCoordinator {
       );
     }
 
-    // Capture the pre-implementation base ref so each altitude's cumulative diff
-    // is correctly scoped from the same starting point.
-    let baseRef: string;
+    // Capture the pre-implementation pass base ref once. This ref is fixed for the
+    // entire pass and is passed to buildGateContext for every altitude so that each
+    // altitude sees a cumulative diff from the same original base through the current
+    // working tree. Checkpoint refs are tracked separately for build contract preservation
+    // and must never replace this pass base ref.
+    let passBaseRef: string;
     try {
       const { execFile } = await import('node:child_process');
       const { promisify } = await import('node:util');
       const exec = promisify(execFile);
       const { stdout } = await exec('git', ['rev-parse', 'HEAD'], { cwd: params.working_directory });
-      baseRef = stdout.trim();
+      passBaseRef = stdout.trim();
     } catch {
-      baseRef = 'HEAD';
+      passBaseRef = 'HEAD';
     }
 
     const acceptedCheckpoints: AcceptedAltitudeCheckpoint[] = [];
@@ -417,16 +420,31 @@ export class ImplementationReviewCoordinator {
         'implementation.review.initial',
         { ...params, implementation_result: currentResult },
         currentResult,
-        { base_ref: baseRef, acceptedCheckpoints: altitude === 'build' ? [...acceptedCheckpoints] : [] },
+        { base_ref: passBaseRef, acceptedCheckpoints: altitude === 'build' ? [...acceptedCheckpoints] : [] },
       );
       if (result.status !== 'complete') {
         return result;
       }
       currentResult = result;
 
-      // After each non-build altitude converges, create a local checkpoint.
-      // The checkpoint ref becomes the base_ref for the next altitude's cumulative diff.
+      // After each non-build altitude converges, run branch guard then create a checkpoint.
+      // Checkpoint refs are stored for build contract preservation; passBaseRef is never
+      // updated — all altitudes always diff cumulatively from the original pass base.
       if (altitude !== 'build') {
+        // Branch guard must run after convergence and before checkpoint creation so that
+        // any drift caused by the last proposer revision is caught before snapshotting.
+        if (this.deps.branchGuard) {
+          try {
+            await this.deps.branchGuard.check(params.working_directory, params.run.branch);
+          } catch (err) {
+            this.deps.logger.error(
+              { event: 'implementation.layer.branch_guard_failed', run_id: params.run.id, gate: altitude, error: String(err) },
+              'Branch guard rejected before checkpoint — failing run',
+            );
+            return { status: 'failed', error: `Branch guard failed before ${altitude} checkpoint: ${String(err)}` };
+          }
+        }
+
         this.deps.logger.info(
           { event: 'implementation.layer.checkpoint_started', run_id: params.run.id, gate: altitude, strategy: 'internal_ref' },
           'Creating altitude checkpoint',
@@ -447,7 +465,6 @@ export class ImplementationReviewCoordinator {
           } catch (progressErr) {
             this.deps.logger.warn({ event: 'progress_failed', run_id: params.run.id, gate: altitude, error: String(progressErr) }, 'Progress message failed to send');
           }
-          baseRef = checkpoint.ref;
           acceptedCheckpoints.push({ gate: altitude as 'layout' | 'public_api' | 'private_api', ref: checkpoint.ref });
         } catch (err) {
           this.deps.logger.error(

--- a/src/core/ai/layered-convergence-policy.ts
+++ b/src/core/ai/layered-convergence-policy.ts
@@ -1,0 +1,61 @@
+import type {
+  ImplementationReviewConvergenceDepth,
+  ImplementationReviewFeedbackDepth,
+  WorkflowConfig,
+} from '../../types/config.js';
+import type { ImplementationReviewFindingCategory } from '../../types/ai.js';
+
+export type LayeredConvergenceGate = 'layout' | 'public_api' | 'private_api' | 'build';
+
+export const IMPLEMENTATION_CONVERGENCE_DEPTHS = ['build_only', 'layout', 'public_api', 'full'] as const;
+export const IMPLEMENTATION_FEEDBACK_DEPTHS = ['build_only', 'layout', 'public_api', 'full', 'inherit'] as const;
+
+export interface ResolvedImplementationConvergencePolicy {
+  enabled: boolean;
+  allow_same_model: boolean;
+  depth: ImplementationReviewConvergenceDepth;
+  feedback_depth: ImplementationReviewFeedbackDepth;
+  max_model_sessions_per_run: number;
+}
+
+const ALTITUDES_BY_DEPTH: Record<ImplementationReviewConvergenceDepth, readonly LayeredConvergenceGate[]> = {
+  build_only: ['build'],
+  layout: ['layout', 'build'],
+  public_api: ['layout', 'public_api', 'build'],
+  full: ['layout', 'public_api', 'private_api', 'build'],
+};
+
+export function altitudesForDepth(depth: ImplementationReviewConvergenceDepth): LayeredConvergenceGate[] {
+  return [...ALTITUDES_BY_DEPTH[depth]];
+}
+
+export function resolveFeedbackDepth(
+  feedbackDepth: ImplementationReviewFeedbackDepth | undefined,
+  initialDepth: ImplementationReviewConvergenceDepth,
+): ImplementationReviewConvergenceDepth {
+  if (feedbackDepth === 'inherit') return initialDepth;
+  return feedbackDepth ?? 'build_only';
+}
+
+export function resolveImplementationConvergencePolicy(config: WorkflowConfig): ResolvedImplementationConvergencePolicy {
+  const raw = config.implementation_review?.convergence;
+  return {
+    enabled: raw?.enabled ?? false,
+    allow_same_model: raw?.allow_same_model ?? false,
+    depth: raw?.depth ?? 'build_only',
+    feedback_depth: raw?.feedback_depth ?? 'build_only',
+    max_model_sessions_per_run: raw?.max_model_sessions_per_run ?? 24,
+  };
+}
+
+export function allowedCategoriesForGate(gate: LayeredConvergenceGate): ImplementationReviewFindingCategory[] {
+  if (gate === 'layout') return ['maintainability', 'docs'];
+  if (gate === 'public_api' || gate === 'private_api') return ['maintainability', 'docs', 'security'];
+  return ['correctness', 'test', 'security', 'maintainability', 'docs', 'pr_readiness'];
+}
+
+export function gateLabel(gate: LayeredConvergenceGate): string {
+  if (gate === 'public_api') return 'Public API';
+  if (gate === 'private_api') return 'Private API';
+  return gate[0]!.toUpperCase() + gate.slice(1);
+}

--- a/src/core/ai/layered-finding-filter.ts
+++ b/src/core/ai/layered-finding-filter.ts
@@ -1,0 +1,155 @@
+import type { ImplementationReviewFinding } from '../../types/ai.js';
+import { allowedCategoriesForGate } from './layered-convergence-policy.js';
+
+const LOWER_ALTITUDE_REASON_CODES = new Set([
+  'missing_lower_altitude_body',
+  'missing_lower_altitude_test',
+  'missing_lower_altitude_implementation',
+  'build_signal_unavailable_until_build',
+]);
+
+const VALID_SCOPES = new Set(['current_altitude', 'lower_altitude', 'prior_context']);
+const VALID_REASON_CODES = new Set([
+  'altitude_contract_violation',
+  'layout_boundary',
+  'public_api_contract',
+  'private_api_contract',
+  'security_contract',
+  'documentation_gap',
+  'missing_lower_altitude_body',
+  'missing_lower_altitude_test',
+  'missing_lower_altitude_implementation',
+  'build_signal_unavailable_until_build',
+]);
+
+export interface FilterLayeredFindingsResult {
+  findings: ImplementationReviewFinding[];  // all findings with layered metadata attached
+  blockingFindings: ImplementationReviewFinding[];  // only findings that block convergence
+  filteredCount: number;
+}
+
+export function filterLayeredFindings(args: {
+  gate: string;
+  round: number;
+  findings: ImplementationReviewFinding[];
+  runId?: string;
+}): FilterLayeredFindingsResult {
+  const { gate, findings } = args;
+  const isEarlyGate = gate === 'layout' || gate === 'public_api' || gate === 'private_api';
+  const allowedCategories = isEarlyGate
+    ? allowedCategoriesForGate(gate as 'layout' | 'public_api' | 'private_api' | 'build')
+    : null; // build gate: no category filtering
+
+  const enrichedFindings: ImplementationReviewFinding[] = [];
+  const blockingFindings: ImplementationReviewFinding[] = [];
+  let filteredCount = 0;
+
+  for (const finding of findings) {
+    const originalSeverity = finding.severity;
+    const originalCategory = finding.category;
+
+    // Step 1: Info severity never blocks
+    if (originalSeverity === 'info') {
+      enrichedFindings.push({
+        ...finding,
+        layered: {
+          scope: finding.scope,
+          reason_code: finding.reason_code,
+          disposition: 'info',
+          original_severity: originalSeverity,
+          original_category: originalCategory,
+        },
+      });
+      continue;
+    }
+
+    if (isEarlyGate) {
+      // Step 2: Missing or invalid layered metadata → filtered_note with invalid_layered_metadata
+      const hasValidScope = finding.scope !== undefined && VALID_SCOPES.has(finding.scope);
+      const hasValidReasonCode = finding.reason_code !== undefined && VALID_REASON_CODES.has(finding.reason_code);
+
+      if (!hasValidScope || !hasValidReasonCode) {
+        enrichedFindings.push({
+          ...finding,
+          layered: {
+            disposition: 'filtered_note',
+            filter_reason: 'invalid_layered_metadata',
+            original_severity: originalSeverity,
+            original_category: originalCategory,
+          },
+        });
+        filteredCount++;
+        continue;
+      }
+
+      // Step 3: Lower altitude scope → filtered_note with lower_altitude_scope
+      if (finding.scope === 'lower_altitude') {
+        enrichedFindings.push({
+          ...finding,
+          layered: {
+            scope: finding.scope,
+            reason_code: finding.reason_code,
+            disposition: 'filtered_note',
+            filter_reason: 'lower_altitude_scope',
+            original_severity: originalSeverity,
+            original_category: originalCategory,
+          },
+        });
+        filteredCount++;
+        continue;
+      }
+
+      // Step 4: Lower altitude reason codes → filtered_note with lower_altitude_reason_code
+      if (finding.reason_code && LOWER_ALTITUDE_REASON_CODES.has(finding.reason_code)) {
+        enrichedFindings.push({
+          ...finding,
+          layered: {
+            scope: finding.scope,
+            reason_code: finding.reason_code,
+            disposition: 'filtered_note',
+            filter_reason: 'lower_altitude_reason_code',
+            original_severity: originalSeverity,
+            original_category: originalCategory,
+          },
+        });
+        filteredCount++;
+        continue;
+      }
+
+      // Step 5: Category not in allowlist → filtered_note with category_not_allowed
+      if (allowedCategories && !allowedCategories.includes(originalCategory)) {
+        enrichedFindings.push({
+          ...finding,
+          layered: {
+            scope: finding.scope,
+            reason_code: finding.reason_code,
+            disposition: 'filtered_note',
+            filter_reason: 'category_not_allowed',
+            original_severity: originalSeverity,
+            original_category: originalCategory,
+          },
+        });
+        filteredCount++;
+        continue;
+      }
+    }
+
+    // Remaining blocker/warning findings block convergence
+    const enrichedFinding: ImplementationReviewFinding = {
+      ...finding,
+      layered: {
+        scope: finding.scope,
+        reason_code: finding.reason_code,
+        disposition: 'blocking',
+        original_severity: originalSeverity,
+        original_category: originalCategory,
+      },
+    };
+    enrichedFindings.push(enrichedFinding);
+    if (originalSeverity === 'blocker' || originalSeverity === 'warning') {
+      blockingFindings.push(enrichedFinding);
+    }
+  }
+
+  return { findings: enrichedFindings, blockingFindings, filteredCount };
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -194,6 +194,20 @@ export function validateConfig(config: WorkflowConfig): void {
       if (convergence['allow_same_model'] !== undefined && typeof convergence['allow_same_model'] !== 'boolean') {
         throw new Error('implementation_review.convergence.allow_same_model must be a boolean');
       }
+      const validDepths = ['build_only', 'layout', 'public_api', 'full'];
+      const validFeedbackDepths = [...validDepths, 'inherit'];
+      if (convergence['depth'] !== undefined && !validDepths.includes(String(convergence['depth']))) {
+        throw new Error('implementation_review.convergence.depth must be one of build_only, layout, public_api, full');
+      }
+      if (convergence['feedback_depth'] !== undefined && !validFeedbackDepths.includes(String(convergence['feedback_depth']))) {
+        throw new Error('implementation_review.convergence.feedback_depth must be one of build_only, layout, public_api, full, inherit');
+      }
+      if (convergence['max_model_sessions_per_run'] !== undefined) {
+        const value = convergence['max_model_sessions_per_run'];
+        if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+          throw new Error('implementation_review.convergence.max_model_sessions_per_run must be a positive integer');
+        }
+      }
     }
   }
 

--- a/src/core/git-checkpoints.ts
+++ b/src/core/git-checkpoints.ts
@@ -1,0 +1,104 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const exec = promisify(execFile);
+
+export interface GitCheckpointResult {
+  strategy: 'internal_ref';
+  ref: string;
+  commit: string;
+  gate: string;
+}
+
+export async function createGitSnapshotCheckpoint(args: {
+  workingDirectory: string;
+  runId: string;
+  gate: string;
+  message?: string;
+}): Promise<GitCheckpointResult> {
+  const { workingDirectory, runId, gate, message } = args;
+
+  // Create a temporary index file
+  const tempDir = await mkdtemp(join(tmpdir(), 'ac-checkpoint-'));
+  const tempIndex = join(tempDir, 'index');
+
+  try {
+    // Read the current HEAD tree into the temp index
+    const headSha = await git(workingDirectory, ['rev-parse', 'HEAD']);
+    await gitWithIndex(workingDirectory, tempIndex, ['read-tree', headSha.trim()]);
+
+    // Update tracked working-tree files in the temp index
+    // This picks up any unstaged modifications to tracked files
+    await gitWithIndex(workingDirectory, tempIndex, ['update-index', '--refresh', '--ignore-missing']).catch(() => {});
+
+    // Add working-tree versions of all tracked changed files
+    const changedTracked = await git(workingDirectory, ['diff', '--name-only', 'HEAD']).catch(() => '');
+    const trackedFiles = changedTracked.trim().split('\n').filter(Boolean);
+    for (const file of trackedFiles) {
+      await gitWithIndex(workingDirectory, tempIndex, ['update-index', '--add', '--', file]).catch(() => {});
+    }
+
+    // Get non-ignored untracked files
+    const untrackedOutput = await git(workingDirectory, ['ls-files', '--others', '--exclude-standard']);
+    const untrackedFiles = untrackedOutput.trim().split('\n').filter(Boolean);
+
+    // Add each untracked file to the temp index using hash-object + update-index
+    for (const file of untrackedFiles) {
+      try {
+        const blobSha = await git(workingDirectory, ['hash-object', '-w', '--', file]);
+        await gitWithIndex(workingDirectory, tempIndex, [
+          'update-index',
+          '--add',
+          '--cacheinfo',
+          `100644,${blobSha.trim()},${file}`,
+        ]);
+      } catch {
+        // Skip files we can't hash
+      }
+    }
+
+    // Write the tree from temp index
+    const treeSha = await gitWithIndex(workingDirectory, tempIndex, ['write-tree']);
+
+    // Create a commit from this tree
+    const parentSha = headSha.trim();
+    const commitMsg = message ?? `autocatalyst: ${gate} checkpoint for ${runId}`;
+    const commitSha = await git(workingDirectory, [
+      'commit-tree',
+      treeSha.trim(),
+      '-p', parentSha,
+      '-m', commitMsg,
+    ]);
+
+    // Create an internal ref
+    const timestamp = Date.now();
+    const ref = `refs/autocatalyst/runs/${runId}/${gate}/${timestamp}`;
+    await git(workingDirectory, ['update-ref', ref, commitSha.trim()]);
+
+    return {
+      strategy: 'internal_ref',
+      ref,
+      commit: commitSha.trim(),
+      gate,
+    };
+  } finally {
+    // Always clean up the temp directory
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const result = await exec('git', args, { cwd });
+  return result.stdout;
+}
+
+async function gitWithIndex(cwd: string, indexFile: string, args: string[]): Promise<string> {
+  const result = await exec('git', args, {
+    cwd,
+    env: { ...process.env, GIT_INDEX_FILE: indexFile },
+  });
+  return result.stdout;
+}

--- a/src/core/handlers/implementation-approval-handler.ts
+++ b/src/core/handlers/implementation-approval-handler.ts
@@ -14,6 +14,8 @@ import type { ImplementationReviewCoordinator } from '../ai/implementation-revie
 import type { AgentSessionCaptureFn, GateReviewExchange, ImplementationResult, ImplementationReviewExchange, IntentClassifyResult } from '../../types/ai.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
+import { ModelSessionBudget, type BudgetWriter } from '../journal/model-session-budget.js';
+import { type ResolvedImplementationConvergencePolicy } from '../ai/layered-convergence-policy.js';
 
 export interface ImplementationApprovalDeps {
   specCommitter?: Pick<SpecCommitter, 'updateStatus'>;
@@ -30,6 +32,8 @@ export interface ImplementationApprovalDeps {
   branchGuard?: BranchGuard;
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runFinalReview'>;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
+  convergencePolicy?: ResolvedImplementationConvergencePolicy;
+  budgetWriter?: BudgetWriter;
 }
 
 export type ImplementationApprovalResult =
@@ -141,6 +145,14 @@ export class ImplementationApprovalHandler {
             }
           }
         : undefined;
+      const sessionBudget = this.deps.convergencePolicy
+        ? new ModelSessionBudget({
+            runId: run.id,
+            requestId: run.request_id,
+            limit: this.deps.convergencePolicy.max_model_sessions_per_run,
+            writer: this.deps.budgetWriter ?? { append: async () => {} },
+          })
+        : undefined;
       const reviewedResult = await this.deps.reviewCoordinator.runFinalReview({
         run,
         artifact_path: localPath ?? '',
@@ -149,6 +161,7 @@ export class ImplementationApprovalHandler {
         onAgentRequest,
         captureSession: captureSessionForReview,
         captureFeedback: captureFeedbackForReview,
+        sessionBudget,
       });
 
       if (reviewedResult.status === 'needs_input') {

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -14,6 +14,7 @@ import {
   resolveFeedbackDepth,
   type ResolvedImplementationConvergencePolicy,
 } from '../ai/layered-convergence-policy.js';
+import { ModelSessionBudget, type BudgetWriter } from '../journal/model-session-budget.js';
 
 export interface ImplementationFeedbackDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -27,6 +28,7 @@ export interface ImplementationFeedbackDeps {
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview' | 'runLayeredImplementation'>;
   convergencePolicy?: ResolvedImplementationConvergencePolicy;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
+  budgetWriter?: BudgetWriter;
 }
 
 export type ImplementationFeedbackResult =
@@ -47,6 +49,15 @@ export class ImplementationFeedbackHandler {
     const additionalContext = await this.additionalContext(run, feedback, routingStage);
     if (additionalContext.status === 'failed') return { status: 'failed' };
 
+    const sessionBudget = this.deps.convergencePolicy
+      ? new ModelSessionBudget({
+          runId: run.id,
+          requestId: run.request_id,
+          limit: this.deps.convergencePolicy.max_model_sessions_per_run,
+          writer: this.deps.budgetWriter ?? { append: async () => {} },
+        })
+      : undefined;
+
     const onProgress = (message: string): Promise<void> =>
       this.deps.postMessage(feedback.conversation, message).catch(err => {
         this.deps.logger.warn(
@@ -61,6 +72,17 @@ export class ImplementationFeedbackHandler {
 
     const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
 
+    let implReservationId: string | undefined;
+    if (sessionBudget) {
+      try {
+        const r = await sessionBudget.reserve({ gate: 'initial', role: 'proposer', round: 1, passKind: 'feedback' });
+        implReservationId = r.session_id;
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
+    }
+
     let result;
     try {
       const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
@@ -73,7 +95,13 @@ export class ImplementationFeedbackHandler {
         onProgress,
         { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession },
       );
+      if (sessionBudget && implReservationId) {
+        await sessionBudget.complete(implReservationId, 'ok').catch(() => {});
+      }
     } catch (err) {
+      if (sessionBudget && implReservationId) {
+        await sessionBudget.complete(implReservationId, 'failed').catch(() => {});
+      }
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };
     }
@@ -161,6 +189,7 @@ export class ImplementationFeedbackHandler {
         onAgentRequest,
         captureSession: captureSessionForReview,
         captureFeedback,
+        sessionBudget,
       };
       const policy = this.deps.convergencePolicy;
       // Feedback uses feedback_depth (defaulting to build_only) to choose altitudes.

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -9,6 +9,11 @@ import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
+import {
+  altitudesForDepth,
+  resolveFeedbackDepth,
+  type ResolvedImplementationConvergencePolicy,
+} from '../ai/layered-convergence-policy.js';
 
 export interface ImplementationFeedbackDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -19,7 +24,8 @@ export interface ImplementationFeedbackDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error' | 'debug'>;
   branchGuard?: BranchGuard;
-  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
+  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview' | 'runLayeredImplementation'>;
+  convergencePolicy?: ResolvedImplementationConvergencePolicy;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
 }
 
@@ -132,7 +138,7 @@ export class ImplementationFeedbackHandler {
             }
           }
         : undefined;
-      reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
+      const reviewParams = {
         run,
         artifact_path: localPath,
         implementation_result: result,
@@ -141,7 +147,19 @@ export class ImplementationFeedbackHandler {
         onAgentRequest,
         captureSession: captureSessionForReview,
         captureFeedback,
-      });
+      };
+      const policy = this.deps.convergencePolicy;
+      // Feedback uses feedback_depth (defaulting to build_only) to choose altitudes.
+      const feedbackDepth = policy
+        ? resolveFeedbackDepth(policy.feedback_depth, policy.depth)
+        : 'build_only';
+      const useLayered =
+        policy?.enabled &&
+        feedbackDepth !== 'build_only' &&
+        typeof this.deps.reviewCoordinator.runLayeredImplementation === 'function';
+      reviewedResult = useLayered
+        ? await this.deps.reviewCoordinator.runLayeredImplementation!(reviewParams, { altitudes: altitudesForDepth(feedbackDepth) })
+        : await this.deps.reviewCoordinator.runInitialReview(reviewParams);
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');
         try {

--- a/src/core/handlers/implementation-feedback-handler.ts
+++ b/src/core/handlers/implementation-feedback-handler.ts
@@ -100,14 +100,20 @@ export class ImplementationFeedbackHandler {
               // GateReviewExchange — emit feedback per finding with gate-aware disposition
               const criticProfile = exchange.critic_profile;
               for (const finding of exchange.findings) {
+                const layered = finding.layered;
                 const response = exchange.responses.find(r => r.id === finding.id);
                 const isBlocking = finding.severity === 'blocker' || finding.severity === 'warning';
-                const disposition =
-                  response?.disposition === 'fixed' ? 'addressed' as const
-                  : response?.disposition === 'declined' ? 'wont_fix' as const
-                  : exchange.converged || finding.severity === 'info' ? 'addressed' as const
-                  : isBlocking ? 'open' as const
-                  : 'addressed' as const;
+                let disposition: 'open' | 'addressed' | 'wont_fix';
+                if (layered?.disposition === 'filtered_note' || layered?.disposition === 'info') {
+                  disposition = 'addressed';
+                } else {
+                  disposition =
+                    response?.disposition === 'fixed' ? 'addressed' as const
+                    : response?.disposition === 'declined' ? 'wont_fix' as const
+                    : exchange.converged || finding.severity === 'info' ? 'addressed' as const
+                    : isBlocking ? 'open' as const
+                    : 'addressed' as const;
+                }
                 void this.deps.journal!.captureFeedback({
                   id: `${exchange.id}:${finding.id}`,
                   run: captureRun,
@@ -118,6 +124,14 @@ export class ImplementationFeedbackHandler {
                   severity: finding.severity,
                   category: finding.category,
                   disposition,
+                  ...(layered?.disposition === 'filtered_note' ? {
+                    note_kind: 'filtered_layered_finding' as const,
+                    filter_reason: layered.filter_reason,
+                    scope: layered.scope,
+                    reason_code: layered.reason_code,
+                    original_severity: layered.original_severity,
+                    original_category: layered.original_category,
+                  } : {}),
                 }).catch(() => {});
               }
             } else {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -105,14 +105,20 @@ export class ImplementationStartHandler {
               // GateReviewExchange — emit feedback per finding with gate-aware disposition
               const criticProfile = exchange.critic_profile;
               for (const finding of exchange.findings) {
+                const layered = finding.layered;
                 const response = exchange.responses.find(r => r.id === finding.id);
                 const isBlocking = finding.severity === 'blocker' || finding.severity === 'warning';
-                const disposition =
-                  response?.disposition === 'fixed' ? 'addressed' as const
-                  : response?.disposition === 'declined' ? 'wont_fix' as const
-                  : exchange.converged || finding.severity === 'info' ? 'addressed' as const
-                  : isBlocking ? 'open' as const
-                  : 'addressed' as const;
+                let disposition: 'open' | 'addressed' | 'wont_fix';
+                if (layered?.disposition === 'filtered_note' || layered?.disposition === 'info') {
+                  disposition = 'addressed';
+                } else {
+                  disposition =
+                    response?.disposition === 'fixed' ? 'addressed' as const
+                    : response?.disposition === 'declined' ? 'wont_fix' as const
+                    : exchange.converged || finding.severity === 'info' ? 'addressed' as const
+                    : isBlocking ? 'open' as const
+                    : 'addressed' as const;
+                }
                 void this.deps.journal!.captureFeedback({
                   id: `${exchange.id}:${finding.id}`,
                   run: captureRun,
@@ -123,6 +129,14 @@ export class ImplementationStartHandler {
                   severity: finding.severity,
                   category: finding.category,
                   disposition,
+                  ...(layered?.disposition === 'filtered_note' ? {
+                    note_kind: 'filtered_layered_finding' as const,
+                    filter_reason: layered.filter_reason,
+                    scope: layered.scope,
+                    reason_code: layered.reason_code,
+                    original_severity: layered.original_severity,
+                    original_category: layered.original_category,
+                  } : {}),
                 }).catch(() => {});
               }
             } else {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -10,6 +10,10 @@ import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
+import {
+  altitudesForDepth,
+  type ResolvedImplementationConvergencePolicy,
+} from '../ai/layered-convergence-policy.js';
 
 export interface ImplementationStartDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -20,7 +24,8 @@ export interface ImplementationStartDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
-  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
+  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview' | 'runLayeredImplementation'>;
+  convergencePolicy?: ResolvedImplementationConvergencePolicy;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
 }
 
@@ -138,7 +143,7 @@ export class ImplementationStartHandler {
             }
           }
         : undefined;
-      reviewedResult = await this.deps.reviewCoordinator.runInitialReview({
+      const reviewParams = {
         run,
         artifact_path: refs.local_path,
         implementation_result: result,
@@ -147,7 +152,15 @@ export class ImplementationStartHandler {
         onAgentRequest,
         captureSession,
         captureFeedback,
-      });
+      };
+      const policy = this.deps.convergencePolicy;
+      const useLayered =
+        policy?.enabled &&
+        policy.depth !== 'build_only' &&
+        typeof this.deps.reviewCoordinator.runLayeredImplementation === 'function';
+      reviewedResult = useLayered
+        ? await this.deps.reviewCoordinator.runLayeredImplementation!(reviewParams, { altitudes: altitudesForDepth(policy!.depth) })
+        : await this.deps.reviewCoordinator.runInitialReview(reviewParams);
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');
         try {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -14,6 +14,7 @@ import {
   altitudesForDepth,
   type ResolvedImplementationConvergencePolicy,
 } from '../ai/layered-convergence-policy.js';
+import { ModelSessionBudget, type BudgetWriter } from '../journal/model-session-budget.js';
 
 export interface ImplementationStartDeps {
   implementer: Pick<ImplementationAgent, 'implement'>;
@@ -27,6 +28,7 @@ export interface ImplementationStartDeps {
   reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview' | 'runLayeredImplementation'>;
   convergencePolicy?: ResolvedImplementationConvergencePolicy;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
+  budgetWriter?: BudgetWriter;
 }
 
 export type ImplementationStartResult =
@@ -57,6 +59,15 @@ export class ImplementationStartHandler {
         );
       });
 
+    const sessionBudget = this.deps.convergencePolicy
+      ? new ModelSessionBudget({
+          runId: run.id,
+          requestId: run.request_id,
+          limit: this.deps.convergencePolicy.max_model_sessions_per_run,
+          writer: this.deps.budgetWriter ?? { append: async () => {} },
+        })
+      : undefined;
+
     if (run.impl_feedback_ref) {
       await this.deps.implFeedbackPage?.updateStatus?.(run.impl_feedback_ref, 'in_progress').catch(err =>
         this.deps.logger.error(
@@ -71,6 +82,17 @@ export class ImplementationStartHandler {
       ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: data.round ?? 1, role: data.role ?? null, gate: data.gate ?? null }).catch(() => {}); }
       : undefined;
 
+    let implReservationId: string | undefined;
+    if (sessionBudget) {
+      try {
+        const r = await sessionBudget.reserve({ gate: 'initial', role: 'proposer', round: 1, passKind: 'initial' });
+        implReservationId = r.session_id;
+      } catch (err) {
+        await this.deps.failRun(run, feedback.conversation, err);
+        return { status: 'failed' };
+      }
+    }
+
     let result;
     try {
       result = await this.deps.implementer.implement(
@@ -81,7 +103,13 @@ export class ImplementationStartHandler {
         { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession },
         planPath,
       );
+      if (sessionBudget && implReservationId) {
+        await sessionBudget.complete(implReservationId, 'ok').catch(() => {});
+      }
     } catch (err) {
+      if (sessionBudget && implReservationId) {
+        await sessionBudget.complete(implReservationId, 'failed').catch(() => {});
+      }
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };
     }
@@ -166,6 +194,7 @@ export class ImplementationStartHandler {
         onAgentRequest,
         captureSession,
         captureFeedback,
+        sessionBudget,
       };
       const policy = this.deps.convergencePolicy;
       const useLayered =

--- a/src/core/journal/model-session-budget.ts
+++ b/src/core/journal/model-session-budget.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto';
+
+export interface ReserveModelSessionInput {
+  gate: string;
+  role: 'proposer' | 'critic' | string;
+  round: number;
+  passKind: 'initial' | 'feedback' | 'final';
+}
+
+export interface ReservationResult {
+  session_id: string;
+  used: number;
+  limit: number;
+}
+
+interface BudgetWriter {
+  append(stream: string, record: unknown): Promise<void>;
+}
+
+interface ModelSessionBudgetOptions {
+  runId: string;
+  requestId: string;
+  limit: number;
+  writer: BudgetWriter;
+}
+
+export class ModelSessionBudget {
+  private readonly runId: string;
+  private readonly requestId: string;
+  private readonly _limit: number;
+  private readonly writer: BudgetWriter;
+  private reservedIds = new Set<string>();
+  private seq = 0;
+
+  constructor(options: ModelSessionBudgetOptions) {
+    this.runId = options.runId;
+    this.requestId = options.requestId;
+    this._limit = options.limit;
+    this.writer = options.writer;
+  }
+
+  async reserve(input: ReserveModelSessionInput): Promise<ReservationResult> {
+    if (this.reservedIds.size >= this._limit) {
+      throw new Error(`Model-session budget exhausted for run ${this.runId}: used ${this.reservedIds.size} of ${this._limit}`);
+    }
+    const session_id = randomUUID();
+    this.seq++;
+    await this.writer.append('sessions', {
+      record_kind: 'model_session_reserved',
+      session_id,
+      run_id: this.runId,
+      request_id: this.requestId,
+      gate: input.gate,
+      role: input.role,
+      round: input.round,
+      pass_kind: input.passKind,
+      reservation_seq: this.seq,
+      budget_limit: this._limit,
+      timestamp: new Date().toISOString(),
+    });
+    this.reservedIds.add(session_id);
+    return { session_id, used: this.reservedIds.size, limit: this._limit };
+  }
+
+  async complete(sessionId: string, outcome: 'ok' | 'failed' | 'incomplete'): Promise<void> {
+    await this.writer.append('sessions', {
+      record_kind: 'model_session_completed',
+      session_id: sessionId,
+      run_id: this.runId,
+      outcome,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  used(): number {
+    return this.reservedIds.size;
+  }
+
+  limit(): number {
+    return this._limit;
+  }
+
+  static fromSessionRecords(args: {
+    runId: string;
+    requestId: string;
+    limit: number;
+    records: unknown[];
+  }): ModelSessionBudget {
+    const budget = new ModelSessionBudget({
+      runId: args.runId,
+      requestId: args.requestId,
+      limit: args.limit,
+      writer: { append: async () => {} },
+    });
+    for (const record of args.records) {
+      if (
+        typeof record === 'object' &&
+        record !== null &&
+        (record as Record<string, unknown>)['record_kind'] === 'model_session_reserved' &&
+        typeof (record as Record<string, unknown>)['session_id'] === 'string'
+      ) {
+        budget.reservedIds.add((record as Record<string, unknown>)['session_id'] as string);
+      }
+    }
+    return budget;
+  }
+}

--- a/src/core/journal/model-session-budget.ts
+++ b/src/core/journal/model-session-budget.ts
@@ -13,7 +13,7 @@ export interface ReservationResult {
   limit: number;
 }
 
-interface BudgetWriter {
+export interface BudgetWriter {
   append(stream: string, record: unknown): Promise<void>;
 }
 

--- a/src/core/journal/run-journal.ts
+++ b/src/core/journal/run-journal.ts
@@ -53,6 +53,13 @@ export interface CaptureFeedbackParams {
   disposition?: JournalFeedbackDisposition;
   thread?: Array<{ author_principal: string | null; ts: string | null; text: string }>;
   received_at?: string;
+  // Additive fields for layered filtered findings — optional for backward compatibility
+  note_kind?: 'filtered_layered_finding';
+  filter_reason?: string;
+  scope?: string;
+  reason_code?: string;
+  original_severity?: string;
+  original_category?: string;
 }
 
 export class RunJournal {
@@ -163,7 +170,7 @@ export class RunJournal {
   }
 
   async captureFeedback(params: CaptureFeedbackParams): Promise<void> {
-    const { id, run, target, gate, author_principal, text, severity, category, disposition = 'open', thread = [], received_at } = params;
+    const { id, run, target, gate, author_principal, text, severity, category, disposition = 'open', thread = [], received_at, note_kind, filter_reason, scope, reason_code, original_severity, original_category } = params;
     const identity = identityForRun(run);
 
     const record: Omit<JournalFeedbackRecord, 'seq' | 'writer_id'> = {
@@ -186,6 +193,12 @@ export class RunJournal {
         ts: item.ts,
         text: redactSecrets(item.text),
       })),
+      ...(note_kind !== undefined ? { note_kind } : {}),
+      ...(filter_reason !== undefined ? { filter_reason } : {}),
+      ...(scope !== undefined ? { scope } : {}),
+      ...(reason_code !== undefined ? { reason_code } : {}),
+      ...(original_severity !== undefined ? { original_severity } : {}),
+      ...(original_category !== undefined ? { original_category } : {}),
     };
 
     try {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -113,12 +113,44 @@ export type ImplementationReviewFindingCategory =
   | 'docs'
   | 'pr_readiness';
 
+export type LayeredConvergenceGateName = 'layout' | 'public_api' | 'private_api' | 'build';
+export type LayeredFindingScope = 'current_altitude' | 'lower_altitude' | 'prior_context';
+export type LayeredFindingReasonCode =
+  | 'altitude_contract_violation'
+  | 'layout_boundary'
+  | 'public_api_contract'
+  | 'private_api_contract'
+  | 'security_contract'
+  | 'documentation_gap'
+  | 'missing_lower_altitude_body'
+  | 'missing_lower_altitude_test'
+  | 'missing_lower_altitude_implementation'
+  | 'build_signal_unavailable_until_build';
+export type LayeredFindingDisposition = 'blocking' | 'info' | 'filtered_note';
+export type LayeredFindingFilterReason =
+  | 'invalid_layered_metadata'
+  | 'lower_altitude_scope'
+  | 'lower_altitude_reason_code'
+  | 'category_not_allowed';
+
+export interface StoredLayeredFindingMetadata {
+  scope?: LayeredFindingScope;
+  reason_code?: LayeredFindingReasonCode;
+  disposition: LayeredFindingDisposition;
+  filter_reason?: LayeredFindingFilterReason;
+  original_severity: ImplementationReviewFindingSeverity;
+  original_category: ImplementationReviewFindingCategory;
+}
+
 export interface ImplementationReviewFinding {
   id: string;
   severity: ImplementationReviewFindingSeverity;
   category: ImplementationReviewFindingCategory;
   finding: string;
   suggested_action?: string;
+  scope?: LayeredFindingScope;
+  reason_code?: LayeredFindingReasonCode;
+  layered?: StoredLayeredFindingMetadata;
 }
 
 export interface ImplementationReviewResult {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -65,9 +65,15 @@ export interface SpecReviewPolicy {
   template_conformance?: boolean;
 }
 
+export type ImplementationReviewConvergenceDepth = 'build_only' | 'layout' | 'public_api' | 'full';
+export type ImplementationReviewFeedbackDepth = ImplementationReviewConvergenceDepth | 'inherit';
+
 export interface ImplementationReviewConvergencePolicy {
   enabled?: boolean;
   allow_same_model?: boolean;
+  depth?: ImplementationReviewConvergenceDepth;
+  feedback_depth?: ImplementationReviewFeedbackDepth;
+  max_model_sessions_per_run?: number;
 }
 
 export interface ImplementationReviewPolicy {

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -113,6 +113,13 @@ export interface JournalFeedbackRecord extends JournalBaseRecord {
   category: JournalFeedbackCategory;
   disposition: JournalFeedbackDisposition;
   thread: JournalFeedbackThreadItem[];
+  // Additive fields for layered filtered findings — optional for backward compatibility
+  note_kind?: 'filtered_layered_finding';
+  filter_reason?: string; // LayeredFindingFilterReason
+  scope?: string; // LayeredFindingScope
+  reason_code?: string; // LayeredFindingReasonCode
+  original_severity?: string; // ImplementationReviewFindingSeverity
+  original_category?: string; // ImplementationReviewFindingCategory
 }
 
 export interface JournalRunEventRecord extends JournalBaseRecord {

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -15,6 +15,8 @@ import type { Intent } from './intent.js';
 import type { Run, RunStage } from './runs.js';
 
 export type JournalStream = 'messages' | 'sessions' | 'feedback' | 'run-events';
+
+export type JournalSessionRecordKind = 'model_session_reserved' | 'model_session_completed';
 export const JOURNAL_STREAMS: JournalStream[] = ['messages', 'sessions', 'feedback', 'run-events'];
 
 /** Raw token counts only. Pricing, usd, rate tables, and cost rollups are intentionally out of scope. */
@@ -81,6 +83,12 @@ export interface JournalSessionRecord extends JournalBaseRecord {
   tool_results: number | null;
   outcome: JournalSessionOutcome;
   runner: JournalRunnerName;
+  /** Optional fields for durable model-session budget reservations (layered-diff convergence). */
+  record_kind?: JournalSessionRecordKind;
+  session_id?: string;
+  reservation_seq?: number;
+  budget_limit?: number;
+  pass_kind?: 'initial' | 'feedback' | 'final';
 }
 
 export interface JournalFeedbackThreadItem {

--- a/tests/adapters/notion/implementation-feedback-page.test.ts
+++ b/tests/adapters/notion/implementation-feedback-page.test.ts
@@ -1521,3 +1521,208 @@ describe('normalizeStep (via update deduplication behavior)', () => {
     expect(newStepIdx).toBeLessThan(additionalIdx);
   });
 });
+
+function makeAltitudeExchange(
+  gate: 'layout' | 'public_api' | 'private_api' | 'build',
+  round: number,
+  converged: boolean,
+  overrides: Partial<GateReviewExchange> = {},
+): GateReviewExchange {
+  return {
+    id: `${gate}-r${round}`,
+    gate,
+    round,
+    created_at: '2026-06-07T00:00:00Z',
+    proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk', model: 'claude-sonnet-4-6' },
+    critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk', model: 'gpt-5.5' },
+    review_status: converged ? 'converged' : 'addressed',
+    review_summary: converged ? 'All clear.' : 'Found findings.',
+    findings: [],
+    responses: [],
+    converged,
+    requires_human_retest: false,
+    ...overrides,
+  };
+}
+
+describe('layered altitude rendering', () => {
+  it('renders Layered implementation review when altitude gate exchanges exist', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      makeAltitudeExchange('layout', 1, true),
+      makeAltitudeExchange('public_api', 1, true),
+      makeAltitudeExchange('build', 1, true),
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    expect(markdown).toContain('### Layered implementation review');
+    expect(markdown).toContain('#### Layout — converged');
+    expect(markdown).toContain('#### Public API — converged');
+    expect(markdown).toContain('#### Build — converged');
+    expect(markdown).not.toContain('### Layout review');
+  });
+
+  it('renders Layered implementation review in create path when altitude gate exchanges exist', async () => {
+    const pagesCreate = vi.fn().mockResolvedValue({ id: 'new-page-id' });
+    const client = makeNotionClient({ pagesCreate });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      makeAltitudeExchange('layout', 1, true),
+      makeAltitudeExchange('build', 1, true),
+    ];
+
+    await page.create(makeReviewInput({ gate_exchanges }));
+
+    const createCall = pagesCreate.mock.calls[0][0] as {
+      children: Array<{ type: string; heading_2?: { rich_text: Array<{ text: { content: string } }> }; paragraph?: { rich_text: Array<{ text: { content: string } }> } }>;
+    };
+    const allTexts = createCall.children.flatMap(b => {
+      if (b.type === 'heading_2') return [b.heading_2!.rich_text[0].text.content];
+      if (b.type === 'paragraph') return [b.paragraph!.rich_text[0].text.content];
+      return [];
+    });
+    const combined = allTexts.join('\n');
+    expect(combined).toContain('Layered implementation review');
+    expect(combined).toContain('Layout — converged');
+    expect(combined).toContain('Build — converged');
+  });
+
+  it('renders early-altitude note about non-compiling code for layout, public_api, private_api but not build', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      makeAltitudeExchange('layout', 1, true),
+      makeAltitudeExchange('public_api', 1, true),
+      makeAltitudeExchange('private_api', 1, true),
+      makeAltitudeExchange('build', 1, true),
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+    // Early altitudes get the note
+    expect(markdown).toContain('Intermediate code at this altitude may not compile; review was by diff context.');
+    // Count occurrences: should appear for layout, public_api, private_api (3 times) but not build
+    const noteCount = (markdown.match(/Intermediate code at this altitude may not compile/g) ?? []).length;
+    expect(noteCount).toBe(3);
+
+    // Build section should follow without the note
+    const buildIdx = markdown.indexOf('#### Build');
+    const noteAfterBuild = markdown.indexOf('Intermediate code at this altitude may not compile', buildIdx);
+    expect(noteAfterBuild).toBe(-1);
+  });
+
+  it('renders filtered notes under Notes filtered by altitude, not as open obligations', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      makeAltitudeExchange('layout', 1, true, {
+        findings: [
+          {
+            id: 'LAYOUT-1',
+            severity: 'blocker',
+            category: 'maintainability',
+            finding: 'New file duplicates the existing review coordinator boundary.',
+            layered: {
+              disposition: 'filtered_note',
+              filter_reason: 'invalid_layered_metadata',
+              original_severity: 'blocker',
+              original_category: 'maintainability',
+            },
+          },
+        ],
+        responses: [],
+      }),
+      makeAltitudeExchange('build', 1, true),
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+
+    // The filtered finding should appear under Notes filtered by altitude
+    expect(markdown).toContain('#### Notes filtered by altitude');
+    expect(markdown).toContain('LAYOUT-1');
+    expect(markdown).toContain('invalid_layered_metadata');
+    expect(markdown).toContain('New file duplicates the existing review coordinator boundary.');
+
+    // It must NOT appear as an open obligation (checkbox)
+    expect(markdown).not.toContain('- [ ] [LAYOUT-1]');
+    expect(markdown).not.toContain('- [x] [LAYOUT-1]');
+  });
+
+  it('falls back to legacy rendering when only initial/final exchanges exist', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      {
+        id: 'initial-1',
+        gate: 'initial',
+        round: 1,
+        created_at: '2026-06-07T00:00:00Z',
+        proposer_profile: { profile: 'impl-agent', provider: 'claude_agent_sdk' },
+        critic_profile: { profile: 'critic-agent', provider: 'openai_agent_sdk' },
+        review_status: 'converged',
+        review_summary: 'All good.',
+        findings: [],
+        responses: [],
+        converged: true,
+        requires_human_retest: false,
+      },
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+
+    // Must NOT use layered rendering
+    expect(markdown).not.toContain('### Layered implementation review');
+    // Must still render AI review content
+    expect(markdown).toContain('## AI review');
+    expect(markdown).toContain('### Initial review');
+  });
+
+  it('shows per-altitude convergence status in Layered implementation review header', async () => {
+    const pagesUpdateMarkdown = vi.fn().mockResolvedValue(undefined);
+    const pagesGetMarkdown = vi.fn().mockResolvedValue('## Human review\n\n');
+    const client = makeNotionClient({ pagesGetMarkdown, pagesUpdateMarkdown, blocksChildrenList: vi.fn().mockResolvedValue({ results: [] }) });
+    const page = new NotionImplementationFeedbackPage(client, 'db-tg-id', { logDestination: nullDest });
+
+    const gate_exchanges: GateReviewExchange[] = [
+      makeAltitudeExchange('layout', 1, false, {
+        review_status: 'non_converged',
+        converged: false,
+        non_convergence_reason: 'max_rounds',
+        findings: [{ id: 'LAYOUT-1', severity: 'blocker', category: 'maintainability', finding: 'Missing skeleton.' }],
+        responses: [],
+      }),
+      makeAltitudeExchange('build', 1, true),
+      makeAltitudeExchange('build', 2, true),
+    ];
+
+    await page.update('page-id', { gate_exchanges });
+
+    const markdown = pagesUpdateMarkdown.mock.calls[0][1].replace_content.new_str as string;
+
+    expect(markdown).toContain('#### Layout — non-converged');
+    expect(markdown).toContain('Non-convergence reason: `max_rounds`');
+    expect(markdown).toContain('- [ ] [LAYOUT-1] Missing skeleton.');
+    expect(markdown).toContain('#### Build — converged in 2 rounds');
+  });
+});

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -19,6 +19,9 @@ import {
   parseSpecReviewResult,
   drainAgentRunner,
   validateRequiredResultFile,
+  buildLayeredProposePrompt,
+  buildLayeredCritiquePrompt,
+  buildLayeredRevisePrompt,
 } from '../../../src/core/ai/agent-services.js';
 import { DefaultAgentRoutingPolicy } from '../../../src/core/ai/routing-policy.js';
 import { createLogger } from '../../../src/core/logger.js';
@@ -1723,5 +1726,130 @@ describe('AgentServiceTelemetry captureSession callback', () => {
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }
+  });
+});
+
+describe('buildLayeredProposePrompt', () => {
+  it('layout prompt includes altitude name and forbids signatures, bodies, and tests', () => {
+    const prompt = buildLayeredProposePrompt({
+      gate: 'layout',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+    });
+
+    expect(prompt).toContain('Layout altitude');
+    expect(prompt).toContain('skeleton files, modules, classes');
+    expect(prompt).toContain('Do not add function signatures');
+    expect(prompt).toContain('TODO(gate-layout)');
+  });
+
+  it('public_api prompt instructs proposer to write exported signatures only', () => {
+    const prompt = buildLayeredProposePrompt({
+      gate: 'public_api',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+    });
+
+    expect(prompt).toContain('Public API altitude');
+    expect(prompt).toContain('exported signatures, public types');
+    expect(prompt).toContain('Do not add private helper signatures');
+    expect(prompt).toContain('TODO(gate-public_api)');
+  });
+
+  it('private_api prompt instructs proposer to write internal helper signatures only', () => {
+    const prompt = buildLayeredProposePrompt({
+      gate: 'private_api',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+    });
+
+    expect(prompt).toContain('Private API altitude');
+    expect(prompt).toContain('internal helper signatures');
+    expect(prompt).toContain('Do not add bodies or tests');
+    expect(prompt).toContain('TODO(gate-private_api)');
+  });
+
+  it('build prompt instructs proposer to implement bodies and preserve upper contracts', () => {
+    const prompt = buildLayeredProposePrompt({
+      gate: 'build',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+    });
+
+    expect(prompt).toContain('Build altitude');
+    expect(prompt).toContain('function bodies, tests');
+    expect(prompt).toContain('Preserve the converged');
+  });
+});
+
+describe('buildLayeredCritiquePrompt', () => {
+  it('early critic prompt says missing bodies are expected and out of scope', () => {
+    const prompt = buildLayeredCritiquePrompt({
+      gate: 'public_api',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+      diffContext: 'diff content',
+      changedFiles: ['src/a.ts'],
+      round: 1,
+      allowedCategories: ['maintainability', 'docs', 'security'],
+    });
+
+    expect(prompt).toContain('You are reviewing a public_api-only diff');
+    expect(prompt).toContain('Do not file missing-body, missing-test, or missing-implementation findings');
+    expect(prompt).toContain('"scope"');
+    expect(prompt).toContain('"reason_code"');
+  });
+
+  it('layout critic prompt mentions allowed categories', () => {
+    const prompt = buildLayeredCritiquePrompt({
+      gate: 'layout',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+      diffContext: '',
+      changedFiles: [],
+      round: 1,
+      allowedCategories: ['maintainability', 'docs'],
+    });
+
+    expect(prompt).toContain('maintainability');
+    expect(prompt).toContain('docs');
+  });
+
+  it('build critic prompt does not include early gate restrictions', () => {
+    const prompt = buildLayeredCritiquePrompt({
+      gate: 'build',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+      diffContext: 'diff',
+      changedFiles: ['src/a.ts'],
+      round: 2,
+      allowedCategories: ['correctness', 'test', 'security', 'maintainability', 'docs', 'pr_readiness'],
+    });
+
+    expect(prompt).not.toContain('Do not file missing-body');
+    expect(prompt).toContain('correctness');
+    expect(prompt).toContain('converged layout');
+  });
+});
+
+describe('buildLayeredRevisePrompt', () => {
+  it('includes findings list and gate contract reminder', () => {
+    const prompt = buildLayeredRevisePrompt({
+      gate: 'layout',
+      artifactPath: 'spec.md',
+      workingDirectory: '/repo',
+      findings: [{
+        id: 'LAYOUT-1',
+        severity: 'blocker',
+        category: 'maintainability',
+        finding: 'New file duplicates existing boundary',
+        suggested_action: 'Move skeleton into existing module',
+      }],
+    });
+
+    expect(prompt).toContain('LAYOUT-1');
+    expect(prompt).toContain('New file duplicates existing boundary');
+    expect(prompt).toContain('Move skeleton into existing module');
+    expect(prompt).toContain('Layout altitude contract');
   });
 });

--- a/tests/core/ai/altitude-contract-validator.test.ts
+++ b/tests/core/ai/altitude-contract-validator.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { validateAltitudeContract } from '../../../src/core/ai/altitude-contract-validator.js';
+
+const layoutWithBody = `diff --git a/src/a.ts b/src/a.ts
+new file mode 100644
+--- /dev/null
++++ b/src/a.ts
+@@ -0,0 +1,3 @@
++export function run() {
++  return 1;
++}
+`;
+
+const layoutWithSkeletonOnly = `diff --git a/src/a.ts b/src/a.ts
+new file mode 100644
+--- /dev/null
++++ b/src/a.ts
+@@ -0,0 +1,4 @@
++// Module: Core runner
++export class Runner {
++  // TODO(gate-layout): implement run method
++}
+`;
+
+const publicApiWithSignature = `diff --git a/src/a.ts b/src/a.ts
+new file mode 100644
+--- /dev/null
++++ b/src/a.ts
+@@ -0,0 +1,2 @@
++export interface Result { ok: boolean }
++export function parse(input: string): Result;
+`;
+
+const publicApiWithBody = `diff --git a/src/a.ts b/src/a.ts
+new file mode 100644
+--- /dev/null
++++ b/src/a.ts
+@@ -0,0 +1,3 @@
++export function parse(input: string): boolean {
++  return input.length > 0;
++}
+`;
+
+const testFile = `diff --git a/src/a.test.ts b/src/a.test.ts
+new file mode 100644
+--- /dev/null
++++ b/src/a.test.ts
+@@ -0,0 +1,3 @@
++describe('test', () => {
++  it('works', () => {});
++});
+`;
+
+describe('validateAltitudeContract', () => {
+  describe('layout gate', () => {
+    it('rejects layout diffs with function bodies', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'layout',
+        diff: layoutWithBody,
+        changedFiles: ['src/a.ts'],
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.violations.length).toBeGreaterThan(0);
+      expect(result.violations[0]!.reason_code).toBe('altitude_contract_violation');
+    });
+
+    it('accepts layout diffs with skeleton/comments only', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'layout',
+        diff: layoutWithSkeletonOnly,
+        changedFiles: ['src/a.ts'],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('rejects layout diffs that include test files', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'layout',
+        diff: testFile,
+        changedFiles: ['src/a.test.ts'],
+      });
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('public_api gate', () => {
+    it('accepts public API exported signatures and types', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'public_api',
+        diff: publicApiWithSignature,
+        changedFiles: ['src/a.ts'],
+      });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects public_api diffs with function bodies', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'public_api',
+        diff: publicApiWithBody,
+        changedFiles: ['src/a.ts'],
+      });
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('build gate', () => {
+    it('always passes (no restriction)', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'build',
+        diff: layoutWithBody,
+        changedFiles: ['src/a.ts'],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+  });
+
+  describe('unsupported file types', () => {
+    it('puts unsupported files in unsupported_files list', async () => {
+      const result = await validateAltitudeContract({
+        gate: 'layout',
+        diff: 'diff --git a/config.yaml b/config.yaml\n+some: value\n',
+        changedFiles: ['config.yaml'],
+      });
+
+      expect(result.unsupported_files).toContain('config.yaml');
+      expect(result.valid).toBe(true); // unsupported files don't fail the gate
+    });
+  });
+});

--- a/tests/core/ai/build-contract-preservation.test.ts
+++ b/tests/core/ai/build-contract-preservation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareBuildToAcceptedContracts,
+} from '../../../src/core/ai/build-contract-preservation.js';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const publicApiSource = `export interface Result { ok: boolean }
+export function parse(input: string): Result;
+`;
+
+const buildWithSameSignature = `export interface Result { ok: boolean }
+export function parse(input: string): Result {
+  return { ok: input.length > 0 };
+}
+`;
+
+const buildWithChangedSignature = `export interface Result { ok: boolean; code: number }
+export function parse(input: string): boolean {
+  return input.length > 0;
+}
+`;
+
+const buildWithRenamedExport = `export interface Outcome { ok: boolean }
+export function processInput(input: string): Outcome {
+  return { ok: input.length > 0 };
+}
+`;
+
+async function makeWorkdir() {
+  const dir = await mkdtemp(join(tmpdir(), 'bcp-test-'));
+  return dir;
+}
+
+describe('compareBuildToAcceptedContracts', () => {
+  it('passes when no checkpoints are accepted', async () => {
+    const dir = await makeWorkdir();
+    const result = await compareBuildToAcceptedContracts({
+      workingDirectory: dir,
+      acceptedCheckpoints: [],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.drift).toHaveLength(0);
+  });
+
+  it('detects exported signature change (return type change)', async () => {
+    const dir = await makeWorkdir();
+    await writeFile(join(dir, 'api.ts'), buildWithChangedSignature);
+
+    const result = await compareBuildToAcceptedContracts({
+      workingDirectory: dir,
+      acceptedCheckpoints: [{ gate: 'public_api', ref: 'mock-ref' }],
+      readFileAtRef: async (_ref, path) => path === 'api.ts' ? publicApiSource : '',
+      listFilesAtRef: async () => ['api.ts'],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.drift.some(d => d.kind === 'exported_signature' || d.kind === 'exported_name')).toBe(true);
+  });
+
+  it('passes when build only adds bodies to existing signatures', async () => {
+    const dir = await makeWorkdir();
+    await writeFile(join(dir, 'api.ts'), buildWithSameSignature);
+
+    const result = await compareBuildToAcceptedContracts({
+      workingDirectory: dir,
+      acceptedCheckpoints: [{ gate: 'public_api', ref: 'mock-ref' }],
+      readFileAtRef: async (_ref, path) => path === 'api.ts' ? publicApiSource : '',
+      listFilesAtRef: async () => ['api.ts'],
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.drift).toHaveLength(0);
+  });
+
+  it('detects source path drift (file moved/deleted)', async () => {
+    const dir = await makeWorkdir();
+    // Write current file at different path, not at original path
+    await writeFile(join(dir, 'api-new.ts'), buildWithSameSignature);
+
+    const result = await compareBuildToAcceptedContracts({
+      workingDirectory: dir,
+      acceptedCheckpoints: [{ gate: 'layout', ref: 'mock-ref' }],
+      readFileAtRef: async (_ref, path) => path === 'src/api.ts' ? publicApiSource : '',
+      listFilesAtRef: async () => ['src/api.ts'],
+    });
+
+    expect(result.drift.some(d => d.kind === 'source_path')).toBe(true);
+  });
+
+  it('detects rename as delete+add drift', async () => {
+    const dir = await makeWorkdir();
+    await writeFile(join(dir, 'api.ts'), buildWithRenamedExport);
+
+    const result = await compareBuildToAcceptedContracts({
+      workingDirectory: dir,
+      acceptedCheckpoints: [{ gate: 'public_api', ref: 'mock-ref' }],
+      readFileAtRef: async (_ref, path) => path === 'api.ts' ? publicApiSource : '',
+      listFilesAtRef: async () => ['api.ts'],
+    });
+
+    // Renamed from parse/Result to processInput/Outcome - should detect drift
+    expect(result.valid).toBe(false);
+    expect(result.drift.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/core/ai/gate-context.test.ts
+++ b/tests/core/ai/gate-context.test.ts
@@ -76,6 +76,68 @@ describe('buildGateContext', () => {
     expect(context.diff).not.toContain('secret.txt');
   });
 
+  it('redacts secret-like values in tracked file diffs before returning', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, 'config.ts'), 'export const a = 1;\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    // Write a tracked file containing a secret-like value
+    await writeFile(join(repo, 'config.ts'), 'const key = "sk-abc123defABC456ghi789jkl";\n');
+    await git(repo, ['add', '.']);
+
+    const context = await buildGateContext({ gate: 'build', base_ref: base, working_directory: repo });
+
+    expect(context.diff).not.toContain('sk-abc123defABC456ghi789jkl');
+    expect(context.diff).toContain('[REDACTED]');
+  });
+
+  it('redacts secret-like values in untracked file diffs before returning', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, 'base.ts'), 'export const x = 1;\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    // Write a new untracked file containing a secret-like value (gho_ matches the GitHub OAuth token pattern)
+    await writeFile(join(repo, 'secrets.ts'), 'const token = "gho_abc1234567890ABCDEF";\n');
+
+    const context = await buildGateContext({ gate: 'layout', base_ref: base, working_directory: repo });
+
+    expect(context.changed_files).toContain('secrets.ts');
+    expect(context.diff).toContain('secrets.ts');
+    expect(context.diff).not.toContain('gho_abc1234567890ABCDEF');
+    expect(context.diff).toContain('[REDACTED]');
+  });
+
+  it('diff_byte_count reflects redacted payload size', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, 'a.ts'), 'export const a = 1;\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    await writeFile(join(repo, 'a.ts'), 'const key = "sk-longsecretABCDEF12345678";\n');
+
+    const context = await buildGateContext({ gate: 'build', base_ref: base, working_directory: repo });
+
+    expect(context.diff_byte_count).toBe(Buffer.byteLength(context.diff, 'utf8'));
+    expect(context.diff).not.toContain('sk-longsecretABCDEF12345678');
+  });
+
   it('returns sorted unique changed_files', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
     await git(repo, ['init']);

--- a/tests/core/ai/gate-context.test.ts
+++ b/tests/core/ai/gate-context.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { buildGateContext } from '../../../src/core/ai/gate-context.js';
+
+const exec = promisify(execFile);
+
+async function git(cwd: string, args: string[]) {
+  await exec('git', args, { cwd });
+}
+
+describe('buildGateContext', () => {
+  it('returns cumulative diff for tracked changes', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, 'src.ts'), 'export const a = 1;\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    await writeFile(join(repo, 'src.ts'), 'export const a = 2;\n');
+
+    const context = await buildGateContext({ gate: 'layout', base_ref: base, working_directory: repo });
+
+    expect(context.changed_files).toContain('src.ts');
+    expect(context.diff).toContain('diff --git a/src.ts b/src.ts');
+    expect(context.gate).toBe('layout');
+    expect(context.base_ref).toBe(base);
+  });
+
+  it('includes non-ignored untracked files in diff and changed_files', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, '.gitignore'), 'ignored.txt\n');
+    await writeFile(join(repo, 'base.ts'), 'export const x = 1;\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    await writeFile(join(repo, 'new.ts'), 'export const b = 1;\n');
+    await writeFile(join(repo, 'ignored.txt'), 'ignored content\n');
+
+    const context = await buildGateContext({ gate: 'layout', base_ref: base, working_directory: repo });
+
+    expect(context.changed_files).toContain('new.ts');
+    expect(context.changed_files).not.toContain('ignored.txt');
+    expect(context.diff).toContain('new.ts');
+    expect(context.diff).not.toContain('ignored.txt');
+  });
+
+  it('excludes ignored untracked files from diff and changed_files', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, '.gitignore'), 'secret.txt\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    await writeFile(join(repo, 'secret.txt'), 'secret content\n');
+
+    const context = await buildGateContext({ gate: 'build', base_ref: base, working_directory: repo });
+
+    expect(context.changed_files).not.toContain('secret.txt');
+    expect(context.diff).not.toContain('secret.txt');
+  });
+
+  it('returns sorted unique changed_files', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'gate-context-'));
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.email', 'test@example.com']);
+    await git(repo, ['config', 'user.name', 'Test']);
+    await writeFile(join(repo, 'a.ts'), 'const a = 1;\n');
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-m', 'base']);
+    const baseResult = await exec('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    const base = baseResult.stdout.trim();
+
+    await writeFile(join(repo, 'z.ts'), 'const z = 1;\n');
+    await writeFile(join(repo, 'b.ts'), 'const b = 1;\n');
+
+    const context = await buildGateContext({ gate: 'public_api', base_ref: base, working_directory: repo });
+
+    expect(context.changed_files).toEqual([...context.changed_files].sort());
+  });
+});

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -1111,6 +1111,98 @@ describe('runLayeredImplementation — regression: no forbidden git operations',
     expect(buildPrompt).not.toContain('Do not file missing-body');
   });
 
+  it('early altitude proposer prompt does not contain build/test run instructions', async () => {
+    // Criteria 8: the proposer (implementer) at early altitudes must stay within
+    // the altitude contract. When the layout critic finds a blocker, the coordinator
+    // calls implementer.implement with buildLayeredRevisePrompt, which restricts work
+    // to the current altitude and must not instruct the agent to run npm test, build, or lint.
+    const capturedProposerPrompts: string[] = [];
+    const capturingImplementer: Pick<ImplementationAgent, 'implement'> = {
+      implement: vi.fn().mockImplementation((_specPath: string, _workDir: string, prompt: string) => {
+        capturedProposerPrompts.push(prompt);
+        // Return complete with a review_responses entry so convergence proceeds
+        return Promise.resolve(makeCompleteResult({
+          review_responses: [{ id: 'L1', disposition: 'fixed', response: 'Fixed layout.' }],
+        }));
+      }),
+    };
+    let callCount = 0;
+    const readFile = vi.fn().mockImplementation(async () => {
+      // Round 1: layout blocker → triggers proposer revision; Round 2: clean
+      const result = callCount === 0
+        ? { status: 'findings', summary: 'Blocked.', findings: [{ id: 'L1', severity: 'blocker', category: 'maintainability', finding: 'Bad layout.', scope: 'current_altitude', reason_code: 'layout_boundary' }] }
+        : { status: 'no_findings', summary: 'Clean.', findings: [] };
+      callCount++;
+      return JSON.stringify(result);
+    });
+    const deps = makeDeps(undefined, { readFile, implementer: capturingImplementer });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'build'] },
+    );
+
+    // The proposer was called during the layout revise round
+    expect(capturedProposerPrompts.length).toBeGreaterThanOrEqual(1);
+    const layoutRevisePrompt = capturedProposerPrompts[0]!;
+
+    // Must not instruct the agent to run build/test/lint commands
+    expect(layoutRevisePrompt).not.toMatch(/npm\s+(test|run\s+build|run\s+lint)/i);
+    expect(layoutRevisePrompt).not.toMatch(/yarn\s+(test|build|lint)/i);
+    expect(layoutRevisePrompt).not.toMatch(/pnpm\s+(test|build|lint)/i);
+
+    // Must include the altitude-contract restriction (stay within current altitude)
+    expect(layoutRevisePrompt).toContain('altitude contract');
+  });
+
+  it('build altitude proposer prompt includes instructions to implement bodies and tests', async () => {
+    // Criteria 9: the proposer at build altitude must be mandated to address
+    // test coverage, code, and docs — not just restricted to a skeleton altitude.
+    // buildImplementerResponsePrompt (used for build) includes "code/tests/docs" and
+    // requests testing_steps, whereas early gates use the altitude-limited revise prompt.
+    const capturedProposerPrompts: string[] = [];
+    const capturingImplementer: Pick<ImplementationAgent, 'implement'> = {
+      implement: vi.fn().mockImplementation((_specPath: string, _workDir: string, prompt: string) => {
+        capturedProposerPrompts.push(prompt);
+        return Promise.resolve(makeCompleteResult({
+          review_responses: [{ id: 'B1', disposition: 'fixed', response: 'Added tests.' }],
+        }));
+      }),
+    };
+    let callCount = 0;
+    const readFile = vi.fn().mockImplementation(async () => {
+      // Round 1 of build: blocker → triggers proposer revision; Round 2: clean
+      const result = callCount === 0
+        ? { status: 'findings', summary: 'Missing tests.', findings: [{ id: 'B1', severity: 'blocker', category: 'test', finding: 'No tests written.' }] }
+        : { status: 'no_findings', summary: 'Clean.', findings: [] };
+      callCount++;
+      return JSON.stringify(result);
+    });
+    const deps = makeDeps(undefined, { readFile, implementer: capturingImplementer });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['build'] },
+    );
+
+    // The proposer was called during the build revise round
+    expect(capturedProposerPrompts.length).toBeGreaterThanOrEqual(1);
+    const buildRevisePrompt = capturedProposerPrompts[0]!;
+
+    // Build proposer must include test/docs mandate (from buildImplementerResponsePrompt)
+    expect(buildRevisePrompt).toMatch(/code\/tests\/docs|tests?|testing_steps/i);
+
+    // Build proposer must NOT contain the early-altitude altitude-contract restriction
+    // (which would incorrectly limit the proposer to skeleton-only work)
+    expect(buildRevisePrompt).not.toContain('do not add lower-altitude work');
+  });
+
   it('convergence disabled falls back to single-pass and review_exchanges is used, not gate_exchanges', async () => {
     const freshDeps = makeDeps();
     freshDeps.policy = { ...freshDeps.policy, convergence: { enabled: false, allow_same_model: false } };

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ImplementationReviewCoordinator } from '../../../src/core/ai/implementation-review-coordinator.js';
+import { ModelSessionBudget } from '../../../src/core/journal/model-session-budget.js';
 import type { AgentRunner, AgentRoutingPolicy, ImplementationAgent, ImplementationResult, ImplementationReviewResult, AgentProfile, GateReviewExchange } from '../../../src/types/ai.js';
 import type { Run } from '../../../src/types/runs.js';
 
@@ -1221,5 +1222,33 @@ describe('runLayeredImplementation — regression: no forbidden git operations',
     expect((run as Record<string, unknown>)['gate_exchanges']).toBeUndefined();
     // Runner called at most once (single-pass review)
     expect(freshDeps.runner.run).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runLayeredImplementation — model-session budget enforcement', () => {
+  it('fails before critic execution when budget is exhausted', async () => {
+    // Budget with limit 0 means no sessions can be reserved
+    const w = { append: vi.fn().mockResolvedValue(undefined) };
+    const sessionBudget = new ModelSessionBudget({ runId: 'run-1', requestId: 'req-1', limit: 0, writer: w });
+
+    const findingsResult: ImplementationReviewResult = {
+      status: 'has_findings',
+      summary: 'Blockers found.',
+      findings: [{ id: 'F1', severity: 'blocker', category: 'correctness', finding: 'Missing impl.' }],
+    };
+    const deps = makeDeps(findingsResult);
+    deps.policy = { ...deps.policy, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun({ id: 'run-1' });
+
+    const result = await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, sessionBudget },
+      { altitudes: ['layout', 'build'] },
+    );
+
+    expect(result.status).toBe('failed');
+    expect((result as { status: 'failed'; error: string }).error).toMatch(/budget exhausted/i);
+    // Runner must NOT have been called (budget rejected before provider call)
+    expect(deps.runner.run).not.toHaveBeenCalled();
   });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -1300,9 +1300,12 @@ describe('runLayeredImplementation — wiring integration', () => {
     expect(calls).toContain('build');
   });
 
-  it('buildGateContext receives distinct base_refs per altitude after checkpointing', async () => {
-    // After layout converges and checkpoints, public_api and build must receive
-    // the checkpoint ref as base_ref, not the initial HEAD.
+  it('buildGateContext receives the same cumulative pass base_ref for all altitudes', async () => {
+    // Spec §Diff context strategy: base_ref is the pre-implementation pass base captured
+    // once before any altitude writes files. All altitudes diff cumulatively from this
+    // same base so the critic at each altitude sees the full accumulated diff.
+    // Checkpoint refs are stored only for build contract preservation, not passed to
+    // buildGateContext — they must NOT become the base_ref for later altitudes.
     const checkpointFn = vi.fn()
       .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/autocatalyst/runs/run-001/layout/1', commit: 'layout-sha', gate: 'layout' })
       .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/autocatalyst/runs/run-001/public_api/2', commit: 'public-sha', gate: 'public_api' });
@@ -1326,12 +1329,13 @@ describe('runLayeredImplementation — wiring integration', () => {
     expect(publicApiCall).toBeDefined();
     expect(buildCall).toBeDefined();
 
-    // layout uses the initial base (not a checkpoint ref)
+    // All three altitudes receive the same pass base ref (not a checkpoint ref)
     expect(layoutCall![0].base_ref).not.toContain('refs/autocatalyst');
-    // public_api uses the layout checkpoint ref
-    expect(publicApiCall![0].base_ref).toBe('refs/autocatalyst/runs/run-001/layout/1');
-    // build uses the public_api checkpoint ref
-    expect(buildCall![0].base_ref).toBe('refs/autocatalyst/runs/run-001/public_api/2');
+    expect(publicApiCall![0].base_ref).not.toContain('refs/autocatalyst');
+    expect(buildCall![0].base_ref).not.toContain('refs/autocatalyst');
+    // public_api and build must match layout's base_ref (same pass base for all)
+    expect(publicApiCall![0].base_ref).toBe(layoutCall![0].base_ref);
+    expect(buildCall![0].base_ref).toBe(layoutCall![0].base_ref);
   });
 
   it('createGitSnapshotCheckpoint is called after each converged non-build altitude', async () => {
@@ -1352,6 +1356,40 @@ describe('runLayeredImplementation — wiring integration', () => {
     expect(gates).toContain('layout');
     expect(gates).toContain('public_api');
     expect(gates).not.toContain('build');
+  });
+
+  it('branch guard failure before checkpoint blocks checkpoint creation and the next altitude', async () => {
+    // Spec §Checkpoints and branch guard: "The branch guard runs after each proposer pass
+    // and before each checkpoint." If the guard rejects before checkpointing an altitude,
+    // the run fails before the checkpoint is created and before the next altitude starts.
+    // Sequence: layout converges (no_findings, no proposer call) → guard called before
+    // layout checkpoint → passes → checkpoint created → public_api converges → guard
+    // called before public_api checkpoint → rejects → run fails, build never starts.
+    const checkpointFn = makeCheckpointFn();
+    const branchGuard = {
+      check: vi.fn()
+        .mockResolvedValueOnce(undefined)  // before layout checkpoint — passes
+        .mockRejectedValue(new Error('branch drift detected')), // before public_api checkpoint — fails
+    };
+    const deps = makeDeps(undefined, { createGitSnapshotCheckpoint: checkpointFn, branchGuard });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    const result = await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    expect(result.status).toBe('failed');
+    expect((result as { status: 'failed'; error: string }).error).toMatch(/branch guard failed before public_api checkpoint/i);
+    // Layout checkpoint was created (guard passed), public_api checkpoint was NOT
+    expect(checkpointFn).toHaveBeenCalledTimes(1);
+    const checkpointedGates = checkpointFn.mock.calls.map((c: [{ gate: string }]) => c[0].gate);
+    expect(checkpointedGates).toContain('layout');
+    expect(checkpointedGates).not.toContain('public_api');
+    // layout and public_api critics ran; build was never started
+    expect(deps.runner.run).toHaveBeenCalledTimes(2);
   });
 
   it('run fails if checkpoint creation fails and does not start the next altitude', async () => {
@@ -1481,9 +1519,11 @@ describe('runLayeredImplementation — wiring integration', () => {
     expect(deps.implementer.implement).toHaveBeenCalledTimes(1);
   });
 
-  it('full-depth run produces distinct diff contexts per altitude, not repeated full diff', async () => {
-    // Each altitude's buildGateContext call must receive the correct cumulative base_ref.
-    // layout gets the initial HEAD, subsequent altitudes get checkpoint refs.
+  it('full-depth run passes the same cumulative pass base_ref to all four altitudes', async () => {
+    // Spec §Diff context strategy: the pass base_ref is captured once before the first
+    // altitude and never changes. All altitudes diff cumulatively from that same base.
+    // Checkpoint refs are stored for build contract preservation (compareBuildToAccepted-
+    // Contracts) and must not become the base_ref for any altitude's buildGateContext call.
     const checkpointFn = vi.fn()
       .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/ckpt/layout', commit: 'sha1', gate: 'layout' })
       .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/ckpt/public_api', commit: 'sha2', gate: 'public_api' })
@@ -1504,15 +1544,13 @@ describe('runLayeredImplementation — wiring integration', () => {
 
     const byGate = Object.fromEntries(calls.map(([c]) => [c.gate, c.base_ref]));
 
-    // layout uses initial HEAD (not a checkpoint ref)
-    expect(byGate['layout']).not.toContain('refs/ckpt');
-    // each subsequent altitude gets the prior altitude's checkpoint ref
-    expect(byGate['public_api']).toBe('refs/ckpt/layout');
-    expect(byGate['private_api']).toBe('refs/ckpt/public_api');
-    expect(byGate['build']).toBe('refs/ckpt/private_api');
+    // No altitude should receive a checkpoint ref as its base_ref
+    for (const [gate, baseRef] of Object.entries(byGate)) {
+      expect(baseRef, `${gate} must not use a checkpoint ref as base_ref`).not.toContain('refs/ckpt');
+    }
 
-    // All four base_refs must be distinct
+    // All four altitudes must receive the same cumulative pass base
     const uniqueBaseRefs = new Set(Object.values(byGate));
-    expect(uniqueBaseRefs.size).toBe(4);
+    expect(uniqueBaseRefs.size).toBe(1);
   });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -59,6 +59,26 @@ function makeImplementer(result: ImplementationResult = makeCompleteResult()): P
   return { implement: vi.fn().mockResolvedValue(result) };
 }
 
+function makeCheckpointFn() {
+  return vi.fn().mockImplementation(({ gate }: { gate: string }) =>
+    Promise.resolve({ strategy: 'internal_ref' as const, ref: `refs/autocatalyst/runs/run-001/${gate}/1`, commit: 'abc123', gate }),
+  );
+}
+
+function makeGateContextFn(diffOverride = '') {
+  return vi.fn().mockImplementation(({ gate, base_ref }: { gate: string; base_ref: string }) =>
+    Promise.resolve({ gate, base_ref, diff: diffOverride, changed_files: [], diff_byte_count: 0 }),
+  );
+}
+
+function makeContractValidatorFn(valid = true) {
+  return vi.fn().mockResolvedValue({ valid, violations: [], unsupported_files: [] });
+}
+
+function makeBuildContractFn(valid = true) {
+  return vi.fn().mockResolvedValue({ valid, drift: [], unsupported_files: [] });
+}
+
 function makeDeps(reviewResult: ImplementationReviewResult = { status: 'no_findings', summary: 'Looks good.', findings: [] }, overrides: Record<string, unknown> = {}) {
   const reviewJson = JSON.stringify(reviewResult);
   return {
@@ -69,6 +89,10 @@ function makeDeps(reviewResult: ImplementationReviewResult = { status: 'no_findi
     branchGuard: { check: vi.fn().mockResolvedValue(undefined) },
     logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     readFile: vi.fn().mockResolvedValue(reviewJson),
+    createGitSnapshotCheckpoint: makeCheckpointFn(),
+    buildGateContext: makeGateContextFn(),
+    validateAltitudeContract: makeContractValidatorFn(),
+    compareBuildToAcceptedContracts: makeBuildContractFn(),
     ...overrides,
   };
 }
@@ -1250,5 +1274,245 @@ describe('runLayeredImplementation — model-session budget enforcement', () => 
     expect((result as { status: 'failed'; error: string }).error).toMatch(/budget exhausted/i);
     // Runner must NOT have been called (budget rejected before provider call)
     expect(deps.runner.run).not.toHaveBeenCalled();
+  });
+});
+
+describe('runLayeredImplementation — wiring integration', () => {
+  it('calls buildGateContext per altitude and per round instead of getGitDiff', async () => {
+    // Each altitude critic round must call buildGateContext with the correct gate,
+    // not the legacy getGitDiff path.
+    const buildGateContext = makeGateContextFn('diff-content');
+    const deps = makeDeps(undefined, { buildGateContext });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    // buildGateContext must be called once per altitude (one round each, all converge)
+    expect(buildGateContext).toHaveBeenCalledTimes(3);
+    const calls = buildGateContext.mock.calls.map((c: [{ gate: string }]) => c[0].gate);
+    expect(calls).toContain('layout');
+    expect(calls).toContain('public_api');
+    expect(calls).toContain('build');
+  });
+
+  it('buildGateContext receives distinct base_refs per altitude after checkpointing', async () => {
+    // After layout converges and checkpoints, public_api and build must receive
+    // the checkpoint ref as base_ref, not the initial HEAD.
+    const checkpointFn = vi.fn()
+      .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/autocatalyst/runs/run-001/layout/1', commit: 'layout-sha', gate: 'layout' })
+      .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/autocatalyst/runs/run-001/public_api/2', commit: 'public-sha', gate: 'public_api' });
+    const buildGateContext = makeGateContextFn('');
+    const deps = makeDeps(undefined, { createGitSnapshotCheckpoint: checkpointFn, buildGateContext });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    const calls = buildGateContext.mock.calls as Array<[{ gate: string; base_ref: string }]>;
+    const layoutCall = calls.find(([c]) => c.gate === 'layout');
+    const publicApiCall = calls.find(([c]) => c.gate === 'public_api');
+    const buildCall = calls.find(([c]) => c.gate === 'build');
+
+    expect(layoutCall).toBeDefined();
+    expect(publicApiCall).toBeDefined();
+    expect(buildCall).toBeDefined();
+
+    // layout uses the initial base (not a checkpoint ref)
+    expect(layoutCall![0].base_ref).not.toContain('refs/autocatalyst');
+    // public_api uses the layout checkpoint ref
+    expect(publicApiCall![0].base_ref).toBe('refs/autocatalyst/runs/run-001/layout/1');
+    // build uses the public_api checkpoint ref
+    expect(buildCall![0].base_ref).toBe('refs/autocatalyst/runs/run-001/public_api/2');
+  });
+
+  it('createGitSnapshotCheckpoint is called after each converged non-build altitude', async () => {
+    const checkpointFn = makeCheckpointFn();
+    const deps = makeDeps(undefined, { createGitSnapshotCheckpoint: checkpointFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    // Checkpoints for layout and public_api only (not build)
+    expect(checkpointFn).toHaveBeenCalledTimes(2);
+    const gates = checkpointFn.mock.calls.map((c: [{ gate: string }]) => c[0].gate);
+    expect(gates).toContain('layout');
+    expect(gates).toContain('public_api');
+    expect(gates).not.toContain('build');
+  });
+
+  it('run fails if checkpoint creation fails and does not start the next altitude', async () => {
+    const checkpointFn = vi.fn().mockRejectedValue(new Error('git ref creation failed'));
+    const deps = makeDeps(undefined, { createGitSnapshotCheckpoint: checkpointFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    const result = await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    expect(result.status).toBe('failed');
+    expect((result as { status: 'failed'; error: string }).error).toMatch(/checkpoint creation failed/i);
+    // Runner must have been called once (layout), but not a second time (public_api blocked)
+    expect(deps.runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('validateAltitudeContract is called for each early-altitude critic round', async () => {
+    const validateFn = makeContractValidatorFn(true);
+    const deps = makeDeps(undefined, { validateAltitudeContract: validateFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'private_api', 'build'] },
+    );
+
+    // validate is called for layout, public_api, private_api (not build)
+    expect(validateFn).toHaveBeenCalledTimes(3);
+    const gates = validateFn.mock.calls.map((c: [{ gate: string }]) => c[0].gate);
+    expect(gates.filter((g: string) => g === 'layout')).toHaveLength(1);
+    expect(gates.filter((g: string) => g === 'public_api')).toHaveLength(1);
+    expect(gates.filter((g: string) => g === 'private_api')).toHaveLength(1);
+    expect(gates).not.toContain('build');
+  });
+
+  it('altitude contract violations force proposer revision and skip critic that round', async () => {
+    // Round 1: validator returns violations → skip critic, run proposer
+    // Round 2: validator passes → run critic (no findings) → converge
+    let validateCallCount = 0;
+    const validateFn = vi.fn().mockImplementation(() => {
+      validateCallCount++;
+      if (validateCallCount === 1) {
+        return Promise.resolve({
+          valid: false,
+          violations: [{ id: 'ALTITUDE-CONTRACT-1', file: 'src/foo.ts', message: 'layout altitude added lower-altitude work', reason_code: 'altitude_contract_violation' }],
+          unsupported_files: [],
+        });
+      }
+      return Promise.resolve({ valid: true, violations: [], unsupported_files: [] });
+    });
+    const deps = makeDeps(undefined, { validateAltitudeContract: validateFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    const result = await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'build'] },
+    );
+
+    // Run succeeds: round 1 revision + round 2 convergence
+    expect(result.status).toBe('complete');
+    // The critic runs only on round 2 (after violations are fixed), layout only
+    expect(deps.runner.run).toHaveBeenCalledTimes(2); // round 2 layout critic + build critic
+    // The proposer was called once for the contract violation revision
+    expect(deps.implementer.implement).toHaveBeenCalledTimes(1);
+  });
+
+  it('compareBuildToAcceptedContracts is called at build altitude with upper checkpoint refs', async () => {
+    const checkpointFn = vi.fn()
+      .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/autocatalyst/runs/run-001/layout/1', commit: 'layout-sha', gate: 'layout' });
+    const compareFn = makeBuildContractFn(true);
+    const deps = makeDeps(undefined, { createGitSnapshotCheckpoint: checkpointFn, compareBuildToAcceptedContracts: compareFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'build'] },
+    );
+
+    // compareBuildToAcceptedContracts must be called once at the build altitude
+    expect(compareFn).toHaveBeenCalledTimes(1);
+    const callArgs = compareFn.mock.calls[0]?.[0] as { acceptedCheckpoints: Array<{ gate: string; ref: string }> };
+    expect(callArgs).toBeDefined();
+    expect(callArgs!.acceptedCheckpoints).toHaveLength(1);
+    expect(callArgs!.acceptedCheckpoints[0]!.gate).toBe('layout');
+    expect(callArgs!.acceptedCheckpoints[0]!.ref).toBe('refs/autocatalyst/runs/run-001/layout/1');
+  });
+
+  it('build contract drift forces proposer revision before reporting convergence', async () => {
+    // Round 1: critic passes (no findings) but drift detected → proposer revision
+    // Round 2: critic passes and drift check passes → converge
+    let driftCallCount = 0;
+    const compareFn = vi.fn().mockImplementation(() => {
+      driftCallCount++;
+      if (driftCallCount === 1) {
+        return Promise.resolve({
+          valid: false,
+          drift: [{ kind: 'exported_name', file: 'src/foo.ts', symbol: 'foo', message: "exported name 'foo' from layout checkpoint was removed" }],
+          unsupported_files: [],
+        });
+      }
+      return Promise.resolve({ valid: true, drift: [], unsupported_files: [] });
+    });
+    const deps = makeDeps(undefined, { compareBuildToAcceptedContracts: compareFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    const result = await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'build'] },
+    );
+
+    expect(result.status).toBe('complete');
+    // compareBuildToAcceptedContracts called twice (round 1: drift, round 2: clean)
+    expect(compareFn).toHaveBeenCalledTimes(2);
+    // Proposer was called once for drift revision
+    expect(deps.implementer.implement).toHaveBeenCalledTimes(1);
+  });
+
+  it('full-depth run produces distinct diff contexts per altitude, not repeated full diff', async () => {
+    // Each altitude's buildGateContext call must receive the correct cumulative base_ref.
+    // layout gets the initial HEAD, subsequent altitudes get checkpoint refs.
+    const checkpointFn = vi.fn()
+      .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/ckpt/layout', commit: 'sha1', gate: 'layout' })
+      .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/ckpt/public_api', commit: 'sha2', gate: 'public_api' })
+      .mockResolvedValueOnce({ strategy: 'internal_ref' as const, ref: 'refs/ckpt/private_api', commit: 'sha3', gate: 'private_api' });
+    const gateContextFn = makeGateContextFn('');
+    const deps = makeDeps(undefined, { createGitSnapshotCheckpoint: checkpointFn, buildGateContext: gateContextFn });
+    deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'private_api', 'build'] },
+    );
+
+    const calls = gateContextFn.mock.calls as Array<[{ gate: string; base_ref: string }]>;
+    expect(calls).toHaveLength(4);
+
+    const byGate = Object.fromEntries(calls.map(([c]) => [c.gate, c.base_ref]));
+
+    // layout uses initial HEAD (not a checkpoint ref)
+    expect(byGate['layout']).not.toContain('refs/ckpt');
+    // each subsequent altitude gets the prior altitude's checkpoint ref
+    expect(byGate['public_api']).toBe('refs/ckpt/layout');
+    expect(byGate['private_api']).toBe('refs/ckpt/public_api');
+    expect(byGate['build']).toBe('refs/ckpt/private_api');
+
+    // All four base_refs must be distinct
+    const uniqueBaseRefs = new Set(Object.values(byGate));
+    expect(uniqueBaseRefs.size).toBe(4);
   });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -834,10 +834,44 @@ describe('ImplementationReviewCoordinator', () => {
       expect(run.gate_exchanges![1].gate).toBe('build');
     });
 
+    it('depth: public_api runs layout, public_api, then build in order', async () => {
+      const readFile = vi.fn().mockImplementation(async () => {
+        return JSON.stringify({ status: 'no_findings', summary: 'Clean.', findings: [] });
+      });
+      const deps = makeDeps(undefined, { readFile });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'public_api', 'build'] },
+      );
+      expect(result.status).toBe('complete');
+      expect(run.gate_exchanges).toHaveLength(3);
+      expect(run.gate_exchanges!.map(g => g.gate)).toEqual(['layout', 'public_api', 'build']);
+    });
+
+    it('depth: full runs all four altitudes in order', async () => {
+      const readFile = vi.fn().mockImplementation(async () => {
+        return JSON.stringify({ status: 'no_findings', summary: 'Clean.', findings: [] });
+      });
+      const deps = makeDeps(undefined, { readFile });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'public_api', 'private_api', 'build'] },
+      );
+      expect(result.status).toBe('complete');
+      expect(run.gate_exchanges).toHaveLength(4);
+      expect(run.gate_exchanges!.map(g => g.gate)).toEqual(['layout', 'public_api', 'private_api', 'build']);
+    });
+
     it('fails immediately when an early altitude does not converge', async () => {
       // layout: blocker on round 1 with max_initial_rounds=1 → fails
       const readFile = vi.fn().mockImplementation(async () => {
-        return JSON.stringify({ status: 'findings', summary: 'Blocked.', findings: [{ id: 'L1', severity: 'blocker', category: 'maintainability', finding: 'Bad layout.' }] });
+        return JSON.stringify({ status: 'findings', summary: 'Blocked.', findings: [{ id: 'L1', severity: 'blocker', category: 'maintainability', finding: 'Bad layout.', scope: 'current_altitude', reason_code: 'layout_boundary' }] });
       });
       const deps = makeDeps(undefined, { readFile });
       deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -775,4 +775,83 @@ describe('ImplementationReviewCoordinator', () => {
       );
     });
   });
+
+  describe('runLayeredImplementation', () => {
+    it('returns single-pass behavior when convergence is disabled', async () => {
+      const deps = makeDeps();
+      deps.policy = { ...deps.policy, convergence: { enabled: false, allow_same_model: false } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const original = makeCompleteResult();
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: original, working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'build'] },
+      );
+      expect(result).toBe(original);
+      // Used legacy review_exchanges, not gate_exchanges
+      expect(run.review_exchanges).toHaveLength(1);
+      expect((run as Record<string, unknown>)['gate_exchanges']).toBeUndefined();
+    });
+
+    it('delegates to existing build convergence for build-only depth and preserves gate: "initial"', async () => {
+      let callCount = 0;
+      const readFile = vi.fn().mockImplementation(async () => {
+        const result = callCount === 0
+          ? { status: 'no_findings', summary: 'Round 1 clean.', findings: [] }
+          : { status: 'no_findings', summary: 'unused', findings: [] };
+        callCount++;
+        return JSON.stringify(result);
+      });
+      const deps = makeDeps(undefined, { readFile });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['build'] },
+      );
+      expect(result.status).toBe('complete');
+      expect(run.gate_exchanges).toHaveLength(1);
+      expect(run.gate_exchanges![0].gate).toBe('initial'); // build-only preserves "initial"
+    });
+
+    it('for layered depth, runs altitudes in order and persists altitude gate names', async () => {
+      // Two altitudes, each converges on first round (no_findings)
+      const readFile = vi.fn().mockImplementation(async () => {
+        return JSON.stringify({ status: 'no_findings', summary: 'Clean.', findings: [] });
+      });
+      const deps = makeDeps(undefined, { readFile });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'build'] },
+      );
+      expect(result.status).toBe('complete');
+      expect(run.gate_exchanges).toHaveLength(2);
+      expect(run.gate_exchanges![0].gate).toBe('layout');
+      expect(run.gate_exchanges![1].gate).toBe('build');
+    });
+
+    it('fails immediately when an early altitude does not converge', async () => {
+      // layout: blocker on round 1 with max_initial_rounds=1 → fails
+      const readFile = vi.fn().mockImplementation(async () => {
+        return JSON.stringify({ status: 'findings', summary: 'Blocked.', findings: [{ id: 'L1', severity: 'blocker', category: 'maintainability', finding: 'Bad layout.' }] });
+      });
+      const deps = makeDeps(undefined, { readFile });
+      deps.policy = { ...deps.policy, max_initial_rounds: 1, convergence: { enabled: true, allow_same_model: true } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'build'] },
+      );
+      expect(result.status).toBe('failed');
+      // Should not have run the build altitude after layout failed
+      expect(run.gate_exchanges).toHaveLength(1);
+      expect(run.gate_exchanges![0].gate).toBe('layout');
+      expect(run.gate_exchanges![0].converged).toBe(false);
+    });
+  });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -888,4 +888,155 @@ describe('ImplementationReviewCoordinator', () => {
       expect(run.gate_exchanges![0].converged).toBe(false);
     });
   });
+
+  describe('runLayeredImplementation — telemetry and progress', () => {
+    function makeLayeredDeps(overrides: Record<string, unknown> = {}) {
+      const readFile = vi.fn().mockImplementation(async () => {
+        return JSON.stringify({ status: 'no_findings', summary: 'Clean.', findings: [] });
+      });
+      const deps = makeDeps(undefined, { readFile, ...overrides });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      return deps;
+    }
+
+    it('logs implementation.layered.started with run_id, depth, enabled_altitudes, and model_session_budget', async () => {
+      const deps = makeLayeredDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      const infoCalls: Array<Record<string, unknown>> = (deps.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0] as Record<string, unknown>,
+      );
+      const started = infoCalls.find(l => l['event'] === 'implementation.layered.started');
+
+      expect(started).toBeDefined();
+      expect(started!['run_id']).toBe('run-001');
+      expect(started!['enabled_altitudes']).toEqual(['layout', 'build']);
+      expect(typeof started!['model_session_budget']).toBe('number');
+    });
+
+    it('logs implementation.layer.started for each named altitude', async () => {
+      const deps = makeLayeredDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      const infoCalls: Array<Record<string, unknown>> = (deps.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0] as Record<string, unknown>,
+      );
+      const layerStarted = infoCalls.filter(l => l['event'] === 'implementation.layer.started');
+
+      // Should have one layer.started per altitude
+      expect(layerStarted).toHaveLength(2);
+      expect(layerStarted[0]!['gate']).toBe('layout');
+      expect(layerStarted[1]!['gate']).toBe('build');
+    });
+
+    it('logs implementation.layer.completed when altitude converges', async () => {
+      const deps = makeLayeredDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      const infoCalls: Array<Record<string, unknown>> = (deps.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => c[0] as Record<string, unknown>,
+      );
+      const layerCompleted = infoCalls.filter(l => l['event'] === 'implementation.layer.completed');
+
+      expect(layerCompleted).toHaveLength(2);
+      expect(layerCompleted[0]!['gate']).toBe('layout');
+      expect(typeof layerCompleted[0]!['elapsed_ms']).toBe('number');
+    });
+
+    it('progress message includes depth information when layered mode is activated', async () => {
+      const deps = makeLayeredDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const progressMessages: string[] = [];
+      const onProgress = vi.fn().mockImplementation((msg: string) => { progressMessages.push(msg); return Promise.resolve(); });
+
+      await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, onProgress },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      const depthMsg = progressMessages.find(m => m.includes('Layered implementation enabled'));
+      expect(depthMsg).toBeDefined();
+      expect(depthMsg).toContain('layout+build');
+    });
+
+    it('progress message for altitude start includes altitude label and proposer profile', async () => {
+      const deps = makeLayeredDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const progressMessages: string[] = [];
+      const onProgress = vi.fn().mockImplementation((msg: string) => { progressMessages.push(msg); return Promise.resolve(); });
+
+      await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, onProgress },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      const layoutMsg = progressMessages.find(m => m.includes('Layout pass started'));
+      expect(layoutMsg).toBeDefined();
+    });
+
+    it('progress callback that throws does not alter review outcome', async () => {
+      const deps = makeLayeredDeps();
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      // onProgress throws every time
+      const onProgress = vi.fn().mockRejectedValue(new Error('progress delivery failed'));
+
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, onProgress },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      // Review should still succeed despite progress failures
+      expect(result.status).toBe('complete');
+      // progress_failed should be logged, not thrown
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'progress_failed' }),
+        expect.any(String),
+      );
+    });
+
+    it('progress failure in sendProgress does not propagate as exception', async () => {
+      // Test specifically the sendProgress path inside the convergence loop
+      let callCount = 0;
+      const readFile = vi.fn().mockImplementation(async () => {
+        const result = callCount === 0
+          ? { status: 'findings', summary: 'Round 1.', findings: [{ id: 'L1', severity: 'blocker', category: 'maintainability', finding: 'Layout issue.' }] }
+          : { status: 'no_findings', summary: 'Clean.', findings: [] };
+        callCount++;
+        return JSON.stringify(result);
+      });
+      const deps = makeDeps(undefined, {
+        readFile,
+        implementer: makeImplementer(makeCompleteResult({ review_responses: [{ id: 'L1', disposition: 'fixed', response: 'Fixed.' }] })),
+      });
+      deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+      const coordinator = new ImplementationReviewCoordinator(deps);
+      const run = makeRun();
+      const onProgress = vi.fn().mockRejectedValue(new Error('network error'));
+
+      const result = await coordinator.runLayeredImplementation(
+        { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR, onProgress },
+        { altitudes: ['layout', 'build'] },
+      );
+
+      expect(result.status).toBe('complete');
+    });
+  });
 });

--- a/tests/core/ai/implementation-review-coordinator.test.ts
+++ b/tests/core/ai/implementation-review-coordinator.test.ts
@@ -1040,3 +1040,94 @@ describe('ImplementationReviewCoordinator', () => {
     });
   });
 });
+
+describe('runLayeredImplementation — regression: no forbidden git operations', () => {
+  it('runner.run is never called with a prompt containing checkout, push, merge, or branch-create commands', async () => {
+    const capturedPrompts: string[] = [];
+    const capturingRunner: AgentRunner = {
+      run: vi.fn().mockImplementation((params: { prompt: string }) => {
+        capturedPrompts.push(params.prompt);
+        return (async function* () {})();
+      }),
+    };
+    const readFile = vi.fn().mockImplementation(async () => {
+      return JSON.stringify({ status: 'no_findings', summary: 'Clean.', findings: [] });
+    });
+    const deps = makeDeps(undefined, { runner: capturingRunner, readFile });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    for (const prompt of capturedPrompts) {
+      // No prompt should instruct the agent to run forbidden git operations
+      expect(prompt).not.toMatch(/git\s+checkout/i);
+      expect(prompt).not.toMatch(/git\s+push/i);
+      expect(prompt).not.toMatch(/git\s+merge/i);
+      expect(prompt).not.toMatch(/git\s+branch\s+-[cCmM]/i);
+      expect(prompt).not.toMatch(/gh pr create/i);
+    }
+  });
+
+  it('early altitude prompts instruct the critic not to file missing-body or missing-test findings', async () => {
+    const capturedPrompts: Map<number, string> = new Map();
+    let callIndex = 0;
+    const capturingRunner: AgentRunner = {
+      run: vi.fn().mockImplementation((params: { prompt: string }) => {
+        capturedPrompts.set(callIndex++, params.prompt);
+        return (async function* () {})();
+      }),
+    };
+    const readFile = vi.fn().mockImplementation(async () => {
+      return JSON.stringify({ status: 'no_findings', summary: 'Clean.', findings: [] });
+    });
+    const deps = makeDeps(undefined, { runner: capturingRunner, readFile });
+    deps.policy = { ...deps.policy, max_initial_rounds: 2, convergence: { enabled: true, allow_same_model: true } };
+    const coordinator = new ImplementationReviewCoordinator(deps);
+    const run = makeRun();
+
+    await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: makeCompleteResult(), working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    // layout (call 0) and public_api (call 1) prompts must include the early-gate restriction
+    const layoutPrompt = capturedPrompts.get(0);
+    const publicApiPrompt = capturedPrompts.get(1);
+    const buildPrompt = capturedPrompts.get(2);
+
+    expect(layoutPrompt).toBeDefined();
+    expect(layoutPrompt).toContain('Do not file missing-body, missing-test, or missing-implementation findings');
+
+    expect(publicApiPrompt).toBeDefined();
+    expect(publicApiPrompt).toContain('Do not file missing-body, missing-test, or missing-implementation findings');
+
+    // build prompt must NOT contain the early-gate restriction
+    expect(buildPrompt).toBeDefined();
+    expect(buildPrompt).not.toContain('Do not file missing-body');
+  });
+
+  it('convergence disabled falls back to single-pass and review_exchanges is used, not gate_exchanges', async () => {
+    const freshDeps = makeDeps();
+    freshDeps.policy = { ...freshDeps.policy, convergence: { enabled: false, allow_same_model: false } };
+    const coordinator = new ImplementationReviewCoordinator(freshDeps);
+    const run = makeRun();
+    const original = makeCompleteResult();
+
+    const result = await coordinator.runLayeredImplementation(
+      { run, artifact_path: '/ws/spec.md', implementation_result: original, working_directory: WORKING_DIR },
+      { altitudes: ['layout', 'public_api', 'build'] },
+    );
+
+    // Single-pass behavior: review_exchanges is populated, gate_exchanges is not
+    expect(result).toBe(original);
+    expect(run.review_exchanges).toHaveLength(1);
+    expect((run as Record<string, unknown>)['gate_exchanges']).toBeUndefined();
+    // Runner called at most once (single-pass review)
+    expect(freshDeps.runner.run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/core/ai/layered-finding-filter.test.ts
+++ b/tests/core/ai/layered-finding-filter.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { filterLayeredFindings } from '../../../src/core/ai/layered-finding-filter.js';
+
+const blockingMaintainabilityFinding = {
+  id: 'LAYOUT-1',
+  severity: 'blocker' as const,
+  category: 'maintainability' as const,
+  finding: 'Function body is missing',
+};
+
+const blockingCorrectnessFinding = {
+  id: 'LAYOUT-2',
+  severity: 'blocker' as const,
+  category: 'correctness' as const,
+  finding: 'Missing implementation',
+};
+
+describe('filterLayeredFindings', () => {
+  describe('early gate — missing layered metadata', () => {
+    it('downgrades missing scope+reason_code to filtered_note with invalid_layered_metadata', () => {
+      const result = filterLayeredFindings({
+        gate: 'layout',
+        round: 1,
+        findings: [blockingMaintainabilityFinding],
+      });
+
+      expect(result.blockingFindings).toHaveLength(0);
+      expect(result.filteredCount).toBe(1);
+      expect(result.findings[0]!.layered).toMatchObject({
+        disposition: 'filtered_note',
+        filter_reason: 'invalid_layered_metadata',
+        original_severity: 'blocker',
+        original_category: 'maintainability',
+      });
+    });
+
+    it('does not block even when missing-body finding uses allowed category (maintainability) without metadata', () => {
+      const result = filterLayeredFindings({
+        gate: 'public_api',
+        round: 1,
+        findings: [{
+          id: 'PUB-1',
+          severity: 'blocker' as const,
+          category: 'maintainability' as const,
+          finding: 'Function body is missing — should be implemented',
+          // No scope or reason_code
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(0);
+      expect(result.findings[0]!.layered?.filter_reason).toBe('invalid_layered_metadata');
+    });
+  });
+
+  describe('early gate — lower altitude scope', () => {
+    it('filters lower_altitude scope findings before category check', () => {
+      const result = filterLayeredFindings({
+        gate: 'public_api',
+        round: 1,
+        findings: [{
+          id: 'PUB-2',
+          severity: 'blocker' as const,
+          category: 'maintainability' as const,
+          finding: 'Missing body',
+          scope: 'lower_altitude' as const,
+          reason_code: 'missing_lower_altitude_body' as const,
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(0);
+      expect(result.findings[0]!.layered?.filter_reason).toBe('lower_altitude_scope');
+    });
+
+    it('filters missing_lower_altitude_body reason code even with current_altitude scope', () => {
+      const result = filterLayeredFindings({
+        gate: 'private_api',
+        round: 1,
+        findings: [{
+          id: 'PRIV-1',
+          severity: 'warning' as const,
+          category: 'maintainability' as const,
+          finding: 'Body not implemented',
+          scope: 'current_altitude' as const,
+          reason_code: 'missing_lower_altitude_body' as const,
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(0);
+      expect(result.findings[0]!.layered?.filter_reason).toBe('lower_altitude_reason_code');
+    });
+  });
+
+  describe('early gate — category not allowed', () => {
+    it('filters correctness findings at layout (not in allowlist)', () => {
+      const result = filterLayeredFindings({
+        gate: 'layout',
+        round: 1,
+        findings: [{
+          id: 'LAYOUT-3',
+          severity: 'blocker' as const,
+          category: 'correctness' as const,
+          finding: 'Logic error',
+          scope: 'current_altitude' as const,
+          reason_code: 'layout_boundary' as const,
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(0);
+      expect(result.findings[0]!.layered?.filter_reason).toBe('category_not_allowed');
+    });
+  });
+
+  describe('early gate — blocking findings that pass all filters', () => {
+    it('allows maintainability blocker at layout with proper metadata', () => {
+      const result = filterLayeredFindings({
+        gate: 'layout',
+        round: 1,
+        findings: [{
+          id: 'LAYOUT-4',
+          severity: 'blocker' as const,
+          category: 'maintainability' as const,
+          finding: 'New file duplicates existing boundary',
+          scope: 'current_altitude' as const,
+          reason_code: 'layout_boundary' as const,
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(1);
+      expect(result.findings[0]!.layered?.disposition).toBe('blocking');
+    });
+  });
+
+  describe('info severity', () => {
+    it('info findings are never blocking', () => {
+      const result = filterLayeredFindings({
+        gate: 'layout',
+        round: 1,
+        findings: [{
+          id: 'INFO-1',
+          severity: 'info' as const,
+          category: 'maintainability' as const,
+          finding: 'Consider renaming',
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(0);
+      expect(result.findings[0]!.layered?.disposition).toBe('info');
+    });
+  });
+
+  describe('build gate — no early filtering', () => {
+    it('does not filter correctness findings at build gate', () => {
+      const result = filterLayeredFindings({
+        gate: 'build',
+        round: 1,
+        findings: [{
+          id: 'BUILD-1',
+          severity: 'blocker' as const,
+          category: 'correctness' as const,
+          finding: 'Logic error in body',
+          // No scope/reason_code needed at build gate
+        }],
+      });
+
+      expect(result.blockingFindings).toHaveLength(1);
+      expect(result.findings[0]!.layered?.disposition).toBe('blocking');
+    });
+
+    it('does not filter missing metadata at build gate', () => {
+      const result = filterLayeredFindings({
+        gate: 'build',
+        round: 1,
+        findings: [blockingCorrectnessFinding],
+      });
+
+      expect(result.blockingFindings).toHaveLength(1);
+    });
+  });
+});

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -20,6 +20,7 @@ import {
   altitudesForDepth,
   resolveFeedbackDepth,
   resolveImplementationConvergencePolicy,
+  allowedCategoriesForGate,
 } from '../../src/core/ai/layered-convergence-policy.js';
 
 const fixture = (name: string) =>
@@ -705,5 +706,25 @@ describe('implementation_review.convergence layered config', () => {
         },
       },
     })).toThrow('implementation_review.convergence.max_model_sessions_per_run must be a positive integer');
+  });
+});
+
+// ─── allowedCategoriesForGate ─────────────────────────────────────────────────
+
+describe('allowedCategoriesForGate', () => {
+  it('returns [maintainability, docs] for layout gate', () => {
+    expect(allowedCategoriesForGate('layout')).toEqual(['maintainability', 'docs']);
+  });
+
+  it('returns [maintainability, docs, security] for public_api gate', () => {
+    expect(allowedCategoriesForGate('public_api')).toEqual(['maintainability', 'docs', 'security']);
+  });
+
+  it('returns [maintainability, docs, security] for private_api gate', () => {
+    expect(allowedCategoriesForGate('private_api')).toEqual(['maintainability', 'docs', 'security']);
+  });
+
+  it('returns [correctness, test, security, maintainability, docs, pr_readiness] for build gate', () => {
+    expect(allowedCategoriesForGate('build')).toEqual(['correctness', 'test', 'security', 'maintainability', 'docs', 'pr_readiness']);
   });
 });

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -16,6 +16,11 @@ import {
   isWorkspaceAutoPruneEnabled,
 } from '../../src/core/config.js';
 import type { WorkflowConfig } from '../../src/types/config.js';
+import {
+  altitudesForDepth,
+  resolveFeedbackDepth,
+  resolveImplementationConvergencePolicy,
+} from '../../src/core/ai/layered-convergence-policy.js';
 
 const fixture = (name: string) =>
   readFileSync(join(import.meta.dirname, '../fixtures', name), 'utf-8');
@@ -640,5 +645,65 @@ describe('isWorkspaceAutoPruneEnabled', () => {
 
   it('returns false when set to false', () => {
     expect(isWorkspaceAutoPruneEnabled({ workspace: { auto_prune: false } } as WorkflowConfig)).toBe(false);
+  });
+});
+
+// ─── implementation_review.convergence layered config ─────────────────────────
+
+function baseConfig(overrides: Partial<WorkflowConfig> = {}): WorkflowConfig {
+  return {
+    ai: { credentials: [], endpoints: [], profiles: [], routing: {} },
+    ...overrides,
+  } as WorkflowConfig;
+}
+
+describe('implementation_review.convergence layered config', () => {
+  it('resolves missing convergence config to disabled build-only defaults', () => {
+    const policy = resolveImplementationConvergencePolicy(baseConfig());
+    expect(policy).toEqual({
+      enabled: false,
+      allow_same_model: false,
+      depth: 'build_only',
+      feedback_depth: 'build_only',
+      max_model_sessions_per_run: 24,
+    });
+  });
+
+  it.each([
+    ['build_only', ['build']],
+    ['layout', ['layout', 'build']],
+    ['public_api', ['layout', 'public_api', 'build']],
+    ['full', ['layout', 'public_api', 'private_api', 'build']],
+  ] as const)('maps depth %s to ordered altitudes', (depth, expected) => {
+    expect(altitudesForDepth(depth)).toEqual(expected);
+  });
+
+  it('resolves feedback_depth inherit to the initial depth', () => {
+    expect(resolveFeedbackDepth('inherit', 'full')).toBe('full');
+    expect(resolveFeedbackDepth(undefined, 'public_api')).toBe('build_only');
+  });
+
+  it('rejects invalid depth with clear error', () => {
+    expect(() => validateConfig({
+      ...baseConfig(),
+      implementation_review: {
+        convergence: {
+          enabled: true,
+          depth: 'wrong-depth' as never,
+        },
+      },
+    })).toThrow('implementation_review.convergence.depth must be one of');
+  });
+
+  it('rejects invalid max_model_sessions_per_run with clear error', () => {
+    expect(() => validateConfig({
+      ...baseConfig(),
+      implementation_review: {
+        convergence: {
+          enabled: true,
+          max_model_sessions_per_run: 0,
+        },
+      },
+    })).toThrow('implementation_review.convergence.max_model_sessions_per_run must be a positive integer');
   });
 });

--- a/tests/core/git-checkpoints.test.ts
+++ b/tests/core/git-checkpoints.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createGitSnapshotCheckpoint } from '../../src/core/git-checkpoints.js';
+
+const exec = promisify(execFile);
+
+async function git(cwd: string, args: string[]) {
+  return exec('git', args, { cwd });
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await git(cwd, args);
+  return result.stdout.trim();
+}
+
+async function setupRepo(): Promise<string> {
+  const repo = await mkdtemp(join(tmpdir(), 'checkpoint-test-'));
+  await git(repo, ['init']);
+  await git(repo, ['config', 'user.email', 'test@example.com']);
+  await git(repo, ['config', 'user.name', 'Test']);
+  await writeFile(join(repo, '.gitignore'), 'ignored.txt\n');
+  await writeFile(join(repo, 'tracked.ts'), 'export const a = 1;\n');
+  await git(repo, ['add', '.']);
+  await git(repo, ['commit', '-m', 'base']);
+  return repo;
+}
+
+describe('createGitSnapshotCheckpoint', () => {
+  it('creates an internal ref checkpoint without mutating real index', async () => {
+    const repo = await setupRepo();
+
+    await writeFile(join(repo, 'tracked.ts'), 'export const a = 2;\n');
+    await writeFile(join(repo, 'new.ts'), 'export const b = 1;\n');
+    await writeFile(join(repo, 'ignored.txt'), 'ignored\n');
+
+    const checkpoint = await createGitSnapshotCheckpoint({
+      workingDirectory: repo,
+      runId: 'run-1',
+      gate: 'layout',
+    });
+
+    expect(checkpoint.strategy).toBe('internal_ref');
+    expect(checkpoint.ref).toMatch(/^refs\/autocatalyst\/runs\/run-1\/layout\//);
+    expect(checkpoint.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    // Verify tracked file change was captured in checkpoint
+    const trackedContent = await gitOutput(repo, ['show', `${checkpoint.commit}:tracked.ts`]);
+    expect(trackedContent).toContain('export const a = 2');
+
+    // Verify untracked non-ignored file was captured
+    const newContent = await gitOutput(repo, ['show', `${checkpoint.commit}:new.ts`]);
+    expect(newContent).toContain('export const b = 1');
+
+    // Verify ignored file was NOT captured
+    await expect(gitOutput(repo, ['show', `${checkpoint.commit}:ignored.txt`])).rejects.toThrow();
+  });
+
+  it('does not leave untracked files staged in the real index', async () => {
+    const repo = await setupRepo();
+    await writeFile(join(repo, 'new.ts'), 'export const b = 1;\n');
+
+    await createGitSnapshotCheckpoint({
+      workingDirectory: repo,
+      runId: 'run-1',
+      gate: 'layout',
+    });
+
+    // Check that new.ts is still untracked (not staged) after checkpoint
+    const statusResult = await git(repo, ['status', '--porcelain']);
+    const status = statusResult.stdout;
+    expect(status).toContain('?? new.ts');
+    expect(status).not.toContain('A  new.ts');
+  });
+
+  it('does not switch or create branches', async () => {
+    const repo = await setupRepo();
+    const branchBefore = await gitOutput(repo, ['branch', '--show-current']);
+
+    await createGitSnapshotCheckpoint({
+      workingDirectory: repo,
+      runId: 'run-1',
+      gate: 'public_api',
+    });
+
+    const branchAfter = await gitOutput(repo, ['branch', '--show-current']);
+    expect(branchAfter).toBe(branchBefore);
+  });
+
+  it('captures the ref under refs/autocatalyst namespace', async () => {
+    const repo = await setupRepo();
+
+    const checkpoint = await createGitSnapshotCheckpoint({
+      workingDirectory: repo,
+      runId: 'run-42',
+      gate: 'private_api',
+    });
+
+    expect(checkpoint.ref.startsWith('refs/autocatalyst/runs/run-42/private_api/')).toBe(true);
+
+    // Verify the ref exists in git
+    const resolvedRef = await gitOutput(repo, ['rev-parse', checkpoint.ref]);
+    expect(resolvedRef).toBe(checkpoint.commit);
+  });
+});

--- a/tests/core/handlers/implementation-approval-handler.test.ts
+++ b/tests/core/handlers/implementation-approval-handler.test.ts
@@ -624,4 +624,83 @@ describe('ImplementationApprovalHandler with reviewCoordinator', () => {
       expect.objectContaining({ gate_exchanges: [gateExchange] }),
     );
   });
+
+  it('calls runFinalReview (not runLayeredImplementation) on final approval', async () => {
+    // The handler must always delegate to runFinalReview for the post-human-approval
+    // review. runLayeredImplementation is only used during initial implementation.
+    const coord = makeReviewCoordinator();
+    const { handler } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(coord.runFinalReview).toHaveBeenCalledTimes(1);
+    // Confirm there is no runLayeredImplementation method on the coordinator type
+    // used by the handler — it only exposes runFinalReview.
+    expect((coord as Record<string, unknown>)['runLayeredImplementation']).toBeUndefined();
+  });
+
+  it('gate_exchanges populated by final review contain gate: "final", not layered altitude gates', async () => {
+    // When convergence is enabled, the final review path must produce gate exchanges
+    // with gate: "final". Layered altitude gates (layout/public_api/private_api)
+    // must NOT appear in exchanges produced by the final review path.
+    const finalGateExchange: GateReviewExchange = {
+      id: 'gate-final-001',
+      gate: 'final',
+      round: 1,
+      created_at: new Date().toISOString(),
+      proposer_profile: { profile: 'impl-agent', provider: 'anthropic_direct' },
+      critic_profile: { profile: 'review-agent', provider: 'anthropic_direct' },
+      review_status: 'converged',
+      review_summary: 'Final review passed.',
+      findings: [],
+      responses: [],
+      converged: true,
+      requires_human_retest: true,
+    };
+
+    const coord = makeReviewCoordinator({ requires_human_retest: true });
+    const { handler, deps } = makeHandler({ reviewCoordinator: coord });
+    const run = makeRun({
+      impl_feedback_ref: 'feedback-page-id',
+      gate_exchanges: [finalGateExchange],
+    });
+
+    await handler.handle(run, makeFeedback());
+
+    // The gate exchange passed to the feedback page has gate: "final"
+    const updateCall = (deps.implFeedbackPage?.update as ReturnType<typeof vi.fn>).mock.calls[0];
+    const updatedPayload = updateCall?.[1] as { gate_exchanges?: GateReviewExchange[] };
+    const exchanges = updatedPayload?.gate_exchanges ?? [];
+    for (const ex of exchanges) {
+      expect(ex.gate).toBe('final');
+      expect(['layout', 'public_api', 'private_api']).not.toContain(ex.gate);
+    }
+  });
+
+  it('does not transition run to a new RunStage during final review — only to existing stages', async () => {
+    // Final review must not introduce new RunStage values. After a normal final
+    // review that passes, the handler transitions to pr_open.  After retest required,
+    // it transitions back to reviewing_implementation. Both are existing stages.
+    const coordPass = makeReviewCoordinator({ requires_human_retest: false });
+    const { handler: handlerPass, deps: depsPass } = makeHandler({ reviewCoordinator: coordPass });
+    const runPass = makeRun();
+    await handlerPass.handle(runPass, makeFeedback());
+    expect(depsPass.transition).toHaveBeenCalledWith(runPass, 'pr_open');
+
+    const coordRetest = makeReviewCoordinator({ requires_human_retest: true });
+    const { handler: handlerRetest, deps: depsRetest } = makeHandler({ reviewCoordinator: coordRetest });
+    const runRetest = makeRun();
+    await handlerRetest.handle(runRetest, makeFeedback());
+    expect(depsRetest.transition).toHaveBeenCalledWith(runRetest, 'reviewing_implementation');
+
+    // In no case does final review trigger a transition to any layered-specific stage.
+    const allTransitionArgs = [
+      ...(depsPass.transition as ReturnType<typeof vi.fn>).mock.calls,
+      ...(depsRetest.transition as ReturnType<typeof vi.fn>).mock.calls,
+    ].map(([, stage]) => stage as string);
+    for (const stage of allTransitionArgs) {
+      expect(['pr_open', 'reviewing_implementation', 'awaiting_impl_input', 'failed']).toContain(stage);
+    }
+  });
 });

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -640,3 +640,59 @@ describe('ImplementationFeedbackHandler with reviewCoordinator', () => {
     expect(coord.runLayeredImplementation).not.toHaveBeenCalled();
   });
 });
+
+describe('ImplementationFeedbackHandler model-session budget enforcement', () => {
+  it('fails the run before calling implementer when max_model_sessions_per_run is 0', async () => {
+    const appendSpy = vi.fn().mockResolvedValue(undefined);
+    const { handler, deps } = makeHandler({
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'build_only',
+        feedback_depth: 'build_only',
+        max_model_sessions_per_run: 0,
+      },
+      budgetWriter: { append: appendSpy },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.implementer.implement).not.toHaveBeenCalled();
+    expect(deps.failRun).toHaveBeenCalled();
+  });
+
+  it('passes an exhausted sessionBudget to the coordinator when limit is 1', async () => {
+    const appendSpy = vi.fn().mockResolvedValue(undefined);
+    let capturedBudget: { used(): number; limit(): number } | undefined;
+    const coord = {
+      runInitialReview: vi.fn().mockImplementation(async (params: { sessionBudget?: { used(): number; limit(): number } }) => {
+        capturedBudget = params.sessionBudget;
+        return {
+          status: 'complete',
+          summary: 'Reviewed ok.',
+          testing_instructions: 'npm test',
+        };
+      }),
+    };
+    const { handler } = makeHandler({
+      reviewCoordinator: coord,
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'build_only',
+        feedback_depth: 'build_only',
+        max_model_sessions_per_run: 1,
+      },
+      budgetWriter: { append: appendSpy },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback(), 'reviewing_implementation');
+
+    expect(capturedBudget).toBeDefined();
+    expect(capturedBudget!.used()).toBe(1);
+    expect(capturedBudget!.limit()).toBe(1);
+  });
+});

--- a/tests/core/handlers/implementation-feedback-handler.test.ts
+++ b/tests/core/handlers/implementation-feedback-handler.test.ts
@@ -605,4 +605,38 @@ describe('ImplementationFeedbackHandler with reviewCoordinator', () => {
     expect(run.last_agent_request_at).toBe('2026-01-02T00:00:00.000Z');
     expect(deps.persist).toHaveBeenCalled();
   });
+
+  it('uses feedback_depth to choose altitudes for runLayeredImplementation', async () => {
+    const coord = {
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'complete', summary: 'unused', testing_instructions: 'unused' }),
+      runLayeredImplementation: vi.fn().mockResolvedValue({ status: 'complete', summary: 'ok', testing_instructions: 'npm test' }),
+    };
+    const { handler } = makeHandler({
+      reviewCoordinator: coord,
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'full',
+        feedback_depth: 'layout',
+        max_model_sessions_per_run: 24,
+      },
+    });
+    await handler.handle(makeRun(), makeFeedback(), 'reviewing_implementation');
+    expect(coord.runLayeredImplementation).toHaveBeenCalledWith(
+      expect.any(Object),
+      { altitudes: ['layout', 'build'] },
+    );
+    expect(coord.runInitialReview).not.toHaveBeenCalled();
+  });
+
+  it('defaults to build_only behavior when no convergencePolicy is provided', async () => {
+    const coord = {
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'complete', summary: 'ok', testing_instructions: 'npm test' }),
+      runLayeredImplementation: vi.fn().mockResolvedValue({ status: 'complete', summary: 'ok', testing_instructions: 'npm test' }),
+    };
+    const { handler } = makeHandler({ reviewCoordinator: coord });
+    await handler.handle(makeRun(), makeFeedback(), 'reviewing_implementation');
+    expect(coord.runInitialReview).toHaveBeenCalled();
+    expect(coord.runLayeredImplementation).not.toHaveBeenCalled();
+  });
 });

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -620,3 +620,59 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     );
   });
 });
+
+describe('ImplementationStartHandler model-session budget enforcement', () => {
+  it('fails the run before calling implementer when max_model_sessions_per_run is 0', async () => {
+    const appendSpy = vi.fn().mockResolvedValue(undefined);
+    const { handler, deps } = makeHandler({
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'build_only',
+        feedback_depth: 'build_only',
+        max_model_sessions_per_run: 0,
+      },
+      budgetWriter: { append: appendSpy },
+    });
+    const run = makeRun();
+
+    const result = await handler.handle(run, makeFeedback());
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(deps.implementer.implement).not.toHaveBeenCalled();
+    expect(deps.failRun).toHaveBeenCalled();
+  });
+
+  it('passes an exhausted sessionBudget to the coordinator when limit is 1', async () => {
+    const appendSpy = vi.fn().mockResolvedValue(undefined);
+    let capturedBudget: { used(): number; limit(): number } | undefined;
+    const coord = {
+      runInitialReview: vi.fn().mockImplementation(async (params: { sessionBudget?: { used(): number; limit(): number } }) => {
+        capturedBudget = params.sessionBudget;
+        return {
+          status: 'complete',
+          summary: 'Reviewed ok.',
+          testing_instructions: 'npm test',
+        };
+      }),
+    };
+    const { handler } = makeHandler({
+      reviewCoordinator: coord,
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'build_only',
+        feedback_depth: 'build_only',
+        max_model_sessions_per_run: 1,
+      },
+      budgetWriter: { append: appendSpy },
+    });
+    const run = makeRun();
+
+    await handler.handle(run, makeFeedback());
+
+    expect(capturedBudget).toBeDefined();
+    expect(capturedBudget!.used()).toBe(1);
+    expect(capturedBudget!.limit()).toBe(1);
+  });
+});

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -548,6 +548,53 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     );
   });
 
+  it('calls runLayeredImplementation when convergencePolicy enables a layered depth', async () => {
+    const coord = {
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'complete', summary: 'unused', testing_instructions: 'unused' }),
+      runLayeredImplementation: vi.fn().mockResolvedValue({
+        status: 'complete',
+        summary: 'Layered done.',
+        testing_instructions: 'npm test',
+      }),
+    };
+    const { handler } = makeHandler({
+      reviewCoordinator: coord,
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'layout',
+        feedback_depth: 'build_only',
+        max_model_sessions_per_run: 24,
+      },
+    });
+    await handler.handle(makeRun(), makeFeedback());
+    expect(coord.runLayeredImplementation).toHaveBeenCalledWith(
+      expect.objectContaining({ artifact_path: '/ws/request-001/context-human/specs/feature-test.md' }),
+      { altitudes: ['layout', 'build'] },
+    );
+    expect(coord.runInitialReview).not.toHaveBeenCalled();
+  });
+
+  it('calls runInitialReview when convergencePolicy is build_only', async () => {
+    const coord = {
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'complete', summary: 'unused', testing_instructions: 'unused' }),
+      runLayeredImplementation: vi.fn().mockResolvedValue({ status: 'complete', summary: 'unused', testing_instructions: 'unused' }),
+    };
+    const { handler } = makeHandler({
+      reviewCoordinator: coord,
+      convergencePolicy: {
+        enabled: true,
+        allow_same_model: false,
+        depth: 'build_only',
+        feedback_depth: 'build_only',
+        max_model_sessions_per_run: 24,
+      },
+    });
+    await handler.handle(makeRun(), makeFeedback());
+    expect(coord.runInitialReview).toHaveBeenCalled();
+    expect(coord.runLayeredImplementation).not.toHaveBeenCalled();
+  });
+
   it('passes gate_exchanges to implFeedbackPage.create when present', async () => {
     const gateExchange: GateReviewExchange = {
       id: 'gate-001',

--- a/tests/core/invariants.test.ts
+++ b/tests/core/invariants.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { rmSync } from 'node:fs';
 import { loadConfig, redactConfig } from '../../src/core/config.js';
 import { VALID_RUN_STAGES } from '../../src/types/runs.js';
+import { allowedCategoriesForGate } from '../../src/core/ai/layered-convergence-policy.js';
 
 describe('cross-cutting: JSON output validity', () => {
   let tempDir: string;
@@ -74,5 +75,42 @@ describe('run stage invariants', () => {
       'reviewing_spec',
       'speccing',
     ]);
+  });
+});
+
+describe('finding category invariants', () => {
+  it('build gate categories include the full approved set of finding categories', () => {
+    // ImplementationReviewFindingCategory is a closed type — this test pins the
+    // allowed set so accidental additions are caught during review.
+    const buildCategories = allowedCategoriesForGate('build');
+    expect(buildCategories.sort()).toEqual([
+      'correctness',
+      'docs',
+      'maintainability',
+      'pr_readiness',
+      'security',
+      'test',
+    ]);
+  });
+
+  it('early altitude finding categories are restricted to a subset (no correctness/test/pr_readiness)', () => {
+    for (const gate of ['layout', 'public_api', 'private_api'] as const) {
+      const cats = allowedCategoriesForGate(gate);
+      expect(cats).not.toContain('correctness');
+      expect(cats).not.toContain('test');
+      expect(cats).not.toContain('pr_readiness');
+    }
+  });
+
+  it('layered depth does not add new RunStage values at any altitude', () => {
+    // All altitudes resolve to existing stages — no new stages are introduced
+    // by the layered-convergence feature. This cross-checks the RunStage
+    // invariant from the perspective of the altitude system.
+    const expectedStages = new Set(VALID_RUN_STAGES);
+    // Simulate what the handler transitions to: still 'implementing' / 'reviewing_implementation'
+    const stagesUsedByLayered = ['implementing', 'reviewing_implementation'] as const;
+    for (const stage of stagesUsedByLayered) {
+      expect(expectedStages.has(stage)).toBe(true);
+    }
   });
 });

--- a/tests/core/journal/model-session-budget.test.ts
+++ b/tests/core/journal/model-session-budget.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { ModelSessionBudget } from '../../../src/core/journal/model-session-budget.js';
+
+function writer() {
+  const records: unknown[] = [];
+  return {
+    records,
+    append: async (_stream: string, record: unknown) => {
+      records.push(record);
+    },
+  };
+}
+
+describe('ModelSessionBudget', () => {
+  it('reserves before provider calls and tracks usage', async () => {
+    const w = writer();
+    const budget = new ModelSessionBudget({ runId: 'run-1', requestId: 'req-1', limit: 3, writer: w });
+
+    const first = await budget.reserve({ gate: 'layout', role: 'proposer', round: 1, passKind: 'initial' });
+    expect(budget.used()).toBe(1);
+    expect(first.session_id).toBeTruthy();
+    expect(first.used).toBe(1);
+    expect(first.limit).toBe(3);
+  });
+
+  it('exhausts budget and throws before making another reservation', async () => {
+    const w = writer();
+    const budget = new ModelSessionBudget({ runId: 'run-1', requestId: 'req-1', limit: 2, writer: w });
+
+    await budget.reserve({ gate: 'layout', role: 'proposer', round: 1, passKind: 'initial' });
+    await budget.reserve({ gate: 'layout', role: 'critic', round: 1, passKind: 'initial' });
+
+    expect(budget.used()).toBe(2);
+    await expect(
+      budget.reserve({ gate: 'public_api', role: 'proposer', round: 1, passKind: 'initial' })
+    ).rejects.toThrow('Model-session budget exhausted for run run-1: used 2 of 2');
+  });
+
+  it('reconstructs consumed budget from session records by stable session_id', async () => {
+    const w = writer();
+    const budget = new ModelSessionBudget({ runId: 'run-1', requestId: 'req-1', limit: 2, writer: w });
+
+    const first = await budget.reserve({ gate: 'layout', role: 'proposer', round: 1, passKind: 'initial' });
+    await budget.complete(first.session_id, 'ok');
+    await budget.reserve({ gate: 'layout', role: 'critic', round: 1, passKind: 'initial' });
+
+    expect(budget.used()).toBe(2);
+
+    const replayed = ModelSessionBudget.fromSessionRecords({
+      runId: 'run-1',
+      requestId: 'req-1',
+      limit: 2,
+      records: w.records,
+    });
+    expect(replayed.used()).toBe(2);
+  });
+
+  it('counts reserved-but-incomplete calls (crash safety)', async () => {
+    const w = writer();
+    const budget = new ModelSessionBudget({ runId: 'run-1', requestId: 'req-1', limit: 2, writer: w });
+
+    await budget.reserve({ gate: 'layout', role: 'proposer', round: 1, passKind: 'initial' });
+    // No complete() call — simulates a crash before completion
+
+    const replayed = ModelSessionBudget.fromSessionRecords({
+      runId: 'run-1',
+      requestId: 'req-1',
+      limit: 2,
+      records: w.records,
+    });
+    expect(replayed.used()).toBe(1);
+  });
+
+  it('does not double-count if same session_id appears multiple times', async () => {
+    const fakeReservedRecord = {
+      record_kind: 'model_session_reserved',
+      session_id: 'stable-id-1',
+    };
+    const replayed = ModelSessionBudget.fromSessionRecords({
+      runId: 'run-1',
+      requestId: 'req-1',
+      limit: 10,
+      records: [fakeReservedRecord, fakeReservedRecord],
+    });
+    expect(replayed.used()).toBe(1);
+  });
+});

--- a/tests/core/journal/run-journal-facade.test.ts
+++ b/tests/core/journal/run-journal-facade.test.ts
@@ -372,7 +372,119 @@ describe('RunJournal facade', () => {
     expect(calls[0].record).toMatchObject({ role: 'critic', round: 2, gate: 'initial' });
   });
 
-  it('captureSession writes correct stream and fields', async () => {
+  it('captureFeedback filtered_note layered finding gets disposition=addressed and note_kind metadata', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureFeedback({
+      id: 'gate-exchange-id:finding-001',
+      run,
+      target: 'implementation',
+      gate: 'layout',
+      author_principal: 'review:anthropic:claude-opus-4-5',
+      text: 'This finding is out of scope for this altitude',
+      severity: 'warning',
+      category: 'correctness',
+      disposition: 'addressed',
+      note_kind: 'filtered_layered_finding',
+      filter_reason: 'lower_altitude_scope',
+      scope: 'build',
+      reason_code: 'build_signal_unavailable_until_build',
+      original_severity: 'warning',
+      original_category: 'correctness',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].stream).toBe('feedback');
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.disposition).toBe('addressed');
+    expect(rec.note_kind).toBe('filtered_layered_finding');
+    expect(rec.filter_reason).toBe('lower_altitude_scope');
+    expect(rec.scope).toBe('build');
+    expect(rec.reason_code).toBe('build_signal_unavailable_until_build');
+    expect(rec.original_severity).toBe('warning');
+    expect(rec.original_category).toBe('correctness');
+    expect(rec.gate).toBe('layout');
+  });
+
+  it('captureFeedback filtered_note layered finding never has disposition=open', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureFeedback({
+      id: 'gate-exchange-id:finding-002',
+      run,
+      target: 'implementation',
+      gate: 'public_api',
+      author_principal: 'review:anthropic:claude-opus-4-5',
+      text: 'Out-of-scope finding filtered by altitude policy',
+      severity: 'blocker',
+      category: 'architecture',
+      disposition: 'addressed',
+      note_kind: 'filtered_layered_finding',
+      filter_reason: 'category_not_allowed',
+      original_severity: 'blocker',
+      original_category: 'architecture',
+    });
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.disposition).not.toBe('open');
+    expect(rec.disposition).toBe('addressed');
+    expect(rec.note_kind).toBe('filtered_layered_finding');
+  });
+
+  it('captureFeedback blocking layered finding that was not addressed gets disposition=open', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureFeedback({
+      id: 'gate-exchange-id:finding-003',
+      run,
+      target: 'implementation',
+      gate: 'layout',
+      author_principal: 'review:anthropic:claude-opus-4-5',
+      text: 'Blocking finding not yet addressed',
+      severity: 'blocker',
+      category: 'correctness',
+      disposition: 'open',
+    });
+
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.disposition).toBe('open');
+    expect(rec.note_kind).toBeUndefined();
+    expect(rec.filter_reason).toBeUndefined();
+  });
+
+  it('captureFeedback legacy finding without layered metadata still works correctly', async () => {
+    const { writer, calls } = makeMockWriter();
+    const journal = new RunJournal(writer);
+    const run = makeRun();
+
+    await journal.captureFeedback({
+      id: 'legacy-finding-001',
+      run,
+      target: 'implementation',
+      author_principal: 'review:anthropic:claude-sonnet-4-6',
+      text: 'Legacy review finding without layered metadata',
+      severity: 'warning',
+      category: 'style',
+    });
+
+    expect(calls).toHaveLength(1);
+    const rec = calls[0].record as Record<string, unknown>;
+    expect(rec.disposition).toBe('open'); // default
+    expect(rec.note_kind).toBeUndefined();
+    expect(rec.filter_reason).toBeUndefined();
+    expect(rec.scope).toBeUndefined();
+    expect(rec.reason_code).toBeUndefined();
+    expect(rec.original_severity).toBeUndefined();
+    expect(rec.original_category).toBeUndefined();
+  });
+
+  it('captureFeedback writes correct stream and fields', async () => {
     const { writer, calls } = makeMockWriter();
     const journal = new RunJournal(writer);
     const run = makeRun();


### PR DESCRIPTION
## Summary

- buildGateContext in gate-context.ts now imports redactSecrets and applies it to the combined tracked+untracked diff before returning
- diff_byte_count is now computed from the redacted payload, keeping it byte-accurate with what reaches model prompts
- Three new regression tests added: tracked file secret redaction (sk-* pattern), untracked file secret redaction (gho_* pattern), and byte-count consistency

## Verify

- [ ] Run npx vitest run tests/core/ai/gate-context.test.ts — all 7 tests should pass including the three new redaction tests
- [ ] Run npx vitest run — all 1635 tests should pass
- [ ] Verify that buildLayeredCritiquePrompt receives [REDACTED] tokens in the diff section when secrets are present in changed files

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/60d94cc8-fcb5-49ca-ba78-e103f68ecaaa
2. npm install
3. npx vitest run tests/core/ai/gate-context.test.ts
4. npx vitest run

---
Spec: `context-human/specs/enhancement-layered-diff-convergence.md`
Closes #194