### PR TITLE
fix: wire convergence policy into implementation handlers so layered convergence runs

### DIFF
--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -53,7 +53,9 @@ import type { DirectModelRunRequest, DirectModelRunResult, DirectModelRunner, Ag
 import { ClaudeAgentSdkAgentRunner } from './anthropic/claude-agent-sdk-agent-runner.js';
 import { OpenAIAgentSdkAgentRunner } from './openai/agent-sdk-agent-runner.js';
 import { ImplementationReviewCoordinator } from '../core/ai/implementation-review-coordinator.js';
+import { resolveImplementationConvergencePolicy } from '../core/ai/layered-convergence-policy.js';
 import { SpecReviewCoordinator } from '../core/ai/spec-review-coordinator.js';
+import type { BudgetWriter } from '../core/journal/model-session-budget.js';
 import { createLogger } from '../core/logger.js';
 import { WorkspacePruner } from '../core/workspace-pruner.js';
 import { CommandConfirmationRegistryImpl } from '../core/command-confirmations.js';
@@ -157,13 +159,17 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
   const workspaceManager = new WorkspaceManagerImpl();
 
   let journal: RunJournal;
+  let budgetWriter: BudgetWriter;
   if (normalizedConfig.journal_enabled) {
     logger.info({ event: 'journal.writer_started' }, 'Journal enabled');
     const writer = new JsonlJournalWriter(workspaceRoot);
     journal = new RunJournal(writer);
+    budgetWriter = writer;
   } else {
     logger.info({ event: 'journal.disabled' }, 'Journal disabled');
-    journal = new RunJournal(new NoopJournalWriter());
+    const writer = new NoopJournalWriter();
+    journal = new RunJournal(writer);
+    budgetWriter = writer;
   }
 
   const runStore = new FileRunStore(workspaceRoot, {
@@ -203,6 +209,8 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     logger,
   });
 
+  const convergencePolicy = resolveImplementationConvergencePolicy(currentConfig.config);
+
   const specReviewCoordinator = new SpecReviewCoordinator({
     runner: agentRunner,
     artifactAuthoringAgent,
@@ -237,6 +245,8 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     channelRepoMap,
     reacjiComplete,
     reviewCoordinator,
+    convergencePolicy,
+    budgetWriter,
     specReviewCoordinator,
     threadPruner,
     workspacePruner,

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -20,6 +20,8 @@ import type { SpecCommitter } from './spec-committer.js';
 import { HandlerRegistryImpl, type HandlerRegistry } from './handler-registry.js';
 import { GitBranchGuard, type BranchGuard } from './git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
+import type { ResolvedImplementationConvergencePolicy } from './ai/layered-convergence-policy.js';
+import type { BudgetWriter } from './journal/model-session-budget.js';
 import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
 import { ArtifactCreationHandler } from './handlers/artifact-creation-handler.js';
 import { ArtifactApprovalHandler, type ArtifactApprovalResult } from './handlers/artifact-approval-handler.js';
@@ -98,6 +100,8 @@ export interface DefaultHandlerRegistryDeps {
   logger: Pick<pino.Logger, 'debug' | 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
   reviewCoordinator?: ImplementationReviewCoordinator;
+  convergencePolicy?: ResolvedImplementationConvergencePolicy;
+  budgetWriter?: BudgetWriter;
   specReviewCoordinator?: SpecReviewCoordinator;
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   workspacePruner?: Pick<WorkspacePruner, 'prune'>;
@@ -262,6 +266,8 @@ async function runImplementation(
     logger: deps.logger,
     branchGuard,
     reviewCoordinator: deps.reviewCoordinator,
+    convergencePolicy: deps.convergencePolicy,
+    budgetWriter: deps.budgetWriter,
     journal: deps.journal,
   });
   await handler.handle(run, feedback, additionalContext);
@@ -307,6 +313,8 @@ async function handleImplementationFeedback(
     logger: deps.logger,
     branchGuard,
     reviewCoordinator: deps.reviewCoordinator,
+    convergencePolicy: deps.convergencePolicy,
+    budgetWriter: deps.budgetWriter,
     journal: deps.journal,
   });
   await handler.handle(run, feedback, routingStage);
@@ -331,6 +339,8 @@ async function handleImplementationApproval(
     logger: deps.logger,
     branchGuard,
     reviewCoordinator: deps.reviewCoordinator,
+    convergencePolicy: deps.convergencePolicy,
+    budgetWriter: deps.budgetWriter,
     journal: deps.journal,
   });
   await handler.handle(run, feedback);

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -28,6 +28,8 @@ import type { HandlerRegistry } from './handler-registry.js';
 import { buildDefaultHandlerRegistry as buildDefaultHandlers } from './default-handler-registry.js';
 import type { BranchGuard } from './git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from './ai/implementation-review-coordinator.js';
+import type { ResolvedImplementationConvergencePolicy } from './ai/layered-convergence-policy.js';
+import type { BudgetWriter } from './journal/model-session-budget.js';
 import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
 import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
@@ -86,6 +88,8 @@ export interface OrchestratorDeps {
   handlerRegistry?: HandlerRegistry;
   branchGuard?: BranchGuard;
   reviewCoordinator?: ImplementationReviewCoordinator;
+  convergencePolicy?: ResolvedImplementationConvergencePolicy;
+  budgetWriter?: BudgetWriter;
   specReviewCoordinator?: SpecReviewCoordinator;
   validatePlanPath?: (workspacePath: string, planPath: string) => string;
   autoPruneWorkspace?: boolean;
@@ -636,6 +640,8 @@ export class OrchestratorImpl implements Orchestrator {
       logger: this.logger,
       branchGuard: this.deps.branchGuard,
       reviewCoordinator: this.deps.reviewCoordinator,
+      convergencePolicy: this.deps.convergencePolicy,
+      budgetWriter: this.deps.budgetWriter,
       specReviewCoordinator: this.deps.specReviewCoordinator,
       validatePlanPath: this.deps.validatePlanPath,
       autoPruneWorkspace: this.deps.autoPruneWorkspace,

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -4,7 +4,56 @@ import pino from 'pino';
 import { buildDefaultHandlerRegistry } from '../../src/core/default-handler-registry.js';
 import type { ThreadMessage, InboundEvent } from '../../src/types/events.js';
 import type { Run } from '../../src/types/runs.js';
+import type { ResolvedImplementationConvergencePolicy } from '../../src/core/ai/layered-convergence-policy.js';
 import { TEST_CHANNEL, TEST_CONVERSATION, TEST_ORIGIN, testChannelBinding } from '../helpers/channel-refs.js';
+
+// Capture the deps passed to each implementation handler's constructor so we can
+// assert that the registry forwards convergencePolicy (the layered-convergence wiring).
+// The factories delegate to the real implementations so existing behavior is unchanged.
+const handlerConstructorDeps = vi.hoisted(() => ({
+  start: [] as Array<{ convergencePolicy?: unknown; budgetWriter?: unknown }>,
+  feedback: [] as Array<{ convergencePolicy?: unknown; budgetWriter?: unknown }>,
+  approval: [] as Array<{ convergencePolicy?: unknown; budgetWriter?: unknown }>,
+}));
+
+vi.mock('../../src/core/handlers/implementation-start-handler.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/core/handlers/implementation-start-handler.js')>();
+  return {
+    ...actual,
+    ImplementationStartHandler: class extends actual.ImplementationStartHandler {
+      constructor(deps: ConstructorParameters<typeof actual.ImplementationStartHandler>[0]) {
+        handlerConstructorDeps.start.push(deps);
+        super(deps);
+      }
+    },
+  };
+});
+
+vi.mock('../../src/core/handlers/implementation-feedback-handler.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/core/handlers/implementation-feedback-handler.js')>();
+  return {
+    ...actual,
+    ImplementationFeedbackHandler: class extends actual.ImplementationFeedbackHandler {
+      constructor(deps: ConstructorParameters<typeof actual.ImplementationFeedbackHandler>[0]) {
+        handlerConstructorDeps.feedback.push(deps);
+        super(deps);
+      }
+    },
+  };
+});
+
+vi.mock('../../src/core/handlers/implementation-approval-handler.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/core/handlers/implementation-approval-handler.js')>();
+  return {
+    ...actual,
+    ImplementationApprovalHandler: class extends actual.ImplementationApprovalHandler {
+      constructor(deps: ConstructorParameters<typeof actual.ImplementationApprovalHandler>[0]) {
+        handlerConstructorDeps.approval.push(deps);
+        super(deps);
+      }
+    },
+  };
+});
 
 function makeFeedback(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
   return {
@@ -428,5 +477,66 @@ describe('buildDefaultHandlerRegistry', () => {
       '/ws/request-001/docs/superpowers/plans/implementation-plan.md',
     );
     expect(run.stage).toBe('reviewing_implementation');
+  });
+
+  // Regression guard: layered-diff convergence only runs when the registry forwards
+  // convergencePolicy into the implementation handlers. Before the wiring fix, the
+  // registry never passed convergencePolicy through, so it was always undefined at
+  // runtime and every run fell back to build-only review. These tests assert the
+  // dep actually reaches each handler's constructor; they FAIL against un-wired code.
+  describe('forwards convergencePolicy into implementation handlers', () => {
+    const convergencePolicy: ResolvedImplementationConvergencePolicy = {
+      enabled: true,
+      allow_same_model: false,
+      depth: 'full',
+      feedback_depth: 'full',
+      max_model_sessions_per_run: 24,
+    };
+    const budgetWriter = { append: vi.fn().mockResolvedValue(undefined) };
+
+    it('forwards convergencePolicy to the ImplementationStartHandler (start path)', async () => {
+      handlerConstructorDeps.start.length = 0;
+      const deps = { ...makeDeps(), convergencePolicy, budgetWriter };
+      const registry = buildDefaultHandlerRegistry(deps);
+      const run = makeRun();
+      const event: InboundEvent = { type: 'thread_message', payload: makeFeedback() };
+
+      const handler = registry.resolve({ event_type: 'thread_message', stage: 'reviewing_spec', intent: 'approval' });
+      await handler?.(event, run);
+
+      expect(handlerConstructorDeps.start.length).toBeGreaterThan(0);
+      expect(handlerConstructorDeps.start.at(-1)?.convergencePolicy).toBe(convergencePolicy);
+      expect(handlerConstructorDeps.start.at(-1)?.budgetWriter).toBe(budgetWriter);
+    });
+
+    it('forwards convergencePolicy to the ImplementationFeedbackHandler (feedback path)', async () => {
+      handlerConstructorDeps.feedback.length = 0;
+      const deps = { ...makeDeps(), convergencePolicy, budgetWriter };
+      const registry = buildDefaultHandlerRegistry(deps);
+      const run = makeRun({ stage: 'reviewing_implementation' });
+      const event: InboundEvent = { type: 'thread_message', payload: makeFeedback({ content: 'please change X' }) };
+
+      const handler = registry.resolve({ event_type: 'thread_message', stage: 'reviewing_implementation', intent: 'feedback' });
+      await handler?.(event, run);
+
+      expect(handlerConstructorDeps.feedback.length).toBeGreaterThan(0);
+      expect(handlerConstructorDeps.feedback.at(-1)?.convergencePolicy).toBe(convergencePolicy);
+      expect(handlerConstructorDeps.feedback.at(-1)?.budgetWriter).toBe(budgetWriter);
+    });
+
+    it('forwards convergencePolicy to the ImplementationApprovalHandler (approval path)', async () => {
+      handlerConstructorDeps.approval.length = 0;
+      const deps = { ...makeDeps(), convergencePolicy, budgetWriter };
+      const registry = buildDefaultHandlerRegistry(deps);
+      const run = makeRun({ stage: 'reviewing_implementation' });
+      const event: InboundEvent = { type: 'thread_message', payload: makeFeedback() };
+
+      const handler = registry.resolve({ event_type: 'thread_message', stage: 'reviewing_implementation', intent: 'approval' });
+      await handler?.(event, run);
+
+      expect(handlerConstructorDeps.approval.length).toBeGreaterThan(0);
+      expect(handlerConstructorDeps.approval.at(-1)?.convergencePolicy).toBe(convergencePolicy);
+      expect(handlerConstructorDeps.approval.at(-1)?.budgetWriter).toBe(budgetWriter);
+    });
   });
 });


### PR DESCRIPTION
## The bug (found by a live run, not the test suite)
Layered-diff convergence (#198) never ran in production, at any config. The implementation handlers gate the layered path on `this.deps.convergencePolicy`, but **nothing in production ever constructed or injected it** — `resolveImplementationConvergencePolicy()` was dead code, and the handler registry built the three implementation handlers without it. So `convergencePolicy` was always `undefined` → `policy?.enabled && policy.depth !== 'build_only'` always false → every run fell to build-only `runInitialReview`, regardless of `depth: full`. The model-session budget was dead for the same reason.

A live `depth: full` run confirmed it: the implementation review session journaled `gate: initial` (build-only) with **zero** `layout`/`public_api`/`private_api`/`build` altitude sessions. The 1632-green suite didn't catch it because tests inject `convergencePolicy` directly — nothing asserted the composition/registry wiring.

## Fix
Thread `convergencePolicy` (and `budgetWriter`) through the full composition chain (composition → orchestrator → registry → handlers):
- `runtime-composition.ts`: call `resolveImplementationConvergencePolicy(config)`, pass it + a `budgetWriter` (the journal writer) into the runtime deps.
- `orchestrator.ts`: forward both through `OrchestratorDeps` into the registry build.
- `default-handler-registry.ts`: add to the deps interface and inject into the start, feedback, and approval handler constructors.

## Regression guard
New `default-handler-registry` tests assert the constructed handlers actually receive the `convergencePolicy`/`budgetWriter` deps — confirmed to FAIL if the forwarding lines are removed (a handler unit test cannot catch a wiring gap; this asserts the wiring).

## Verification
- The bug-exposing grep now shows production callers: `resolveImplementationConvergencePolicy` called in composition; `convergencePolicy:` injected at registry + orchestrator.
- `npm run lint` clean; `npm test` 1638 passing (+ the new wiring tests).
- Static-verified; live `gate: layout` proof pending a restart + re-run.