### PR TITLE
feat: add authoring-phase api convergence and fix proposer/critic review init edge cases

### DIFF
--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -89,6 +89,8 @@ ai:
     implementation.review.final: grove-gpt-5.5-medium
     question.answer: grove-sonnet-4.6-low
     issue.triage: grove-sonnet-4.6-high
+    artifact.api.propose: grove-gpt-5.5-high
+    artifact.api.critique: grove-gpt-5.5-high
 implementation_review:
   max_initial_rounds: 1
   max_final_rounds: 1
@@ -97,6 +99,11 @@ spec_review:
   max_rounds: 1
   on_review_failure: warn
   template_conformance: true
+spec_authoring:
+  api_convergence:
+    enabled: false
+    max_rounds: 5
+    allow_same_model: false
 telemetry:
   metrics_endpoint: http://localhost:8428/opentelemetry/v1/metrics
   logs_endpoint: http://localhost:9428/insert/opentelemetry/v1/logs

--- a/context-human/specs/enhancement-authoring-api-convergence.md
+++ b/context-human/specs/enhancement-authoring-api-convergence.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-07
 last_updated: 2026-06-07
-status: implementing
+status: complete
 issue: 200
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/context-human/specs/enhancement-authoring-api-convergence.md
+++ b/context-human/specs/enhancement-authoring-api-convergence.md
@@ -1,0 +1,237 @@
+---
+created: 2026-06-07
+last_updated: 2026-06-07
+status: implementing
+issue: 200
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+# Enhancement: Authoring API convergence
+
+## Parent feature
+
+Primary parent feature:
+- `feature-idea-to-spec.md` — provides idea intake, `speccing`, mm:planning artifact authoring, human spec review, and feedback-driven spec revision.
+Related specs that this enhancement extends or supersedes:
+- `feature-approval-to-implementation.md` — provides the approved-spec to implementation lifecycle where the old implementation-phase altitude path currently runs.
+- `enhancement-bounded-convergence-review.md` — provides the bounded proposer/critic convergence loop, role-aware routing, same-model guard, `gate_exchanges`, and journal enrichment that this enhancement reuses for API convergence.
+- `enhancement-layered-diff-convergence.md` — introduced implementation-phase layout/public API/private API/build altitude passes. This enhancement supersedes the early implementation altitude passes by moving coarse API convergence into authoring.
+- `enhancement-spec-ai-review-pass.md` — provides the internal spec review coordinator pattern and reinforces that spec quality gates happen before human review.
+- `enhancement-append-only-backfill-journal.md` — provides durable `sessions.jsonl` and `feedback.jsonl` streams that this enhancement enriches with `gate: "api"`, role, and round metadata.
+- `enhancement-run-status-workspace-ai-context.md` — surfaces active model request metadata while artifact authoring and convergence agents run.
+- `enhancement-model-provider-config.md` and `feature-openai-agent-sdk-runner.md` — provide provider-neutral AI profiles, role-aware routing, and future provider compatibility.
+GitHub issue: [#200 — Move convergence to the authoring phase: adversarial API convergence before task decomposition](https://github.com/markdstafford/autocatalyst-v0/issues/200)
+## What
+
+Autocatalyst can optionally change `speccing` from one end-to-end mm:planning call into an orchestrated authoring sequence. When authoring API convergence is enabled for a run, Autocatalyst asks mm:planning to write the spec only through the tech-spec stage, runs a bounded adversarial proposer/critic loop over a structured API artifact, writes the converged API into the spec markdown between the tech spec and task decomposition, and then asks mm:planning to run only task decomposition while respecting the agreed API. When the feature is disabled, `speccing` remains exactly the current one-call flow through task decomposition.
+## Why
+
+The implementation-phase layered altitude experiment runs too late. The implementation agent creates a full task-list implementation in one autonomous pass, so layout and API gates can only review code that already exists. Moving convergence to authoring gives the implementation plan a reviewed API contract before decomposition starts, which lets human reviewers approve or challenge the API before any code is built. The v0 version is deliberately coarse: one full-API convergence gate, lenient on non-convergence, no micromanager skill edits, and no build conformance enforcement.
+## User stories
+
+- As Enzo, I can enable authoring-phase API convergence so the spec includes an adversarially reviewed API before task decomposition.
+- As Enzo, I can review the agreed API in the spec before approving implementation, instead of discovering API disagreements after code exists.
+- As Phoebe, I can leave the feature off and receive the same spec-generation behavior as today.
+- As an operator, I can configure the proposer and critic profiles separately and keep convergence off by default for safe rollout.
+- As an analytics agent, I can inspect `sessions.jsonl`, `feedback.jsonl`, and `gate_exchanges` to see API convergence rounds, roles, findings, and the model profiles used.
+- As an implementation agent, I receive a task list that was decomposed after the API surface was agreed, reducing guesswork during build.
+- As Enzo, I can trust that reaching the API round cap does not fail the run; the current API is folded into the spec and reviewed by the human.
+- As an operator, I can verify through integration tests that API convergence is actually wired into the `speccing` flow and injected through runtime composition.
+## Design changes
+
+This is a backend workflow enhancement. It does not add a new human UI, run stage, or primary interaction surface.
+Human-visible behavior changes only in the generated spec:
+- With authoring API convergence disabled, generated specs are unchanged.
+- With it enabled, generated specs include an `## Converged API` section after the tech spec and before the task list.
+- The final spec still moves to `reviewing_spec` through the existing publication flow.
+- Humans still approve or reject the full spec through the existing spec review surface.
+Progress updates should make the longer authoring flow understandable in Slack or any future human interface:
+```plain text
+Spec authoring started — drafting through tech spec
+Tech spec draft complete — starting API convergence
+API convergence round 1 started — proposer drafting API artifact
+API critic returned 2 findings — revising API artifact
+API convergence reached round cap — proceeding with current API
+Converged API folded into spec — decomposing tasks
+Task decomposition complete — publishing spec for review
+```
+Progress update failures are non-blocking and logged with `event: "progress_failed"`, `phase: "authoring_api_convergence"`, `run_id`, and the safe error string.
+## Technical changes
+
+### Affected files
+
+- `src/types/config.ts` — add authoring-phase API convergence configuration types under a new spec-authoring or artifact-authoring policy block.
+- `src/config/defaults.ts` and config normalization modules — resolve defaults with authoring API convergence disabled, max rounds default `5`, and same-model policy compatible with existing convergence behavior.
+- `src/types/ai.ts` — add structured API artifact types, API convergence result types, optional `ArtifactAuthoringAgent` method contracts, and `AgentTaskKind` route keys if new route tasks are introduced.
+- `src/core/ai/agent-services.ts` — split artifact creation prompts into full-spec, tech-spec-only, and task-decomposition-only variants; add API-specific propose, critique, and revise prompts; add structured API artifact parsing and markdown rendering helpers.
+- `src/core/ai/authoring-api-convergence-coordinator.ts` — add a coordinator that runs proposer/critic API convergence, persists `gate_exchanges`, journals sessions and findings, handles max-round leniency, and renders the agreed API.
+- `src/core/handlers/artifact-creation-handler.ts` — orchestrate the enabled `speccing` sequence for idea artifacts: tech-spec-only authoring, API convergence, spec mutation, task-decomposition-only authoring, branch guards, spec review, and publication.
+- `src/core/handlers/artifact-feedback-handler.ts` — keep current revision behavior unchanged for v0 and add stale generated API cleanup for pre-approval artifact feedback; feedback revisions must not rerun the authoring API convergence coordinator in v0.
+- `src/core/default-handler-registry.ts` — accept and inject the authoring API convergence coordinator into artifact creation only; v0 feedback handling must not receive or invoke the coordinator.
+- `src/adapters/runtime-composition.ts` and `src/core/runtime-composition.ts` — construct the coordinator from runtime dependencies and pass it into the default handler registry.
+- `src/core/ai/implementation-review-coordinator.ts` — stop using implementation-phase layered altitude orchestration for initial implementation while preserving build-level bounded review.
+- `src/core/handlers/implementation-start-handler.ts` — remove or disable the `runLayeredImplementation` path so initial implementation no longer runs layout/public API/private API altitude passes.
+- `src/core/ai/layered-convergence-policy.ts` — retire early implementation altitude depth selection or leave it unused behind compatibility helpers; keep build-level convergence policy intact.
+- `src/core/ai/gate-context.ts`, `src/core/ai/git-checkpoints.ts`, `src/core/ai/altitude-contract-validator.ts`, and `src/core/ai/build-contract-preservation.ts` — remove if clean after disabling implementation altitude passes, or leave as dead code only if removal creates unnecessary churn.
+- `src/core/journal/run-journal.ts`, `src/core/journal/model-session-budget.ts`, and `src/types/journal.ts` — ensure authoring API convergence sessions and critic findings are captured with `gate: "api"`, `role`, `round`, route/profile metadata, and critic principal attribution.
+- `tests/core/ai/agent-services.test.ts` — cover new prompts, parse recovery, API artifact schema validation, markdown rendering, and mm:planning stop/resume instructions.
+- `tests/core/ai/authoring-api-convergence-coordinator.test.ts` — cover convergence, max-round leniency, same-model guard, proposer/critic routing, parse failures, feedback capture, and markdown output.
+- `tests/core/handlers/artifact-creation-handler.test.ts` — cover disabled one-call behavior and enabled orchestration order.
+- `tests/adapters/runtime-composition.test.ts` or `tests/core/default-handler-registry.test.ts` — prove the convergence dependency is constructed and injected through runtime composition.
+- `tests/core/handlers/implementation-start-handler.test.ts` — prove implementation no longer calls `runLayeredImplementation` and still runs build-level initial review.
+- `tests/integration` or the nearest existing integration-style handler suite — add a wiring test that asserts proposer and critic are invoked inside `speccing` when enabled and the spec gains the API section.
+- `autocatalyst.yaml` — document optional disabled-by-default config and any role-specific routes needed by the repository's runtime profile set.
+### Changes
+
+#### 1. Prerequisites and assumptions
+
+- ADR-001 requires agent-first implementation and agent-queryable diagnostics.
+- ADR-002 places human-reviewed specs in `context-human/specs/` and agent-owned technical notes in `context-agent/`.
+- ADR-003 makes the Markdown spec the canonical artifact consumed by implementation.
+- ADR-004 and the handler-registry decision keep scheduling and route dispatch centralized outside individual handlers.
+- The existing artifact creation path already runs in `speccing`, writes a local spec file, runs branch guards, optionally runs spec review, publishes the artifact, and transitions to `reviewing_spec`.
+- The existing implementation review coordinator already has bounded proposer/critic convergence, same-model enforcement, role-aware routing, `gate_exchanges`, and journal feedback emission that can be reused or factored into a smaller shared helper.
+- No new database, external API endpoint, human UI, or run stage is required.
+- No micromanager skill files may be edited. mm:planning is controlled only through prompts.
+- The enabled design has two prompt-only mm:planning control assumptions, and both are load-bearing: first, mm:planning must stop after the tech-spec stage without decomposing tasks while still leaving a canonical empty top-level `## Task list` placeholder; second, mm:planning must later resume at task decomposition only without re-authoring requirements, design, or tech spec.
+- The first implementation step must be a tiny real-runner prompt spike that validates both boundaries and the required `## Task list` placeholder with the actual mm:planning runner before building the coordinator, artifact parser, config wiring, or runtime composition.
+- If either prompt-only boundary proves unreliable in the spike or later real execution, the implementer must stop and report the blocker rather than modifying mm:planning or continuing with coordinator work that depends on the assumption.
+#### 2. Configuration and rollout
+
+Add a disabled-by-default policy for authoring-phase API convergence. The exact nesting is the implementer's call, but it must not reuse `implementation_review.convergence.depth` because that field describes implementation review behavior. A clear v0 shape is:
+```yaml
+spec_authoring:
+  api_convergence:
+    enabled: false
+    max_rounds: 5
+    allow_same_model: false
+```
+Rules:
+- Missing `spec_authoring.api_convergence.enabled` means `false`.
+- Missing `max_rounds` means `5`.
+- `max_rounds` must be a positive integer.
+- Missing `allow_same_model` means `false`.
+- With `enabled: false`, `ArtifactCreationHandler` must call `artifactAuthoringAgent.create()` exactly as it does today for idea artifacts.
+- With `enabled: true`, only idea/feature-spec creation uses the new sequence. Bug triage, chore plans, issue filing, implementation planning, implementation, and final review keep their existing behavior unless explicitly noted below.
+- Role-specific routing should mirror existing convergence style. If new route tasks are added, use names that make the design phase clear, such as `artifact.api.propose` and `artifact.api.critique`. If existing `artifact.create` / `spec.review` route tasks are reused, the route must include `role: "proposer"` or `role: "critic"` and session capture must record the role.
+- Proposer and critic must resolve to distinct profile IDs unless `allow_same_model: true`.
+- The feature must be switchable per run through the resolved config available when `speccing` starts.
+Legacy implementation convergence depth after retiring issue 198:
+- Existing configs may still contain `implementation_review.convergence.depth: full`, `public_api`, `private_api`, or `layout`.
+- After this enhancement retires implementation-phase altitude passes, `depth` is a legacy compatibility field for early altitude selection only. It must not cause layout/public/private API gates to run.
+- The resolver must keep existing configs valid and degrade them to build-level convergence behavior. When `implementation_review.convergence.enabled` is true, build-level initial/final review still runs; when it is false, implementation review remains disabled as before.
+- Non-build `depth` values should be accepted but ignored for altitude orchestration and should emit a safe structured compatibility warning, such as `implementation_review.convergence.depth_ignored`, with the configured value and the effective behavior `build_only`. This avoids surprising silent no-ops while preserving backwards compatibility.
+- New documentation and config examples should stop presenting `depth` as an active control. If a schema field remains for compatibility, mark it deprecated/ignored.
+#### 3. Disabled flow compatibility
+
+The disabled path is a compatibility contract, not only a config default.
+When the feature is off:
+1. `ArtifactCreationHandler` transitions the run to `speccing`.
+2. It creates the workspace and branch exactly as today.
+3. It invokes `artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, telemetry)` once for idea artifacts.
+4. The generated prompt still says `Use the mm:planning skill to create a complete product spec` and allows mm:planning to run through task decomposition.
+5. Branch guard, spec review, publication, status update, and transition to `reviewing_spec` stay in the existing order.
+6. No API convergence coordinator is called.
+7. No `gate: "api"` sessions, findings, or `gate_exchanges` are written.
+Tests must assert the create-call count and arguments for the disabled path. If byte-for-byte prompt equality is practical, assert it. If not, assert the exact prompt builder output used by the disabled path is unchanged.
+#### 4. Enabled `speccing` lifecycle
+
+When the feature is on for an idea artifact, `speccing` becomes:
+```mermaid
+flowchart TD
+  Start[New idea request] --> Workspace[Create run workspace]
+  Workspace --> TechPrompt[mm:planning authoring call: requirements through tech spec only]
+  TechPrompt --> Guard1[Branch guard]
+  Guard1 --> ApiLoop[API convergence proposer/critic loop]
+  ApiLoop --> Fold[Render converged API into spec markdown]
+  Fold --> Decompose[mm:planning task-decomposition-only call]
+  Decompose --> Guard2[Branch guard]
+  Guard2 --> SpecReview[Existing spec AI review if configured]
+  SpecReview --> Guard3[Branch guard if review edited]
+  Guard3 --> Publish[Publish artifact]
+  Publish --> Reviewing[reviewing_spec]
+```
+Lifecycle rules:
+- The first mm:planning prompt must clearly say: author requirements, design if applicable, and tech spec; create a canonical empty top-level `## Task list` placeholder; stop after the tech spec; do not run task decomposition; write the normal result JSON only after the tech-spec-stage draft exists.
+- The first call still writes a valid spec file at the requested artifact path. It must contain the canonical `## Task list` heading as an empty placeholder, but it must not contain decomposed implementation tasks.
+- The API convergence loop reads the current spec file after the first branch guard.
+- The folded API markdown is inserted at top-level heading `## Converged API` between the tech spec and task list. The insertion helper must find the first top-level `## Task list` heading and insert the generated API section immediately before it. Missing `## Task list` is fatal for v0 because there is no safe, template-conformant insertion point; the helper must fail clearly before task decomposition resumes rather than appending the section heuristically.
+- The second mm:planning prompt must clearly say: run only the task-decomposition stage on the existing spec, preserve the existing requirements/design/tech/converged API sections, respect the agreed API surface, and write the result JSON after tasks are added.
+- The second call must not re-run requirements, design, or tech spec from scratch except for minimal edits needed to make the task list consistent with the converged API.
+- Existing spec review still runs after branch guard and before publication.
+- Any branch drift fails the run using the current branch guard behavior.
+Safe insertion algorithm:
+1. Parse the spec as Markdown headings, ignoring fenced code blocks.
+2. If an existing generated top-level `## Converged API` section is present, remove that section through the next top-level `##` heading before inserting the replacement.
+3. Find the first top-level heading whose normalized text is exactly `Task list`. This canonical `## Task list` heading is the only acceptable insertion point for v0.
+4. Insert the rendered `## Converged API` section immediately before that task-list heading.
+5. If no canonical task-list heading exists, abort with an actionable error that says the spec is missing the required `## Task list` insertion point. The missing heading is not recoverable by appending after the tech spec because that can break the canonical mm:planning template order.
+#### 4.1 Artifact feedback handling in v0
+
+Feedback-driven spec revision remains intentionally conservative in v0:
+- `ArtifactFeedbackHandler` must not rerun the authoring API convergence coordinator during human feedback revisions, even when `spec_authoring.api_convergence.enabled` is true.
+- Before asking mm:planning to revise a pre-approval spec in response to artifact feedback, the handler must remove any existing generated top-level `## Converged API` section from the draft. This avoids preserving an API contract that may have been invalidated by human feedback to requirements, design, or tech spec.
+- The feedback revision prompt should tell mm:planning that any prior generated API convergence section was removed because feedback may invalidate it, and that it should revise the spec using the normal feedback path rather than inventing a replacement `## Converged API` section.
+- If a future configured reconvergence mode is added, it must be specified separately. This v0 enhancement does not include it.
+- The cleanup must use the same fenced-code-aware heading parser as the insertion helper and must remove only the generated top-level `## Converged API` section through the next top-level `##` heading.
+- Emit a safe structured warning or telemetry event, for example `artifact.api_convergence.stale_section_removed`, with `run_id`, `request_id`, and no raw prompt or secret-bearing content.
+#### 5. Structured API artifact
+
+The proposer emits an intermediate structured API artifact. Keep the schema coarse and parseable:
+```typescript
+export interface ConvergedApiArtifact {
+  files: Array;
+  public_api: Array;
+    returns: string;
+    errors: string[];
+  }>;
+  types: Array;
+  notes: string;
+}
+```
+Validation rules:
+- `files`, `public_api`, and `types` must be arrays. Empty arrays are valid only when the spec truly has no code-facing API changes, and the proposer must explain that in `notes`.
+- File paths must be repository-relative POSIX paths.
+- `symbol`, `signature`, `returns`, `name`, and `shape` must be non-empty strings where applicable.
+- `errors` must be an array of strings. Use `[]` when no error contract is expected.
+- Unknown fields are ignored for forward compatibility.
+- Invalid JSON or invalid shape consumes one API artifact attempt and causes a proposer-revision round when budget remains. It should not silently fold malformed data into the spec.
+The final committed form is Markdown, not JSON. Render the artifact as:
+```javascript
+[section begins with the literal heading: ## Converged API]
+
+### Files
+
+| Path | Purpose | Exports |
+|---|---|---|
+| `src/example.ts` | ... | `symbolA`, `TypeB` |
+
+### Public API
+
+#### `symbolA`
+
+```
+export function symbolA(input: Input): Result
+```javascript
+
+- Parameters:
+  - `input: Input` — ...
+- Returns: `Result`
+- Errors:
+  - `ConfigError` when ...
+
+### Types
+
+#### `TypeB`
+
+```
+type TypeB = ...
+```javascript
+
+### Notes
+
+...
+```
+- [ ] Any skipped provider/integration tests are documented with exact reason.
+- **Dependencies**: "Task: Add speccing integration coverage", "Task: Clean up or quarantine dead layered modules"

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -8,7 +8,7 @@ import { App } from '@slack/bolt';
 import Anthropic from '@anthropic-ai/sdk';
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { loadConfigFromPath, repoNameFromUrl, resolveEnvVars, resolveAiConfig, getImplementationReviewPolicy, getSpecReviewPolicy, type ResolvedAiConfig } from '../core/config.js';
+import { loadConfigFromPath, repoNameFromUrl, resolveEnvVars, resolveAiConfig, getImplementationReviewPolicy, getSpecReviewPolicy, getSpecAuthoringPolicy, type ResolvedAiConfig } from '../core/config.js';
 import { bootstrapWorkflowRuntime } from '../core/bootstrap.js';
 import { normalizeWorkflowConfig } from '../core/config-normalizer.js';
 import { configExists, runInit } from '../core/init.js';
@@ -55,6 +55,7 @@ import { OpenAIAgentSdkAgentRunner } from './openai/agent-sdk-agent-runner.js';
 import { ImplementationReviewCoordinator } from '../core/ai/implementation-review-coordinator.js';
 import { resolveImplementationConvergencePolicy } from '../core/ai/layered-convergence-policy.js';
 import { SpecReviewCoordinator } from '../core/ai/spec-review-coordinator.js';
+import { AuthoringApiConvergenceCoordinator } from '../core/ai/authoring-api-convergence-coordinator.js';
 import type { BudgetWriter } from '../core/journal/model-session-budget.js';
 import { createLogger } from '../core/logger.js';
 import { WorkspacePruner } from '../core/workspace-pruner.js';
@@ -219,6 +220,14 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     logger,
   });
 
+  const specAuthoringPolicy = getSpecAuthoringPolicy(currentConfig.config);
+  const authoringApiConvergenceCoordinator = new AuthoringApiConvergenceCoordinator({
+    runner: agentRunner,
+    routingPolicy: aiRoutingPolicy,
+    policy: specAuthoringPolicy.api_convergence,
+    logger,
+  });
+
   const threadPruner = new SlackThreadPruner(boltApp);
   const workspacePruner = new WorkspacePruner();
   const pruneLogger = createLogger('prune-commands');
@@ -248,6 +257,8 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     convergencePolicy,
     budgetWriter,
     specReviewCoordinator,
+    specAuthoringPolicy,
+    authoringApiConvergenceCoordinator,
     threadPruner,
     workspacePruner,
     confirmationRegistry,

--- a/src/adapters/runtime-composition.ts
+++ b/src/adapters/runtime-composition.ts
@@ -210,7 +210,10 @@ export async function composeBuiltInWorkflowRuntime(options: ComposeWorkflowRunt
     logger,
   });
 
-  const convergencePolicy = resolveImplementationConvergencePolicy(currentConfig.config);
+  const convergencePolicy = resolveImplementationConvergencePolicy(
+    currentConfig.config,
+    warning => logger.warn(warning, 'Ignoring legacy implementation convergence depth'),
+  );
 
   const specReviewCoordinator = new SpecReviewCoordinator({
     runner: agentRunner,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -98,11 +98,19 @@ ai:
     implementation.review.final: review-agent
     question.answer: question-agent
     issue.triage: triage-agent
+    artifact.api.propose: artifact-agent
+    artifact.api.critique: review-agent
 
 spec_review:
   max_rounds: 1
   on_review_failure: warn
   template_conformance: true
+
+spec_authoring:
+  api_convergence:
+    enabled: false
+    max_rounds: 5
+    allow_same_model: false
 
 sandbox:
   env_tokens:

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -242,6 +242,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
       reviseResultPath,
       currentArtifact,
       hasAnchors ? this.commentAnchorCodec?.promptInstructions(originalAnchors) ?? [] : [],
+      telemetry?.staleConvergedApiRemoved,
     );
 
     this.logger.debug(
@@ -1514,13 +1515,14 @@ function buildArtifactCreatePrompt(
   ].join('\n');
 }
 
-function buildArtifactRevisePrompt(
+export function buildArtifactRevisePrompt(
   feedback: ThreadMessage,
   artifact_comments: ArtifactComment[],
   artifact_path: string,
   reviseResultPath: string,
   currentArtifact: string,
   anchorInstructions: string[],
+  staleConvergedApiRemoved?: boolean,
 ): string {
   const commentSection = artifact_comments.length > 0
     ? [
@@ -1538,6 +1540,14 @@ function buildArtifactRevisePrompt(
     ? [``, `Use an empty array for comment_responses since there are no publisher comments.`]
     : [];
   const anchorInstructionLines = anchorInstructions.length > 0 ? [``, ...anchorInstructions] : [];
+  const staleApiNote = staleConvergedApiRemoved
+    ? [
+        ``,
+        `Note: A previously generated \`## Converged API\` section was removed from the draft because`,
+        `human feedback may have invalidated the agreed API contract. Revise the spec using the normal`,
+        `feedback path. Do not invent or recreate a \`## Converged API\` section.`,
+      ]
+    : [];
 
   return [
     `Revise the artifact below based on the following feedback.`,
@@ -1553,6 +1563,7 @@ function buildArtifactRevisePrompt(
     ...noCommentNote,
     `Do not signal completion until the result file has been written.`,
     ...anchorInstructionLines,
+    ...staleApiNote,
     ``,
     `Channel message:`,
     `<<<`,

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -21,6 +21,7 @@ import type {
   ArtifactCommentResponse,
   ArtifactCreateResult,
   ArtifactRevisionResult,
+  ConvergedApiArtifact,
   ImplementationAgent,
   ImplementationPlanResult,
   ImplementationPlanningAgent,
@@ -399,6 +400,127 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     }
 
     return parsed;
+  }
+
+  async createTechSpecDraft(
+    request: Request,
+    workspace_path: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: AgentServiceTelemetry,
+  ): Promise<ArtifactCreateResult> {
+    const createResultPath = join(workspace_path, '.autocatalyst', 'spec-create-result.json');
+    const artifactDir = join(workspace_path, 'context-human', 'specs');
+    const route: AgentRoute = {
+      task: 'artifact.create' as const,
+      stage: 'new_thread' as const,
+      intent: 'idea',
+      artifact_kind: 'feature_spec',
+    };
+    const prompt = buildArtifactTechSpecDraftPrompt(request, artifactDir, createResultPath);
+
+    this.logger.debug({ event: 'artifact.tech_spec_draft.started', request_id: request.id }, 'Invoking agent for tech spec draft');
+
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
+    const progressWithHeartbeat = onProgress && telemetry?.onAgentRequest
+      ? async (msg: string) => { notifyAgentRequest(telemetry, profile, route, true); return onProgress(msg); }
+      : onProgress;
+
+    const ts_start = new Date().toISOString();
+    let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
+    try {
+      await ensureResultDir(createResultPath);
+      drainSummary = await drainAgentRunner(
+        this.runner.run({ route, profile, working_directory: workspace_path, prompt, telemetry: { request_id: request.id, phase: 'artifact_generation', route_task: route.task, handler: 'AgentRunnerArtifactAuthoringAgent', ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}) } }),
+        progressWithHeartbeat,
+        this.logger,
+        'artifact_generation',
+        { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
+      );
+    } catch (err) {
+      sessionOutcome = 'failed';
+      this.logger.error({ event: 'artifact.tech_spec_draft.failed', request_id: request.id, error: String(err) }, 'Agent failed during tech spec draft');
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
+      throw new Error(`Tech spec draft failed: ${String(err)}`);
+    }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
+
+    const content = await validateRequiredResultFile({
+      readFileFn: this.readFileFn,
+      path: createResultPath,
+      label: 'Tech spec draft',
+      logger: this.logger,
+      phase: 'artifact_generation',
+      route_task: 'artifact.create',
+      request_id: request.id,
+      run_id: telemetry?.run_id,
+      drainSummary,
+    });
+    const result = parseArtifactCreateResult(content, createResultPath);
+    this.logger.info({ event: 'artifact.tech_spec_draft.complete', request_id: request.id, artifact_path: result.artifact_path }, 'Tech spec draft complete');
+    return result;
+  }
+
+  async decomposeTasks(
+    artifact_path: string,
+    workspace_path: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: AgentServiceTelemetry,
+  ): Promise<ArtifactCreateResult> {
+    const createResultPath = join(workspace_path, '.autocatalyst', 'spec-create-result.json');
+    const route: AgentRoute = {
+      task: 'artifact.create' as const,
+      stage: 'new_thread' as const,
+      intent: 'idea',
+      artifact_kind: 'feature_spec',
+    };
+    const prompt = buildArtifactTaskDecompositionPrompt(artifact_path, createResultPath);
+
+    this.logger.debug({ event: 'artifact.task_decomposition.started' }, 'Invoking agent for task decomposition');
+
+    const profile = this.routingPolicy.resolve(route);
+    notifyAgentRequest(telemetry, profile, route);
+
+    const progressWithHeartbeat = onProgress && telemetry?.onAgentRequest
+      ? async (msg: string) => { notifyAgentRequest(telemetry, profile, route, true); return onProgress(msg); }
+      : onProgress;
+
+    const ts_start = new Date().toISOString();
+    let drainSummary: AgentDrainSummary | undefined;
+    let sessionOutcome: 'ok' | 'failed' | 'incomplete' = 'ok';
+    try {
+      await ensureResultDir(createResultPath);
+      drainSummary = await drainAgentRunner(
+        this.runner.run({ route, profile, working_directory: workspace_path, prompt, telemetry: { phase: 'artifact_generation', route_task: route.task, handler: 'AgentRunnerArtifactAuthoringAgent', ...(telemetry?.run_id ? { run_id: telemetry.run_id } : {}), ...(telemetry?.request_id ? { request_id: telemetry.request_id } : {}) } }),
+        progressWithHeartbeat,
+        this.logger,
+        'artifact_generation',
+        { run_id: telemetry?.run_id, request_id: telemetry?.request_id },
+      );
+    } catch (err) {
+      sessionOutcome = 'failed';
+      this.logger.error({ event: 'artifact.task_decomposition.failed', error: String(err) }, 'Agent failed during task decomposition');
+      emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
+      throw new Error(`Task decomposition failed: ${String(err)}`);
+    }
+    emitSessionRecord(telemetry, profile, route, ts_start, sessionOutcome, drainSummary);
+
+    const content = await validateRequiredResultFile({
+      readFileFn: this.readFileFn,
+      path: createResultPath,
+      label: 'Task decomposition',
+      logger: this.logger,
+      phase: 'artifact_generation',
+      route_task: 'artifact.create',
+      request_id: telemetry?.request_id,
+      run_id: telemetry?.run_id,
+      drainSummary,
+    });
+    const result = parseArtifactCreateResult(content, createResultPath);
+    this.logger.info({ event: 'artifact.task_decomposition.complete', artifact_path: result.artifact_path }, 'Task decomposition complete');
+    return result;
   }
 }
 
@@ -1442,6 +1564,204 @@ function buildArtifactRevisePrompt(
     `<<<`,
     currentArtifact,
     `>>>`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildArtifactTechSpecDraftPrompt(
+  request: Request,
+  artifactDir: string,
+  createResultPath: string,
+): string {
+  return [
+    `Use the \`mm:planning\` skill to create a product spec for the following request, but stop after requirements/design/tech spec.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    MM_PLANNING_BRANCH_OVERRIDE,
+    ``,
+    `Create a canonical empty top-level \`## Task list\` placeholder.`,
+    `Do not decompose implementation tasks.`,
+    ``,
+    `Request:`,
+    `<<<`,
+    request.content,
+    `>>>`,
+    ``,
+    `When the tech spec draft is complete:`,
+    `- Write the spec file to: ${artifactDir}`,
+    `  Use "feature-<slug>.md" for new standalone functionality, "enhancement-<slug>.md" for improvements.`,
+    `- Write the result to: ${createResultPath}`,
+    `  Content must be: { "artifact_path": "<absolute path to the spec file you wrote>" }`,
+    ``,
+    `Write the normal result JSON only after the tech-spec-stage draft exists.`,
+    `Do not signal completion until both files have been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildArtifactTaskDecompositionPrompt(
+  artifactPath: string,
+  createResultPath: string,
+): string {
+  return [
+    `Use the \`mm:planning\` skill to run only the task-decomposition stage on the existing spec.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    MM_PLANNING_BRANCH_OVERRIDE,
+    ``,
+    `Preserve the existing requirements, design, tech spec, and \`## Converged API\` sections.`,
+    `Respect the agreed API surface.`,
+    ``,
+    `Existing spec: ${artifactPath}`,
+    ``,
+    `When task decomposition is complete:`,
+    `- Update the spec at: ${artifactPath}`,
+    `- Write the result to: ${createResultPath}`,
+    `  Content must be: { "artifact_path": "${artifactPath}" }`,
+    ``,
+    `Write the normal result JSON only after tasks are added.`,
+    `Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildAuthoringApiProposePrompt(
+  specMarkdown: string,
+  artifactResultPath: string,
+  round: number,
+): string {
+  return [
+    `You are an API proposer. Review the spec below and produce a structured API artifact in JSON.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    `Round: ${round}`,
+    ``,
+    `The JSON artifact must follow this schema:`,
+    `{`,
+    `  "files": [{ "path": "src/...", "purpose": "...", "exports": ["SymbolA"] }],`,
+    `  "public_api": [{`,
+    `    "symbol": "SymbolA",`,
+    `    "signature": "export function SymbolA(...): ...",`,
+    `    "parameters": [{ "name": "x", "type": "T", "description": "..." }],`,
+    `    "returns": "ReturnType",`,
+    `    "errors": ["ErrorX when ..."]`,
+    `  }],`,
+    `  "types": [{ "name": "T", "shape": "interface T { ... }", "description": "..." }],`,
+    `  "notes": "Explanation if files/public_api/types are empty."`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- files, public_api, and types must be arrays. Empty arrays are valid only when the spec truly has no code-facing API changes; explain in notes.`,
+    `- File paths must be repository-relative POSIX paths (no leading /, no ..).`,
+    `- symbol, signature, returns, name, and shape must be non-empty strings.`,
+    `- errors must be an array of strings. Use [] when no error contract is expected.`,
+    ``,
+    `Spec:`,
+    `<<<`,
+    specMarkdown,
+    `>>>`,
+    ``,
+    `Write the artifact to: ${artifactResultPath}`,
+    `Do not signal completion until the artifact file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildAuthoringApiCritiquePrompt(
+  specMarkdown: string,
+  artifact: ConvergedApiArtifact,
+  reviewResultPath: string,
+  round: number,
+): string {
+  return [
+    `You are an adversarial API critic. Review the proposed API artifact against the spec below and return structured findings.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    `Round: ${round}`,
+    ``,
+    `Proposed API artifact:`,
+    `<<<`,
+    JSON.stringify(artifact, null, 2),
+    `>>>`,
+    ``,
+    `Spec:`,
+    `<<<`,
+    specMarkdown,
+    `>>>`,
+    ``,
+    `Write the critique result to: ${reviewResultPath}`,
+    `Content must be:`,
+    `{`,
+    `  "status": "no_findings" | "findings" | "failed",`,
+    `  "summary": "1-2 sentence summary",`,
+    `  "findings": [`,
+    `    {`,
+    `      "id": "API-1",`,
+    `      "severity": "blocker" | "warning" | "info",`,
+    `      "category": "correctness" | "maintainability" | "security" | "docs" | "test" | "pr_readiness",`,
+    `      "finding": "concise description",`,
+    `      "suggested_action": "optional action"`,
+    `    }`,
+    `  ],`,
+    `  "error": "only when status is failed"`,
+    `}`,
+    ``,
+    `Rules:`,
+    `- Use sequential IDs: API-1, API-2, etc.`,
+    `- If no issues found, use status: "no_findings" with empty findings array.`,
+    `- Do not signal completion until the result file has been written.`,
+    ``,
+    CHECKPOINT_INSTRUCTIONS,
+  ].join('\n');
+}
+
+export function buildAuthoringApiRevisePrompt(
+  specMarkdown: string,
+  artifact: ConvergedApiArtifact,
+  findings: ImplementationReviewFinding[],
+  artifactResultPath: string,
+  round: number,
+): string {
+  const findingBlocks = findings.map(f => [
+    `[API_FINDING_ID: ${f.id}]`,
+    `Severity: ${f.severity}`,
+    `Category: ${f.category}`,
+    `Finding: ${f.finding}`,
+    ...(f.suggested_action ? [`Suggested action: ${f.suggested_action}`] : []),
+  ].join('\n'));
+
+  return [
+    `You are an API proposer. The critic returned findings on your API artifact. Revise it to address the findings.`,
+    ``,
+    BRANCH_OWNERSHIP_POLICY,
+    ``,
+    `Round: ${round}`,
+    ``,
+    `Current API artifact:`,
+    `<<<`,
+    JSON.stringify(artifact, null, 2),
+    `>>>`,
+    ``,
+    `Critic findings:`,
+    ``,
+    findingBlocks.join('\n\n'),
+    ``,
+    `Spec:`,
+    `<<<`,
+    specMarkdown,
+    `>>>`,
+    ``,
+    `Write the revised artifact to: ${artifactResultPath}`,
+    `The artifact must follow the same JSON schema as before.`,
+    `Do not signal completion until the artifact file has been written.`,
     ``,
     CHECKPOINT_INSTRUCTIONS,
   ].join('\n');

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -223,6 +223,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     current_page_markdown?: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
+    options?: { staleConvergedApiRemoved?: boolean },
   ): Promise<ArtifactRevisionResult> {
     const reviseResultPath = join(workspace_path, '.autocatalyst', 'spec-revise-result.json');
     const originalAnchors = current_page_markdown && this.commentAnchorCodec
@@ -242,6 +243,7 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
       reviseResultPath,
       currentArtifact,
       hasAnchors ? this.commentAnchorCodec?.promptInstructions(originalAnchors) ?? [] : [],
+      options,
     );
 
     this.logger.debug(
@@ -1521,6 +1523,7 @@ function buildArtifactRevisePrompt(
   reviseResultPath: string,
   currentArtifact: string,
   anchorInstructions: string[],
+  options?: { staleConvergedApiRemoved?: boolean },
 ): string {
   const commentSection = artifact_comments.length > 0
     ? [
@@ -1538,6 +1541,12 @@ function buildArtifactRevisePrompt(
     ? [``, `Use an empty array for comment_responses since there are no publisher comments.`]
     : [];
   const anchorInstructionLines = anchorInstructions.length > 0 ? [``, ...anchorInstructions] : [];
+  const staleApiNote = options?.staleConvergedApiRemoved
+    ? [
+        ``,
+        `A prior generated \`## Converged API\` section was removed before this revision because human feedback may invalidate it. Use the normal feedback revision path. Do not invent a replacement \`## Converged API\` section.`,
+      ]
+    : [];
 
   return [
     `Revise the artifact below based on the following feedback.`,
@@ -1553,6 +1562,7 @@ function buildArtifactRevisePrompt(
     ...noCommentNote,
     `Do not signal completion until the result file has been written.`,
     ...anchorInstructionLines,
+    ...staleApiNote,
     ``,
     `Channel message:`,
     `<<<`,

--- a/src/core/ai/agent-services.ts
+++ b/src/core/ai/agent-services.ts
@@ -223,7 +223,6 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
     current_page_markdown?: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
-    options?: { staleConvergedApiRemoved?: boolean },
   ): Promise<ArtifactRevisionResult> {
     const reviseResultPath = join(workspace_path, '.autocatalyst', 'spec-revise-result.json');
     const originalAnchors = current_page_markdown && this.commentAnchorCodec
@@ -243,7 +242,6 @@ export class AgentRunnerArtifactAuthoringAgent implements ArtifactAuthoringAgent
       reviseResultPath,
       currentArtifact,
       hasAnchors ? this.commentAnchorCodec?.promptInstructions(originalAnchors) ?? [] : [],
-      options,
     );
 
     this.logger.debug(
@@ -1523,7 +1521,6 @@ function buildArtifactRevisePrompt(
   reviseResultPath: string,
   currentArtifact: string,
   anchorInstructions: string[],
-  options?: { staleConvergedApiRemoved?: boolean },
 ): string {
   const commentSection = artifact_comments.length > 0
     ? [
@@ -1541,12 +1538,6 @@ function buildArtifactRevisePrompt(
     ? [``, `Use an empty array for comment_responses since there are no publisher comments.`]
     : [];
   const anchorInstructionLines = anchorInstructions.length > 0 ? [``, ...anchorInstructions] : [];
-  const staleApiNote = options?.staleConvergedApiRemoved
-    ? [
-        ``,
-        `A prior generated \`## Converged API\` section was removed before this revision because human feedback may invalidate it. Use the normal feedback revision path. Do not invent a replacement \`## Converged API\` section.`,
-      ]
-    : [];
 
   return [
     `Revise the artifact below based on the following feedback.`,
@@ -1562,7 +1553,6 @@ function buildArtifactRevisePrompt(
     ...noCommentNote,
     `Do not signal completion until the result file has been written.`,
     ...anchorInstructionLines,
-    ...staleApiNote,
     ``,
     `Channel message:`,
     `<<<`,

--- a/src/core/ai/authoring-api-artifact.ts
+++ b/src/core/ai/authoring-api-artifact.ts
@@ -1,0 +1,278 @@
+import type { ConvergedApiArtifact, ConvergedApiFile, ConvergedApiPublicItem, ConvergedApiTypeItem } from '../../types/ai.js';
+
+export function parseConvergedApiArtifact(content: string, path: string): ConvergedApiArtifact {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(content);
+  } catch (err) {
+    throw new Error(`Converged API artifact at "${path}" is not valid JSON: ${String(err)}`);
+  }
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(`Converged API artifact at "${path}" is not valid JSON: not an object`);
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (!Array.isArray(obj['files'])) {
+    throw new Error(`Converged API artifact at "${path}": files must be an array`);
+  }
+  if (!Array.isArray(obj['public_api'])) {
+    throw new Error(`Converged API artifact at "${path}": public_api must be an array`);
+  }
+  if (!Array.isArray(obj['types'])) {
+    throw new Error(`Converged API artifact at "${path}": types must be an array`);
+  }
+
+  const files: ConvergedApiFile[] = (obj['files'] as unknown[]).map((f, i) => {
+    if (typeof f !== 'object' || f === null || Array.isArray(f)) {
+      throw new Error(`Converged API artifact at "${path}": files[${i}] must be an object`);
+    }
+    const fe = f as Record<string, unknown>;
+    const fp = fe['path'];
+    if (typeof fp !== 'string' || fp === '') {
+      throw new Error(`Converged API artifact at "${path}": file path must be a relative POSIX path: "${fp}"`);
+    }
+    if (fp.startsWith('/') || fp.includes('\\') || fp.split('/').some((seg) => seg === '..')) {
+      throw new Error(`Converged API artifact at "${path}": file path must be a relative POSIX path: "${fp}"`);
+    }
+    const purpose = typeof fe['purpose'] === 'string' ? fe['purpose'] : '';
+    const exports = Array.isArray(fe['exports']) ? (fe['exports'] as unknown[]).map(String) : [];
+    return { path: fp, purpose, exports };
+  });
+
+  const public_api: ConvergedApiPublicItem[] = (obj['public_api'] as unknown[]).map((item, i) => {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+      throw new Error(`Converged API artifact at "${path}": public_api[${i}] must be an object`);
+    }
+    const pe = item as Record<string, unknown>;
+    const symbol = typeof pe['symbol'] === 'string' && pe['symbol'] !== '' ? pe['symbol'] : '';
+    const signature = typeof pe['signature'] === 'string' && pe['signature'] !== '' ? pe['signature'] : '';
+    const returns = typeof pe['returns'] === 'string' ? pe['returns'] : '';
+    const errors = Array.isArray(pe['errors']) ? (pe['errors'] as unknown[]).map(String) : [];
+    const notes = typeof pe['notes'] === 'string' ? pe['notes'] : '';
+    const parameters = Array.isArray(pe['parameters'])
+      ? (pe['parameters'] as unknown[]).map((p) => {
+          if (typeof p !== 'object' || p === null || Array.isArray(p)) {
+            return { name: '', type: '', description: '' };
+          }
+          const pr = p as Record<string, unknown>;
+          return {
+            name: typeof pr['name'] === 'string' ? pr['name'] : '',
+            type: typeof pr['type'] === 'string' ? pr['type'] : '',
+            description: typeof pr['description'] === 'string' ? pr['description'] : '',
+          };
+        })
+      : [];
+    void notes; // notes field not in ConvergedApiPublicItem
+    return { symbol, signature, parameters, returns, errors };
+  });
+
+  const types: ConvergedApiTypeItem[] = (obj['types'] as unknown[]).map((item, i) => {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+      throw new Error(`Converged API artifact at "${path}": types[${i}] must be an object`);
+    }
+    const te = item as Record<string, unknown>;
+    const name = typeof te['name'] === 'string' ? te['name'] : '';
+    const shape = typeof te['shape'] === 'string' ? te['shape'] : '';
+    const description = typeof te['description'] === 'string' ? te['description'] : '';
+    return { name, shape, description };
+  });
+
+  const notes = typeof obj['notes'] === 'string' ? obj['notes'] : '';
+
+  return { files, public_api, types, notes };
+}
+
+export function renderConvergedApiMarkdown(artifact: ConvergedApiArtifact): string {
+  const lines: string[] = [];
+
+  lines.push('## Converged API');
+  lines.push('');
+
+  // Files table
+  lines.push('### Files');
+  lines.push('');
+  lines.push('| Path | Purpose | Exports |');
+  lines.push('|---|---|---|');
+  for (const file of artifact.files) {
+    const exportsStr = file.exports.map((e) => `\`${e}\``).join(', ');
+    lines.push(`| \`${file.path}\` | ${file.purpose} | ${exportsStr} |`);
+  }
+  lines.push('');
+
+  // Public API
+  if (artifact.public_api.length === 0) {
+    lines.push('### Public API');
+    lines.push('');
+    lines.push('_No public API changes._');
+    lines.push('');
+  } else {
+    lines.push('### Public API');
+    lines.push('');
+    for (const item of artifact.public_api) {
+      lines.push(`#### \`${item.symbol}\``);
+      lines.push('');
+      lines.push('```ts');
+      lines.push(item.signature);
+      lines.push('```');
+      lines.push('');
+      if (item.parameters.length > 0) {
+        lines.push('- Parameters:');
+        for (const param of item.parameters) {
+          lines.push(`  - \`${param.name}: ${param.type}\` — ${param.description}`);
+        }
+      }
+      lines.push(`- Returns: \`${item.returns}\``);
+      if (item.errors.length > 0) {
+        lines.push('- Errors:');
+        for (const err of item.errors) {
+          lines.push(`  - \`${err}\``);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  // Types
+  if (artifact.types.length === 0) {
+    lines.push('### Types');
+    lines.push('');
+    lines.push('_No type changes._');
+    lines.push('');
+  } else {
+    lines.push('### Types');
+    lines.push('');
+    for (const type of artifact.types) {
+      lines.push(`#### \`${type.name}\``);
+      lines.push('');
+      lines.push('```ts');
+      lines.push(type.shape);
+      lines.push('```');
+      lines.push('');
+    }
+  }
+
+  // Notes
+  lines.push('### Notes');
+  lines.push('');
+  lines.push(artifact.notes);
+
+  return lines.join('\n');
+}
+
+interface ParsedHeading {
+  lineIndex: number;
+  level: number;
+  text: string;
+  normalizedText: string;
+}
+
+function parseTopLevelHeadings(markdown: string): ParsedHeading[] {
+  const sourceLines = markdown.split('\n');
+  const headings: ParsedHeading[] = [];
+  let inFence = false;
+
+  for (let i = 0; i < sourceLines.length; i++) {
+    const line = sourceLines[i]!;
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (match) {
+      const level = match[1]!.length;
+      const text = match[2]!;
+      const normalizedText = text.trim().replace(/\s+/g, ' ').toLowerCase();
+      headings.push({ lineIndex: i, level, text, normalizedText });
+    }
+  }
+
+  return headings;
+}
+
+export function insertConvergedApiSection(specMarkdown: string, apiMarkdown: string): string {
+  // Remove existing Converged API section first
+  const working = removeConvergedApiSection(specMarkdown);
+
+  const sourceLines = working.split('\n');
+
+  // Find the first line matching ## Task list (literal scan, not fence-aware)
+  // so that the rendered section is inserted before the first occurrence of the heading
+  let insertionLineIndex = -1;
+  for (let i = 0; i < sourceLines.length; i++) {
+    const line = sourceLines[i] ?? '';
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (match && match[1]!.length === 2) {
+      const normalizedText = match[2]!.trim().replace(/\s+/g, ' ').toLowerCase();
+      if (normalizedText === 'task list') {
+        insertionLineIndex = i;
+        break;
+      }
+    }
+  }
+
+  if (insertionLineIndex === -1) {
+    throw new Error(
+      'Spec is missing the required `## Task list` insertion point. Cannot safely insert `## Converged API` section.',
+    );
+  }
+
+  const before = sourceLines.slice(0, insertionLineIndex).join('\n');
+  const after = sourceLines.slice(insertionLineIndex).join('\n');
+
+  // Ensure a clean join: trim trailing whitespace from before, add double newline separator
+  const beforeTrimmed = before.trimEnd();
+  return `${beforeTrimmed}\n\n${apiMarkdown}\n\n${after}`;
+}
+
+export function removeConvergedApiSection(specMarkdown: string): string {
+  const sourceLines = specMarkdown.split('\n');
+  const headings = parseTopLevelHeadings(specMarkdown);
+
+  const convergedApiIdx = headings.findIndex((h) => h.level === 2 && h.normalizedText === 'converged api');
+  if (convergedApiIdx === -1) {
+    return specMarkdown;
+  }
+
+  const convergedHeading = headings[convergedApiIdx]!;
+  const startLine = convergedHeading.lineIndex;
+
+  // Find the next top-level (##) heading after the converged api section
+  const nextTopLevelHeading = headings.slice(convergedApiIdx + 1).find((h) => h.level === 2);
+
+  let endLine: number;
+  if (nextTopLevelHeading) {
+    endLine = nextTopLevelHeading.lineIndex;
+  } else {
+    endLine = sourceLines.length;
+  }
+
+  // Build the result: lines before the section + lines from the next heading onward
+  const before = sourceLines.slice(0, startLine);
+  const after = endLine < sourceLines.length ? sourceLines.slice(endLine) : [];
+
+  // Remove trailing blank lines from before and leading blank lines from after
+  // to avoid double blank lines at the splice point
+  while (before.length > 0 && before[before.length - 1]!.trim() === '') {
+    before.pop();
+  }
+  let afterStart = 0;
+  while (afterStart < after.length && after[afterStart]!.trim() === '') {
+    afterStart++;
+  }
+  const afterTrimmed = after.slice(afterStart);
+
+  if (before.length === 0 && afterTrimmed.length === 0) {
+    return '';
+  }
+  if (before.length === 0) {
+    return afterTrimmed.join('\n');
+  }
+  if (afterTrimmed.length === 0) {
+    return before.join('\n');
+  }
+
+  return `${before.join('\n')}\n\n${afterTrimmed.join('\n')}`;
+}

--- a/src/core/ai/authoring-api-artifact.ts
+++ b/src/core/ai/authoring-api-artifact.ts
@@ -198,14 +198,19 @@ export function insertConvergedApiSection(specMarkdown: string, apiMarkdown: str
 
   const sourceLines = working.split('\n');
 
-  // Find the first line matching ## Task list (literal scan, not fence-aware)
-  // so that the rendered section is inserted before the first occurrence of the heading
+  // Find the first top-level ## Task list heading outside fenced code blocks
   let insertionLineIndex = -1;
+  let inFence = false;
   for (let i = 0; i < sourceLines.length; i++) {
     const line = sourceLines[i] ?? '';
-    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
-    if (match && match[1]!.length === 2) {
-      const normalizedText = match[2]!.trim().replace(/\s+/g, ' ').toLowerCase();
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const match = /^##\s+(.+)\s*$/.exec(line);
+    if (match) {
+      const normalizedText = match[1]!.trim().replace(/\s+/g, ' ').toLowerCase();
       if (normalizedText === 'task list') {
         insertionLineIndex = i;
         break;

--- a/src/core/ai/authoring-api-artifact.ts
+++ b/src/core/ai/authoring-api-artifact.ts
@@ -46,9 +46,18 @@ export function parseConvergedApiArtifact(content: string, path: string): Conver
       throw new Error(`Converged API artifact at "${path}": public_api[${i}] must be an object`);
     }
     const pe = item as Record<string, unknown>;
-    const symbol = typeof pe['symbol'] === 'string' && pe['symbol'] !== '' ? pe['symbol'] : '';
-    const signature = typeof pe['signature'] === 'string' && pe['signature'] !== '' ? pe['signature'] : '';
-    const returns = typeof pe['returns'] === 'string' ? pe['returns'] : '';
+    if (typeof pe['symbol'] !== 'string' || pe['symbol'].trim() === '') {
+      throw new Error(`Converged API artifact at "${path}": public_api[${i}].symbol must be a non-empty string`);
+    }
+    if (typeof pe['signature'] !== 'string' || pe['signature'].trim() === '') {
+      throw new Error(`Converged API artifact at "${path}": public_api[${i}].signature must be a non-empty string`);
+    }
+    if (typeof pe['returns'] !== 'string' || pe['returns'].trim() === '') {
+      throw new Error(`Converged API artifact at "${path}": public_api[${i}].returns must be a non-empty string`);
+    }
+    const symbol = pe['symbol'];
+    const signature = pe['signature'];
+    const returns = pe['returns'];
     const errors = Array.isArray(pe['errors']) ? (pe['errors'] as unknown[]).map(String) : [];
     const notes = typeof pe['notes'] === 'string' ? pe['notes'] : '';
     const parameters = Array.isArray(pe['parameters'])
@@ -73,8 +82,14 @@ export function parseConvergedApiArtifact(content: string, path: string): Conver
       throw new Error(`Converged API artifact at "${path}": types[${i}] must be an object`);
     }
     const te = item as Record<string, unknown>;
-    const name = typeof te['name'] === 'string' ? te['name'] : '';
-    const shape = typeof te['shape'] === 'string' ? te['shape'] : '';
+    if (typeof te['name'] !== 'string' || te['name'].trim() === '') {
+      throw new Error(`Converged API artifact at "${path}": types[${i}].name must be a non-empty string`);
+    }
+    if (typeof te['shape'] !== 'string' || te['shape'].trim() === '') {
+      throw new Error(`Converged API artifact at "${path}": types[${i}].shape must be a non-empty string`);
+    }
+    const name = te['name'];
+    const shape = te['shape'];
     const description = typeof te['description'] === 'string' ? te['description'] : '';
     return { name, shape, description };
   });

--- a/src/core/ai/authoring-api-convergence-coordinator.ts
+++ b/src/core/ai/authoring-api-convergence-coordinator.ts
@@ -1,0 +1,457 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile as _readFile, writeFile as _writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import type pino from 'pino';
+import type {
+  AgentInvocationMetadata,
+  AgentProfile,
+  AgentRoute,
+  AgentRunner,
+  AgentRoutingPolicy,
+  AgentSessionCaptureFn,
+  AuthoringApiConvergenceResult,
+  AuthoringApiCritiqueResult,
+  ConvergedApiArtifact,
+  GateReviewExchange,
+  ImplementationReviewFinding,
+} from '../../types/ai.js';
+import type { Run } from '../../types/runs.js';
+import {
+  buildAuthoringApiProposePrompt,
+  buildAuthoringApiCritiquePrompt,
+  buildAuthoringApiRevisePrompt,
+  drainAgentRunner,
+} from './agent-services.js';
+import { parseConvergedApiArtifact, renderConvergedApiMarkdown } from './authoring-api-artifact.js';
+import { agentProfileSummary } from './routing-policy.js';
+
+export interface AuthoringApiConvergencePolicy {
+  enabled: boolean;
+  max_rounds: number;
+  allow_same_model: boolean;
+}
+
+export interface AuthoringApiConvergenceCoordinatorDeps {
+  runner: AgentRunner;
+  routingPolicy: AgentRoutingPolicy;
+  policy: AuthoringApiConvergencePolicy;
+  logger: Pick<pino.Logger, 'info' | 'warn' | 'debug' | 'error'>;
+  readFile?: (path: string, encoding: 'utf-8') => Promise<string>;
+  writeFile?: (path: string, content: string, encoding: 'utf-8') => Promise<void>;
+}
+
+export interface AuthoringApiConvergenceParams {
+  run: Run;
+  artifact_path: string;
+  working_directory: string;
+  onProgress?: (message: string) => Promise<void>;
+  onAgentRequest?: (metadata: AgentInvocationMetadata) => void;
+  captureSession?: AgentSessionCaptureFn;
+  captureFeedback?: (exchange: GateReviewExchange, run: Run) => void;
+}
+
+export class AuthoringApiConvergenceCoordinator {
+  private readonly readFileFn: (path: string, encoding: 'utf-8') => Promise<string>;
+  private readonly writeFileFn: (path: string, content: string, encoding: 'utf-8') => Promise<void>;
+
+  constructor(private readonly deps: AuthoringApiConvergenceCoordinatorDeps) {
+    this.readFileFn = deps.readFile ?? ((path, enc) => _readFile(path, enc));
+    this.writeFileFn = deps.writeFile ?? ((path, content, enc) => _writeFile(path, content, enc));
+  }
+
+  async run(params: AuthoringApiConvergenceParams): Promise<AuthoringApiConvergenceResult> {
+    const { run, artifact_path, working_directory, onProgress, onAgentRequest, captureSession, captureFeedback } = params;
+    const { routingPolicy, policy, logger, runner } = this.deps;
+    const maxRounds = policy.max_rounds;
+
+    // 1. Resolve profiles (all before any async work)
+    const proposerProfile =
+      routingPolicy.resolveOptional({ task: 'artifact.api.propose', role: 'proposer' }) ??
+      routingPolicy.resolveOptional({ task: 'artifact.create', role: 'proposer' }) ??
+      routingPolicy.resolveOptional({ task: 'artifact.create' });
+
+    const criticProfile =
+      routingPolicy.resolveOptional({ task: 'artifact.api.critique', role: 'critic' }) ??
+      routingPolicy.resolveOptional({ task: 'spec.review', role: 'critic' }) ??
+      routingPolicy.resolveOptional({ task: 'spec.review' });
+
+    if (!proposerProfile) {
+      throw new Error('Authoring API convergence requires a proposer profile. Configure artifact.api.propose:proposer, artifact.create:proposer, or artifact.create.');
+    }
+    if (!criticProfile) {
+      throw new Error('Authoring API convergence requires a critic profile. Configure artifact.api.critique:critic, spec.review:critic, or spec.review.');
+    }
+
+    // 2. Same-model guard
+    if (proposerProfile.id === criticProfile.id) {
+      if (!policy.allow_same_model) {
+        throw new Error(
+          'Authoring API convergence requires distinct proposer and critic profiles. Set spec_authoring.api_convergence.allow_same_model: true to allow same profile.',
+        );
+      }
+    } else if (proposerProfile.provider === criticProfile.provider && proposerProfile.model === criticProfile.model) {
+      logger.warn(
+        {
+          event: 'artifact.api_convergence.same_model_alias_warning',
+          proposer_id: proposerProfile.id,
+          critic_id: criticProfile.id,
+          run_id: run.id,
+        },
+        'Proposer and critic have different profile IDs but same provider/model',
+      );
+    }
+
+    const proposerSummary = agentProfileSummary(proposerProfile);
+    const criticSummary = agentProfileSummary(criticProfile);
+
+    // 3. Log started
+    logger.info(
+      {
+        event: 'artifact.api_convergence.started',
+        run_id: run.id,
+        max_rounds: maxRounds,
+        proposer_profile: proposerSummary.profile,
+        critic_profile: criticSummary.profile,
+      },
+      'Authoring API convergence started',
+    );
+
+    const artifactResultPath = join(working_directory, '.autocatalyst', 'authoring-api-artifact.json');
+    const critiqueResultPath = join(working_directory, '.autocatalyst', 'authoring-api-critique-result.json');
+
+    let currentArtifact: ConvergedApiArtifact | null = null;
+
+    // 4. Convergence loop
+    for (let round = 1; round <= maxRounds; round++) {
+      // a. Emit progress
+      const roundAction = round === 1 ? 'proposer drafting API artifact' : 'critic reviewing revised API artifact';
+      try {
+        await onProgress?.(`API convergence round ${round} started — ${roundAction}`);
+      } catch { /* ignore */ }
+
+      // b. Log round started
+      logger.info(
+        { event: 'artifact.api_convergence.round_started', run_id: run.id, round },
+        'API convergence round started',
+      );
+
+      // c. Read current spec
+      const specMarkdown = await this.readFileFn(artifact_path, 'utf-8');
+
+      // d+e. Run proposer on round 1 to get initial artifact
+      if (round === 1) {
+        try {
+          await mkdir(dirname(artifactResultPath), { recursive: true });
+        } catch { /* ignore */ }
+
+        const proposePrompt = buildAuthoringApiProposePrompt(specMarkdown, artifactResultPath, round);
+        const proposeRoute: AgentRoute = { task: 'artifact.api.propose', role: 'proposer' };
+        const ts_start = new Date().toISOString();
+
+        if (onAgentRequest) {
+          onAgentRequest({
+            model: proposerProfile.model?.trim() || 'unknown',
+            requested_at: ts_start,
+            route: proposeRoute,
+          });
+        }
+
+        let drainSummary;
+        try {
+          drainSummary = await drainAgentRunner(
+            runner.run({
+              route: proposeRoute,
+              profile: proposerProfile,
+              working_directory,
+              prompt: proposePrompt,
+              telemetry: {
+                run_id: run.id,
+                request_id: run.request_id,
+                phase: 'artifact_api_propose',
+                route_task: proposeRoute.task,
+                handler: 'AuthoringApiConvergenceCoordinator',
+              },
+            }),
+            onProgress,
+            logger,
+            'artifact_api_propose',
+            { run_id: run.id, request_id: run.request_id },
+          );
+          this.emitSessionRecord(captureSession, proposerProfile, proposeRoute, ts_start, 'ok', drainSummary, { role: 'proposer', round, gate: 'api' });
+        } catch (err) {
+          this.emitSessionRecord(captureSession, proposerProfile, proposeRoute, ts_start, 'failed', undefined, { role: 'proposer', round, gate: 'api' });
+          throw new Error(`Authoring API convergence proposer failed at round ${round}: ${String(err)}`);
+        }
+
+        // f. Parse artifact
+        try {
+          const content = await this.readFileFn(artifactResultPath, 'utf-8');
+          currentArtifact = parseConvergedApiArtifact(content, artifactResultPath);
+        } catch (err) {
+          if (round === maxRounds) {
+            logger.error(
+              { event: 'artifact.api_convergence.failed', run_id: run.id, round, error: String(err) },
+              'Authoring API convergence failed: proposer produced invalid JSON artifact at max rounds',
+            );
+            throw new Error(`Authoring API convergence failed at max rounds: proposer produced invalid JSON artifact: ${String(err)}`);
+          }
+          // Synthetic finding for parse failure before max rounds — consume this round
+          logger.warn(
+            { event: 'artifact.api_convergence.parse_failed', run_id: run.id, round, error: String(err) },
+            'Proposer returned invalid JSON artifact, consuming round',
+          );
+          continue;
+        }
+      }
+
+      // At this point currentArtifact must be non-null (either from round 1 propose or from revision)
+      if (!currentArtifact) {
+        // This shouldn't happen after round 1 succeeds, but be safe
+        continue;
+      }
+
+      // g. Run critic
+      try {
+        await mkdir(dirname(critiqueResultPath), { recursive: true });
+      } catch { /* ignore */ }
+
+      const critiquePrompt = buildAuthoringApiCritiquePrompt(specMarkdown, currentArtifact, critiqueResultPath, round);
+      const critiqueRoute: AgentRoute = { task: 'artifact.api.critique', role: 'critic' };
+      const critic_ts_start = new Date().toISOString();
+
+      if (onAgentRequest) {
+        onAgentRequest({
+          model: criticProfile.model?.trim() || 'unknown',
+          requested_at: critic_ts_start,
+          route: critiqueRoute,
+        });
+      }
+
+      let criticDrainSummary;
+      try {
+        criticDrainSummary = await drainAgentRunner(
+          runner.run({
+            route: critiqueRoute,
+            profile: criticProfile,
+            working_directory,
+            prompt: critiquePrompt,
+            telemetry: {
+              run_id: run.id,
+              request_id: run.request_id,
+              phase: 'artifact_api_critique',
+              route_task: critiqueRoute.task,
+              handler: 'AuthoringApiConvergenceCoordinator',
+            },
+          }),
+          onProgress,
+          logger,
+          'artifact_api_critique',
+          { run_id: run.id, request_id: run.request_id },
+        );
+        this.emitSessionRecord(captureSession, criticProfile, critiqueRoute, critic_ts_start, 'ok', criticDrainSummary, { role: 'critic', round, gate: 'api' });
+      } catch (err) {
+        this.emitSessionRecord(captureSession, criticProfile, critiqueRoute, critic_ts_start, 'failed', undefined, { role: 'critic', round, gate: 'api' });
+        throw new Error(`Authoring API convergence critic failed at round ${round}: ${String(err)}`);
+      }
+
+      // h. Parse critique
+      let critique: AuthoringApiCritiqueResult;
+      try {
+        const content = await this.readFileFn(critiqueResultPath, 'utf-8');
+        const parsed = JSON.parse(content) as Record<string, unknown>;
+        critique = {
+          status: (typeof parsed['status'] === 'string' ? parsed['status'] : 'failed') as AuthoringApiCritiqueResult['status'],
+          summary: typeof parsed['summary'] === 'string' ? parsed['summary'] : '',
+          findings: Array.isArray(parsed['findings']) ? (parsed['findings'] as ImplementationReviewFinding[]) : [],
+          error: typeof parsed['error'] === 'string' ? parsed['error'] : undefined,
+        };
+        if (critique.status === 'failed') {
+          logger.warn(
+            { event: 'artifact.api_convergence.critique_status_failed', run_id: run.id, round, error: critique.error },
+            'Critic reported status failed, treating as no findings',
+          );
+          critique = { status: 'no_findings', summary: critique.summary || critique.error || '', findings: [] };
+        }
+      } catch (err) {
+        logger.warn(
+          { event: 'artifact.api_convergence.critique_parse_failed', run_id: run.id, round, error: String(err) },
+          'Critique result parse failed, treating as no findings',
+        );
+        critique = { status: 'no_findings', summary: '', findings: [] };
+      }
+
+      const blockingFindings = critique.findings.filter(f => f.severity === 'blocker' || f.severity === 'warning');
+
+      // i. Log round completed
+      logger.info(
+        {
+          event: 'artifact.api_convergence.round_completed',
+          run_id: run.id,
+          round,
+          finding_count: critique.findings.length,
+          blocker_count: blockingFindings.filter(f => f.severity === 'blocker').length,
+          warning_count: blockingFindings.filter(f => f.severity === 'warning').length,
+        },
+        'API convergence round completed',
+      );
+
+      // j. Converged?
+      if (critique.status === 'no_findings' || blockingFindings.length === 0) {
+        const markdown = renderConvergedApiMarkdown(currentArtifact);
+        const exchange: GateReviewExchange = {
+          id: randomUUID(),
+          gate: 'api',
+          round,
+          created_at: new Date().toISOString(),
+          proposer_profile: proposerSummary,
+          critic_profile: criticSummary,
+          review_status: 'converged',
+          review_summary: critique.summary,
+          findings: critique.findings,
+          responses: [],
+          converged: true,
+          requires_human_retest: false,
+        };
+        this.appendGateExchange(run, exchange);
+        captureFeedback?.(exchange, run);
+
+        try {
+          await onProgress?.(`API convergence complete — ${currentArtifact.files.length} file(s), ${currentArtifact.public_api.length} public API item(s)`);
+        } catch { /* ignore */ }
+
+        logger.info(
+          { event: 'artifact.api_convergence.converged', run_id: run.id, round },
+          'Authoring API convergence converged',
+        );
+
+        return { artifact: currentArtifact, markdown, converged: true };
+      }
+
+      // k. Max rounds reached?
+      if (round === maxRounds) {
+        const markdown = renderConvergedApiMarkdown(currentArtifact);
+        const exchange: GateReviewExchange = {
+          id: randomUUID(),
+          gate: 'api',
+          round,
+          created_at: new Date().toISOString(),
+          proposer_profile: proposerSummary,
+          critic_profile: criticSummary,
+          review_status: 'non_converged',
+          review_summary: critique.summary,
+          findings: critique.findings,
+          responses: [],
+          converged: false,
+          non_convergence_reason: 'max_rounds',
+          requires_human_retest: false,
+        };
+        this.appendGateExchange(run, exchange);
+        captureFeedback?.(exchange, run);
+
+        try {
+          await onProgress?.(`API convergence reached round cap — proceeding with current API`);
+        } catch { /* ignore */ }
+
+        logger.info(
+          { event: 'artifact.api_convergence.non_converged', run_id: run.id, round, reason: 'max_rounds' },
+          'Authoring API convergence did not converge: max_rounds reached',
+        );
+
+        return { artifact: currentArtifact, markdown, converged: false, non_convergence_reason: 'max_rounds' };
+      }
+
+      // l. More rounds: revise
+      const findingCount = blockingFindings.length;
+      try {
+        await onProgress?.(`API critic returned ${findingCount} finding(s) — revising API artifact`);
+      } catch { /* ignore */ }
+
+      const revisePrompt = buildAuthoringApiRevisePrompt(specMarkdown, currentArtifact, critique.findings, artifactResultPath, round);
+      const reviseRoute: AgentRoute = { task: 'artifact.api.propose', role: 'proposer' };
+      const revise_ts_start = new Date().toISOString();
+
+      if (onAgentRequest) {
+        onAgentRequest({
+          model: proposerProfile.model?.trim() || 'unknown',
+          requested_at: revise_ts_start,
+          route: reviseRoute,
+        });
+      }
+
+      let reviseDrainSummary;
+      try {
+        reviseDrainSummary = await drainAgentRunner(
+          runner.run({
+            route: reviseRoute,
+            profile: proposerProfile,
+            working_directory,
+            prompt: revisePrompt,
+            telemetry: {
+              run_id: run.id,
+              request_id: run.request_id,
+              phase: 'artifact_api_revise',
+              route_task: reviseRoute.task,
+              handler: 'AuthoringApiConvergenceCoordinator',
+            },
+          }),
+          onProgress,
+          logger,
+          'artifact_api_revise',
+          { run_id: run.id, request_id: run.request_id },
+        );
+        this.emitSessionRecord(captureSession, proposerProfile, reviseRoute, revise_ts_start, 'ok', reviseDrainSummary, { role: 'proposer', round, gate: 'api' });
+      } catch (err) {
+        this.emitSessionRecord(captureSession, proposerProfile, reviseRoute, revise_ts_start, 'failed', undefined, { role: 'proposer', round, gate: 'api' });
+        throw new Error(`Authoring API convergence proposer revision failed at round ${round}: ${String(err)}`);
+      }
+
+      // Parse revised artifact (used in next round's critique)
+      try {
+        const content = await this.readFileFn(artifactResultPath, 'utf-8');
+        currentArtifact = parseConvergedApiArtifact(content, artifactResultPath);
+      } catch (err) {
+        logger.warn(
+          { event: 'artifact.api_convergence.revision_parse_failed', run_id: run.id, round, error: String(err) },
+          'Revision artifact parse failed, keeping old artifact for next round',
+        );
+        // Keep currentArtifact unchanged — next round will critique with the old artifact
+      }
+    }
+
+    // Should not reach here but TypeScript needs a return
+    throw new Error('Authoring API convergence loop exited unexpectedly');
+  }
+
+  private appendGateExchange(run: Run, exchange: GateReviewExchange): void {
+    if (!run.gate_exchanges) run.gate_exchanges = [];
+    run.gate_exchanges.push(exchange);
+  }
+
+  private emitSessionRecord(
+    captureSession: AgentSessionCaptureFn | undefined,
+    profile: AgentProfile,
+    route: AgentRoute,
+    ts_start: string,
+    outcome: 'ok' | 'failed',
+    drainSummary: Awaited<ReturnType<typeof drainAgentRunner>> | undefined,
+    meta: { role: 'proposer' | 'critic'; round: number; gate: string },
+  ): void {
+    if (!captureSession) return;
+    const runner = profile.provider === 'openai_agent_sdk' ? 'openai_agent' : 'anthropic_agent';
+    captureSession({
+      phase: `artifact_api_convergence`,
+      step: route.task,
+      ts_start,
+      ts_end: new Date().toISOString(),
+      model: { provider: profile.provider, name: profile.model ?? null },
+      inference: { effort: profile.effort ?? null, thinking: profile.thinking ?? null },
+      tokens: drainSummary?.terminal_usage ?? null,
+      assistant_turns: drainSummary?.assistant_turn_count ?? null,
+      tool_calls: drainSummary?.tool_call_count ?? null,
+      tool_results: drainSummary?.tool_result_count ?? null,
+      outcome,
+      runner,
+      ...meta,
+    });
+  }
+}

--- a/src/core/ai/authoring-api-convergence-coordinator.ts
+++ b/src/core/ai/authoring-api-convergence-coordinator.ts
@@ -124,7 +124,7 @@ export class AuthoringApiConvergenceCoordinator {
     // 4. Convergence loop
     for (let round = 1; round <= maxRounds; round++) {
       // a. Emit progress
-      const roundAction = round === 1 ? 'proposer drafting API artifact' : 'critic reviewing revised API artifact';
+      const roundAction = (round === 1 || currentArtifact === null) ? 'proposer drafting API artifact' : 'critic reviewing revised API artifact';
       try {
         await onProgress?.(`API convergence round ${round} started — ${roundAction}`);
       } catch { /* ignore */ }
@@ -138,8 +138,8 @@ export class AuthoringApiConvergenceCoordinator {
       // c. Read current spec
       const specMarkdown = await this.readFileFn(artifact_path, 'utf-8');
 
-      // d+e. Run proposer on round 1 to get initial artifact
-      if (round === 1) {
+      // d+e. Run proposer on round 1, or when previous parse produced no valid artifact
+      if (round === 1 || currentArtifact === null) {
         try {
           await mkdir(dirname(artifactResultPath), { recursive: true });
         } catch { /* ignore */ }
@@ -202,12 +202,6 @@ export class AuthoringApiConvergenceCoordinator {
           );
           continue;
         }
-      }
-
-      // At this point currentArtifact must be non-null (either from round 1 propose or from revision)
-      if (!currentArtifact) {
-        // This shouldn't happen after round 1 succeeds, but be safe
-        continue;
       }
 
       // g. Run critic

--- a/src/core/ai/layered-convergence-policy.ts
+++ b/src/core/ai/layered-convergence-policy.ts
@@ -37,12 +37,26 @@ export function resolveFeedbackDepth(
   return feedbackDepth ?? 'build_only';
 }
 
-export function resolveImplementationConvergencePolicy(config: WorkflowConfig): ResolvedImplementationConvergencePolicy {
+export function resolveImplementationConvergencePolicy(
+  config: WorkflowConfig,
+  warn?: (warning: object) => void,
+): ResolvedImplementationConvergencePolicy {
   const raw = config.implementation_review?.convergence;
+  const configuredDepth = raw?.depth ?? 'build_only';
+  let effectiveDepth: ImplementationReviewConvergenceDepth = 'build_only';
+  if (configuredDepth !== 'build_only') {
+    warn?.({
+      event: 'implementation_review.convergence.depth_ignored',
+      configured_depth: configuredDepth,
+      effective_behavior: 'build_only',
+    });
+  } else {
+    effectiveDepth = configuredDepth;
+  }
   return {
     enabled: raw?.enabled ?? false,
     allow_same_model: raw?.allow_same_model ?? false,
-    depth: raw?.depth ?? 'build_only',
+    depth: effectiveDepth,
     feedback_depth: raw?.feedback_depth ?? 'build_only',
     max_model_sessions_per_run: raw?.max_model_sessions_per_run ?? 24,
   };

--- a/src/core/ai/route-skills.ts
+++ b/src/core/ai/route-skills.ts
@@ -20,6 +20,8 @@ export function requiredSkillsForRoute(route: AgentRoute): AgentSkillRef[] {
     case 'question.answer':
     case 'implementation.review.initial':
     case 'implementation.review.final':
+    case 'artifact.api.propose':
+    case 'artifact.api.critique':
       return [];
   }
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -482,3 +482,28 @@ export function getSpecReviewPolicy(config: WorkflowConfig): Required<SpecReview
     template_conformance: raw?.['template_conformance'] === false ? false : true,
   };
 }
+
+export function getSpecAuthoringPolicy(config: WorkflowConfig): {
+  api_convergence: { enabled: boolean; max_rounds: number; allow_same_model: boolean };
+} {
+  const rawAuthoring = (config as Record<string, unknown>)['spec_authoring'];
+  const authoring = rawAuthoring && typeof rawAuthoring === 'object' && !Array.isArray(rawAuthoring)
+    ? rawAuthoring as Record<string, unknown>
+    : {};
+  const rawApi = authoring['api_convergence'];
+  const api = rawApi && typeof rawApi === 'object' && !Array.isArray(rawApi)
+    ? rawApi as Record<string, unknown>
+    : {};
+  const rawMaxRounds = api['max_rounds'];
+  const max_rounds = typeof rawMaxRounds === 'number' ? rawMaxRounds : 5;
+  if (!Number.isInteger(max_rounds) || max_rounds < 1) {
+    throw new Error('spec_authoring.api_convergence.max_rounds must be a positive integer');
+  }
+  return {
+    api_convergence: {
+      enabled: api['enabled'] === true,
+      max_rounds,
+      allow_same_model: api['allow_same_model'] === true,
+    },
+  };
+}

--- a/src/core/default-handler-registry.ts
+++ b/src/core/default-handler-registry.ts
@@ -23,6 +23,7 @@ import type { ImplementationReviewCoordinator } from './ai/implementation-review
 import type { ResolvedImplementationConvergencePolicy } from './ai/layered-convergence-policy.js';
 import type { BudgetWriter } from './journal/model-session-budget.js';
 import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
+import type { AuthoringApiConvergenceCoordinator } from './ai/authoring-api-convergence-coordinator.js';
 import { ArtifactCreationHandler } from './handlers/artifact-creation-handler.js';
 import { ArtifactApprovalHandler, type ArtifactApprovalResult } from './handlers/artifact-approval-handler.js';
 import { ArtifactFeedbackHandler } from './handlers/artifact-feedback-handler.js';
@@ -107,6 +108,8 @@ export interface DefaultHandlerRegistryDeps {
   workspacePruner?: Pick<WorkspacePruner, 'prune'>;
   autoPruneWorkspace?: boolean;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
+  specAuthoringPolicy?: { api_convergence: { enabled: boolean; max_rounds: number; allow_same_model: boolean } };
+  authoringApiConvergenceCoordinator?: Pick<AuthoringApiConvergenceCoordinator, 'run'>;
 }
 
 export function buildDefaultHandlerRegistry(deps: DefaultHandlerRegistryDeps): HandlerRegistry {
@@ -199,6 +202,8 @@ async function startArtifactCreation(
     branchGuard,
     specReviewCoordinator: deps.specReviewCoordinator,
     journal: deps.journal,
+    specAuthoringPolicy: deps.specAuthoringPolicy,
+    authoringApiConvergenceCoordinator: deps.authoringApiConvergenceCoordinator,
   });
   await handler.handle(run, request, intent);
 }

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -1,5 +1,5 @@
 import type pino from 'pino';
-import type { ArtifactAuthoringAgent } from '../../types/ai.js';
+import type { ArtifactAuthoringAgent, GateReviewExchange } from '../../types/ai.js';
 import type { ArtifactPublication, ArtifactPublisher } from '../../types/publisher.js';
 import type { Request } from '../../types/events.js';
 import type { ArtifactKind } from '../../types/artifact.js';
@@ -13,12 +13,14 @@ import type { SpecReviewCoordinator } from '../ai/spec-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
 import type { AgentSessionCaptureFn } from '../../types/ai.js';
+import type { AuthoringApiConvergenceCoordinator } from '../ai/authoring-api-convergence-coordinator.js';
+import { insertConvergedApiSection } from '../ai/authoring-api-artifact.js';
 
 type ArtifactCreationIntent = Extract<RequestIntent, 'idea' | 'bug' | 'chore'>;
 
 export interface ArtifactCreationDeps {
   workspaceManager: Pick<WorkspaceManager, 'create' | 'destroy'>;
-  artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'create'>;
+  artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'create' | 'createTechSpecDraft' | 'decomposeTasks'>;
   artifactPublisher: Pick<ArtifactPublisher, 'createArtifact' | 'updateStatus'>;
   channelRepoMap: ChannelRepoMap;
   postMessage: (conversation: ConversationRef, text: string) => Promise<void>;
@@ -28,7 +30,11 @@ export interface ArtifactCreationDeps {
   logger: Pick<pino.Logger, 'warn' | 'error' | 'info'>;
   branchGuard?: BranchGuard;
   specReviewCoordinator?: Pick<SpecReviewCoordinator, 'runSpecReview'>;
-  journal?: Pick<RunJournal, 'captureSession'>;
+  journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
+  specAuthoringPolicy?: { api_convergence: { enabled: boolean; max_rounds: number; allow_same_model: boolean } };
+  authoringApiConvergenceCoordinator?: Pick<AuthoringApiConvergenceCoordinator, 'run'>;
+  readFile?: (path: string, encoding: 'utf-8') => Promise<string>;
+  writeFile?: (path: string, content: string, encoding: 'utf-8') => Promise<void>;
 }
 
 export class ArtifactCreationHandler {
@@ -67,24 +73,110 @@ export class ArtifactCreationHandler {
 
     const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
 
+    const useApiConvergence = intent === 'idea'
+      && this.deps.specAuthoringPolicy?.api_convergence.enabled === true
+      && this.deps.authoringApiConvergenceCoordinator != null
+      && typeof this.deps.artifactAuthoringAgent.createTechSpecDraft === 'function'
+      && typeof this.deps.artifactAuthoringAgent.decomposeTasks === 'function';
+
     let local_path: string;
-    try {
-      const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
-        ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
-        : undefined;
-      const result = intent === 'idea'
-        ? await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession })
-        : await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, intent, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
-      local_path = result.artifact_path;
-      this.setArtifactDraft(run, artifactKindForIntent(intent)!, local_path);
-      if (intent !== 'idea' && result.existing_issue !== undefined) {
-        run.issue = result.existing_issue;
-        this.deps.persist();
+    const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
+      ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+      : undefined;
+
+    if (useApiConvergence) {
+      // Enabled path: tech spec → branch guard → API convergence → insert API section → task decomposition
+      try {
+        await onProgress('Spec authoring started — drafting through tech spec');
+        const techResult = await this.deps.artifactAuthoringAgent.createTechSpecDraft!(request, workspace_path, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
+        local_path = techResult.artifact_path;
+        this.setArtifactDraft(run, artifactKindForIntent(intent)!, local_path);
+      } catch (err) {
+        await this.deps.workspaceManager.destroy(workspace_path);
+        await this.deps.failRun(run, request.conversation, err);
+        return;
       }
-    } catch (err) {
-      await this.deps.workspaceManager.destroy(workspace_path);
-      await this.deps.failRun(run, request.conversation, err);
-      return;
+
+      // Branch guard after tech spec
+      if (this.deps.branchGuard) {
+        try {
+          await this.deps.branchGuard.check(workspace_path, branch);
+        } catch (err) {
+          await this.deps.workspaceManager.destroy(workspace_path);
+          await this.deps.failRun(run, request.conversation, err);
+          return;
+        }
+      }
+
+      try {
+        await onProgress('Tech spec draft complete — starting API convergence');
+
+        // Build captureFeedback for API exchanges
+        const captureFeedbackForApi = this.deps.journal
+          ? (exchange: GateReviewExchange, captureRun: Run) => {
+              const criticProfile = exchange.critic_profile;
+              for (const finding of exchange.findings) {
+                const disposition: 'open' | 'addressed' = (exchange.converged || finding.severity === 'info') ? 'addressed' : 'open';
+                void this.deps.journal!.captureFeedback!({
+                  id: `${exchange.id}:${finding.id}`,
+                  run: captureRun,
+                  target: 'artifact',
+                  gate: exchange.gate,
+                  author_principal: `review:${criticProfile.provider}:${criticProfile.profile}`,
+                  text: finding.finding + (finding.suggested_action ? ' | ' + finding.suggested_action : ''),
+                  severity: finding.severity,
+                  category: finding.category,
+                  disposition,
+                }).catch(() => {});
+              }
+            }
+          : undefined;
+
+        // Run API convergence
+        const apiResult = await this.deps.authoringApiConvergenceCoordinator!.run({
+          run,
+          artifact_path: local_path,
+          working_directory: workspace_path,
+          onProgress,
+          onAgentRequest,
+          captureSession,
+          captureFeedback: captureFeedbackForApi,
+        });
+
+        // Insert converged API section into spec
+        const readFileFn = this.deps.readFile ?? ((p: string, e: 'utf-8') => import('node:fs/promises').then(m => m.readFile(p, e)));
+        const writeFileFn = this.deps.writeFile ?? ((p: string, c: string, e: 'utf-8') => import('node:fs/promises').then(m => m.writeFile(p, c, e)));
+        const currentSpec = await readFileFn(local_path, 'utf-8');
+        await writeFileFn(local_path, insertConvergedApiSection(currentSpec, apiResult.markdown), 'utf-8');
+
+        await onProgress('Converged API folded into spec — decomposing tasks');
+
+        // Task decomposition
+        await this.deps.artifactAuthoringAgent.decomposeTasks!(local_path, workspace_path, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
+
+        await onProgress('Task decomposition complete — publishing spec for review');
+      } catch (err) {
+        await this.deps.workspaceManager.destroy(workspace_path);
+        await this.deps.failRun(run, request.conversation, err);
+        return;
+      }
+    } else {
+      // Disabled path: existing create() flow
+      try {
+        const result = intent === 'idea'
+          ? await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, undefined, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession })
+          : await this.deps.artifactAuthoringAgent.create(request, workspace_path, onProgress, intent, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
+        local_path = result.artifact_path;
+        this.setArtifactDraft(run, artifactKindForIntent(intent)!, local_path);
+        if (intent !== 'idea' && result.existing_issue !== undefined) {
+          run.issue = result.existing_issue;
+          this.deps.persist();
+        }
+      } catch (err) {
+        await this.deps.workspaceManager.destroy(workspace_path);
+        await this.deps.failRun(run, request.conversation, err);
+        return;
+      }
     }
 
     // Guard: fail if the agent drifted to another branch

--- a/src/core/handlers/artifact-creation-handler.ts
+++ b/src/core/handlers/artifact-creation-handler.ts
@@ -73,15 +73,27 @@ export class ArtifactCreationHandler {
 
     const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
 
+    // Fail clearly when api_convergence is enabled but required dependencies are absent
+    if (intent === 'idea' && this.deps.specAuthoringPolicy?.api_convergence.enabled === true) {
+      const missingDeps: string[] = [];
+      if (!this.deps.authoringApiConvergenceCoordinator) missingDeps.push('authoringApiConvergenceCoordinator');
+      if (typeof this.deps.artifactAuthoringAgent.createTechSpecDraft !== 'function') missingDeps.push('createTechSpecDraft');
+      if (typeof this.deps.artifactAuthoringAgent.decomposeTasks !== 'function') missingDeps.push('decomposeTasks');
+      if (missingDeps.length > 0) {
+        await this.deps.workspaceManager.destroy(workspace_path);
+        await this.deps.failRun(run, request.conversation, new Error(
+          `spec_authoring.api_convergence is enabled but required dependencies are missing: ${missingDeps.join(', ')}`,
+        ));
+        return;
+      }
+    }
+
     const useApiConvergence = intent === 'idea'
-      && this.deps.specAuthoringPolicy?.api_convergence.enabled === true
-      && this.deps.authoringApiConvergenceCoordinator != null
-      && typeof this.deps.artifactAuthoringAgent.createTechSpecDraft === 'function'
-      && typeof this.deps.artifactAuthoringAgent.decomposeTasks === 'function';
+      && this.deps.specAuthoringPolicy?.api_convergence.enabled === true;
 
     let local_path: string;
     const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
-      ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
+      ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: data.round ?? 1 }).catch(() => {}); }
       : undefined;
 
     if (useApiConvergence) {

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -1,3 +1,4 @@
+import { readFile, writeFile } from 'node:fs/promises';
 import type pino from 'pino';
 import type { ArtifactAuthoringAgent, AgentSessionCaptureFn } from '../../types/ai.js';
 import type { ThreadMessage } from '../../types/events.js';
@@ -10,6 +11,7 @@ import type { BranchGuard } from '../git-branch-guard.js';
 import type { SpecReviewCoordinator } from '../ai/spec-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
+import { removeConvergedApiSection } from '../ai/authoring-api-artifact.js';
 
 export interface ArtifactFeedbackDeps {
   artifactAuthoringAgent: Pick<ArtifactAuthoringAgent, 'revise'>;
@@ -24,6 +26,8 @@ export interface ArtifactFeedbackDeps {
   branchGuard?: BranchGuard;
   specReviewCoordinator?: Pick<SpecReviewCoordinator, 'runSpecReview'>;
   journal?: Pick<RunJournal, 'captureSession'>;
+  readFile?: (path: string, encoding: 'utf-8') => Promise<string>;
+  writeFile?: (path: string, content: string, encoding: 'utf-8') => Promise<void>;
 }
 
 export type ArtifactFeedbackResult = { status: 'revised' } | { status: 'failed' };
@@ -50,7 +54,7 @@ export class ArtifactFeedbackHandler {
     const publisherComments = await this.fetchPublisherComments(run, feedback, refs.publication_ref);
     if (!publisherComments) return { status: 'failed' };
 
-    const pageMarkdown = await this.getContent(run, refs.publication_ref);
+    let pageMarkdown = await this.getContent(run, refs.publication_ref);
     this.deps.logger.debug({
       event: 'spec_revision.enriched',
       run_id: run.id,
@@ -70,12 +74,42 @@ export class ArtifactFeedbackHandler {
 
     const onAgentRequest = makeRunAgentRequestRecorder(run, this.deps.persist, this.deps.logger);
 
+    // Only for feature specs: remove any stale generated ## Converged API section
+    let staleApiRemoved = false;
+    if (refs.artifact.kind === 'feature_spec') {
+      const readFileFn = this.deps.readFile ?? ((p: string, e: 'utf-8') => readFile(p, e));
+      const writeFileFn = this.deps.writeFile ?? ((p: string, c: string, e: 'utf-8') => writeFile(p, c, e));
+      try {
+        const localContent = await readFileFn(refs.local_path, 'utf-8');
+        const cleaned = removeConvergedApiSection(localContent);
+        if (cleaned !== localContent) {
+          await writeFileFn(refs.local_path, cleaned, 'utf-8');
+          staleApiRemoved = true;
+          this.deps.logger.warn({
+            event: 'artifact.api_convergence.stale_section_removed',
+            run_id: run.id,
+            request_id: run.request_id,
+          }, 'Removed stale generated API section before feedback revision');
+        }
+      } catch (err) {
+        this.deps.logger.warn({
+          event: 'artifact.api_convergence.stale_section_cleanup_failed',
+          run_id: run.id,
+          error: String(err),
+        }, 'Failed to check/remove stale converged API section');
+      }
+      // Also clean page markdown if available
+      if (pageMarkdown && staleApiRemoved) {
+        pageMarkdown = removeConvergedApiSection(pageMarkdown);
+      }
+    }
+
     let result;
     try {
       const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
         ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
         : undefined;
-      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
+      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession }, { staleConvergedApiRemoved: staleApiRemoved });
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -109,7 +109,7 @@ export class ArtifactFeedbackHandler {
       const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
         ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
         : undefined;
-      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession }, { staleConvergedApiRemoved: staleApiRemoved });
+      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -98,9 +98,20 @@ export class ArtifactFeedbackHandler {
           error: String(err),
         }, 'Failed to check/remove stale converged API section');
       }
-      // Also clean page markdown if available
-      if (pageMarkdown && staleApiRemoved) {
-        pageMarkdown = removeConvergedApiSection(pageMarkdown);
+      // Also clean page markdown independently: the published/anchored markdown may
+      // still contain a stale ## Converged API section even when the local file does not.
+      if (pageMarkdown) {
+        const cleanedPage = removeConvergedApiSection(pageMarkdown);
+        if (cleanedPage !== pageMarkdown) {
+          pageMarkdown = cleanedPage;
+          staleApiRemoved = true;
+          this.deps.logger.warn({
+            event: 'artifact.api_convergence.stale_section_removed',
+            run_id: run.id,
+            request_id: run.request_id,
+            source: 'published_markdown',
+          }, 'Removed stale generated API section from published markdown before feedback revision');
+        }
       }
     }
 

--- a/src/core/handlers/artifact-feedback-handler.ts
+++ b/src/core/handlers/artifact-feedback-handler.ts
@@ -109,7 +109,7 @@ export class ArtifactFeedbackHandler {
       const captureSession: AgentSessionCaptureFn | undefined = this.deps.journal
         ? (data) => { void this.deps.journal!.captureSession({ ...data, run, round: 1 }).catch(() => {}); }
         : undefined;
-      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession });
+      result = await this.deps.artifactAuthoringAgent.revise(feedback, publisherComments, refs.local_path, run.workspace_path, pageMarkdown, onProgress, { run_id: run.id, request_id: run.request_id, onAgentRequest, captureSession, staleConvergedApiRemoved: staleApiRemoved });
     } catch (err) {
       await this.deps.failRun(run, feedback.conversation, err);
       return { status: 'failed' };

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -10,10 +10,7 @@ import type { BranchGuard } from '../git-branch-guard.js';
 import type { ImplementationReviewCoordinator } from '../ai/implementation-review-coordinator.js';
 import { makeRunAgentRequestRecorder } from '../run-ai-context.js';
 import type { RunJournal } from '../journal/run-journal.js';
-import {
-  altitudesForDepth,
-  type ResolvedImplementationConvergencePolicy,
-} from '../ai/layered-convergence-policy.js';
+import type { ResolvedImplementationConvergencePolicy } from '../ai/layered-convergence-policy.js';
 import { ModelSessionBudget, type BudgetWriter } from '../journal/model-session-budget.js';
 
 export interface ImplementationStartDeps {
@@ -196,14 +193,7 @@ export class ImplementationStartHandler {
         captureFeedback,
         sessionBudget,
       };
-      const policy = this.deps.convergencePolicy;
-      const useLayered =
-        policy?.enabled &&
-        policy.depth !== 'build_only' &&
-        typeof this.deps.reviewCoordinator.runLayeredImplementation === 'function';
-      reviewedResult = useLayered
-        ? await this.deps.reviewCoordinator.runLayeredImplementation!(reviewParams, { altitudes: altitudesForDepth(policy!.depth) })
-        : await this.deps.reviewCoordinator.runInitialReview(reviewParams);
+      reviewedResult = await this.deps.reviewCoordinator.runInitialReview(reviewParams);
       if (reviewedResult.status === 'needs_input') {
         this.deps.logger.info({ event: 'implementation.review.needs_input', run_id: run.id }, 'Review response needs input');
         try {

--- a/src/core/handlers/implementation-start-handler.ts
+++ b/src/core/handlers/implementation-start-handler.ts
@@ -22,7 +22,7 @@ export interface ImplementationStartDeps {
   persist: () => void;
   logger: Pick<pino.Logger, 'info' | 'warn' | 'error'>;
   branchGuard?: BranchGuard;
-  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview' | 'runLayeredImplementation'>;
+  reviewCoordinator?: Pick<ImplementationReviewCoordinator, 'runInitialReview'>;
   convergencePolicy?: ResolvedImplementationConvergencePolicy;
   journal?: Pick<RunJournal, 'captureSession' | 'captureFeedback'>;
   budgetWriter?: BudgetWriter;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -31,6 +31,7 @@ import type { ImplementationReviewCoordinator } from './ai/implementation-review
 import type { ResolvedImplementationConvergencePolicy } from './ai/layered-convergence-policy.js';
 import type { BudgetWriter } from './journal/model-session-budget.js';
 import type { SpecReviewCoordinator } from './ai/spec-review-coordinator.js';
+import type { AuthoringApiConvergenceCoordinator } from './ai/authoring-api-convergence-coordinator.js';
 import { clearAgentRequestContext, isAiActiveStage } from './run-ai-context.js';
 import { extractIssueReference, buildEnrichedClassificationMessage } from './issue-reference.js';
 import type { RunJournal } from './journal/run-journal.js';
@@ -95,6 +96,8 @@ export interface OrchestratorDeps {
   autoPruneWorkspace?: boolean;
   workspacePruner?: import('./workspace-pruner.js').WorkspacePruner;
   journal?: RunJournal;
+  specAuthoringPolicy?: { api_convergence: { enabled: boolean; max_rounds: number; allow_same_model: boolean } };
+  authoringApiConvergenceCoordinator?: Pick<AuthoringApiConvergenceCoordinator, 'run'>;
 }
 
 interface OrchestratorOptions {
@@ -647,6 +650,8 @@ export class OrchestratorImpl implements Orchestrator {
       autoPruneWorkspace: this.deps.autoPruneWorkspace,
       workspacePruner: this.deps.workspacePruner,
       journal: this.deps.journal,
+      specAuthoringPolicy: this.deps.specAuthoringPolicy,
+      authoringApiConvergenceCoordinator: this.deps.authoringApiConvergenceCoordinator,
     });
   }
 

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -350,7 +350,6 @@ export interface ArtifactAuthoringAgent {
     current_page_markdown?: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
-    options?: { staleConvergedApiRemoved?: boolean },
   ): Promise<ArtifactRevisionResult>;
   respondToSpecReview(
     artifact_path: string,

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -65,6 +65,7 @@ export interface AgentServiceTelemetry {
   role?: AgentRole | string;
   round?: number;
   gate?: 'initial' | 'final' | string;
+  staleConvergedApiRemoved?: boolean;
 }
 
 export type AgentEffort = 'low' | 'medium' | 'high' | 'max';

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -34,7 +34,9 @@ export type AgentTaskKind =
   | 'implementation.review.final'
   | 'question.answer'
   | 'issue.triage'
-  | 'pr.title_generate';
+  | 'pr.title_generate'
+  | 'artifact.api.propose'
+  | 'artifact.api.critique';
 
 export type AgentRole = 'proposer' | 'critic';
 
@@ -286,6 +288,47 @@ export interface ArtifactCreateResult {
   existing_issue?: number;
 }
 
+export interface ConvergedApiFile {
+  path: string;
+  purpose: string;
+  exports: string[];
+}
+
+export interface ConvergedApiPublicItem {
+  symbol: string;
+  signature: string;
+  parameters: Array<{ name: string; type: string; description: string }>;
+  returns: string;
+  errors: string[];
+}
+
+export interface ConvergedApiTypeItem {
+  name: string;
+  shape: string;
+  description: string;
+}
+
+export interface ConvergedApiArtifact {
+  files: ConvergedApiFile[];
+  public_api: ConvergedApiPublicItem[];
+  types: ConvergedApiTypeItem[];
+  notes: string;
+}
+
+export interface AuthoringApiConvergenceResult {
+  artifact: ConvergedApiArtifact;
+  markdown: string;
+  converged: boolean;
+  non_convergence_reason?: GateNonConvergenceReason;
+}
+
+export interface AuthoringApiCritiqueResult {
+  status: 'no_findings' | 'findings' | 'failed';
+  summary: string;
+  findings: ImplementationReviewFinding[];
+  error?: string;
+}
+
 export interface ArtifactRevisionResult {
   comment_responses: ArtifactCommentResponse[];
   page_content?: string;
@@ -316,6 +359,18 @@ export interface ArtifactAuthoringAgent {
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
   ): Promise<SpecReviewAuthorResponseResult>;
+  createTechSpecDraft?(
+    request: Request,
+    workspace_path: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: AgentServiceTelemetry,
+  ): Promise<ArtifactCreateResult>;
+  decomposeTasks?(
+    artifact_path: string,
+    workspace_path: string,
+    onProgress?: (message: string) => Promise<void>,
+    telemetry?: AgentServiceTelemetry,
+  ): Promise<ArtifactCreateResult>;
 }
 
 export type ImplementationStatus = 'complete' | 'needs_input' | 'failed';

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -350,6 +350,7 @@ export interface ArtifactAuthoringAgent {
     current_page_markdown?: string,
     onProgress?: (message: string) => Promise<void>,
     telemetry?: AgentServiceTelemetry,
+    options?: { staleConvergedApiRemoved?: boolean },
   ): Promise<ArtifactRevisionResult>;
   respondToSpecReview(
     artifact_path: string,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -65,6 +65,16 @@ export interface SpecReviewPolicy {
   template_conformance?: boolean;
 }
 
+export interface SpecAuthoringApiConvergencePolicy {
+  enabled?: boolean;
+  max_rounds?: number;
+  allow_same_model?: boolean;
+}
+
+export interface SpecAuthoringPolicy {
+  api_convergence?: SpecAuthoringApiConvergencePolicy;
+}
+
 export type ImplementationReviewConvergenceDepth = 'build_only' | 'layout' | 'public_api' | 'full';
 export type ImplementationReviewFeedbackDepth = ImplementationReviewConvergenceDepth | 'inherit';
 
@@ -136,6 +146,7 @@ export interface WorkflowConfig {
   ai: AiConfig;
   implementation_review?: ImplementationReviewPolicy;
   spec_review?: SpecReviewPolicy;
+  spec_authoring?: SpecAuthoringPolicy;
   sandbox?: SandboxConfig;
   journal?: JournalConfig;
   [key: string]: unknown;

--- a/tests/adapters/runtime-composition.test.ts
+++ b/tests/adapters/runtime-composition.test.ts
@@ -8,6 +8,8 @@ import { OpenAIDirectModelRunner } from '../../src/adapters/openai/direct-model-
 import { AnthropicDirectModelRunner } from '../../src/adapters/anthropic/direct-model-runner.js';
 import { OpenAIAgentSdkAgentRunner } from '../../src/adapters/openai/agent-sdk-agent-runner.js';
 import { ClaudeAgentSdkAgentRunner } from '../../src/adapters/anthropic/claude-agent-sdk-agent-runner.js';
+import { AuthoringApiConvergenceCoordinator } from '../../src/core/ai/authoring-api-convergence-coordinator.js';
+import { getSpecAuthoringPolicy } from '../../src/core/config.js';
 import type { ResolvedAiConfig } from '../../src/core/config.js';
 import type { RuntimeLogger } from '../../src/adapters/runtime-composition.js';
 import type { DirectModelRunner, DirectModelRunRequest, AgentRunner, AgentRunRequest } from '../../src/types/ai.js';
@@ -386,6 +388,31 @@ describe('buildAgentRunner — requestLogDir threading', () => {
     expect(runner).toBeInstanceOf(OpenAIAgentSdkAgentRunner);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((runner as any).requestLog).toBeUndefined();
+  });
+});
+
+describe('runtime wiring: AuthoringApiConvergenceCoordinator construction', () => {
+  it('AuthoringApiConvergenceCoordinator can be constructed with agentRunner, routingPolicy, policy, and logger', () => {
+    const agentRunner: AgentRunner = {
+      run: vi.fn().mockImplementation(async function* () {
+        yield { type: 'assistant', content: [{ type: 'text', text: 'ok' }] };
+      }),
+    };
+    const routingPolicy = {
+      resolve: vi.fn(),
+    } as unknown as import('../../src/core/ai/routing-policy.js').DefaultAgentRoutingPolicy;
+
+    const workflowConfig = {} as WorkflowConfig;
+    const specAuthoringPolicy = getSpecAuthoringPolicy(workflowConfig);
+
+    const coordinator = new AuthoringApiConvergenceCoordinator({
+      runner: agentRunner,
+      routingPolicy,
+      policy: specAuthoringPolicy.api_convergence,
+      logger: noopLogger,
+    });
+
+    expect(coordinator).toBeInstanceOf(AuthoringApiConvergenceCoordinator);
   });
 });
 

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -27,6 +27,7 @@ import {
   buildAuthoringApiProposePrompt,
   buildAuthoringApiCritiquePrompt,
   buildAuthoringApiRevisePrompt,
+  buildArtifactRevisePrompt,
 } from '../../../src/core/ai/agent-services.js';
 import { DefaultAgentRoutingPolicy } from '../../../src/core/ai/routing-policy.js';
 import { createLogger } from '../../../src/core/logger.js';
@@ -1911,6 +1912,44 @@ describe('buildArtifactTaskDecompositionPrompt', () => {
 
     expect(prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
     expect(prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+  });
+});
+
+describe('buildArtifactRevisePrompt', () => {
+  function makeFeedback(content = 'Please clarify the auth flow'): ThreadMessage {
+    return {
+      request_id: 'req-001',
+      channel: channel,
+      conversation: conversation,
+      origin: origin,
+      content,
+      author: 'U123',
+      received_at: new Date().toISOString(),
+    };
+  }
+
+  it('includes feedback content and artifact paths', () => {
+    const prompt = buildArtifactRevisePrompt(makeFeedback(), [], '/specs/feature.md', '/ws/.autocatalyst/result.json', '# Spec', []);
+
+    expect(prompt).toContain('Please clarify the auth flow');
+    expect(prompt).toContain('/specs/feature.md');
+    expect(prompt).toContain('/ws/.autocatalyst/result.json');
+    expect(prompt).toContain('# Spec');
+  });
+
+  it('does not include stale-API note when staleConvergedApiRemoved is false', () => {
+    const prompt = buildArtifactRevisePrompt(makeFeedback(), [], '/specs/feature.md', '/ws/.autocatalyst/result.json', '# Spec', [], false);
+
+    expect(prompt).not.toContain('## Converged API` section was removed');
+    expect(prompt).not.toContain('Do not invent or recreate a `## Converged API`');
+  });
+
+  it('includes stale-API-removal note when staleConvergedApiRemoved is true', () => {
+    const prompt = buildArtifactRevisePrompt(makeFeedback(), [], '/specs/feature.md', '/ws/.autocatalyst/result.json', '# Spec', [], true);
+
+    expect(prompt).toContain('## Converged API` section was removed');
+    expect(prompt).toContain('human feedback may have invalidated the agreed API contract');
+    expect(prompt).toContain('Do not invent or recreate a `## Converged API` section');
   });
 });
 

--- a/tests/core/ai/agent-services.test.ts
+++ b/tests/core/ai/agent-services.test.ts
@@ -22,10 +22,15 @@ import {
   buildLayeredProposePrompt,
   buildLayeredCritiquePrompt,
   buildLayeredRevisePrompt,
+  buildArtifactTechSpecDraftPrompt,
+  buildArtifactTaskDecompositionPrompt,
+  buildAuthoringApiProposePrompt,
+  buildAuthoringApiCritiquePrompt,
+  buildAuthoringApiRevisePrompt,
 } from '../../../src/core/ai/agent-services.js';
 import { DefaultAgentRoutingPolicy } from '../../../src/core/ai/routing-policy.js';
 import { createLogger } from '../../../src/core/logger.js';
-import type { AgentDrainSummary, AgentRunEvent, AgentRunRequest, AgentRunner, ImplementationResult } from '../../../src/types/ai.js';
+import type { AgentDrainSummary, AgentRunEvent, AgentRunRequest, AgentRunner, ConvergedApiArtifact, ImplementationResult, ImplementationReviewFinding } from '../../../src/types/ai.js';
 import type { Request, ThreadMessage } from '../../../src/types/events.js';
 import type { IssueManager } from '../../../src/types/issue-tracker.js';
 import type { ArtifactCommentAnchorCodec } from '../../../src/types/publisher.js';
@@ -1851,5 +1856,250 @@ describe('buildLayeredRevisePrompt', () => {
     expect(prompt).toContain('New file duplicates existing boundary');
     expect(prompt).toContain('Move skeleton into existing module');
     expect(prompt).toContain('Layout altitude contract');
+  });
+});
+
+describe('buildArtifactTechSpecDraftPrompt', () => {
+  it('contains required constraint strings for tech spec draft stage', () => {
+    const request = makeRequest('Build a new auth system');
+    const prompt = buildArtifactTechSpecDraftPrompt(request, '/workspace/specs', '/workspace/.autocatalyst/result.json');
+
+    expect(prompt).toContain('stop after requirements/design/tech spec');
+    expect(prompt).toContain('canonical empty top-level');
+    expect(prompt).toContain('## Task list');
+    expect(prompt).toContain('Do not decompose implementation tasks');
+  });
+
+  it('includes the request content and result path', () => {
+    const request = makeRequest('Build a new auth system');
+    const prompt = buildArtifactTechSpecDraftPrompt(request, '/workspace/specs', '/workspace/.autocatalyst/result.json');
+
+    expect(prompt).toContain('Build a new auth system');
+    expect(prompt).toContain('/workspace/.autocatalyst/result.json');
+    expect(prompt).toContain('/workspace/specs');
+  });
+
+  it('includes branch ownership policy and mm:planning override', () => {
+    const request = makeRequest('Build a new auth system');
+    const prompt = buildArtifactTechSpecDraftPrompt(request, '/workspace/specs', '/workspace/.autocatalyst/result.json');
+
+    expect(prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+    expect(prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+    expect(prompt).toContain('When using mm:planning, treat its Branch setup section as already complete.');
+    expect(prompt).toContain('Do not run git checkout -b feat/..., enhancement/..., or fix/...');
+  });
+});
+
+describe('buildArtifactTaskDecompositionPrompt', () => {
+  it('contains required constraint strings for task decomposition stage', () => {
+    const prompt = buildArtifactTaskDecompositionPrompt('/workspace/specs/feature-auth.md', '/workspace/.autocatalyst/result.json');
+
+    expect(prompt).toContain('run only the task-decomposition stage');
+    expect(prompt).toContain('Preserve the existing requirements, design, tech spec, and `## Converged API` sections');
+    expect(prompt).toContain('Respect the agreed API surface');
+  });
+
+  it('includes artifact path and result path', () => {
+    const prompt = buildArtifactTaskDecompositionPrompt('/workspace/specs/feature-auth.md', '/workspace/.autocatalyst/result.json');
+
+    expect(prompt).toContain('/workspace/specs/feature-auth.md');
+    expect(prompt).toContain('/workspace/.autocatalyst/result.json');
+  });
+
+  it('includes branch ownership policy', () => {
+    const prompt = buildArtifactTaskDecompositionPrompt('/workspace/specs/feature-auth.md', '/workspace/.autocatalyst/result.json');
+
+    expect(prompt).toContain('Autocatalyst owns git branch and PR management for this run.');
+    expect(prompt).toContain('Do not create branches, switch branches, or create worktrees.');
+  });
+});
+
+describe('buildAuthoringApiProposePrompt', () => {
+  it('contains JSON schema hint and round number', () => {
+    const prompt = buildAuthoringApiProposePrompt('# Spec content', '/workspace/.autocatalyst/api-artifact.json', 2);
+
+    expect(prompt).toContain('"files"');
+    expect(prompt).toContain('"public_api"');
+    expect(prompt).toContain('"types"');
+    expect(prompt).toContain('Round: 2');
+  });
+
+  it('includes spec content and artifact result path', () => {
+    const prompt = buildAuthoringApiProposePrompt('# My spec', '/workspace/.autocatalyst/api-artifact.json', 1);
+
+    expect(prompt).toContain('# My spec');
+    expect(prompt).toContain('/workspace/.autocatalyst/api-artifact.json');
+  });
+
+  it('identifies the agent role as API proposer', () => {
+    const prompt = buildAuthoringApiProposePrompt('# Spec', '/result.json', 1);
+
+    expect(prompt).toContain('You are an API proposer');
+  });
+});
+
+describe('buildAuthoringApiCritiquePrompt', () => {
+  const fakeArtifact: ConvergedApiArtifact = {
+    files: [{ path: 'src/auth.ts', purpose: 'Auth module', exports: ['AuthService'] }],
+    public_api: [{ symbol: 'AuthService', signature: 'export class AuthService', parameters: [], returns: 'AuthService', errors: [] }],
+    types: [],
+    notes: '',
+  };
+
+  it('contains the result schema and round number', () => {
+    const prompt = buildAuthoringApiCritiquePrompt('# Spec', fakeArtifact, '/workspace/.autocatalyst/critique.json', 3);
+
+    expect(prompt).toContain('"status"');
+    expect(prompt).toContain('"findings"');
+    expect(prompt).toContain('"no_findings"');
+    expect(prompt).toContain('Round: 3');
+  });
+
+  it('includes the serialized artifact and spec', () => {
+    const prompt = buildAuthoringApiCritiquePrompt('# My spec content', fakeArtifact, '/result.json', 1);
+
+    expect(prompt).toContain('# My spec content');
+    expect(prompt).toContain('AuthService');
+    expect(prompt).toContain('/result.json');
+  });
+
+  it('identifies the agent role as adversarial API critic', () => {
+    const prompt = buildAuthoringApiCritiquePrompt('# Spec', fakeArtifact, '/result.json', 1);
+
+    expect(prompt).toContain('You are an adversarial API critic');
+  });
+});
+
+describe('buildAuthoringApiRevisePrompt', () => {
+  const fakeArtifact: ConvergedApiArtifact = {
+    files: [{ path: 'src/auth.ts', purpose: 'Auth module', exports: ['AuthService'] }],
+    public_api: [{ symbol: 'AuthService', signature: 'export class AuthService', parameters: [], returns: 'AuthService', errors: [] }],
+    types: [],
+    notes: '',
+  };
+
+  const fakeFindings: ImplementationReviewFinding[] = [
+    {
+      id: 'API-1',
+      severity: 'blocker',
+      category: 'correctness',
+      finding: 'Missing error contract for invalid credentials',
+      suggested_action: 'Add AuthError to errors array',
+    },
+    {
+      id: 'API-2',
+      severity: 'warning',
+      category: 'docs',
+      finding: 'Parameter description is missing',
+    },
+  ];
+
+  it('contains finding IDs and current artifact', () => {
+    const prompt = buildAuthoringApiRevisePrompt('# Spec', fakeArtifact, fakeFindings, '/workspace/.autocatalyst/api-artifact.json', 2);
+
+    expect(prompt).toContain('API-1');
+    expect(prompt).toContain('API-2');
+    expect(prompt).toContain('Missing error contract for invalid credentials');
+    expect(prompt).toContain('AuthService');
+  });
+
+  it('includes suggested actions when present', () => {
+    const prompt = buildAuthoringApiRevisePrompt('# Spec', fakeArtifact, fakeFindings, '/result.json', 1);
+
+    expect(prompt).toContain('Add AuthError to errors array');
+  });
+
+  it('does not include suggested action line when absent', () => {
+    const prompt = buildAuthoringApiRevisePrompt('# Spec', fakeArtifact, fakeFindings, '/result.json', 1);
+
+    // API-2 has no suggested_action — should not produce a "Suggested action:" for it
+    const lines = prompt.split('\n');
+    const api2Idx = lines.findIndex(l => l.includes('API-2'));
+    const nextSuggested = lines.slice(api2Idx + 1).findIndex(l => l.startsWith('Suggested action:'));
+    const nextId = lines.slice(api2Idx + 1).findIndex(l => l.startsWith('[API_FINDING_ID:'));
+    // There should be no suggested action line between API-2 and the end of findings
+    expect(nextSuggested === -1 || (nextId !== -1 && nextSuggested > nextId)).toBe(true);
+  });
+
+  it('includes round number and artifact result path', () => {
+    const prompt = buildAuthoringApiRevisePrompt('# Spec', fakeArtifact, fakeFindings, '/workspace/result.json', 4);
+
+    expect(prompt).toContain('Round: 4');
+    expect(prompt).toContain('/workspace/result.json');
+  });
+
+  it('identifies the agent role as API proposer in revise mode', () => {
+    const prompt = buildAuthoringApiRevisePrompt('# Spec', fakeArtifact, fakeFindings, '/result.json', 1);
+
+    expect(prompt).toContain('You are an API proposer');
+  });
+});
+
+describe('AgentRunnerArtifactAuthoringAgent two-phase spec authoring', () => {
+  test('createTechSpecDraft passes tech spec draft prompt to runner and returns artifact path', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-tech-spec-draft-'));
+    try {
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: join(workspace, 'context-human', 'specs', 'feature-auth.md') }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+      const progress = vi.fn();
+
+      const result = await service.createTechSpecDraft(makeRequest('Build a new auth system'), workspace, progress);
+
+      expect(result.artifact_path).toContain('feature-auth.md');
+      expect(calls[0].route).toMatchObject({
+        task: 'artifact.create',
+        stage: 'new_thread',
+        intent: 'idea',
+        artifact_kind: 'feature_spec',
+      });
+      expect(calls[0].prompt).toContain('stop after requirements/design/tech spec');
+      expect(calls[0].prompt).toContain('Do not decompose implementation tasks');
+      expect(calls[0].working_directory).toBe(workspace);
+      expect(progress).toHaveBeenCalledWith('working');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('decomposeTasks passes task decomposition prompt to runner and returns artifact path', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'ac-decompose-tasks-'));
+    try {
+      const specPath = join(workspace, 'context-human', 'specs', 'feature-auth.md');
+      const calls: AgentRunRequest[] = [];
+      const runner = fakeAgentRunner(async request => {
+        calls.push(request);
+        const match = request.prompt.match(/Write the result to:\s*(.+)/i);
+        const resultPath = match?.[1]?.trim();
+        if (!resultPath) throw new Error('result path not found');
+        await mkdir(dirname(resultPath), { recursive: true });
+        await writeFile(resultPath, JSON.stringify({ artifact_path: specPath }), 'utf8');
+      });
+      const service = new AgentRunnerArtifactAuthoringAgent(runner, makePolicy());
+      const progress = vi.fn();
+
+      const result = await service.decomposeTasks(specPath, workspace, progress);
+
+      expect(result.artifact_path).toBe(specPath);
+      expect(calls[0].route).toMatchObject({
+        task: 'artifact.create',
+        stage: 'new_thread',
+        intent: 'idea',
+        artifact_kind: 'feature_spec',
+      });
+      expect(calls[0].prompt).toContain('run only the task-decomposition stage');
+      expect(calls[0].prompt).toContain('Preserve the existing requirements, design, tech spec');
+      expect(calls[0].working_directory).toBe(workspace);
+      expect(progress).toHaveBeenCalledWith('working');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/core/ai/authoring-api-artifact.test.ts
+++ b/tests/core/ai/authoring-api-artifact.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  insertConvergedApiSection,
+  parseConvergedApiArtifact,
+  removeConvergedApiSection,
+  renderConvergedApiMarkdown,
+} from '../../../src/core/ai/authoring-api-artifact.js';
+
+const artifact = {
+  files: [{ path: 'src/example.ts', purpose: 'Expose setup wizard orchestration', exports: ['createWizard'] }],
+  public_api: [{
+    symbol: 'createWizard',
+    signature: 'export function createWizard(input: WizardInput): WizardResult',
+    parameters: [{ name: 'input', type: 'WizardInput', description: 'Wizard configuration' }],
+    returns: 'WizardResult',
+    errors: ['ConfigError when required fields are missing'],
+  }],
+  types: [{ name: 'WizardInput', shape: 'interface WizardInput { repo: string }', description: 'Wizard configuration input' }],
+  notes: 'The API is intentionally small.',
+};
+
+describe('authoring API artifact helpers', () => {
+  it('parses valid JSON and ignores unknown fields', () => {
+    expect(parseConvergedApiArtifact(JSON.stringify({ ...artifact, extra: true }), 'api.json')).toEqual(artifact);
+  });
+
+  it('rejects invalid JSON shape with actionable paths', () => {
+    expect(() => parseConvergedApiArtifact('{"files":"bad"}', 'api.json')).toThrow(/files must be an array/);
+  });
+
+  it('renders canonical Converged API markdown', () => {
+    const markdown = renderConvergedApiMarkdown(artifact);
+    expect(markdown).toContain('## Converged API');
+    expect(markdown).toContain('| `src/example.ts` | Expose setup wizard orchestration | `createWizard` |');
+    expect(markdown).toContain('#### `createWizard`');
+    expect(markdown).toContain('- `input: WizardInput` — Wizard configuration');
+  });
+
+  it('inserts before top-level Task list and ignores headings inside fences', () => {
+    const source = '# Spec\n\n## Tech spec\n\n```md\n## Task list\n```\n\n## Task list\n';
+    const result = insertConvergedApiSection(source, renderConvergedApiMarkdown(artifact));
+    expect(result.indexOf('## Converged API')).toBeLessThan(result.indexOf('## Task list', result.indexOf('```') + 3));
+  });
+
+  it('removes an existing top-level generated section before replacement', () => {
+    const source = '# Spec\n\n## Tech spec\n\n## Converged API\nold\n\n## Task list\n';
+    const result = insertConvergedApiSection(source, renderConvergedApiMarkdown(artifact));
+    expect(result).not.toContain('old');
+    expect((result.match(/## Converged API/g) ?? []).length).toBe(1);
+  });
+
+  it('fails clearly when Task list insertion point is missing', () => {
+    expect(() => insertConvergedApiSection('# Spec\n\n## Tech spec\n', renderConvergedApiMarkdown(artifact))).toThrow(/missing the required `## Task list` insertion point/);
+  });
+
+  it('removes only the generated top-level section during feedback cleanup', () => {
+    const source = '# Spec\n\n## Converged API\nold\n\n## Task list\n- keep\n';
+    expect(removeConvergedApiSection(source)).toBe('# Spec\n\n## Task list\n- keep\n');
+  });
+});

--- a/tests/core/ai/authoring-api-artifact.test.ts
+++ b/tests/core/ai/authoring-api-artifact.test.ts
@@ -37,9 +37,17 @@ describe('authoring API artifact helpers', () => {
   });
 
   it('inserts before top-level Task list and ignores headings inside fences', () => {
+    // Source has ## Task list inside a fence AND a real ## Task list outside it.
+    // The insertion must go before the real (outside-fence) ## Task list, not the fenced one.
     const source = '# Spec\n\n## Tech spec\n\n```md\n## Task list\n```\n\n## Task list\n';
     const result = insertConvergedApiSection(source, renderConvergedApiMarkdown(artifact));
-    expect(result.indexOf('## Converged API')).toBeLessThan(result.indexOf('## Task list', result.indexOf('```') + 3));
+    // The original fenced block must be preserved intact
+    expect(result).toContain('```md\n## Task list\n```');
+    // ## Converged API must be inserted before the last (real) ## Task list
+    const convergedApiPos = result.indexOf('## Converged API');
+    const lastTaskListPos = result.lastIndexOf('## Task list');
+    expect(convergedApiPos).toBeGreaterThan(0);
+    expect(convergedApiPos).toBeLessThan(lastTaskListPos);
   });
 
   it('removes an existing top-level generated section before replacement', () => {

--- a/tests/core/ai/authoring-api-artifact.test.ts
+++ b/tests/core/ai/authoring-api-artifact.test.ts
@@ -65,4 +65,42 @@ describe('authoring API artifact helpers', () => {
     const source = '# Spec\n\n## Converged API\nold\n\n## Task list\n- keep\n';
     expect(removeConvergedApiSection(source)).toBe('# Spec\n\n## Task list\n- keep\n');
   });
+
+  describe('parseConvergedApiArtifact required field validation', () => {
+    it('rejects public_api item with empty symbol', () => {
+      const data = { ...artifact, public_api: [{ ...artifact.public_api[0], symbol: '' }] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).toThrow(/public_api\[0\]\.symbol/);
+    });
+
+    it('rejects public_api item with missing symbol', () => {
+      const { symbol: _s, ...rest } = artifact.public_api[0]!;
+      const data = { ...artifact, public_api: [rest] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).toThrow(/public_api\[0\]\.symbol/);
+    });
+
+    it('rejects public_api item with empty signature', () => {
+      const data = { ...artifact, public_api: [{ ...artifact.public_api[0], signature: '' }] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).toThrow(/public_api\[0\]\.signature/);
+    });
+
+    it('rejects public_api item with empty returns', () => {
+      const data = { ...artifact, public_api: [{ ...artifact.public_api[0], returns: '' }] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).toThrow(/public_api\[0\]\.returns/);
+    });
+
+    it('rejects types item with empty name', () => {
+      const data = { ...artifact, types: [{ ...artifact.types[0], name: '' }] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).toThrow(/types\[0\]\.name/);
+    });
+
+    it('rejects types item with empty shape', () => {
+      const data = { ...artifact, types: [{ ...artifact.types[0], shape: '' }] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).toThrow(/types\[0\]\.shape/);
+    });
+
+    it('accepts empty public_api and types arrays without validation errors', () => {
+      const data = { ...artifact, public_api: [], types: [] };
+      expect(() => parseConvergedApiArtifact(JSON.stringify(data), 'api.json')).not.toThrow();
+    });
+  });
 });

--- a/tests/core/ai/authoring-api-convergence-coordinator.test.ts
+++ b/tests/core/ai/authoring-api-convergence-coordinator.test.ts
@@ -1,0 +1,715 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AuthoringApiConvergenceCoordinator } from '../../../src/core/ai/authoring-api-convergence-coordinator.js';
+import type { AuthoringApiConvergenceCoordinatorDeps } from '../../../src/core/ai/authoring-api-convergence-coordinator.js';
+import type { AgentProfile, AgentRoute, GateReviewExchange } from '../../../src/types/ai.js';
+import type { Run } from '../../../src/types/runs.js';
+
+const WORKING_DIR = '/ws/test';
+
+const proposerProfile: AgentProfile = {
+  id: 'artifact-agent',
+  provider: 'anthropic_agent_sdk',
+  model: 'claude-sonnet-4-6',
+};
+const criticProfile: AgentProfile = {
+  id: 'review-agent',
+  provider: 'anthropic_agent_sdk',
+  model: 'claude-opus-4-5',
+};
+
+const routingPolicy = {
+  resolve: (route: AgentRoute): AgentProfile => {
+    if (route.task === 'artifact.api.propose') return proposerProfile;
+    if (route.task === 'artifact.api.critique') return criticProfile;
+    if (route.task === 'artifact.create') return proposerProfile;
+    if (route.task === 'spec.review') return criticProfile;
+    throw new Error(`Unexpected route: ${route.task}`);
+  },
+  resolveOptional: (route: AgentRoute): AgentProfile | null => {
+    try {
+      return routingPolicy.resolve(route);
+    } catch {
+      return null;
+    }
+  },
+};
+
+const validArtifact = {
+  files: [{ path: 'src/example.ts', purpose: 'main module', exports: ['foo'] }],
+  public_api: [
+    {
+      symbol: 'foo',
+      signature: 'export function foo(): void',
+      parameters: [],
+      returns: 'void',
+      errors: [],
+    },
+  ],
+  types: [],
+  notes: '',
+};
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-001',
+    request_id: 'req-001',
+    intent: 'idea',
+    stage: 'implementing',
+    workspace_path: WORKING_DIR,
+    branch: 'spec/req-001',
+    impl_feedback_ref: undefined,
+    issue: undefined,
+    attempt: 1,
+    pr_url: undefined,
+    last_impl_result: undefined,
+    review_exchanges: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRunner() {
+  return {
+    run: vi.fn().mockReturnValue((async function* () {
+      yield { type: 'assistant', content: [] };
+    })()),
+  };
+}
+
+function makeDeps(overrides: Partial<AuthoringApiConvergenceCoordinatorDeps> = {}): AuthoringApiConvergenceCoordinatorDeps {
+  return {
+    runner: makeRunner() as never,
+    routingPolicy,
+    policy: { enabled: true, max_rounds: 5, allow_same_model: false },
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    readFile: vi.fn().mockResolvedValue(JSON.stringify(validArtifact)),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeArtifactReadFile(critiqueResult: object) {
+  return async (path: string, _enc: 'utf-8'): Promise<string> => {
+    if (path.includes('authoring-api-artifact.json')) {
+      return JSON.stringify(validArtifact);
+    }
+    if (path.includes('authoring-api-critique-result.json')) {
+      return JSON.stringify(critiqueResult);
+    }
+    // Spec file
+    return '# Feature\n\n## Task list\n';
+  };
+}
+
+describe('AuthoringApiConvergenceCoordinator', () => {
+  describe('converges when critic returns no_findings', () => {
+    it('returns { artifact, markdown, converged: true }', async () => {
+      const deps = makeDeps({
+        readFile: makeArtifactReadFile({ status: 'no_findings', summary: 'Looks good', findings: [] }),
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const run = makeRun();
+      const result = await coordinator.run({
+        run,
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        captureFeedback: vi.fn(),
+      });
+      expect(result.converged).toBe(true);
+      expect(result.markdown).toContain('## Converged API');
+      expect(result.artifact).toBeDefined();
+    });
+
+    it('writes one GateReviewExchange with gate: api and converged: true', async () => {
+      const deps = makeDeps({
+        readFile: makeArtifactReadFile({ status: 'no_findings', summary: 'Clean', findings: [] }),
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const run = makeRun();
+      const capturedExchanges: unknown[] = [];
+
+      await coordinator.run({
+        run,
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        captureFeedback: (exchange: GateReviewExchange) => capturedExchanges.push(exchange),
+      });
+
+      expect(capturedExchanges).toHaveLength(1);
+      expect((capturedExchanges[0] as GateReviewExchange).gate).toBe('api');
+      expect((capturedExchanges[0] as GateReviewExchange).converged).toBe(true);
+    });
+
+    it('appends gate_exchange to run.gate_exchanges', async () => {
+      const deps = makeDeps({
+        readFile: makeArtifactReadFile({ status: 'no_findings', summary: 'Clean', findings: [] }),
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const run = makeRun();
+
+      await coordinator.run({
+        run,
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+      });
+
+      expect(run.gate_exchanges).toHaveLength(1);
+      expect(run.gate_exchanges![0]!.gate).toBe('api');
+      expect(run.gate_exchanges![0]!.converged).toBe(true);
+    });
+  });
+
+  describe('on findings, runs proposer revision with role proposer then critic round 2', () => {
+    it('converges on round 2 when critic returns findings in round 1 and no_findings in round 2', async () => {
+      let critiqueCallCount = 0;
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return JSON.stringify(validArtifact);
+        }
+        if (path.includes('authoring-api-critique-result.json')) {
+          critiqueCallCount++;
+          if (critiqueCallCount === 1) {
+            return JSON.stringify({
+              status: 'findings',
+              summary: 'Round 1 issues',
+              findings: [{ id: 'API-1', severity: 'warning', category: 'api', finding: 'Missing error handling.' }],
+            });
+          }
+          return JSON.stringify({ status: 'no_findings', summary: 'All clear', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockReturnValue((async function* () {
+          yield { type: 'assistant', content: [] };
+        })()),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.run({
+        run,
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+      });
+
+      expect(result.converged).toBe(true);
+      // runner.run called: proposer (round 1), critic (round 1), proposer revise, critic (round 2)
+      expect(runner.run).toHaveBeenCalledTimes(4);
+    });
+
+    it('calls proposer revision with role proposer', async () => {
+      let critiqueCallCount = 0;
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return JSON.stringify(validArtifact);
+        }
+        if (path.includes('authoring-api-critique-result.json')) {
+          critiqueCallCount++;
+          if (critiqueCallCount === 1) {
+            return JSON.stringify({
+              status: 'findings',
+              summary: 'Issues found',
+              findings: [{ id: 'API-1', severity: 'warning', category: 'api', finding: 'Problem.' }],
+            });
+          }
+          return JSON.stringify({ status: 'no_findings', summary: 'Clean', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const capturedRequests: Array<{ route: AgentRoute }> = [];
+      const runner = {
+        run: vi.fn().mockImplementation((req: { route: AgentRoute }) => {
+          capturedRequests.push(req);
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+      });
+
+      // Third call should be the revision (proposer, role proposer)
+      const revisionCall = capturedRequests[2];
+      expect(revisionCall).toBeDefined();
+      expect(revisionCall!.route.task).toBe('artifact.api.propose');
+      expect(revisionCall!.route.role).toBe('proposer');
+    });
+  });
+
+  describe('at max rounds, returns non-converged without failing', () => {
+    it('returns { converged: false, non_convergence_reason: max_rounds } at max_rounds=1 with findings', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return JSON.stringify(validArtifact);
+        }
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({
+            status: 'findings',
+            summary: 'Still blocked',
+            findings: [{ id: 'API-1', severity: 'blocker', category: 'api', finding: 'Critical issue.' }],
+          });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const deps = makeDeps({
+        readFile,
+        policy: { enabled: true, max_rounds: 1, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const run = makeRun();
+
+      const result = await coordinator.run({
+        run,
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+      });
+
+      expect(result.converged).toBe(false);
+      expect(result.non_convergence_reason).toBe('max_rounds');
+    });
+
+    it('does NOT throw when max rounds is reached', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return JSON.stringify(validArtifact);
+        }
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({
+            status: 'findings',
+            summary: 'Blockers remain',
+            findings: [{ id: 'API-1', severity: 'blocker', category: 'api', finding: 'Still blocked.' }],
+          });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const deps = makeDeps({
+        readFile,
+        policy: { enabled: true, max_rounds: 1, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+
+      await expect(
+        coordinator.run({
+          run: makeRun(),
+          artifact_path: '/ws/spec.md',
+          working_directory: WORKING_DIR,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it('emits a gate exchange with converged: false at max rounds', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return JSON.stringify(validArtifact);
+        }
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({
+            status: 'findings',
+            summary: 'Cap reached',
+            findings: [{ id: 'API-1', severity: 'warning', category: 'api', finding: 'Issue.' }],
+          });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const deps = makeDeps({
+        readFile,
+        policy: { enabled: true, max_rounds: 1, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const run = makeRun();
+      const capturedExchanges: GateReviewExchange[] = [];
+
+      await coordinator.run({
+        run,
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        captureFeedback: (exchange: GateReviewExchange) => capturedExchanges.push(exchange),
+      });
+
+      expect(capturedExchanges).toHaveLength(1);
+      expect(capturedExchanges[0]!.converged).toBe(false);
+      expect(capturedExchanges[0]!.non_convergence_reason).toBe('max_rounds');
+    });
+  });
+
+  describe('rejects same proposer/critic profile ID unless allow_same_model: true', () => {
+    it('throws with message mentioning allow_same_model when profiles share the same ID', async () => {
+      const sameProfile: AgentProfile = {
+        id: 'same-agent',
+        provider: 'anthropic_agent_sdk',
+        model: 'claude-sonnet-4-6',
+      };
+
+      const sameRoutingPolicy = {
+        resolve: (_route: AgentRoute): AgentProfile => sameProfile,
+        resolveOptional: (_route: AgentRoute): AgentProfile | null => sameProfile,
+      };
+
+      const deps = makeDeps({
+        routingPolicy: sameRoutingPolicy,
+        policy: { enabled: true, max_rounds: 5, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+
+      await expect(
+        coordinator.run({
+          run: makeRun(),
+          artifact_path: '/ws/spec.md',
+          working_directory: WORKING_DIR,
+        }),
+      ).rejects.toThrow(/allow_same_model/);
+    });
+
+    it('does not throw when same profile ID and allow_same_model: true', async () => {
+      const sameProfile: AgentProfile = {
+        id: 'same-agent',
+        provider: 'anthropic_agent_sdk',
+        model: 'claude-sonnet-4-6',
+      };
+
+      const sameRoutingPolicy = {
+        resolve: (_route: AgentRoute): AgentProfile => sameProfile,
+        resolveOptional: (_route: AgentRoute): AgentProfile | null => sameProfile,
+      };
+
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({ status: 'no_findings', summary: 'OK', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const deps = makeDeps({
+        routingPolicy: sameRoutingPolicy,
+        policy: { enabled: true, max_rounds: 5, allow_same_model: true },
+        readFile,
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+
+      await expect(
+        coordinator.run({
+          run: makeRun(),
+          artifact_path: '/ws/spec.md',
+          working_directory: WORKING_DIR,
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('invalid proposer JSON consumes a round', () => {
+    it('at max_rounds=1 with invalid artifact JSON, throws error', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return 'this is not valid json { broken }';
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const deps = makeDeps({
+        readFile,
+        policy: { enabled: true, max_rounds: 1, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+
+      await expect(
+        coordinator.run({
+          run: makeRun(),
+          artifact_path: '/ws/spec.md',
+          working_directory: WORKING_DIR,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('with max_rounds=2 and invalid JSON on round 1, round is consumed and remaining rounds exhaust without throwing unexpectedly', async () => {
+      // When round 1 has invalid artifact JSON, it's consumed via `continue`.
+      // Round 2 skips the proposer (round !== 1) and currentArtifact is still null,
+      // so it also `continue`s. The loop exits without a result, and the coordinator
+      // throws "loop exited unexpectedly". This is the documented behavior for this scenario.
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) {
+          return 'bad json';
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({
+        readFile,
+        runner: runner as never,
+        policy: { enabled: true, max_rounds: 2, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+
+      // With invalid JSON on round 1, all rounds are consumed without a valid artifact,
+      // and the coordinator throws the "loop exited unexpectedly" sentinel error.
+      await expect(
+        coordinator.run({
+          run: makeRun(),
+          artifact_path: '/ws/spec.md',
+          working_directory: WORKING_DIR,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('captures sessions with gate: api, role, and round', () => {
+    it('proposer session has gate: api, role: proposer, round: 1', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({ status: 'no_findings', summary: 'OK', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const capturedSessions: unknown[] = [];
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        captureSession: (data) => capturedSessions.push(data),
+      });
+
+      const proposerSession = capturedSessions.find(
+        (s) => (s as Record<string, unknown>)['role'] === 'proposer',
+      ) as Record<string, unknown> | undefined;
+
+      expect(proposerSession).toBeDefined();
+      expect(proposerSession!['gate']).toBe('api');
+      expect(proposerSession!['role']).toBe('proposer');
+      expect(proposerSession!['round']).toBe(1);
+    });
+
+    it('critic session has gate: api, role: critic, round: 1', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({ status: 'no_findings', summary: 'OK', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const capturedSessions: unknown[] = [];
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        captureSession: (data) => capturedSessions.push(data),
+      });
+
+      const criticSession = capturedSessions.find(
+        (s) => (s as Record<string, unknown>)['role'] === 'critic',
+      ) as Record<string, unknown> | undefined;
+
+      expect(criticSession).toBeDefined();
+      expect(criticSession!['gate']).toBe('api');
+      expect(criticSession!['role']).toBe('critic');
+      expect(criticSession!['round']).toBe(1);
+    });
+
+    it('multi-round run captures correct round numbers per session', async () => {
+      let critiqueCount = 0;
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          critiqueCount++;
+          if (critiqueCount === 1) {
+            return JSON.stringify({
+              status: 'findings',
+              summary: 'Round 1 issues',
+              findings: [{ id: 'API-1', severity: 'warning', category: 'api', finding: 'Issue.' }],
+            });
+          }
+          return JSON.stringify({ status: 'no_findings', summary: 'Clean', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const capturedSessions: Array<Record<string, unknown>> = [];
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        captureSession: (data) => capturedSessions.push(data as Record<string, unknown>),
+      });
+
+      // Expect: proposer(round=1), critic(round=1), proposer-revise(round=1), critic(round=2)
+      const round1Proposers = capturedSessions.filter((s) => s['role'] === 'proposer' && s['round'] === 1);
+      const round1Critics = capturedSessions.filter((s) => s['role'] === 'critic' && s['round'] === 1);
+      const round2Critics = capturedSessions.filter((s) => s['role'] === 'critic' && s['round'] === 2);
+
+      expect(round1Proposers.length).toBeGreaterThanOrEqual(1);
+      expect(round1Critics).toHaveLength(1);
+      expect(round2Critics).toHaveLength(1);
+    });
+  });
+
+  describe('progress messages are emitted', () => {
+    it('emits "API convergence round 1 started — proposer drafting API artifact"', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({ status: 'no_findings', summary: 'OK', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const progressMessages: string[] = [];
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        onProgress: async (msg) => { progressMessages.push(msg); },
+      });
+
+      expect(progressMessages.some((m) => m.includes('API convergence round 1 started') && m.includes('proposer drafting API artifact'))).toBe(true);
+    });
+
+    it('emits "API critic returned N finding(s) — revising API artifact" when findings are present', async () => {
+      let critiqueCount = 0;
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          critiqueCount++;
+          if (critiqueCount === 1) {
+            return JSON.stringify({
+              status: 'findings',
+              summary: 'Issues',
+              findings: [{ id: 'API-1', severity: 'warning', category: 'api', finding: 'Issue.' }],
+            });
+          }
+          return JSON.stringify({ status: 'no_findings', summary: 'Clean', findings: [] });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({ readFile, runner: runner as never });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const progressMessages: string[] = [];
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        onProgress: async (msg) => { progressMessages.push(msg); },
+      });
+
+      expect(progressMessages.some((m) => m.includes('API critic returned') && m.includes('finding(s)') && m.includes('revising API artifact'))).toBe(true);
+    });
+
+    it('emits "API convergence reached round cap — proceeding with current API" at max_rounds', async () => {
+      const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
+        if (path.includes('authoring-api-artifact.json')) return JSON.stringify(validArtifact);
+        if (path.includes('authoring-api-critique-result.json')) {
+          return JSON.stringify({
+            status: 'findings',
+            summary: 'Blocked',
+            findings: [{ id: 'API-1', severity: 'blocker', category: 'api', finding: 'Still blocked.' }],
+          });
+        }
+        return '# Feature\n\n## Task list\n';
+      };
+
+      const runner = {
+        run: vi.fn().mockImplementation(() => {
+          return (async function* () {
+            yield { type: 'assistant', content: [] };
+          })();
+        }),
+      };
+
+      const deps = makeDeps({
+        readFile,
+        runner: runner as never,
+        policy: { enabled: true, max_rounds: 1, allow_same_model: false },
+      });
+      const coordinator = new AuthoringApiConvergenceCoordinator(deps);
+      const progressMessages: string[] = [];
+
+      await coordinator.run({
+        run: makeRun(),
+        artifact_path: '/ws/spec.md',
+        working_directory: WORKING_DIR,
+        onProgress: async (msg) => { progressMessages.push(msg); },
+      });
+
+      expect(progressMessages.some((m) => m.includes('API convergence reached round cap') && m.includes('proceeding with current API'))).toBe(true);
+    });
+  });
+});

--- a/tests/core/ai/authoring-api-convergence-coordinator.test.ts
+++ b/tests/core/ai/authoring-api-convergence-coordinator.test.ts
@@ -437,11 +437,9 @@ describe('AuthoringApiConvergenceCoordinator', () => {
       ).rejects.toThrow();
     });
 
-    it('with max_rounds=2 and invalid JSON on round 1, round is consumed and remaining rounds exhaust without throwing unexpectedly', async () => {
-      // When round 1 has invalid artifact JSON, it's consumed via `continue`.
-      // Round 2 skips the proposer (round !== 1) and currentArtifact is still null,
-      // so it also `continue`s. The loop exits without a result, and the coordinator
-      // throws "loop exited unexpectedly". This is the documented behavior for this scenario.
+    it('with max_rounds=2 and invalid JSON on both rounds, proposer is called twice then throws at max rounds', async () => {
+      // When round 1 parse fails, round 2 re-invokes the proposer (currentArtifact === null).
+      // If round 2 also produces invalid JSON, the coordinator throws the max-rounds parse error.
       const readFile = async (path: string, _enc: 'utf-8'): Promise<string> => {
         if (path.includes('authoring-api-artifact.json')) {
           return 'bad json';
@@ -464,15 +462,18 @@ describe('AuthoringApiConvergenceCoordinator', () => {
       });
       const coordinator = new AuthoringApiConvergenceCoordinator(deps);
 
-      // With invalid JSON on round 1, all rounds are consumed without a valid artifact,
-      // and the coordinator throws the "loop exited unexpectedly" sentinel error.
+      // Proposer is called on round 1 and round 2 (re-invoked due to null artifact).
+      // At max rounds with still-invalid JSON, throws a parse error (not "loop exited unexpectedly").
       await expect(
         coordinator.run({
           run: makeRun(),
           artifact_path: '/ws/spec.md',
           working_directory: WORKING_DIR,
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/invalid JSON artifact/);
+
+      // Proposer was re-invoked on round 2 since currentArtifact was null after round 1 failure
+      expect(runner.run).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/core/ai/layered-convergence-policy.test.ts
+++ b/tests/core/ai/layered-convergence-policy.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { resolveImplementationConvergencePolicy } from '../../../src/core/ai/layered-convergence-policy.js';
+import type { WorkflowConfig } from '../../../src/types/config.js';
+
+function makeConfig(overrides: Partial<WorkflowConfig['implementation_review']> = {}): WorkflowConfig {
+  return {
+    implementation_review: {
+      convergence: {
+        enabled: true,
+        depth: 'build_only',
+        ...overrides.convergence,
+      },
+      ...overrides,
+    },
+  } as WorkflowConfig;
+}
+
+describe('resolveImplementationConvergencePolicy', () => {
+  it('returns build_only depth unchanged with no warning when depth is build_only', () => {
+    const warnings: unknown[] = [];
+    const config = makeConfig({ convergence: { enabled: true, depth: 'build_only' } });
+    const policy = resolveImplementationConvergencePolicy(config, warning => warnings.push(warning));
+    expect(policy.depth).toBe('build_only');
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('maps full depth to build_only and emits a depth_ignored warning', () => {
+    const warnings: unknown[] = [];
+    const config = makeConfig({ convergence: { enabled: true, depth: 'full' } });
+    const policy = resolveImplementationConvergencePolicy(config, warning => warnings.push(warning));
+    expect(policy.depth).toBe('build_only');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      event: 'implementation_review.convergence.depth_ignored',
+      configured_depth: 'full',
+      effective_behavior: 'build_only',
+    });
+  });
+
+  it('maps layout depth to build_only and emits a depth_ignored warning', () => {
+    const warnings: unknown[] = [];
+    const config = makeConfig({ convergence: { enabled: true, depth: 'layout' } });
+    const policy = resolveImplementationConvergencePolicy(config, warning => warnings.push(warning));
+    expect(policy.depth).toBe('build_only');
+    expect(warnings[0]).toMatchObject({
+      event: 'implementation_review.convergence.depth_ignored',
+      configured_depth: 'layout',
+      effective_behavior: 'build_only',
+    });
+  });
+
+  it('maps public_api depth to build_only and emits a depth_ignored warning', () => {
+    const warnings: unknown[] = [];
+    const config = makeConfig({ convergence: { enabled: true, depth: 'public_api' } });
+    const policy = resolveImplementationConvergencePolicy(config, warning => warnings.push(warning));
+    expect(policy.depth).toBe('build_only');
+    expect(warnings[0]).toMatchObject({
+      event: 'implementation_review.convergence.depth_ignored',
+      configured_depth: 'public_api',
+      effective_behavior: 'build_only',
+    });
+  });
+
+  it('works without a warn callback (no throw)', () => {
+    const config = makeConfig({ convergence: { enabled: true, depth: 'full' } });
+    const policy = resolveImplementationConvergencePolicy(config);
+    expect(policy.depth).toBe('build_only');
+  });
+
+  it('preserves other policy fields (enabled, allow_same_model, max_model_sessions_per_run)', () => {
+    const warnings: unknown[] = [];
+    const config = makeConfig({ convergence: { enabled: true, allow_same_model: true, depth: 'full', max_model_sessions_per_run: 10 } });
+    const policy = resolveImplementationConvergencePolicy(config, warning => warnings.push(warning));
+    expect(policy.enabled).toBe(true);
+    expect(policy.allow_same_model).toBe(true);
+    expect(policy.max_model_sessions_per_run).toBe(10);
+  });
+});

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -13,6 +13,7 @@ import {
   resolveAiConfig,
   getImplementationReviewPolicy,
   getSpecReviewPolicy,
+  getSpecAuthoringPolicy,
   isWorkspaceAutoPruneEnabled,
 } from '../../src/core/config.js';
 import type { WorkflowConfig } from '../../src/types/config.js';
@@ -706,6 +707,34 @@ describe('implementation_review.convergence layered config', () => {
         },
       },
     })).toThrow('implementation_review.convergence.max_model_sessions_per_run must be a positive integer');
+  });
+});
+
+// ─── getSpecAuthoringPolicy ───────────────────────────────────────────────────
+
+describe('getSpecAuthoringPolicy', () => {
+  const base = { ai: { credentials: [], endpoints: [], profiles: [], routing: {} } } as WorkflowConfig;
+
+  it('defaults authoring API convergence off with five rounds and distinct profiles', () => {
+    expect(getSpecAuthoringPolicy(base)).toEqual({
+      api_convergence: { enabled: false, max_rounds: 5, allow_same_model: false },
+    });
+  });
+
+  it('reads enabled authoring API convergence policy', () => {
+    expect(getSpecAuthoringPolicy({
+      ...base,
+      spec_authoring: { api_convergence: { enabled: true, max_rounds: 3, allow_same_model: true } },
+    })).toEqual({
+      api_convergence: { enabled: true, max_rounds: 3, allow_same_model: true },
+    });
+  });
+
+  it('rejects non-positive max_rounds', () => {
+    expect(() => getSpecAuthoringPolicy({
+      ...base,
+      spec_authoring: { api_convergence: { enabled: true, max_rounds: 0 } },
+    })).toThrow(/spec_authoring\.api_convergence\.max_rounds must be a positive integer/);
   });
 });
 

--- a/tests/core/default-handler-registry.test.ts
+++ b/tests/core/default-handler-registry.test.ts
@@ -14,6 +14,8 @@ const handlerConstructorDeps = vi.hoisted(() => ({
   start: [] as Array<{ convergencePolicy?: unknown; budgetWriter?: unknown }>,
   feedback: [] as Array<{ convergencePolicy?: unknown; budgetWriter?: unknown }>,
   approval: [] as Array<{ convergencePolicy?: unknown; budgetWriter?: unknown }>,
+  artifactCreation: [] as Array<{ specAuthoringPolicy?: unknown; authoringApiConvergenceCoordinator?: unknown }>,
+  artifactFeedback: [] as Array<{ specAuthoringPolicy?: unknown; authoringApiConvergenceCoordinator?: unknown }>,
 }));
 
 vi.mock('../../src/core/handlers/implementation-start-handler.js', async (importActual) => {
@@ -49,6 +51,32 @@ vi.mock('../../src/core/handlers/implementation-approval-handler.js', async (imp
     ImplementationApprovalHandler: class extends actual.ImplementationApprovalHandler {
       constructor(deps: ConstructorParameters<typeof actual.ImplementationApprovalHandler>[0]) {
         handlerConstructorDeps.approval.push(deps);
+        super(deps);
+      }
+    },
+  };
+});
+
+vi.mock('../../src/core/handlers/artifact-creation-handler.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/core/handlers/artifact-creation-handler.js')>();
+  return {
+    ...actual,
+    ArtifactCreationHandler: class extends actual.ArtifactCreationHandler {
+      constructor(deps: ConstructorParameters<typeof actual.ArtifactCreationHandler>[0]) {
+        handlerConstructorDeps.artifactCreation.push(deps);
+        super(deps);
+      }
+    },
+  };
+});
+
+vi.mock('../../src/core/handlers/artifact-feedback-handler.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/core/handlers/artifact-feedback-handler.js')>();
+  return {
+    ...actual,
+    ArtifactFeedbackHandler: class extends actual.ArtifactFeedbackHandler {
+      constructor(deps: ConstructorParameters<typeof actual.ArtifactFeedbackHandler>[0]) {
+        handlerConstructorDeps.artifactFeedback.push(deps);
         super(deps);
       }
     },
@@ -537,6 +565,68 @@ describe('buildDefaultHandlerRegistry', () => {
       expect(handlerConstructorDeps.approval.length).toBeGreaterThan(0);
       expect(handlerConstructorDeps.approval.at(-1)?.convergencePolicy).toBe(convergencePolicy);
       expect(handlerConstructorDeps.approval.at(-1)?.budgetWriter).toBe(budgetWriter);
+    });
+  });
+
+  // Wiring guard: authoring API convergence deps must flow to ArtifactCreationHandler
+  // but must NOT bleed into ArtifactFeedbackHandler (which runs the revise path, not create).
+  describe('forwards specAuthoringPolicy and authoringApiConvergenceCoordinator', () => {
+    it('passes both deps to ArtifactCreationHandler when provided', async () => {
+      handlerConstructorDeps.artifactCreation.length = 0;
+      const specAuthoringPolicy = { api_convergence: { enabled: true, max_rounds: 3, allow_same_model: false } };
+      const authoringApiConvergenceCoordinator = { run: vi.fn() };
+      const deps = {
+        ...makeDeps(),
+        specAuthoringPolicy,
+        authoringApiConvergenceCoordinator,
+      };
+      (deps.workspaceManager.create as ReturnType<typeof vi.fn>).mockResolvedValue({ workspace_path: '/ws/request-001', branch: 'spec/request-001' });
+      (deps.artifactAuthoringAgent.create as ReturnType<typeof vi.fn>).mockResolvedValue({ artifact_path: '/ws/request-001/spec.md' });
+      (deps.artifactPublisher.createArtifact as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'CANVAS-X', url: 'https://x' });
+
+      const registry = buildDefaultHandlerRegistry(deps);
+      const run = makeRun({ stage: 'new_thread', intent: 'idea' });
+      const handler = registry.resolve({ event_type: 'new_request', stage: 'new_thread', intent: 'idea' });
+      const event: InboundEvent = {
+        type: 'new_request',
+        payload: {
+          request_id: 'request-001',
+          channel: run.channel,
+          conversation: run.conversation,
+          origin: run.origin,
+          author: 'U123',
+          content: 'idea',
+          intent: 'idea',
+          received_at: new Date().toISOString(),
+        },
+      };
+      await handler?.(event, run);
+
+      expect(handlerConstructorDeps.artifactCreation.length).toBeGreaterThan(0);
+      expect(handlerConstructorDeps.artifactCreation.at(-1)?.specAuthoringPolicy).toBe(specAuthoringPolicy);
+      expect(handlerConstructorDeps.artifactCreation.at(-1)?.authoringApiConvergenceCoordinator).toBe(authoringApiConvergenceCoordinator);
+    });
+
+    it('does NOT pass specAuthoringPolicy or authoringApiConvergenceCoordinator to ArtifactFeedbackHandler', async () => {
+      handlerConstructorDeps.artifactFeedback.length = 0;
+      const specAuthoringPolicy = { api_convergence: { enabled: true, max_rounds: 3, allow_same_model: false } };
+      const authoringApiConvergenceCoordinator = { run: vi.fn() };
+      const deps = {
+        ...makeDeps(),
+        specAuthoringPolicy,
+        authoringApiConvergenceCoordinator,
+      };
+      (deps.artifactAuthoringAgent.revise as ReturnType<typeof vi.fn>).mockResolvedValue({ comment_responses: [], page_content: '# Revised' });
+
+      const registry = buildDefaultHandlerRegistry(deps);
+      const run = makeRun();
+      const event: InboundEvent = { type: 'thread_message', payload: makeFeedback({ content: 'tweak this' }) };
+      const handler = registry.resolve({ event_type: 'thread_message', stage: 'reviewing_spec', intent: 'feedback' });
+      await handler?.(event, run);
+
+      expect(handlerConstructorDeps.artifactFeedback.length).toBeGreaterThan(0);
+      expect(handlerConstructorDeps.artifactFeedback.at(-1)?.specAuthoringPolicy).toBeUndefined();
+      expect(handlerConstructorDeps.artifactFeedback.at(-1)?.authoringApiConvergenceCoordinator).toBeUndefined();
     });
   });
 });

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -343,4 +343,162 @@ describe('ArtifactCreationHandler', () => {
       expect.stringContaining('Artifact ready for review'),
     );
   });
+
+  describe('authoring API convergence', () => {
+    it('disabled policy calls create() once for idea and does not call coordinator', async () => {
+      const create = vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/feature-test.md' });
+      const coordinatorRun = vi.fn();
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: { create },
+        specAuthoringPolicy: { api_convergence: { enabled: false, max_rounds: 3, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: coordinatorRun },
+      });
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(create).toHaveBeenCalledOnce();
+      expect(coordinatorRun).not.toHaveBeenCalled();
+      expect(deps.failRun).not.toHaveBeenCalled();
+    });
+
+    it('enabled policy for idea calls createTechSpecDraft, branchGuard, coordinator, decomposeTasks, then existing flow', async () => {
+      const callOrder: string[] = [];
+
+      const createTechSpecDraft = vi.fn().mockImplementation(async () => {
+        callOrder.push('techDraft');
+        return { artifact_path: '/ws/request-001/context-human/specs/feature-test.md' };
+      });
+      const branchGuardCheck = vi.fn().mockImplementation(async () => { callOrder.push('branchGuard'); });
+      const coordinatorRun = vi.fn().mockImplementation(async () => {
+        callOrder.push('apiConvergence');
+        return { artifact: { files: [], public_api: [], types: [], notes: '' }, markdown: '## Converged API\n\n### Notes\n\n', converged: true };
+      });
+      const decomposeTasks = vi.fn().mockImplementation(async () => {
+        callOrder.push('decomposeTasks');
+        return { artifact_path: '/ws/request-001/context-human/specs/feature-test.md' };
+      });
+      const createArtifact = vi.fn().mockImplementation(async () => {
+        callOrder.push('publish');
+        return { id: 'CANVAS001', url: 'https://artifact.example.test/CANVAS001' };
+      });
+      const specContent = '# Spec\n\n## Task list\n\n- [ ] Task 1\n';
+      const readFile = vi.fn().mockResolvedValue(specContent);
+      const writeFile = vi.fn().mockResolvedValue(undefined);
+
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: {
+          create: vi.fn(),
+          createTechSpecDraft,
+          decomposeTasks,
+        },
+        branchGuard: { check: branchGuardCheck },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: coordinatorRun },
+        readFile,
+        writeFile,
+        artifactPublisher: {
+          createArtifact,
+          updateStatus: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      // Tech spec draft, then branch guard #1, then API convergence, then decompose tasks,
+      // then branch guard #2 (existing), then publish
+      expect(callOrder).toEqual(['techDraft', 'branchGuard', 'apiConvergence', 'decomposeTasks', 'branchGuard', 'publish']);
+      expect(deps.artifactAuthoringAgent.create).not.toHaveBeenCalled();
+      expect(coordinatorRun).toHaveBeenCalledWith(expect.objectContaining({
+        artifact_path: '/ws/request-001/context-human/specs/feature-test.md',
+        working_directory: '/ws/request-001',
+      }));
+      expect(writeFile).toHaveBeenCalledWith('/ws/request-001/context-human/specs/feature-test.md', expect.stringContaining('## Converged API'), 'utf-8');
+      expect(deps.failRun).not.toHaveBeenCalled();
+      expect(run.stage).toBe('reviewing_spec');
+    });
+
+    it('enabled policy does not affect bug triage — uses create() instead', async () => {
+      const create = vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/bug-login.md' });
+      const coordinatorRun = vi.fn();
+      const createTechSpecDraft = vi.fn();
+      const decomposeTasks = vi.fn();
+
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: { create, createTechSpecDraft, decomposeTasks },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: coordinatorRun },
+      });
+
+      const run = makeRun({ intent: 'bug' });
+      await handler.handle(run, makeRequest(), 'bug');
+
+      expect(create).toHaveBeenCalledOnce();
+      expect(createTechSpecDraft).not.toHaveBeenCalled();
+      expect(coordinatorRun).not.toHaveBeenCalled();
+      expect(decomposeTasks).not.toHaveBeenCalled();
+      expect(deps.failRun).not.toHaveBeenCalled();
+    });
+
+    it('enabled policy does not activate when coordinator is missing', async () => {
+      const create = vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/feature-test.md' });
+      const createTechSpecDraft = vi.fn();
+      const decomposeTasks = vi.fn();
+
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: { create, createTechSpecDraft, decomposeTasks },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        // authoringApiConvergenceCoordinator intentionally omitted
+      });
+
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(create).toHaveBeenCalledOnce();
+      expect(createTechSpecDraft).not.toHaveBeenCalled();
+      expect(deps.failRun).not.toHaveBeenCalled();
+    });
+
+    it('enabled path destroys workspace and fails run when tech spec draft throws', async () => {
+      const draftError = new Error('tech spec draft failed');
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: {
+          create: vi.fn(),
+          createTechSpecDraft: vi.fn().mockRejectedValue(draftError),
+          decomposeTasks: vi.fn(),
+        },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: vi.fn() },
+      });
+
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
+      expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, draftError);
+      expect(deps.artifactPublisher.createArtifact).not.toHaveBeenCalled();
+    });
+
+    it('enabled path destroys workspace and fails run when coordinator throws', async () => {
+      const coordinatorError = new Error('coordinator failed');
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: {
+          create: vi.fn(),
+          createTechSpecDraft: vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/feature-test.md' }),
+          decomposeTasks: vi.fn(),
+        },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: vi.fn().mockRejectedValue(coordinatorError) },
+        readFile: vi.fn().mockResolvedValue('# Spec\n\n## Task list\n\n'),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
+      expect(deps.failRun).toHaveBeenCalledWith(run, TEST_CONVERSATION, coordinatorError);
+      expect(deps.artifactPublisher.createArtifact).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { ArtifactCreationHandler } from '../../../src/core/handlers/artifact-creation-handler.js';
 import type { Request } from '../../../src/types/events.js';
 import type { Run } from '../../../src/types/runs.js';
@@ -326,6 +329,81 @@ describe('ArtifactCreationHandler', () => {
 
       expect(deps.artifactPublisher.createArtifact).toHaveBeenCalled();
       expect(deps.failRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('authoring API convergence — integration (real file I/O)', () => {
+    let tmpDir: string;
+
+    afterEach(async () => {
+      if (tmpDir) {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('full enabled speccing lifecycle writes Converged API section before Task list and transitions to reviewing_spec', async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ach-integration-'));
+      const specFile = path.join(tmpDir, 'feature-spec.md');
+      const specContent = [
+        '# Feature Spec',
+        '',
+        '## What',
+        'Build a setup wizard.',
+        '',
+        '## Tech spec',
+        'Use TypeScript.',
+        '',
+        '## Task list',
+        '',
+      ].join('\n');
+      await fs.writeFile(specFile, specContent, 'utf-8');
+
+      const convergedMarkdown = '## Converged API\n\n### Notes\n\nTest.';
+
+      const createTechSpecDraft = vi.fn().mockResolvedValue({ artifact_path: specFile });
+      const coordinatorRun = vi.fn().mockResolvedValue({
+        artifact: { files: [], public_api: [], types: [], notes: 'Test.' },
+        markdown: convergedMarkdown,
+        converged: true,
+      });
+      const decomposeTasks = vi.fn().mockResolvedValue({ artifact_path: specFile });
+
+      const { handler, deps } = makeHandler({
+        workspaceManager: {
+          create: vi.fn().mockResolvedValue({ workspace_path: tmpDir, branch: 'spec/request-001' }),
+          destroy: vi.fn().mockResolvedValue(undefined),
+        },
+        artifactAuthoringAgent: {
+          create: vi.fn(),
+          createTechSpecDraft,
+          decomposeTasks,
+        },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: coordinatorRun },
+        // Use real fs — omit readFile/writeFile so the handler defaults to node:fs/promises
+      });
+
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      // Verify steps were called
+      expect(createTechSpecDraft).toHaveBeenCalledOnce();
+      expect(coordinatorRun).toHaveBeenCalledWith(expect.objectContaining({
+        artifact_path: specFile,
+        working_directory: tmpDir,
+      }));
+      expect(decomposeTasks).toHaveBeenCalledOnce();
+      expect(deps.failRun).not.toHaveBeenCalled();
+
+      // Read the final spec file from disk
+      const finalSpec = await fs.readFile(specFile, 'utf-8');
+
+      // Assert section ordering
+      expect(finalSpec.indexOf('## Tech spec')).toBeLessThan(finalSpec.indexOf('## Converged API'));
+      expect(finalSpec.indexOf('## Converged API')).toBeLessThan(finalSpec.indexOf('## Task list'));
+
+      // Assert the run transitioned to reviewing_spec
+      expect(run.stage).toBe('reviewing_spec');
     });
   });
 

--- a/tests/core/handlers/artifact-creation-handler.test.ts
+++ b/tests/core/handlers/artifact-creation-handler.test.ts
@@ -518,8 +518,8 @@ describe('ArtifactCreationHandler', () => {
       expect(deps.failRun).not.toHaveBeenCalled();
     });
 
-    it('enabled policy does not activate when coordinator is missing', async () => {
-      const create = vi.fn().mockResolvedValue({ artifact_path: '/ws/request-001/context-human/specs/feature-test.md' });
+    it('enabled policy fails clearly when coordinator is missing', async () => {
+      const create = vi.fn();
       const createTechSpecDraft = vi.fn();
       const decomposeTasks = vi.fn();
 
@@ -532,9 +532,33 @@ describe('ArtifactCreationHandler', () => {
       const run = makeRun({ intent: 'idea' });
       await handler.handle(run, makeRequest(), 'idea');
 
-      expect(create).toHaveBeenCalledOnce();
+      expect(deps.failRun).toHaveBeenCalledWith(
+        run,
+        TEST_CONVERSATION,
+        expect.objectContaining({ message: expect.stringContaining('authoringApiConvergenceCoordinator') }),
+      );
+      expect(create).not.toHaveBeenCalled();
       expect(createTechSpecDraft).not.toHaveBeenCalled();
-      expect(deps.failRun).not.toHaveBeenCalled();
+      expect(deps.workspaceManager.destroy).toHaveBeenCalledWith('/ws/request-001');
+    });
+
+    it('enabled policy fails clearly when createTechSpecDraft is missing', async () => {
+      const create = vi.fn();
+      const { handler, deps } = makeHandler({
+        artifactAuthoringAgent: { create },
+        specAuthoringPolicy: { api_convergence: { enabled: true, max_rounds: 2, allow_same_model: false } },
+        authoringApiConvergenceCoordinator: { run: vi.fn() },
+      });
+
+      const run = makeRun({ intent: 'idea' });
+      await handler.handle(run, makeRequest(), 'idea');
+
+      expect(deps.failRun).toHaveBeenCalledWith(
+        run,
+        TEST_CONVERSATION,
+        expect.objectContaining({ message: expect.stringContaining('createTechSpecDraft') }),
+      );
+      expect(create).not.toHaveBeenCalled();
     });
 
     it('enabled path destroys workspace and fails run when tech spec draft throws', async () => {

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -430,7 +430,7 @@ describe('ArtifactFeedbackHandler', () => {
       );
     });
 
-    it('calls revise() without extra options when section was removed', async () => {
+    it('passes staleConvergedApiRemoved: true in telemetry when section was removed', async () => {
       const specWithApi = '# Feature Spec\n\n## Converged API\n\nOld API.\n';
       const { handler, deps } = makeHandler({
         readFile: vi.fn().mockResolvedValue(specWithApi),
@@ -448,7 +448,7 @@ describe('ArtifactFeedbackHandler', () => {
         '/ws/request-001',
         undefined,
         expect.any(Function),
-        expect.objectContaining({ run_id: 'run-001' }),
+        expect.objectContaining({ run_id: 'run-001', staleConvergedApiRemoved: true }),
       );
     });
 
@@ -475,7 +475,7 @@ describe('ArtifactFeedbackHandler', () => {
         '/ws/request-001',
         undefined,
         expect.any(Function),
-        expect.objectContaining({ run_id: 'run-001' }),
+        expect.objectContaining({ run_id: 'run-001', staleConvergedApiRemoved: false }),
       );
     });
 

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -73,6 +73,8 @@ function makeHandler(overrides: Partial<ConstructorParameters<typeof ArtifactFee
       warn: vi.fn(),
       error: vi.fn(),
     },
+    readFile: vi.fn().mockResolvedValue('# Feature Spec\n\nSome content.\n'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 
@@ -106,6 +108,7 @@ describe('ArtifactFeedbackHandler', () => {
       undefined,
       expect.any(Function),
       expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
+      { staleConvergedApiRemoved: false },
     );
     expect(deps.artifactPublisher.updateArtifact).toHaveBeenCalledWith(
       'CANVAS-TYPED',
@@ -163,6 +166,7 @@ describe('ArtifactFeedbackHandler', () => {
       '# Current\n\n<span discussion-urls="discussion://disc-1">text</span>',
       expect.any(Function),
       expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
+      { staleConvergedApiRemoved: false },
     );
     expect(deps.artifactPublisher.updateArtifact).toHaveBeenCalledWith(
       'CANVAS001',
@@ -201,6 +205,7 @@ describe('ArtifactFeedbackHandler', () => {
       undefined,
       expect.any(Function),
       expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
+      { staleConvergedApiRemoved: false },
     );
     expect(deps.failRun).not.toHaveBeenCalled();
     expect(run.stage).toBe('reviewing_spec');
@@ -401,6 +406,158 @@ describe('ArtifactFeedbackHandler', () => {
       expect(result).toEqual({ status: 'failed' });
       expect(deps.artifactPublisher.updateArtifact).not.toHaveBeenCalled();
       expect(deps.failRun).toHaveBeenCalled();
+    });
+  });
+
+  describe('stale Converged API cleanup', () => {
+    it('removes ## Converged API section from local file before revise() for feature_spec', async () => {
+      const specWithApi = '# Feature Spec\n\nSome content.\n\n## Converged API\n\nOld API here.\n\n## Other Section\n\nMore.\n';
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockResolvedValue(specWithApi),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      });
+      const run = makeRun();
+      const feedback = makeFeedback();
+
+      const result = await handler.handle(run, feedback);
+
+      expect(result).toEqual({ status: 'revised' });
+      expect(deps.writeFile).toHaveBeenCalledWith(
+        '/ws/request-001/context-human/specs/feature-test.md',
+        expect.not.stringContaining('## Converged API'),
+        'utf-8',
+      );
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'artifact.api_convergence.stale_section_removed', run_id: 'run-001' }),
+        'Removed stale generated API section before feedback revision',
+      );
+    });
+
+    it('passes staleConvergedApiRemoved: true to revise() when section was removed', async () => {
+      const specWithApi = '# Feature Spec\n\n## Converged API\n\nOld API.\n';
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockResolvedValue(specWithApi),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      });
+      const run = makeRun();
+      const feedback = makeFeedback();
+
+      await handler.handle(run, feedback);
+
+      expect(deps.artifactAuthoringAgent.revise).toHaveBeenCalledWith(
+        feedback,
+        [],
+        '/ws/request-001/context-human/specs/feature-test.md',
+        '/ws/request-001',
+        undefined,
+        expect.any(Function),
+        expect.objectContaining({ run_id: 'run-001' }),
+        { staleConvergedApiRemoved: true },
+      );
+    });
+
+    it('does not warn and passes staleConvergedApiRemoved: false when no ## Converged API section', async () => {
+      const specWithoutApi = '# Feature Spec\n\nSome content.\n';
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockResolvedValue(specWithoutApi),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      });
+      const run = makeRun();
+      const feedback = makeFeedback();
+
+      await handler.handle(run, feedback);
+
+      expect(deps.writeFile).not.toHaveBeenCalled();
+      expect(deps.logger.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'artifact.api_convergence.stale_section_removed' }),
+        expect.any(String),
+      );
+      expect(deps.artifactAuthoringAgent.revise).toHaveBeenCalledWith(
+        feedback,
+        [],
+        '/ws/request-001/context-human/specs/feature-test.md',
+        '/ws/request-001',
+        undefined,
+        expect.any(Function),
+        expect.objectContaining({ run_id: 'run-001' }),
+        { staleConvergedApiRemoved: false },
+      );
+    });
+
+    it('does not run cleanup for non-feature_spec artifact kinds', async () => {
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockResolvedValue('# Bug spec\n'),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      });
+      const run = makeRun({
+        artifact: {
+          kind: 'bug_triage',
+          local_path: '/ws/request-001/context-human/specs/bug.md',
+          published_ref: { provider: 'artifact_publisher', id: 'CANVAS001' },
+          status: 'waiting_on_feedback',
+        },
+      });
+
+      await handler.handle(run, makeFeedback());
+
+      expect(deps.readFile).not.toHaveBeenCalled();
+      expect(deps.writeFile).not.toHaveBeenCalled();
+      expect(deps.artifactAuthoringAgent.revise).toHaveBeenCalledWith(
+        expect.anything(),
+        [],
+        '/ws/request-001/context-human/specs/bug.md',
+        '/ws/request-001',
+        undefined,
+        expect.any(Function),
+        expect.objectContaining({ run_id: 'run-001' }),
+        { staleConvergedApiRemoved: false },
+      );
+    });
+
+    it('logs a warning and continues when readFile throws during cleanup', async () => {
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockRejectedValue(new Error('file not found')),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      });
+      const run = makeRun();
+
+      const result = await handler.handle(run, makeFeedback());
+
+      expect(result).toEqual({ status: 'revised' });
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'artifact.api_convergence.stale_section_cleanup_failed', run_id: 'run-001' }),
+        'Failed to check/remove stale converged API section',
+      );
+      expect(deps.artifactAuthoringAgent.revise).toHaveBeenCalledWith(
+        expect.anything(),
+        [],
+        '/ws/request-001/context-human/specs/feature-test.md',
+        '/ws/request-001',
+        undefined,
+        expect.any(Function),
+        expect.objectContaining({ run_id: 'run-001' }),
+        { staleConvergedApiRemoved: false },
+      );
+    });
+
+    it('also cleans pageMarkdown when ## Converged API section is removed from file', async () => {
+      const specWithApi = '# Feature Spec\n\n## Converged API\n\nOld API.\n';
+      const pageWithApi = '# Feature Spec\n\n## Converged API\n\nSame API.\n';
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockResolvedValue(specWithApi),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        artifactContentSource: {
+          getContent: vi.fn().mockResolvedValue(pageWithApi),
+        },
+      });
+      const run = makeRun();
+      const feedback = makeFeedback();
+
+      await handler.handle(run, feedback);
+
+      const reviseCall = (deps.artifactAuthoringAgent.revise as ReturnType<typeof vi.fn>).mock.calls[0];
+      const passedPageMarkdown = reviseCall[4] as string;
+      expect(passedPageMarkdown).not.toContain('## Converged API');
     });
   });
 

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -108,7 +108,6 @@ describe('ArtifactFeedbackHandler', () => {
       undefined,
       expect.any(Function),
       expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
-      { staleConvergedApiRemoved: false },
     );
     expect(deps.artifactPublisher.updateArtifact).toHaveBeenCalledWith(
       'CANVAS-TYPED',
@@ -166,7 +165,6 @@ describe('ArtifactFeedbackHandler', () => {
       '# Current\n\n<span discussion-urls="discussion://disc-1">text</span>',
       expect.any(Function),
       expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
-      { staleConvergedApiRemoved: false },
     );
     expect(deps.artifactPublisher.updateArtifact).toHaveBeenCalledWith(
       'CANVAS001',
@@ -205,7 +203,6 @@ describe('ArtifactFeedbackHandler', () => {
       undefined,
       expect.any(Function),
       expect.objectContaining({ run_id: 'run-001', request_id: 'request-001' }),
-      { staleConvergedApiRemoved: false },
     );
     expect(deps.failRun).not.toHaveBeenCalled();
     expect(run.stage).toBe('reviewing_spec');
@@ -433,7 +430,7 @@ describe('ArtifactFeedbackHandler', () => {
       );
     });
 
-    it('passes staleConvergedApiRemoved: true to revise() when section was removed', async () => {
+    it('calls revise() without extra options when section was removed', async () => {
       const specWithApi = '# Feature Spec\n\n## Converged API\n\nOld API.\n';
       const { handler, deps } = makeHandler({
         readFile: vi.fn().mockResolvedValue(specWithApi),
@@ -452,11 +449,10 @@ describe('ArtifactFeedbackHandler', () => {
         undefined,
         expect.any(Function),
         expect.objectContaining({ run_id: 'run-001' }),
-        { staleConvergedApiRemoved: true },
       );
     });
 
-    it('does not warn and passes staleConvergedApiRemoved: false when no ## Converged API section', async () => {
+    it('does not warn and calls revise() when no ## Converged API section', async () => {
       const specWithoutApi = '# Feature Spec\n\nSome content.\n';
       const { handler, deps } = makeHandler({
         readFile: vi.fn().mockResolvedValue(specWithoutApi),
@@ -480,7 +476,6 @@ describe('ArtifactFeedbackHandler', () => {
         undefined,
         expect.any(Function),
         expect.objectContaining({ run_id: 'run-001' }),
-        { staleConvergedApiRemoved: false },
       );
     });
 
@@ -510,7 +505,6 @@ describe('ArtifactFeedbackHandler', () => {
         undefined,
         expect.any(Function),
         expect.objectContaining({ run_id: 'run-001' }),
-        { staleConvergedApiRemoved: false },
       );
     });
 
@@ -536,7 +530,6 @@ describe('ArtifactFeedbackHandler', () => {
         undefined,
         expect.any(Function),
         expect.objectContaining({ run_id: 'run-001' }),
-        { staleConvergedApiRemoved: false },
       );
     });
 

--- a/tests/core/handlers/artifact-feedback-handler.test.ts
+++ b/tests/core/handlers/artifact-feedback-handler.test.ts
@@ -479,6 +479,38 @@ describe('ArtifactFeedbackHandler', () => {
       );
     });
 
+    it('cleans the published markdown independently when the local file is already clean', async () => {
+      // Regression: the published/anchored markdown can carry a stale ## Converged API
+      // section even when the local spec file does not. It must still be stripped before
+      // revise() drafts from it, and staleConvergedApiRemoved must reflect either source.
+      const cleanLocal = '# Feature Spec\n\nSome content.\n';
+      const pageWithApi = '# Feature Spec\n\nSome content.\n\n## Converged API\n\nStale published API.\n';
+      const { handler, deps } = makeHandler({
+        readFile: vi.fn().mockResolvedValue(cleanLocal),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        artifactContentSource: { getContent: vi.fn().mockResolvedValue(pageWithApi) },
+      });
+      const run = makeRun();
+      const feedback = makeFeedback();
+
+      await handler.handle(run, feedback);
+
+      // Local file was already clean → not rewritten.
+      expect(deps.writeFile).not.toHaveBeenCalled();
+
+      const reviseCall = (deps.artifactAuthoringAgent.revise as ReturnType<typeof vi.fn>).mock.calls[0];
+      // Published markdown handed to revise() must have the stale section stripped.
+      expect(typeof reviseCall[4]).toBe('string');
+      expect(reviseCall[4]).not.toContain('## Converged API');
+      // Flag set because the published source changed, even though the local file did not.
+      expect(reviseCall[6]).toEqual(expect.objectContaining({ staleConvergedApiRemoved: true }));
+      // Warned specifically about the published-markdown cleanup.
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'artifact.api_convergence.stale_section_removed', source: 'published_markdown' }),
+        expect.any(String),
+      );
+    });
+
     it('does not run cleanup for non-feature_spec artifact kinds', async () => {
       const { handler, deps } = makeHandler({
         readFile: vi.fn().mockResolvedValue('# Bug spec\n'),

--- a/tests/core/handlers/implementation-start-handler.test.ts
+++ b/tests/core/handlers/implementation-start-handler.test.ts
@@ -548,9 +548,9 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
     );
   });
 
-  it('calls runLayeredImplementation when convergencePolicy enables a layered depth', async () => {
+  it('calls runInitialReview (not runLayeredImplementation) even when convergencePolicy enables a full depth', async () => {
     const coord = {
-      runInitialReview: vi.fn().mockResolvedValue({ status: 'complete', summary: 'unused', testing_instructions: 'unused' }),
+      runInitialReview: vi.fn().mockResolvedValue({ status: 'complete', summary: 'Initial review done.', testing_instructions: 'npm test' }),
       runLayeredImplementation: vi.fn().mockResolvedValue({
         status: 'complete',
         summary: 'Layered done.',
@@ -562,17 +562,14 @@ describe('ImplementationStartHandler with reviewCoordinator', () => {
       convergencePolicy: {
         enabled: true,
         allow_same_model: false,
-        depth: 'layout',
+        depth: 'full',
         feedback_depth: 'build_only',
         max_model_sessions_per_run: 24,
       },
     });
     await handler.handle(makeRun(), makeFeedback());
-    expect(coord.runLayeredImplementation).toHaveBeenCalledWith(
-      expect.objectContaining({ artifact_path: '/ws/request-001/context-human/specs/feature-test.md' }),
-      { altitudes: ['layout', 'build'] },
-    );
-    expect(coord.runInitialReview).not.toHaveBeenCalled();
+    expect(coord.runLayeredImplementation).not.toHaveBeenCalled();
+    expect(coord.runInitialReview).toHaveBeenCalled();
   });
 
   it('calls runInitialReview when convergencePolicy is build_only', async () => {

--- a/tests/core/journal/run-journal.test.ts
+++ b/tests/core/journal/run-journal.test.ts
@@ -81,6 +81,39 @@ describe('journal types (compile-focused)', () => {
     expect(record.tool_results).toBe(5);
   });
 
+  it('constructs a JournalSessionRecord with authoring_api_convergence metadata', () => {
+    const record: JournalSessionRecord = {
+      seq: 10,
+      writer_id: 'test-writer',
+      session_seq: 2,
+      ts_start: new Date().toISOString(),
+      ts_end: new Date().toISOString(),
+      conversation_id: 'slack:C123:T456',
+      topic_id: 'run-002',
+      run_id: 'run-002',
+      request_id: 'req-002',
+      phase: 'authoring_api_convergence',
+      step: 'artifact.api.critique',
+      role: 'critic',
+      round: 2,
+      gate: 'api',
+      model: { provider: 'anthropic', name: 'claude-sonnet-4-6' },
+      inference: { effort: null, thinking: null },
+      tokens: null,
+      assistant_turns: null,
+      tool_calls: null,
+      tool_results: null,
+      outcome: 'ok',
+      runner: 'anthropic_agent',
+    };
+
+    expect(record.phase).toBe('authoring_api_convergence');
+    expect(record.step).toBe('artifact.api.critique');
+    expect(record.role).toBe('critic');
+    expect(record.round).toBe(2);
+    expect(record.gate).toBe('api');
+  });
+
   it('constructs a valid JournalFeedbackRecord', () => {
     const record: JournalFeedbackRecord = {
       seq: 3,
@@ -105,6 +138,35 @@ describe('journal types (compile-focused)', () => {
     expect(record.target).toBe('implementation');
     expect(record.severity).toBe('warning');
     expect(record.category).toBe('correctness');
+    expect(record.disposition).toBe('open');
+  });
+
+  it('constructs a JournalFeedbackRecord with api gate artifact metadata', () => {
+    const record: JournalFeedbackRecord = {
+      seq: 11,
+      writer_id: 'test-writer',
+      id: 'fb-api-001',
+      ts_created: new Date().toISOString(),
+      conversation_id: 'slack:C123:T456',
+      topic_id: 'run-002',
+      run_id: 'run-002',
+      request_id: 'req-002',
+      target: 'artifact',
+      gate: 'api',
+      author_principal: 'review:anthropic_agent_sdk:review-agent',
+      text: 'Public method missing return type annotation',
+      anchor: null,
+      severity: 'warning',
+      category: 'maintainability',
+      disposition: 'open',
+      thread: [],
+    };
+
+    expect(record.target).toBe('artifact');
+    expect(record.gate).toBe('api');
+    expect(record.author_principal).toBe('review:anthropic_agent_sdk:review-agent');
+    expect(record.severity).toBe('warning');
+    expect(record.category).toBe('maintainability');
     expect(record.disposition).toBe('open');
   });
 


### PR DESCRIPTION
## Summary

- INIT-1: coordinator loop now uses `if (round === 1 || currentArtifact === null)` so parse failures trigger a fresh proposer invocation on subsequent rounds rather than silently cycling. Removed dead null-guard `continue`.
- INIT-2: parseConvergedApiArtifact now throws for empty/missing symbol, signature, returns (public_api) and name, shape (types); 7 new validation tests added.
- INIT-3: ArtifactCreationHandler now calls failRun with an actionable error when api_convergence.enabled is true but required dependencies are absent — no longer silently falls back to legacy path.
- INIT-4: captureSession now uses `data.round ?? 1` so coordinator-provided round metadata is preserved in sessions.jsonl.

## Verify

- [ ] With api_convergence enabled and persistent invalid proposer JSON, the coordinator retries the proposer each round until max_rounds then throws a parse error (not 'loop exited unexpectedly').
- [ ] parseConvergedApiArtifact rejects artifacts with empty symbol, signature, returns, name, or shape.
- [ ] When api_convergence is enabled but required dependencies are missing, failRun is called with a message naming the missing dependency.
- [ ] Multi-round sessions in sessions.jsonl carry the correct round number rather than always round 1.

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/autocatalyst/0fcd9ca5-d6ad-4cff-bafe-7f000eb8a8fa
2. npm test -- tests/core/ai/authoring-api-convergence-coordinator.test.ts tests/core/ai/authoring-api-artifact.test.ts tests/core/handlers/artifact-creation-handler.test.ts
3. npm test (full suite — 1713 pass, 4 pre-existing orchestrator.test.ts failures unrelated to this feature)

---
Spec: `context-human/specs/enhancement-authoring-api-convergence.md`
Closes #200